### PR TITLE
Simplify list views and card labels

### DIFF
--- a/apps/jokes/all-jokes.html
+++ b/apps/jokes/all-jokes.html
@@ -65,26 +65,11 @@
       background: rgba(255, 255, 255, 0.9);
     }
 
-    th,
     td {
       padding: 12px 14px;
       border: 1px solid rgba(0, 0, 0, 0.15);
       vertical-align: top;
       text-align: left;
-    }
-
-    th {
-      width: 3.5rem;
-      text-align: right;
-      font-weight: 600;
-    }
-
-    .index-cell {
-      white-space: nowrap;
-    }
-
-    .index-spacer {
-      width: 3.5rem;
     }
 
     .setup-cell,
@@ -113,7 +98,7 @@
       <caption>Setup followed by punchline</caption>
       <tbody>
         <tr>
-          <td colspan="2">Loading jokes…</td>
+          <td>Loading jokes…</td>
         </tr>
       </tbody>
     </table>

--- a/apps/jokes/render-all.js
+++ b/apps/jokes/render-all.js
@@ -37,7 +37,6 @@
   if (!deck.length) {
     const emptyRow = document.createElement('tr');
     const emptyCell = document.createElement('td');
-    emptyCell.colSpan = 2;
     emptyCell.textContent = 'No jokes available.';
     emptyRow.appendChild(emptyCell);
     tbody.appendChild(emptyRow);
@@ -46,32 +45,22 @@
 
   const fragment = document.createDocumentFragment();
 
-  deck.forEach((entry, idx) => {
+  deck.forEach((entry) => {
     const setupRow = document.createElement('tr');
-
-    const indexCell = document.createElement('th');
-    indexCell.scope = 'row';
-    indexCell.className = 'index-cell';
-    indexCell.textContent = String(idx + 1);
 
     const setupCell = document.createElement('td');
     setupCell.className = 'setup-cell';
     setupCell.textContent = entry.joke;
 
-    setupRow.appendChild(indexCell);
     setupRow.appendChild(setupCell);
 
     const punchlineRow = document.createElement('tr');
     punchlineRow.className = 'punchline-row';
 
-    const spacerCell = document.createElement('td');
-    spacerCell.className = 'index-spacer';
-    spacerCell.setAttribute('aria-hidden', 'true');
     const punchlineCell = document.createElement('td');
     punchlineCell.className = 'punchline-cell';
     punchlineCell.textContent = formatPunchline(entry.punchline);
 
-    punchlineRow.appendChild(spacerCell);
     punchlineRow.appendChild(punchlineCell);
 
     fragment.appendChild(setupRow);

--- a/apps/proverbs/all-proverbs.html
+++ b/apps/proverbs/all-proverbs.html
@@ -61,22 +61,11 @@
       background: rgba(255, 255, 255, 0.9);
     }
 
-    th,
     td {
       padding: 12px 14px;
       border: 1px solid rgba(0, 0, 0, 0.15);
       vertical-align: top;
       text-align: left;
-    }
-
-    th {
-      width: 3.5rem;
-      text-align: right;
-      font-weight: 600;
-    }
-
-    .index-cell {
-      white-space: nowrap;
     }
 
     .text-cell {
@@ -99,7 +88,7 @@
       <caption>Complete list of proverbs</caption>
       <tbody>
         <tr>
-          <td colspan="2">Loading proverbs…</td>
+          <td>Loading proverbs…</td>
         </tr>
       </tbody>
     </table>

--- a/apps/proverbs/render-all.js
+++ b/apps/proverbs/render-all.js
@@ -30,7 +30,6 @@
   if (!deck.length) {
     const emptyRow = document.createElement('tr');
     const emptyCell = document.createElement('td');
-    emptyCell.colSpan = 2;
     emptyCell.textContent = 'No proverbs available.';
     emptyRow.appendChild(emptyCell);
     tbody.appendChild(emptyRow);
@@ -39,19 +38,13 @@
 
   const fragment = document.createDocumentFragment();
 
-  deck.forEach((entry, idx) => {
+  deck.forEach((entry) => {
     const row = document.createElement('tr');
-
-    const indexCell = document.createElement('th');
-    indexCell.scope = 'row';
-    indexCell.className = 'index-cell';
-    indexCell.textContent = String(idx + 1);
 
     const textCell = document.createElement('td');
     textCell.className = 'text-cell';
     textCell.textContent = entry.text;
 
-    row.appendChild(indexCell);
     row.appendChild(textCell);
 
     fragment.appendChild(row);

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
         <a class="app-card" href="apps/jokes/">
           <h2>Random Jokes</h2>
           <p>Shuffle developer-friendly jokes, step back for another look, and reveal punchlines when you are ready.</p>
-          <span class="app-card__cta">Open app
+          <span class="app-card__cta">
             <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L13.94 12 8.47 6.53a.75.75 0 0 1 0-1.06Z"/></svg>
           </span>
         </a>
@@ -222,7 +222,7 @@
         <a class="app-card" href="apps/proverbs/">
           <h2>Proverbs</h2>
           <p>Browse a constantly shuffled deck of proverbs with quick controls and keyboard navigation.</p>
-          <span class="app-card__cta">Open app
+          <span class="app-card__cta">
             <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L13.94 12 8.47 6.53a.75.75 0 0 1 0-1.06Z"/></svg>
           </span>
         </a>
@@ -230,8 +230,8 @@
     </ul>
     <section class="dev-tools" aria-label="Utility pages">
       <a class="dev-link" href="apps/value-formatter/">Value Formatter — Quick mapping for long lists.</a>
-      <a class="dev-link" href="apps/jokes/all-jokes.html">All Jokes — table view.</a>
-      <a class="dev-link" href="apps/proverbs/all-proverbs.html">All Proverbs — table view.</a>
+      <a class="dev-link" href="apps/jokes/all-jokes.html">All Jokes</a>
+      <a class="dev-link" href="apps/proverbs/all-proverbs.html">All Proverbs</a>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- remove the "Open app" call-to-action text from the home page cards
- trim the "table view" suffix from the All Jokes and All Proverbs utility links
- drop the numbering column from the jokes and proverbs table views and update their render scripts accordingly

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce2d6e840483288f44887829fda0cd