### PR TITLE
Remove chevron icon from landing cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,21 +138,6 @@
       font-size: 0.98rem;
     }
 
-    .app-card__cta {
-      margin-top: auto;
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      font-weight: 600;
-      color: var(--accent);
-      font-size: 0.95rem;
-    }
-
-    .app-card__cta svg {
-      width: 18px;
-      height: 18px;
-    }
-
     section.dev-tools {
       display: flex;
       flex-wrap: wrap;
@@ -213,18 +198,12 @@
         <a class="app-card" href="apps/jokes/">
           <h2>Random Jokes</h2>
           <p>Shuffle developer-friendly jokes, step back for another look, and reveal punchlines when you are ready.</p>
-          <span class="app-card__cta">
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L13.94 12 8.47 6.53a.75.75 0 0 1 0-1.06Z"/></svg>
-          </span>
         </a>
       </li>
       <li>
         <a class="app-card" href="apps/proverbs/">
           <h2>Proverbs</h2>
           <p>Browse a constantly shuffled deck of proverbs with quick controls and keyboard navigation.</p>
-          <span class="app-card__cta">
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L13.94 12 8.47 6.53a.75.75 0 0 1 0-1.06Z"/></svg>
-          </span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- remove the chevron icon span from each landing card so only the title and description remain
- drop the unused call-to-action styling from the index page stylesheet

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce301466488328b49a74a5f30f27d7