### PR TITLE
Refresh jokes UI and add list views

### DIFF
--- a/apps/jokes/all-jokes-compact.html
+++ b/apps/jokes/all-jokes-compact.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>All Jokes — Compact Table</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      --bg-color: #f6f7fb;
+      --bg-gradient: radial-gradient(circle at top, rgba(120, 140, 220, 0.12), rgba(15, 23, 42, 0.05) 70%);
+      --surface: rgba(255, 255, 255, 0.95);
+      --surface-shadow: 0 30px 70px rgba(15, 23, 42, 0.14);
+      --surface-border: rgba(15, 23, 42, 0.08);
+      --text-primary: #0f172a;
+      --text-secondary: rgba(15, 23, 42, 0.65);
+      --table-header: rgba(15, 23, 42, 0.05);
+      --table-stripe: rgba(15, 23, 42, 0.03);
+      --table-border: rgba(15, 23, 42, 0.1);
+      --badge-bg: rgba(74, 99, 255, 0.14);
+      background-color: var(--bg-color);
+      color: var(--text-primary);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-color: #0b1020;
+        --bg-gradient: radial-gradient(circle at top, rgba(72, 101, 216, 0.28), rgba(9, 17, 35, 0.86) 65%);
+        --surface: rgba(14, 20, 36, 0.92);
+        --surface-shadow: 0 32px 80px rgba(0, 0, 0, 0.45);
+        --surface-border: rgba(148, 163, 209, 0.08);
+        --text-primary: #f1f5ff;
+        --text-secondary: rgba(209, 216, 255, 0.7);
+        --table-header: rgba(105, 128, 255, 0.18);
+        --table-stripe: rgba(255, 255, 255, 0.04);
+        --table-border: rgba(148, 163, 209, 0.12);
+        --badge-bg: rgba(105, 128, 255, 0.16);
+      }
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      padding: clamp(24px, 5vw, 48px);
+      background: var(--bg-gradient);
+      background-color: var(--bg-color);
+    }
+
+    main {
+      width: min(1040px, 100%);
+      background: var(--surface);
+      border-radius: 24px;
+      box-shadow: var(--surface-shadow);
+      border: 1px solid var(--surface-border);
+      padding: clamp(28px, 4vw, 48px);
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    header.page-header {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    header.page-header h1 {
+      margin: 0;
+      font-size: clamp(1.8rem, 2vw + 1.4rem, 2.6rem);
+      font-weight: 700;
+    }
+
+    header.page-header p {
+      margin: 0;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--badge-bg);
+      padding: 6px 12px;
+      border-radius: 999px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: inherit;
+    }
+
+    .table-wrapper {
+      border: 1px solid var(--table-border);
+      border-radius: 16px;
+      overflow: hidden;
+      background: rgba(255, 255, 255, 0.02);
+      max-height: 85vh;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 640px;
+    }
+
+    thead th {
+      position: sticky;
+      top: 0;
+      background: var(--table-header);
+      backdrop-filter: blur(6px);
+      text-align: left;
+      padding: 12px 14px;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    tbody tr:nth-child(even) {
+      background: var(--table-stripe);
+    }
+
+    th,
+    td {
+      padding: 10px 14px;
+      vertical-align: top;
+      border-bottom: 1px solid var(--table-border);
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-size: 0.92rem;
+      line-height: 1.45;
+    }
+
+    th[scope="row"] {
+      width: 52px;
+      font-weight: 600;
+      text-align: right;
+    }
+
+    tbody tr:last-child th,
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    body.is-compact th,
+    body.is-compact td {
+      padding: 8px 10px;
+      font-size: 0.85rem;
+    }
+
+    body.is-compact thead th {
+      padding: 8px 10px;
+      font-size: 0.72rem;
+    }
+
+    @media (max-width: 720px) {
+      main {
+        padding: clamp(20px, 6vw, 32px);
+      }
+
+      table {
+        min-width: 100%;
+      }
+    }
+  </style>
+</head>
+<body data-compact="true">
+  <main>
+    <header class="page-header">
+      <h1>All Jokes (Compact)</h1>
+      <p>Condensed view with tighter spacing for quicker scanning. <span class="badge"><span data-count>0</span> jokes</span></p>
+    </header>
+    <div class="table-wrapper" role="region" aria-live="polite">
+      <table>
+        <caption class="sr-only">Compact list of jokes with punchlines</caption>
+        <thead>
+          <tr>
+            <th scope="col">#</th>
+            <th scope="col">Joke</th>
+            <th scope="col">Punchline</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td colspan="3">Loading jokes…</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </main>
+  <script src="jokes.js" defer></script>
+  <script src="render-all.js" defer></script>
+</body>
+</html>

--- a/apps/jokes/all-jokes.html
+++ b/apps/jokes/all-jokes.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>All Jokes — Table View</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      --bg-color: #f6f7fb;
+      --bg-gradient: radial-gradient(circle at top, rgba(120, 140, 220, 0.12), rgba(15, 23, 42, 0.05) 70%);
+      --surface: rgba(255, 255, 255, 0.95);
+      --surface-shadow: 0 30px 70px rgba(15, 23, 42, 0.14);
+      --surface-border: rgba(15, 23, 42, 0.08);
+      --text-primary: #0f172a;
+      --text-secondary: rgba(15, 23, 42, 0.65);
+      --table-header: rgba(15, 23, 42, 0.05);
+      --table-stripe: rgba(15, 23, 42, 0.03);
+      --table-border: rgba(15, 23, 42, 0.1);
+      --badge-bg: rgba(74, 99, 255, 0.14);
+      background-color: var(--bg-color);
+      color: var(--text-primary);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-color: #0b1020;
+        --bg-gradient: radial-gradient(circle at top, rgba(72, 101, 216, 0.28), rgba(9, 17, 35, 0.86) 65%);
+        --surface: rgba(14, 20, 36, 0.92);
+        --surface-shadow: 0 32px 80px rgba(0, 0, 0, 0.45);
+        --surface-border: rgba(148, 163, 209, 0.08);
+        --text-primary: #f1f5ff;
+        --text-secondary: rgba(209, 216, 255, 0.7);
+        --table-header: rgba(105, 128, 255, 0.18);
+        --table-stripe: rgba(255, 255, 255, 0.04);
+        --table-border: rgba(148, 163, 209, 0.12);
+        --badge-bg: rgba(105, 128, 255, 0.16);
+      }
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      padding: clamp(24px, 5vw, 48px);
+      background: var(--bg-gradient);
+      background-color: var(--bg-color);
+    }
+
+    main {
+      width: min(1040px, 100%);
+      background: var(--surface);
+      border-radius: 24px;
+      box-shadow: var(--surface-shadow);
+      border: 1px solid var(--surface-border);
+      padding: clamp(28px, 4vw, 48px);
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    header.page-header {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    header.page-header h1 {
+      margin: 0;
+      font-size: clamp(1.8rem, 2vw + 1.4rem, 2.6rem);
+      font-weight: 700;
+    }
+
+    header.page-header p {
+      margin: 0;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--badge-bg);
+      padding: 6px 12px;
+      border-radius: 999px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: inherit;
+    }
+
+    .table-wrapper {
+      border: 1px solid var(--table-border);
+      border-radius: 16px;
+      overflow: hidden;
+      background: rgba(255, 255, 255, 0.02);
+      max-height: 80vh;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 640px;
+    }
+
+    thead th {
+      position: sticky;
+      top: 0;
+      background: var(--table-header);
+      backdrop-filter: blur(6px);
+      text-align: left;
+      padding: 14px 18px;
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    tbody tr:nth-child(even) {
+      background: var(--table-stripe);
+    }
+
+    th,
+    td {
+      padding: 14px 18px;
+      vertical-align: top;
+      border-bottom: 1px solid var(--table-border);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    th[scope="row"] {
+      width: 60px;
+      font-weight: 600;
+    }
+
+    tbody tr:last-child th,
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    body.is-compact th,
+    body.is-compact td {
+      padding: 10px 12px;
+      font-size: 0.92rem;
+    }
+
+    body.is-compact thead th {
+      padding: 10px 12px;
+      font-size: 0.75rem;
+    }
+
+    @media (max-width: 720px) {
+      main {
+        padding: clamp(20px, 6vw, 32px);
+      }
+
+      table {
+        min-width: 100%;
+      }
+    }
+  </style>
+</head>
+<body data-compact="false">
+  <main>
+    <header class="page-header">
+      <h1>All Jokes</h1>
+      <p>Browse the full dataset from <code>jokes.js</code>. Use your browser search to find a joke or punchline. <span class="badge"><span data-count>0</span> jokes</span></p>
+    </header>
+    <div class="table-wrapper" role="region" aria-live="polite">
+      <table>
+        <caption class="sr-only">Complete list of jokes with punchlines</caption>
+        <thead>
+          <tr>
+            <th scope="col">#</th>
+            <th scope="col">Joke</th>
+            <th scope="col">Punchline</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td colspan="3">Loading jokes…</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </main>
+  <script src="jokes.js" defer></script>
+  <script src="render-all.js" defer></script>
+</body>
+</html>

--- a/apps/jokes/app.js
+++ b/apps/jokes/app.js
@@ -1,0 +1,131 @@
+(function () {
+  const setupEl = document.getElementById('joke-setup');
+  const punchlineEl = document.getElementById('joke-punchline');
+  const statusEl = document.getElementById('card-status');
+  const prevButton = document.getElementById('prev-button');
+  const nextButton = document.getElementById('next-button');
+  const revealButton = document.getElementById('reveal-button');
+
+  if (!setupEl || !punchlineEl || !statusEl || !prevButton || !nextButton || !revealButton) {
+    return;
+  }
+
+  const jokes = Array.isArray(window.jokes)
+    ? window.jokes.filter((entry) => entry && entry.joke)
+    : [];
+
+  let deck = [];
+  let index = 0;
+  let punchlineVisible = false;
+
+  function shuffle(array) {
+    const copy = array.slice();
+    for (let i = copy.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [copy[i], copy[j]] = [copy[j], copy[i]];
+    }
+    return copy;
+  }
+
+  function ensureDeck() {
+    if (deck.length === 0) {
+      deck = shuffle(jokes);
+      index = 0;
+    }
+  }
+
+  function updateStatus() {
+    if (!deck.length) {
+      statusEl.textContent = 'No jokes available.';
+      return;
+    }
+
+    statusEl.textContent = punchlineVisible
+      ? 'Punchline revealed.'
+      : 'Punchline hidden — reveal when you\'re ready.';
+  }
+
+  function setPunchlineVisible(visible) {
+    punchlineVisible = visible;
+    punchlineEl.classList.toggle('is-visible', visible);
+    punchlineEl.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    revealButton.setAttribute('aria-pressed', visible ? 'true' : 'false');
+    revealButton.textContent = visible ? 'Hide punchline' : 'Reveal punchline';
+    updateStatus();
+  }
+
+  function render() {
+    if (!jokes.length) {
+      setupEl.textContent = 'No jokes available.';
+      punchlineEl.textContent = '';
+      punchlineEl.classList.remove('is-visible');
+      punchlineEl.setAttribute('aria-hidden', 'true');
+      revealButton.hidden = true;
+      prevButton.disabled = true;
+      nextButton.disabled = true;
+      updateStatus();
+      return;
+    }
+
+    ensureDeck();
+    const current = deck[index];
+    const hasPunchline = typeof current.punchline === 'string' && current.punchline.trim().length > 0;
+    const punchlineText = hasPunchline ? current.punchline : '💩';
+
+    setupEl.textContent = current.joke;
+    punchlineEl.textContent = punchlineText;
+    revealButton.hidden = false;
+
+    setPunchlineVisible(false);
+
+    const buttonsDisabled = deck.length <= 1;
+    prevButton.disabled = buttonsDisabled;
+    nextButton.disabled = buttonsDisabled;
+  }
+
+  function showNext() {
+    ensureDeck();
+    index = (index + 1) % deck.length;
+    render();
+  }
+
+  function showPrev() {
+    ensureDeck();
+    index = (index - 1 + deck.length) % deck.length;
+    render();
+  }
+
+  function togglePunchline() {
+    if (!deck.length) {
+      return;
+    }
+    setPunchlineVisible(!punchlineVisible);
+  }
+
+  prevButton.addEventListener('click', showPrev);
+  nextButton.addEventListener('click', showNext);
+  revealButton.addEventListener('click', togglePunchline);
+
+  document.addEventListener('keydown', (event) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      showNext();
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      showPrev();
+    } else if (event.key === ' ') {
+      const active = document.activeElement;
+      if (active && active.tagName === 'BUTTON') {
+        return;
+      }
+      event.preventDefault();
+      togglePunchline();
+    }
+  });
+
+  render();
+})();

--- a/apps/jokes/index.html
+++ b/apps/jokes/index.html
@@ -1,154 +1,187 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"> <!-- Prevent zooming -->
-    <title>Random Jokes</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            display: flex;
-            justify-content: center; /* Center content vertically */
-            align-items: center; /* Center content horizontally */
-            flex-direction: column;
-            height: 100vh;
-            margin: 0;
-            padding: 20px;
-            background-color: #f0f0f0;
-            -webkit-touch-callout: none; /* Prevent callout to copy text in Safari */
-            -webkit-user-select: none;   /* Prevent copy paste, to disable zoom */
-            user-select: none;           /* Non-prefixed version, currently */
-            touch-action: manipulation;  /* Disable double-tap zoom */
-        }
-        #joke-container {
-            width: 100%;
-            max-width: 600px;
-            text-align: center;
-            background: #fff;
-            padding: 30px;
-            border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-            margin-bottom: 20px;
-        }
-        #joke-container p {
-            margin: 0;
-            font-size: 24px; /* Increase font size for jokes */
-        }
-        .punchline {
-            display: none;
-            font-style: italic;
-            color: #555;
-        }
-        .buttons {
-            text-align: center;
-            margin-top: 20px;
-        }
-        button {
-            margin: 0 5px;
-            padding: 10px 20px;
-            font-size: 16px;
-            cursor: pointer;
-            border: none;
-            background: #007bff;
-            color: #fff;
-            border-radius: 5px;
-            transition: background-color 0.3s;
-        }
-        button:hover {
-            background-color: #0056b3;
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Random Jokes</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      --background-color: #f5f5f5;
+      --background-gradient: radial-gradient(circle at top, rgba(112, 147, 220, 0.2), transparent 65%);
+      --card-background: rgba(255, 255, 255, 0.88);
+      --card-border: rgba(15, 23, 42, 0.06);
+      --card-shadow: 0 26px 52px -24px rgba(15, 23, 42, 0.28);
+      --text-primary: #111827;
+      --text-secondary: rgba(30, 41, 59, 0.68);
+      --punchline-color: #334155;
+      --accent: #3056d3;
+      --accent-contrast: #ffffff;
+      background-color: var(--background-color);
+      color: var(--text-primary);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --background-color: #101524;
+        --background-gradient: radial-gradient(circle at top, rgba(72, 101, 216, 0.34), rgba(7, 13, 27, 0.92) 60%);
+        --card-background: rgba(20, 27, 45, 0.92);
+        --card-border: rgba(148, 163, 209, 0.08);
+        --card-shadow: 0 30px 60px -30px rgba(0, 0, 0, 0.65);
+        --text-primary: #e8ecff;
+        --text-secondary: rgba(224, 230, 255, 0.72);
+        --punchline-color: rgba(224, 230, 255, 0.86);
+        --accent: #7084ff;
+        --accent-contrast: #0b1020;
+      }
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(20px, 6vw, 40px);
+      background: var(--background-gradient);
+      background-color: var(--background-color);
+    }
+
+    main {
+      max-width: 720px;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      gap: clamp(24px, 4vw, 40px);
+    }
+
+    .card {
+      background: var(--card-background);
+      border-radius: 20px;
+      border: 1px solid var(--card-border);
+      box-shadow: var(--card-shadow);
+      backdrop-filter: blur(14px);
+      padding: clamp(28px, 6vw, 40px);
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+      min-height: 240px;
+    }
+
+    .card__content {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    #joke-setup {
+      margin: 0;
+      font-size: clamp(1.35rem, 2.4vw + 1rem, 2.2rem);
+      line-height: 1.4;
+      font-weight: 600;
+    }
+
+    #joke-punchline {
+      margin: 0;
+      font-size: clamp(1.1rem, 1.8vw + 0.8rem, 1.6rem);
+      line-height: 1.5;
+      color: var(--punchline-color);
+      display: none;
+    }
+
+    #joke-punchline.is-visible {
+      display: block;
+    }
+
+    .card__meta {
+      margin: 0;
+      font-size: 0.98rem;
+      color: var(--text-secondary);
+    }
+
+    .controls {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+    }
+
+    button {
+      border: none;
+      border-radius: 999px;
+      padding: 12px 20px;
+      font-size: 1rem;
+      cursor: pointer;
+      background: var(--accent);
+      color: var(--accent-contrast);
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+      touch-action: manipulation;
+    }
+
+    button.secondary {
+      background: transparent;
+      color: var(--accent);
+      border: 1px solid currentColor;
+      box-shadow: none;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      button.secondary {
+        color: #9ba9ff;
+        border-color: rgba(155, 169, 255, 0.5);
+        background: rgba(112, 132, 255, 0.12);
+      }
+    }
+
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      box-shadow: none;
+      transform: none;
+    }
+
+    button:not(:disabled):hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 24px rgba(48, 86, 211, 0.28);
+    }
+
+    button:focus-visible {
+      outline: 2px solid rgba(112, 132, 255, 0.65);
+      outline-offset: 3px;
+    }
+
+    @media (hover: none) and (pointer: coarse) {
+      button:not(:disabled) {
+        transition: none;
+      }
+
+      button:not(:disabled):hover,
+      button:not(:disabled):active,
+      button:not(:disabled):focus {
+        transform: none;
+        box-shadow: none;
+      }
+    }
+  </style>
 </head>
 <body>
-    <div id="joke-container">
-        <p id="joke-text">Loading...</p>
-        <p id="punchline-text" class="punchline"></p>
+  <main aria-label="Random jokes">
+    <article class="card" aria-live="polite">
+      <div class="card__content">
+        <p id="joke-setup">Loading joke…</p>
+        <p id="joke-punchline" aria-hidden="true">Punchline</p>
+      </div>
+      <p class="card__meta" id="card-status">Punchline hidden — reveal when you're ready.</p>
+    </article>
+    <div class="controls">
+      <button id="prev-button" type="button" aria-label="Show previous joke">⟵ Previous</button>
+      <button id="reveal-button" class="secondary" type="button" aria-pressed="false">Reveal punchline</button>
+      <button id="next-button" type="button" aria-label="Show next joke">Next ⟶</button>
     </div>
-    <div class="buttons">
-        <button id="prev-joke">Prev</button>
-        <button id="new-joke">Next</button>
-        <button id="reveal-punchline" style="display: none;">Punchline</button>
-    </div>
-
-    <!-- Include the jokes.js script -->
-    <script src="jokes.js"></script>
-    <script>
-        let currentIndex = 0;
-        let shuffledJokes = [];
-        let punchlinesVisible = false;  // To track the visibility of punchlines
-
-        // Function to shuffle the jokes array based on a seed
-        function shuffle(array, seed) {
-            let currentIndex = array.length, temporaryValue, randomIndex;
-            
-            // While there remain elements to shuffle...
-            while (0 !== currentIndex) {
-                // Pick a remaining element...
-                randomIndex = Math.floor(random(seed++) * currentIndex);
-                currentIndex -= 1;
-
-                // And swap it with the current element.
-                temporaryValue = array[currentIndex];
-                array[currentIndex] = array[randomIndex];
-                array[randomIndex] = temporaryValue;
-            }
-            return array;
-        }
-
-        // Random function with seed
-        function random(seed) {
-            const x = Math.sin(seed) * 10000;
-            return x - Math.floor(x);
-        }
-
-        // Seed based on time and initial shuffle
-        const seed = Math.floor(Math.random() * 1000);
-        shuffledJokes = shuffle(window.jokes.slice(), seed);
-
-        function showJoke() {
-            // Get the current joke
-            const joke = shuffledJokes[currentIndex];
-            
-            // Display the joke
-            document.getElementById('joke-text').textContent = joke.joke;
-
-            // Display the punchline or poop emoji if empty
-            const punchline = joke.punchline ? joke.punchline : '💩';
-            document.getElementById('punchline-text').textContent = punchline;
-            
-            // Hide the punchline initially
-            document.getElementById('punchline-text').style.display = 'none';
-            document.getElementById('reveal-punchline').style.display = 'inline';
-            punchlinesVisible = false;
-        }
-
-        function showNextJoke() {
-            currentIndex = (currentIndex + 1) % shuffledJokes.length;
-            showJoke();
-        }
-
-        function showPrevJoke() {
-            currentIndex = (currentIndex - 1 + shuffledJokes.length) % shuffledJokes.length;
-            showJoke();
-        }
-
-        function toggleAllPunchlines() {
-            const punchlineText = document.getElementById('punchline-text');
-            if (punchlinesVisible) {
-                punchlineText.style.display = 'none';
-                punchlinesVisible = false;
-            } else {
-                punchlineText.style.display = 'block';
-                punchlinesVisible = true;
-            }
-        }
-
-        document.getElementById('new-joke').addEventListener('click', showNextJoke);
-        document.getElementById('prev-joke').addEventListener('click', showPrevJoke);
-        document.getElementById('reveal-punchline').addEventListener('click', toggleAllPunchlines);
-
-        // Load the first joke on page load
-        showJoke();
-    </script>
+  </main>
+  <script src="jokes.js" defer></script>
+  <script src="app.js" defer></script>
 </body>
 </html>

--- a/apps/jokes/render-all.js
+++ b/apps/jokes/render-all.js
@@ -1,0 +1,63 @@
+(function () {
+  const tbody = document.querySelector('tbody');
+  const countTarget = document.querySelector('[data-count]');
+  const isCompact = document.body.dataset.compact === 'true';
+
+  const jokes = Array.isArray(window.jokes)
+    ? window.jokes.filter((entry) => entry && entry.joke)
+    : [];
+
+  if (countTarget) {
+    countTarget.textContent = jokes.length.toLocaleString();
+  }
+
+  if (!tbody) {
+    return;
+  }
+
+  if (isCompact) {
+    document.body.classList.add('is-compact');
+  }
+
+  tbody.textContent = '';
+
+  if (!jokes.length) {
+    const emptyRow = document.createElement('tr');
+    const emptyCell = document.createElement('td');
+    emptyCell.colSpan = 3;
+    emptyCell.textContent = 'No jokes available.';
+    emptyRow.appendChild(emptyCell);
+    tbody.appendChild(emptyRow);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  const formatPunchline = (value) => {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+    return '💩';
+  };
+
+  jokes.forEach((entry, idx) => {
+    const row = document.createElement('tr');
+
+    const indexCell = document.createElement('th');
+    indexCell.scope = 'row';
+    indexCell.textContent = String(idx + 1);
+
+    const jokeCell = document.createElement('td');
+    jokeCell.textContent = entry.joke;
+
+    const punchlineCell = document.createElement('td');
+    punchlineCell.textContent = formatPunchline(entry.punchline);
+
+    row.appendChild(indexCell);
+    row.appendChild(jokeCell);
+    row.appendChild(punchlineCell);
+
+    fragment.appendChild(row);
+  });
+
+  tbody.appendChild(fragment);
+})();

--- a/index.html
+++ b/index.html
@@ -8,8 +8,41 @@
     :root {
       color-scheme: light dark;
       font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
-      background-color: #10131a;
-      color: #f5f7ff;
+      --body-base: #f5f7ff;
+      --body-gradient: radial-gradient(circle at top, rgba(85, 112, 225, 0.16), rgba(15, 21, 40, 0.08) 55%);
+      --text-primary: #10172a;
+      --text-secondary: rgba(16, 23, 42, 0.65);
+      --surface: rgba(255, 255, 255, 0.94);
+      --surface-shadow: 0 28px 70px rgba(15, 23, 42, 0.14);
+      --surface-border: rgba(15, 23, 42, 0.08);
+      --card-background: rgba(255, 255, 255, 0.88);
+      --card-hover-background: rgba(255, 255, 255, 0.96);
+      --card-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+      --card-hover-shadow: 0 26px 52px rgba(15, 23, 42, 0.16);
+      --accent: #4a63ff;
+      --accent-contrast: #0b1020;
+      --dev-link-background: rgba(74, 99, 255, 0.12);
+      --dev-link-hover: rgba(74, 99, 255, 0.18);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --body-base: #090d18;
+        --body-gradient: radial-gradient(circle at top, rgba(72, 101, 216, 0.28), rgba(9, 17, 35, 0.92) 60%);
+        --text-primary: #f5f7ff;
+        --text-secondary: rgba(245, 247, 255, 0.7);
+        --surface: rgba(12, 17, 31, 0.85);
+        --surface-shadow: 0 30px 80px rgba(0, 0, 0, 0.35);
+        --surface-border: rgba(255, 255, 255, 0.04);
+        --card-background: rgba(255, 255, 255, 0.06);
+        --card-hover-background: rgba(255, 255, 255, 0.1);
+        --card-shadow: 0 20px 40px rgba(12, 18, 40, 0.3);
+        --card-hover-shadow: 0 28px 54px rgba(12, 18, 40, 0.38);
+        --accent: #9ba9ff;
+        --accent-contrast: #0a1020;
+        --dev-link-background: rgba(255, 255, 255, 0.08);
+        --dev-link-hover: rgba(255, 255, 255, 0.12);
+      }
     }
 
     body {
@@ -18,20 +51,42 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      background: radial-gradient(circle at top, rgba(72, 101, 216, 0.35), rgba(9, 17, 35, 0.95) 55%);
-      padding: 24px;
+      background: var(--body-gradient);
+      background-color: var(--body-base);
+      padding: clamp(24px, 5vw, 56px);
+      color: var(--text-primary);
     }
 
     main {
       width: min(960px, 100%);
-      background: rgba(12, 17, 31, 0.85);
-      border-radius: 24px;
-      box-shadow: 0 30px 80px rgba(0, 0, 0, 0.35);
-      backdrop-filter: blur(12px);
-      padding: clamp(32px, 5vw, 56px);
+      background: var(--surface);
+      border-radius: 26px;
+      box-shadow: var(--surface-shadow);
+      backdrop-filter: blur(14px);
+      border: 1px solid var(--surface-border);
+      padding: clamp(32px, 5vw, 60px);
       display: flex;
       flex-direction: column;
-      gap: 32px;
+      gap: clamp(28px, 4vw, 44px);
+    }
+
+    header.site-header {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    header.site-header h1 {
+      margin: 0;
+      font-size: clamp(1.8rem, 2vw + 1.4rem, 2.6rem);
+      font-weight: 700;
+    }
+
+    header.site-header p {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 1rem;
+      line-height: 1.5;
     }
 
     ul.apps {
@@ -43,98 +98,140 @@
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
 
-    li.app-card {
-      background: rgba(255, 255, 255, 0.05);
-      border-radius: 18px;
-      padding: 24px;
+    ul.apps li {
+      margin: 0;
+    }
+
+    a.app-card {
       display: flex;
       flex-direction: column;
-      gap: 16px;
-      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
-    }
-
-    li.app-card:hover {
-      transform: translateY(-6px);
-      background: rgba(255, 255, 255, 0.08);
-      box-shadow: 0 20px 40px rgba(14, 23, 53, 0.35);
-    }
-
-    li.app-card h2 {
-      margin: 0;
-      font-size: 1.35rem;
-      font-weight: 600;
-    }
-
-    li.app-card p {
-      margin: 0;
-      color: rgba(245, 247, 255, 0.72);
-      line-height: 1.5;
-    }
-
-    a.launch {
-      align-self: flex-start;
+      gap: 14px;
+      padding: 24px;
+      border-radius: 20px;
+      background: var(--card-background);
       text-decoration: none;
-      background: linear-gradient(135deg, #4b6bff, #8b9bff);
-      color: #0a1020;
+      color: inherit;
+      box-shadow: var(--card-shadow);
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+      border: 1px solid transparent;
+    }
+
+    a.app-card:hover,
+    a.app-card:focus-visible {
+      transform: translateY(-6px);
+      box-shadow: var(--card-hover-shadow);
+      background: var(--card-hover-background);
+      outline: none;
+      border-color: rgba(115, 135, 255, 0.45);
+    }
+
+    a.app-card h2 {
+      margin: 0;
+      font-size: 1.32rem;
       font-weight: 600;
-      padding: 10px 18px;
-      border-radius: 999px;
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
-      box-shadow: 0 12px 30px rgba(76, 108, 255, 0.4);
     }
 
-    a.launch:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 16px 36px rgba(76, 108, 255, 0.55);
+    a.app-card p {
+      margin: 0;
+      color: var(--text-secondary);
+      line-height: 1.5;
+      font-size: 0.98rem;
     }
 
-    a.launch:focus-visible,
-    a.dev-link:focus-visible {
-      outline: 2px solid rgba(139, 155, 255, 0.9);
-      outline-offset: 3px;
+    .app-card__cta {
+      margin-top: auto;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 600;
+      color: var(--accent);
+      font-size: 0.95rem;
+    }
+
+    .app-card__cta svg {
+      width: 18px;
+      height: 18px;
     }
 
     section.dev-tools {
       display: flex;
+      flex-wrap: wrap;
       justify-content: center;
+      gap: 12px;
     }
 
     a.dev-link {
       display: inline-flex;
       align-items: center;
-      gap: 12px;
-      padding: 14px 18px;
+      justify-content: center;
+      padding: 12px 18px;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.05);
+      background: var(--dev-link-background);
       color: inherit;
       text-decoration: none;
       font-weight: 500;
-      transition: background 0.18s ease, box-shadow 0.18s ease;
-      box-shadow: 0 12px 32px rgba(12, 18, 40, 0.25);
+      transition: transform 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+      box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
     }
 
-    a.dev-link:hover {
-      background: rgba(255, 255, 255, 0.08);
-      box-shadow: 0 18px 40px rgba(12, 18, 40, 0.35);
+    a.dev-link:hover,
+    a.dev-link:focus-visible {
+      background: var(--dev-link-hover);
+      transform: translateY(-2px);
+      outline: none;
+      box-shadow: 0 16px 34px rgba(15, 23, 42, 0.18);
+    }
+
+    a.dev-link:focus-visible,
+    a.app-card:focus-visible {
+      box-shadow: 0 0 0 3px rgba(121, 134, 255, 0.35), inset 0 0 0 1px rgba(121, 134, 255, 0.6);
+    }
+
+    @media (max-width: 640px) {
+      main {
+        padding: clamp(24px, 8vw, 36px);
+      }
+
+      a.app-card {
+        padding: 20px;
+      }
+
+      header.site-header h1 {
+        font-size: clamp(1.6rem, 4vw + 1rem, 2.2rem);
+      }
     }
   </style>
 </head>
 <body>
   <main aria-label="Apps">
+    <header class="site-header">
+      <h1>Toolbox</h1>
+      <p>Select an app to explore a shuffled deck or jump into a utility view.</p>
+    </header>
     <ul class="apps">
-      <li class="app-card">
-        <h2>Random Jokes</h2>
-        <p>Shuffle through developer-friendly jokes and reveal punchlines one by one or go back if you missed the setup.</p>
-        <a class="launch" href="apps/jokes/">Open app</a>
+      <li>
+        <a class="app-card" href="apps/jokes/">
+          <h2>Random Jokes</h2>
+          <p>Shuffle developer-friendly jokes, step back for another look, and reveal punchlines when you are ready.</p>
+          <span class="app-card__cta">Open app
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L13.94 12 8.47 6.53a.75.75 0 0 1 0-1.06Z"/></svg>
+          </span>
+        </a>
       </li>
-      <li class="app-card">
-        <h2>Proverbs</h2>
-        <p>Walk through a constantly shuffled deck of proverbs with quick previous and next controls.</p>
-        <a class="launch" href="apps/proverbs/">Open app</a>
+      <li>
+        <a class="app-card" href="apps/proverbs/">
+          <h2>Proverbs</h2>
+          <p>Browse a constantly shuffled deck of proverbs with quick controls and keyboard navigation.</p>
+          <span class="app-card__cta">Open app
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L13.94 12 8.47 6.53a.75.75 0 0 1 0-1.06Z"/></svg>
+          </span>
+        </a>
       </li>
     </ul>
-    <section class="dev-tools">
+    <section class="dev-tools" aria-label="Utility pages">
       <a class="dev-link" href="apps/value-formatter/">Value Formatter — Quick mapping for long lists.</a>
+      <a class="dev-link" href="apps/jokes/all-jokes.html">All Jokes — table view.</a>
+      <a class="dev-link" href="apps/jokes/all-jokes-compact.html">All Jokes — compact table.</a>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- restyle the landing page to honour light and dark themes, make app cards clickable, and link to new jokes tables
- rebuild the jokes app with the proverbs-inspired layout, accessible punchline reveal, and keyboard navigation
- add full and compact table views for all jokes powered by a shared renderer for easy in-browser searching

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce252de0a88328bd00860e4865a523