### PR TITLE
Simplify jokes UI and add shuffled proverb list

### DIFF
--- a/apps/jokes/app.js
+++ b/apps/jokes/app.js
@@ -1,12 +1,11 @@
 (function () {
   const setupEl = document.getElementById('joke-setup');
   const punchlineEl = document.getElementById('joke-punchline');
-  const statusEl = document.getElementById('card-status');
   const prevButton = document.getElementById('prev-button');
   const nextButton = document.getElementById('next-button');
   const revealButton = document.getElementById('reveal-button');
 
-  if (!setupEl || !punchlineEl || !statusEl || !prevButton || !nextButton || !revealButton) {
+  if (!setupEl || !punchlineEl || !prevButton || !nextButton || !revealButton) {
     return;
   }
 
@@ -34,24 +33,11 @@
     }
   }
 
-  function updateStatus() {
-    if (!deck.length) {
-      statusEl.textContent = 'No jokes available.';
-      return;
-    }
-
-    statusEl.textContent = punchlineVisible
-      ? 'Punchline revealed.'
-      : 'Punchline hidden — reveal when you\'re ready.';
-  }
-
   function setPunchlineVisible(visible) {
     punchlineVisible = visible;
     punchlineEl.classList.toggle('is-visible', visible);
     punchlineEl.setAttribute('aria-hidden', visible ? 'false' : 'true');
     revealButton.setAttribute('aria-pressed', visible ? 'true' : 'false');
-    revealButton.textContent = visible ? 'Hide punchline' : 'Reveal punchline';
-    updateStatus();
   }
 
   function render() {
@@ -60,10 +46,11 @@
       punchlineEl.textContent = '';
       punchlineEl.classList.remove('is-visible');
       punchlineEl.setAttribute('aria-hidden', 'true');
+      punchlineVisible = false;
+      revealButton.setAttribute('aria-pressed', 'false');
       revealButton.hidden = true;
       prevButton.disabled = true;
       nextButton.disabled = true;
-      updateStatus();
       return;
     }
 

--- a/apps/jokes/index.html
+++ b/apps/jokes/index.html
@@ -94,18 +94,26 @@
       display: block;
     }
 
-    .card__meta {
-      margin: 0;
-      font-size: 0.98rem;
-      color: var(--text-secondary);
+    .controls {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 14px;
     }
 
-    .controls {
+    .controls__nav {
       display: flex;
       justify-content: center;
       align-items: center;
       flex-wrap: wrap;
       gap: 16px;
+      width: 100%;
+    }
+
+    .controls__punchline {
+      display: flex;
+      justify-content: center;
+      width: 100%;
     }
 
     button {
@@ -171,14 +179,17 @@
     <article class="card" aria-live="polite">
       <div class="card__content">
         <p id="joke-setup">Loading joke…</p>
-        <p id="joke-punchline" aria-hidden="true">Punchline</p>
+        <p id="joke-punchline" aria-hidden="true"></p>
       </div>
-      <p class="card__meta" id="card-status">Punchline hidden — reveal when you're ready.</p>
     </article>
     <div class="controls">
-      <button id="prev-button" type="button" aria-label="Show previous joke">⟵ Previous</button>
-      <button id="reveal-button" class="secondary" type="button" aria-pressed="false">Reveal punchline</button>
-      <button id="next-button" type="button" aria-label="Show next joke">Next ⟶</button>
+      <div class="controls__nav">
+        <button id="prev-button" type="button" aria-label="Show previous joke">⟵ Previous</button>
+        <button id="next-button" type="button" aria-label="Show next joke">Next ⟶</button>
+      </div>
+      <div class="controls__punchline">
+        <button id="reveal-button" class="secondary" type="button" aria-pressed="false">Punchline</button>
+      </div>
     </div>
   </main>
   <script src="jokes.js" defer></script>

--- a/apps/jokes/render-all.js
+++ b/apps/jokes/render-all.js
@@ -1,37 +1,15 @@
 (function () {
   const tbody = document.querySelector('tbody');
   const countTarget = document.querySelector('[data-count]');
-  const isCompact = document.body.dataset.compact === 'true';
 
   const jokes = Array.isArray(window.jokes)
     ? window.jokes.filter((entry) => entry && entry.joke)
     : [];
 
-  if (countTarget) {
-    countTarget.textContent = jokes.length.toLocaleString();
-  }
-
   if (!tbody) {
     return;
   }
 
-  if (isCompact) {
-    document.body.classList.add('is-compact');
-  }
-
-  tbody.textContent = '';
-
-  if (!jokes.length) {
-    const emptyRow = document.createElement('tr');
-    const emptyCell = document.createElement('td');
-    emptyCell.colSpan = 3;
-    emptyCell.textContent = 'No jokes available.';
-    emptyRow.appendChild(emptyCell);
-    tbody.appendChild(emptyRow);
-    return;
-  }
-
-  const fragment = document.createDocumentFragment();
   const formatPunchline = (value) => {
     if (typeof value === 'string' && value.trim().length > 0) {
       return value;
@@ -39,24 +17,65 @@
     return '💩';
   };
 
-  jokes.forEach((entry, idx) => {
-    const row = document.createElement('tr');
+  function shuffle(array) {
+    const copy = array.slice();
+    for (let i = copy.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [copy[i], copy[j]] = [copy[j], copy[i]];
+    }
+    return copy;
+  }
+
+  const deck = shuffle(jokes);
+
+  if (countTarget) {
+    countTarget.textContent = deck.length.toLocaleString();
+  }
+
+  tbody.textContent = '';
+
+  if (!deck.length) {
+    const emptyRow = document.createElement('tr');
+    const emptyCell = document.createElement('td');
+    emptyCell.colSpan = 2;
+    emptyCell.textContent = 'No jokes available.';
+    emptyRow.appendChild(emptyCell);
+    tbody.appendChild(emptyRow);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  deck.forEach((entry, idx) => {
+    const setupRow = document.createElement('tr');
 
     const indexCell = document.createElement('th');
     indexCell.scope = 'row';
+    indexCell.className = 'index-cell';
     indexCell.textContent = String(idx + 1);
 
-    const jokeCell = document.createElement('td');
-    jokeCell.textContent = entry.joke;
+    const setupCell = document.createElement('td');
+    setupCell.className = 'setup-cell';
+    setupCell.textContent = entry.joke;
 
+    setupRow.appendChild(indexCell);
+    setupRow.appendChild(setupCell);
+
+    const punchlineRow = document.createElement('tr');
+    punchlineRow.className = 'punchline-row';
+
+    const spacerCell = document.createElement('td');
+    spacerCell.className = 'index-spacer';
+    spacerCell.setAttribute('aria-hidden', 'true');
     const punchlineCell = document.createElement('td');
+    punchlineCell.className = 'punchline-cell';
     punchlineCell.textContent = formatPunchline(entry.punchline);
 
-    row.appendChild(indexCell);
-    row.appendChild(jokeCell);
-    row.appendChild(punchlineCell);
+    punchlineRow.appendChild(spacerCell);
+    punchlineRow.appendChild(punchlineCell);
 
-    fragment.appendChild(row);
+    fragment.appendChild(setupRow);
+    fragment.appendChild(punchlineRow);
   });
 
   tbody.appendChild(fragment);

--- a/apps/proverbs/all-proverbs.html
+++ b/apps/proverbs/all-proverbs.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>All Jokes</title>
+  <title>All Proverbs</title>
   <style>
     :root {
       color-scheme: light dark;
@@ -31,10 +31,6 @@
       td,
       table {
         border-color: rgba(255, 255, 255, 0.2);
-      }
-
-      .punchline-row td {
-        background: rgba(255, 255, 255, 0.08);
       }
     }
 
@@ -83,18 +79,8 @@
       white-space: nowrap;
     }
 
-    .index-spacer {
-      width: 3.5rem;
-    }
-
-    .setup-cell,
-    .punchline-cell {
+    .text-cell {
       white-space: pre-wrap;
-    }
-
-    .punchline-row td {
-      font-style: italic;
-      background: rgba(48, 86, 211, 0.08);
     }
 
     caption {
@@ -106,19 +92,19 @@
 </head>
 <body>
   <main>
-    <h1>All Jokes</h1>
-    <p>Every joke from the dataset in one place. Use your browser search to find a favourite.</p>
-    <p class="count"><span data-count>0</span> jokes</p>
+    <h1>All Proverbs</h1>
+    <p>Browse the shuffled list of proverbs pulled from the dataset.</p>
+    <p class="count"><span data-count>0</span> proverbs</p>
     <table>
-      <caption>Setup followed by punchline</caption>
+      <caption>Complete list of proverbs</caption>
       <tbody>
         <tr>
-          <td colspan="2">Loading jokes…</td>
+          <td colspan="2">Loading proverbs…</td>
         </tr>
       </tbody>
     </table>
   </main>
-  <script src="jokes.js" defer></script>
+  <script src="proverbs-data.js" defer></script>
   <script src="render-all.js" defer></script>
 </body>
 </html>

--- a/apps/proverbs/render-all.js
+++ b/apps/proverbs/render-all.js
@@ -1,0 +1,61 @@
+(function () {
+  const tbody = document.querySelector('tbody');
+  const countTarget = document.querySelector('[data-count]');
+
+  const proverbs = Array.isArray(window.proverbsData)
+    ? window.proverbsData.filter((entry) => entry && entry.text)
+    : [];
+
+  if (!tbody) {
+    return;
+  }
+
+  function shuffle(array) {
+    const copy = array.slice();
+    for (let i = copy.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [copy[i], copy[j]] = [copy[j], copy[i]];
+    }
+    return copy;
+  }
+
+  const deck = shuffle(proverbs);
+
+  if (countTarget) {
+    countTarget.textContent = deck.length.toLocaleString();
+  }
+
+  tbody.textContent = '';
+
+  if (!deck.length) {
+    const emptyRow = document.createElement('tr');
+    const emptyCell = document.createElement('td');
+    emptyCell.colSpan = 2;
+    emptyCell.textContent = 'No proverbs available.';
+    emptyRow.appendChild(emptyCell);
+    tbody.appendChild(emptyRow);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  deck.forEach((entry, idx) => {
+    const row = document.createElement('tr');
+
+    const indexCell = document.createElement('th');
+    indexCell.scope = 'row';
+    indexCell.className = 'index-cell';
+    indexCell.textContent = String(idx + 1);
+
+    const textCell = document.createElement('td');
+    textCell.className = 'text-cell';
+    textCell.textContent = entry.text;
+
+    row.appendChild(indexCell);
+    row.appendChild(textCell);
+
+    fragment.appendChild(row);
+  });
+
+  tbody.appendChild(fragment);
+})();

--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
     <section class="dev-tools" aria-label="Utility pages">
       <a class="dev-link" href="apps/value-formatter/">Value Formatter — Quick mapping for long lists.</a>
       <a class="dev-link" href="apps/jokes/all-jokes.html">All Jokes — table view.</a>
-      <a class="dev-link" href="apps/jokes/all-jokes-compact.html">All Jokes — compact table.</a>
+      <a class="dev-link" href="apps/proverbs/all-proverbs.html">All Proverbs — table view.</a>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- rework the joke viewer controls to drop the status copy, keep the punchline button labeled "Punchline," and show the fallback emoji when needed
- rebuild the all-jokes page as a simple shuffled table with alternating setup/punchline rows
- add a shuffled proverb list page and link to it from the homepage utilities section

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ce29df015883289dae4714c62d0223