### PR TITLE
Disable GitHub Pages Jekyll build

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disables the default GitHub Pages Jekyll build.


### PR DESCRIPTION
## Summary
- add the `.nojekyll` marker file so GitHub Pages skips the default Jekyll build step

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68ceaee425048328ad841831a038ac58