### PR TITLE
Simplify home layout and streamline proverbs app

### DIFF
--- a/apps/proverbs/app.js
+++ b/apps/proverbs/app.js
@@ -1,10 +1,7 @@
 (function () {
   const textEl = document.getElementById('proverb-text');
-  const sourceEl = document.getElementById('proverb-source');
-  const positionEl = document.getElementById('proverb-position');
   const prevButton = document.getElementById('prev-button');
   const nextButton = document.getElementById('next-button');
-  const reshuffleButton = document.getElementById('reshuffle-button');
 
   const proverbs = Array.isArray(window.proverbsData)
     ? window.proverbsData.filter((entry) => entry && entry.text)
@@ -32,19 +29,14 @@
   function render() {
     if (!proverbs.length) {
       textEl.textContent = 'No proverbs available.';
-      sourceEl.textContent = '';
-      positionEl.textContent = '';
       prevButton.disabled = true;
       nextButton.disabled = true;
-      reshuffleButton.disabled = true;
       return;
     }
 
     ensureDeck();
     const item = shuffled[index];
     textEl.textContent = item.text;
-    sourceEl.textContent = item.source ? `— ${item.source}` : '';
-    positionEl.textContent = `${index + 1} / ${shuffled.length}`;
 
     prevButton.disabled = shuffled.length <= 1;
     nextButton.disabled = shuffled.length <= 1;
@@ -62,23 +54,14 @@
     render();
   }
 
-  function reshuffle() {
-    shuffled = shuffle(proverbs);
-    index = 0;
-    render();
-  }
-
   prevButton.addEventListener('click', showPrev);
   nextButton.addEventListener('click', showNext);
-  reshuffleButton.addEventListener('click', reshuffle);
 
   document.addEventListener('keydown', (event) => {
     if (event.key === 'ArrowRight') {
       showNext();
     } else if (event.key === 'ArrowLeft') {
       showPrev();
-    } else if (event.key.toLowerCase() === 'r') {
-      reshuffle();
     }
   });
 

--- a/apps/proverbs/index.html
+++ b/apps/proverbs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Proverbs Explorer</title>
+  <title>Proverbs</title>
   <style>
     :root {
       color-scheme: light dark;
@@ -32,20 +32,9 @@
     main {
       max-width: 720px;
       width: 100%;
-    }
-
-    h1 {
-      margin-top: 0;
-      font-weight: 600;
-      text-align: center;
-      letter-spacing: 0.02em;
-    }
-
-    p.description {
-      text-align: center;
-      margin-bottom: 24px;
-      color: inherit;
-      opacity: 0.85;
+      display: flex;
+      flex-direction: column;
+      gap: 28px;
     }
 
     .card {
@@ -69,14 +58,6 @@
       font-weight: 500;
     }
 
-    .card cite {
-      font-size: 1rem;
-      font-style: normal;
-      color: inherit;
-      opacity: 0.7;
-      align-self: flex-end;
-    }
-
     .controls {
       display: flex;
       justify-content: center;
@@ -95,6 +76,7 @@
       background: #3056d3;
       color: #ffffff;
       transition: transform 0.15s ease, box-shadow 0.15s ease;
+      touch-action: manipulation;
     }
 
     button:disabled {
@@ -109,46 +91,34 @@
       box-shadow: 0 8px 20px rgba(48, 86, 211, 0.35);
     }
 
-    button.secondary {
-      background: #586380;
+    button:focus-visible {
+      outline: 2px solid rgba(48, 86, 211, 0.6);
+      outline-offset: 3px;
     }
 
-    .position {
-      font-variant-numeric: tabular-nums;
-      opacity: 0.7;
-      min-width: 120px;
-      text-align: center;
-    }
+    @media (hover: none) and (pointer: coarse) {
+      button:not(:disabled) {
+        transition: none;
+      }
 
-    footer {
-      margin-top: 24px;
-      text-align: center;
-      font-size: 0.85rem;
-      opacity: 0.7;
-    }
-
-    a {
-      color: inherit;
+      button:not(:disabled):hover,
+      button:not(:disabled):active,
+      button:not(:disabled):focus {
+        transform: none;
+        box-shadow: none;
+      }
     }
   </style>
 </head>
 <body>
-  <main>
-    <h1>Proverbs Explorer</h1>
-    <p class="description">Shuffle through wisdom from around the world. Use the buttons or your keyboard arrows to navigate.</p>
+  <main aria-label="Proverbs">
     <div class="card" role="group" aria-live="polite">
       <blockquote id="proverb-text">Loading proverb…</blockquote>
-      <cite id="proverb-source"></cite>
     </div>
     <div class="controls">
       <button id="prev-button" type="button" aria-label="Show previous proverb">⟵ Previous</button>
-      <span class="position" id="proverb-position"></span>
       <button id="next-button" type="button" aria-label="Show next proverb">Next ⟶</button>
-      <button id="reshuffle-button" type="button" class="secondary" aria-label="Reshuffle proverbs">Reshuffle</button>
     </div>
-    <footer>
-      Data source: <a href="https://github.com/increpare/ML_Satz" target="_blank" rel="noopener noreferrer">ML_Satz merged collection</a>.
-    </footer>
   </main>
   <script src="proverbs-data.js" defer></script>
   <script src="app.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -29,22 +29,9 @@
       box-shadow: 0 30px 80px rgba(0, 0, 0, 0.35);
       backdrop-filter: blur(12px);
       padding: clamp(32px, 5vw, 56px);
-    }
-
-    h1 {
-      margin: 0 0 12px;
-      font-size: clamp(2rem, 3vw + 1rem, 3rem);
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-align: center;
-    }
-
-    p.lead {
-      margin: 0 0 40px;
-      text-align: center;
-      color: rgba(245, 247, 255, 0.75);
-      font-size: 1.1rem;
-      line-height: 1.5;
+      display: flex;
+      flex-direction: column;
+      gap: 32px;
     }
 
     ul.apps {
@@ -101,45 +88,54 @@
       box-shadow: 0 16px 36px rgba(76, 108, 255, 0.55);
     }
 
-    footer {
-      margin-top: 40px;
-      text-align: center;
-      color: rgba(245, 247, 255, 0.5);
-      font-size: 0.9rem;
+    a.launch:focus-visible,
+    a.dev-link:focus-visible {
+      outline: 2px solid rgba(139, 155, 255, 0.9);
+      outline-offset: 3px;
     }
 
-    footer a {
+    section.dev-tools {
+      display: flex;
+      justify-content: center;
+    }
+
+    a.dev-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 18px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.05);
       color: inherit;
+      text-decoration: none;
+      font-weight: 500;
+      transition: background 0.18s ease, box-shadow 0.18s ease;
+      box-shadow: 0 12px 32px rgba(12, 18, 40, 0.25);
+    }
+
+    a.dev-link:hover {
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow: 0 18px 40px rgba(12, 18, 40, 0.35);
     }
   </style>
 </head>
 <body>
-  <main>
-    <h1>Denis's Web Toolbox</h1>
-    <p class="lead">
-      Choose an app to launch. Each tool is isolated in its own workspace so you can
-      jump straight into what you need.
-    </p>
+  <main aria-label="Apps">
     <ul class="apps">
-      <li class="app-card">
-        <h2>Value Formatter</h2>
-        <p>Transform lists of values using presets or your own custom mapping without losing your previous session.</p>
-        <a class="launch" href="apps/value-formatter/">Open app</a>
-      </li>
       <li class="app-card">
         <h2>Random Jokes</h2>
         <p>Shuffle through developer-friendly jokes and reveal punchlines one by one or go back if you missed the setup.</p>
         <a class="launch" href="apps/jokes/">Open app</a>
       </li>
       <li class="app-card">
-        <h2>Proverbs Explorer</h2>
-        <p>Browse through over four thousand proverbs sourced from the ML_Satz collection with a reshuffleable random deck.</p>
+        <h2>Proverbs</h2>
+        <p>Walk through a constantly shuffled deck of proverbs with quick previous and next controls.</p>
         <a class="launch" href="apps/proverbs/">Open app</a>
       </li>
     </ul>
-    <footer>
-      Maintained with ❤️. <a href="https://github.com/increpare/ML_Satz" target="_blank" rel="noopener noreferrer">Proverbs dataset by increpare</a>.
-    </footer>
+    <section class="dev-tools">
+      <a class="dev-link" href="apps/value-formatter/">Value Formatter — Quick mapping for long lists.</a>
+    </section>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- strip the homepage down to an apps grid with a compact dev tools link and no attribution footer
- streamline the proverbs interface by dropping the title, source credit, counter, and reshuffle button while keeping navigation accessible
- add mobile-friendly button handling to prevent zooming during rapid taps

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce21edea548328afe9cd0bb046ad58