### PR TITLE
Split quotes into text and author fields

### DIFF
--- a/apps/quotes/all-quotes.html
+++ b/apps/quotes/all-quotes.html
@@ -8,6 +8,8 @@
     :root {
       color-scheme: light dark;
       font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      --author-font: "Georgia", "Times New Roman", serif;
+      --author-color: rgba(32, 32, 32, 0.65);
     }
 
     body {
@@ -21,6 +23,10 @@
       body {
         background-color: #121212;
         color: #f1f5ff;
+      }
+
+      :root {
+        --author-color: rgba(241, 245, 255, 0.7);
       }
 
       table {
@@ -83,6 +89,12 @@
       font-weight: 600;
       margin-bottom: 0.75rem;
     }
+
+    .author-cell {
+      font-family: var(--author-font);
+      color: var(--author-color);
+      text-align: right;
+    }
   </style>
 </head>
 <body>
@@ -96,11 +108,12 @@
         <tr>
           <th scope="col">Category</th>
           <th scope="col">Quote</th>
+          <th scope="col">Author</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td colspan="2">Loading quotes…</td>
+          <td colspan="3">Loading quotes…</td>
         </tr>
       </tbody>
     </table>

--- a/apps/quotes/app.js
+++ b/apps/quotes/app.js
@@ -1,10 +1,12 @@
 (function () {
   const textEl = document.getElementById('quote-text');
+  const metaEl = document.getElementById('quote-meta');
+  const authorEl = document.getElementById('quote-author');
   const prevButton = document.getElementById('prev-button');
   const nextButton = document.getElementById('next-button');
   const selectEl = document.getElementById('category-select');
 
-  if (!textEl || !prevButton || !nextButton || !selectEl) {
+  if (!textEl || !metaEl || !authorEl || !prevButton || !nextButton || !selectEl) {
     return;
   }
 
@@ -15,8 +17,12 @@
           label: entry && typeof entry.label === 'string' ? entry.label : '',
           quotes: Array.isArray(entry && entry.quotes)
             ? entry.quotes
-                .map((quote) => (typeof quote === 'string' ? quote.trim() : ''))
-                .filter((quote) => quote.length > 0)
+                .map((quote) => {
+                  const text = quote && typeof quote.text === 'string' ? quote.text.trim() : '';
+                  const author = quote && typeof quote.author === 'string' ? quote.author.trim() : '';
+                  return text && author ? { text, author } : null;
+                })
+                .filter(Boolean)
             : [],
         }))
         .filter((entry) => entry.id && entry.label && entry.quotes.length > 0)
@@ -80,13 +86,18 @@
 
     if (!available.length) {
       textEl.textContent = 'No quotes available.';
+      authorEl.textContent = '';
+      metaEl.hidden = true;
       prevButton.disabled = true;
       nextButton.disabled = true;
       return;
     }
 
     ensureDeck();
-    textEl.textContent = deck[index];
+    const current = deck[index];
+    textEl.textContent = current.text;
+    authorEl.textContent = current.author;
+    metaEl.hidden = false;
 
     const disableNavigation = deck.length <= 1;
     prevButton.disabled = disableNavigation;

--- a/apps/quotes/index.html
+++ b/apps/quotes/index.html
@@ -10,12 +10,15 @@
       font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
       background-color: #f5f5f5;
       color: #1f1f1f;
+      --quote-author-color: rgba(31, 31, 31, 0.6);
+      --quote-author-font: "Georgia", "Times New Roman", serif;
     }
 
     @media (prefers-color-scheme: dark) {
       :root {
         background-color: #1f1f1f;
         color: #f5f5f5;
+        --quote-author-color: rgba(245, 245, 245, 0.7);
       }
 
       .category-picker select {
@@ -61,6 +64,30 @@
       font-size: clamp(1.25rem, 2.2vw + 1rem, 2rem);
       line-height: 1.45;
       font-weight: 500;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+
+    .card blockquote p {
+      margin: 0;
+    }
+
+    .quote-meta {
+      font-family: var(--quote-author-font);
+      color: var(--quote-author-color);
+      text-align: right;
+      font-size: clamp(0.95rem, 0.8vw + 0.8rem, 1.1rem);
+      letter-spacing: 0.01em;
+      align-self: flex-end;
+    }
+
+    .quote-meta::before {
+      content: '— ';
+    }
+
+    .quote-meta cite {
+      font-style: normal;
     }
 
     .controls {
@@ -154,7 +181,12 @@
 <body>
   <main aria-label="Quotes">
     <div class="card" role="group" aria-live="polite">
-      <blockquote id="quote-text">Loading quote…</blockquote>
+      <blockquote>
+        <p id="quote-text">Loading quote…</p>
+        <footer class="quote-meta" id="quote-meta" hidden>
+          <cite id="quote-author"></cite>
+        </footer>
+      </blockquote>
     </div>
     <div class="controls">
       <button id="prev-button" type="button" aria-label="Show previous quote">⟵ Previous</button>

--- a/apps/quotes/quotes-data.js
+++ b/apps/quotes/quotes-data.js
@@ -3,611 +3,2224 @@ window.quotesData = [
     "id": "adventure",
     "label": "Adventure",
     "quotes": [
-      "“The danger of adventure is worth a thousand days of ease and comfort.” – Paulo Coelho",
-      "“The world is a book and those who do not travel read only one page.” – Saint Augustine",
-      "“If we were meant to stay in one place, we’d have roots instead of feet.” – Rachel Wolchin",
-      "“If you are always trying to be normal, you will never know how amazing you can be.” – Maya Angelou",
-      "“Do not go where the path may lead, go instead where there is no path and leave a trail.” – Ralph Waldo Emerson",
-      "“Travel makes one modest. You see what a tiny place you occupy in the world.” – Gustav Flaubert",
-      "“A ship in harbor is safe, but that is not what ships are built for.” – John A. Shedd",
-      "“Until you step into the unknown, you don’t know what you’re made of.” – Roy T. Bennett",
-      "“To live is the rarest thing in the world. Most people just exist.” – Oscar Wilde",
-      "“Only those who risk going too far can possibly find out how far one can go.” – T. S. Eliot",
-      "“Life isn’t about the number of breaths we take, but the moments that take our breath away.” – Maya Angelou",
-      "“Don’t get so busy making a living that you forget to make a life.” – Dolly Parton",
-      "“Man cannot discover new oceans unless he has the courage to lose sight of the shore.” – Andre Gide",
-      "“Move out of your comfort zone. You can only grow if you are willing to feel awkward and uncomfortable when you try something new.” – Brian Tracy",
-      "“Not all those who wander are lost.” – J. R. R. Tolkien",
-      "“Every man dies. Not every man really lives.” – William Wallace",
-      "“The worst thing you can do is nothing.” – Terry Pratchett",
-      "“To travel is to evolve.” – Pierre Bernardo",
-      "“It is not length of life, but depth of life.” – Ralph Waldo Emerson",
-      "“Life begins at the end of your comfort zone.” – Neale Donald Walsch",
-      "“Travel far enough, you meet yourself.” – David Mitchell",
-      "“Don’t ask for security, ask for adventure.” – Jim Rohn",
-      "“Live your life by a compass not a clock.” – Stephen R. Covey",
-      "“Adventure is worthwhile in itself.” – Amelia Earhart",
-      "“Travel is the only thing you buy that makes you richer.” – Unknown",
-      "“Life is short and the world is wide.” – Unknown",
-      "“Once a year, go somewhere you have never been before.” – Dalai Lama",
-      "“The goal is to die with memories not dreams.” – Anonymous",
-      "“Take only memories, leave only footprints.” – Chief Seattle",
-      "“Life is an adventure. Live it.” – Anonymous",
-      "“Investment in travel is an investment in yourself.” – Matthew Karsten",
-      "“Don’t live the same year 75 times and call it a life.” – Robin Sharma",
-      "“All life is an experiment. The more experiments you make the better.” – Ralph Waldo Emerson",
-      "“The purpose of life is to live it, to taste experience to the utmost, to reach out eagerly and without fear for newer and richer experiences.” – Eleanor Roosevelt",
-      "“Better to see something once than hear about it a thousand times.” – Asian Proverb",
-      "“If you think adventure is dangerous, try routine, it is lethal.” – Paulo Coelho",
-      "“Travel makes one modest, you see what a tiny place you occupy in the world.” – Gustave Flaubert",
-      "“Travel. As much as you can. As far as you can. As long as you can. Life’s not meant to be lived in one place.” – Unknown",
-      "“The real voyage of discovery consists not in seeking new landscapes, but in having new eyes.” – Marcel Proust",
-      "“I would rather own a little and see the world than own the world and see a little of it.” – Alexander Sattler",
-      "“Traveling – it leaves you speechless, then turns you into a storyteller.” – Ibn Battuta",
-      "“The best way to experience the world is by going outside and exploring it.” – Anonymous",
-      "“I travel because it makes me realize how much I haven’t seen, how much I’m not going to see, and how much I still need to see.” – Carew Papritz",
-      "“For my part, I travel not to go anywhere, but to go. I travel for travel’s sake. The great affair is to move.” – Robert Louis Stevenson",
-      "“A mind that is stretched by a new experience can never go back to its old dimensions.” – Oliver Wendell Holmes, Jr",
-      "“A good traveler has no fixed plans and is not intent on arriving.” – Lao Tzu"
+      {
+        "text": "The danger of adventure is worth a thousand days of ease and comfort.",
+        "author": "Paulo Coelho"
+      },
+      {
+        "text": "The world is a book and those who do not travel read only one page.",
+        "author": "Saint Augustine"
+      },
+      {
+        "text": "If we were meant to stay in one place, we’d have roots instead of feet.",
+        "author": "Rachel Wolchin"
+      },
+      {
+        "text": "If you are always trying to be normal, you will never know how amazing you can be.",
+        "author": "Maya Angelou"
+      },
+      {
+        "text": "Do not go where the path may lead, go instead where there is no path and leave a trail.",
+        "author": "Ralph Waldo Emerson"
+      },
+      {
+        "text": "Travel makes one modest. You see what a tiny place you occupy in the world.",
+        "author": "Gustav Flaubert"
+      },
+      {
+        "text": "A ship in harbor is safe, but that is not what ships are built for.",
+        "author": "John A. Shedd"
+      },
+      {
+        "text": "Until you step into the unknown, you don’t know what you’re made of.",
+        "author": "Roy T. Bennett"
+      },
+      {
+        "text": "To live is the rarest thing in the world. Most people just exist.",
+        "author": "Oscar Wilde"
+      },
+      {
+        "text": "Only those who risk going too far can possibly find out how far one can go.",
+        "author": "T. S. Eliot"
+      },
+      {
+        "text": "Life isn’t about the number of breaths we take, but the moments that take our breath away.",
+        "author": "Maya Angelou"
+      },
+      {
+        "text": "Don’t get so busy making a living that you forget to make a life.",
+        "author": "Dolly Parton"
+      },
+      {
+        "text": "Man cannot discover new oceans unless he has the courage to lose sight of the shore.",
+        "author": "Andre Gide"
+      },
+      {
+        "text": "Move out of your comfort zone. You can only grow if you are willing to feel awkward and uncomfortable when you try something new.",
+        "author": "Brian Tracy"
+      },
+      {
+        "text": "Not all those who wander are lost.",
+        "author": "J. R. R. Tolkien"
+      },
+      {
+        "text": "Every man dies. Not every man really lives.",
+        "author": "William Wallace"
+      },
+      {
+        "text": "The worst thing you can do is nothing.",
+        "author": "Terry Pratchett"
+      },
+      {
+        "text": "To travel is to evolve.",
+        "author": "Pierre Bernardo"
+      },
+      {
+        "text": "It is not length of life, but depth of life.",
+        "author": "Ralph Waldo Emerson"
+      },
+      {
+        "text": "Life begins at the end of your comfort zone.",
+        "author": "Neale Donald Walsch"
+      },
+      {
+        "text": "Travel far enough, you meet yourself.",
+        "author": "David Mitchell"
+      },
+      {
+        "text": "Don’t ask for security, ask for adventure.",
+        "author": "Jim Rohn"
+      },
+      {
+        "text": "Live your life by a compass not a clock.",
+        "author": "Stephen R. Covey"
+      },
+      {
+        "text": "Adventure is worthwhile in itself.",
+        "author": "Amelia Earhart"
+      },
+      {
+        "text": "Travel is the only thing you buy that makes you richer.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Life is short and the world is wide.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Once a year, go somewhere you have never been before.",
+        "author": "Dalai Lama"
+      },
+      {
+        "text": "The goal is to die with memories not dreams.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "Take only memories, leave only footprints.",
+        "author": "Chief Seattle"
+      },
+      {
+        "text": "Life is an adventure. Live it.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "Investment in travel is an investment in yourself.",
+        "author": "Matthew Karsten"
+      },
+      {
+        "text": "Don’t live the same year 75 times and call it a life.",
+        "author": "Robin Sharma"
+      },
+      {
+        "text": "All life is an experiment. The more experiments you make the better.",
+        "author": "Ralph Waldo Emerson"
+      },
+      {
+        "text": "The purpose of life is to live it, to taste experience to the utmost, to reach out eagerly and without fear for newer and richer experiences.",
+        "author": "Eleanor Roosevelt"
+      },
+      {
+        "text": "Better to see something once than hear about it a thousand times.",
+        "author": "Asian Proverb"
+      },
+      {
+        "text": "If you think adventure is dangerous, try routine, it is lethal.",
+        "author": "Paulo Coelho"
+      },
+      {
+        "text": "Travel makes one modest, you see what a tiny place you occupy in the world.",
+        "author": "Gustave Flaubert"
+      },
+      {
+        "text": "Travel. As much as you can. As far as you can. As long as you can. Life’s not meant to be lived in one place.",
+        "author": "Unknown"
+      },
+      {
+        "text": "The real voyage of discovery consists not in seeking new landscapes, but in having new eyes.",
+        "author": "Marcel Proust"
+      },
+      {
+        "text": "I would rather own a little and see the world than own the world and see a little of it.",
+        "author": "Alexander Sattler"
+      },
+      {
+        "text": "Traveling – it leaves you speechless, then turns you into a storyteller.",
+        "author": "Ibn Battuta"
+      },
+      {
+        "text": "The best way to experience the world is by going outside and exploring it.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "I travel because it makes me realize how much I haven’t seen, how much I’m not going to see, and how much I still need to see.",
+        "author": "Carew Papritz"
+      },
+      {
+        "text": "For my part, I travel not to go anywhere, but to go. I travel for travel’s sake. The great affair is to move.",
+        "author": "Robert Louis Stevenson"
+      },
+      {
+        "text": "A mind that is stretched by a new experience can never go back to its old dimensions.",
+        "author": "Oliver Wendell Holmes, Jr"
+      },
+      {
+        "text": "A good traveler has no fixed plans and is not intent on arriving.",
+        "author": "Lao Tzu"
+      }
     ]
   },
   {
     "id": "time",
     "label": "Time",
     "quotes": [
-      "\"The two most powerful warriors are patience and time.\" — Leo Tolstoy, War and Peace",
-      "“Time is what we want most, but what we use worst.” — William Penn, Fruits of Solitude",
-      "“All we have to decide is what to do with the time that is given us.” — J. R. R. Tolkien, The Fellowship of the Ring",
-      "“The most precious resource we all have is time.” — Steve Jobs",
-      "“Time has a wonderful way of showing us what really matters.” — Margaret Peters",
-      "“Time is a created thing. To say ‘I don’t have time’ is to say ‘I don’t want to.’” — Lao Tzu",
-      "\"No man goes before his time. Unless the boss leaves early.” — Groucho Marx",
-      "“Time is free, but it’s priceless. You can’t own it, but you can use it. You can’t keep it, but you can spend it. Once you’ve lost it, you can never get it back.” — Harvey MacKay",
-      "“The future is something which everyone reaches at the rate of sixty minutes an hour, whatever he does, whoever he is.” — C. S. Lewis",
-      "“The bad news is time flies. The good news is you’re the pilot.” — Michael Altshuler",
-      "\"There’s only one thing more precious than our time and that’s who we spend it on.” — Leo Christopher",
-      "\"An inch of time is an inch of gold, but you can’t buy that inch of time with an inch of gold.” — Chinese Proverb",
-      "\"There’s never enough time to do it right, but there’s always enough time to do it over.” — Jack Bergman",
-      "“A man who dares to waste an hour of time has not discovered the value of life.” — Charles Darwin",
-      "\"Time isn’t the main thing. It’s the only thing.” — Miles Davis",
-      "\"I am not particularly interested in saving time; I prefer to enjoy it.” — Eduardo Galeano",
-      "\"Time flies over us, but leaves its shadow behind.” — Nathaniel Hawthorne, The Marble Faun",
-      "\"Time is what keeps everything from happening at once.” — Ray Cummings, The Girl in the Golden Atom",
-      "“It’s not that we have little time, but more that we waste a good deal of it.” — Seneca",
-      "“I wish I could turn back the clock and find you sooner so I can love you longer.” — Unknown",
-      "“Time moves slowly, but passes quickly.” — Alice Walker, The Color Purple",
-      "“You will never find time for anything. If you want time, you must make it.” — Charles Buxton",
-      "\"There’s never enough time to do all the nothing you want.” — “Calvin and Hobbes” by Bill Watterson",
-      "“They always say time changes things, but you actually have to change them yourself.” — Andy Warhol, The Philosophy of Andy Warhol",
-      "“Time is a waste of money.” — Oscar Wilde",
-      "“Time is a great healer, but a poor beautician.” — Lucille S. Harper",
-      "“No measure of time with you will be long enough. But let’s start with forever.” — Stephenie Meyer, Breaking Dawn",
-      "“You can’t turn back the clock. But you can wind it up again.” — Bonnie Prudden",
-      "“Time and tide wait for no man, but time always stands still for a woman of 30.” — Robert Frost",
-      "“Time has no meaning when you’re in love.” — Unknown",
-      "“Better three hours too soon than one minute too late.” — William Shakespeare, The Merry Wives of Windsor",
-      "“There is never a time or place for true love. It happens accidentally, in a heartbeat, in a single flashing, throbbing moment.” — Sarah Dessen, The Truth About Forever",
-      "“There is a time for work and a time for love. That leaves no other time.” — Coco Chanel",
-      "“Time is the longest distance between two places.” — Tennessee Williams, The Glass Menagerie",
-      "“To live is so startling, it leaves little time for anything else.” — Emily Dickinson",
-      "“Lost time is never found again.” — Benjamin Franklin, Poor Richard’s Almanac",
-      "“The only reason for time is so that everything doesn’t happen at once.” — Albert Einstein",
-      "“Time you enjoy wasted was not time wasted.” — John Lennon",
-      "“Time is precious. Make sure you spend it with the right people.” — Unknown",
-      "\"Who controls the past, controls the future: who controls the present controls the past.” — George Orwell, 1984",
-      "“Time, which changes people, does not alter the image we have of them.” — Marcel Proust",
-      "“If you judge people, you have no time to love them.” — Mother Teresa",
-      "“The few hours I spend with you are worth the thousand hours I spend without you.” — Unknown",
-      "“If you spend too much time thinking about a thing, you’ll never get it done.” — Bruce Lee",
-      "“Men talk of killing time, while time quietly kills them.” — Dion Boucicault",
-      "“Don’t waste your time in anger, regrets, worries, and grudges. Life is too short to be unhappy.” — Roy T. Bennett, The Light in the Heart",
-      "“It is the time you have wasted for your rose that makes your rose so important.” — Antoine de Saint - Exupéry, The Little Prince",
-      "“Own time, or time will own you.” — Brian Norgard",
-      "“Punctuality is the thief of time.” — Oscar Wilde, The Picture of Dorian Gray",
-      "“The wisest are the most annoyed at the loss of time.” — Dante Alighieri"
+      {
+        "text": "The two most powerful warriors are patience and time.",
+        "author": "Leo Tolstoy, War and Peace"
+      },
+      {
+        "text": "Time is what we want most, but what we use worst.",
+        "author": "William Penn, Fruits of Solitude"
+      },
+      {
+        "text": "All we have to decide is what to do with the time that is given us.",
+        "author": "J. R. R. Tolkien, The Fellowship of the Ring"
+      },
+      {
+        "text": "The most precious resource we all have is time.",
+        "author": "Steve Jobs"
+      },
+      {
+        "text": "Time has a wonderful way of showing us what really matters.",
+        "author": "Margaret Peters"
+      },
+      {
+        "text": "Time is a created thing. To say ‘I don’t have time’ is to say ‘I don’t want to.’",
+        "author": "Lao Tzu"
+      },
+      {
+        "text": "No man goes before his time. Unless the boss leaves early.",
+        "author": "Groucho Marx"
+      },
+      {
+        "text": "Time is free, but it’s priceless. You can’t own it, but you can use it. You can’t keep it, but you can spend it. Once you’ve lost it, you can never get it back.",
+        "author": "Harvey MacKay"
+      },
+      {
+        "text": "The future is something which everyone reaches at the rate of sixty minutes an hour, whatever he does, whoever he is.",
+        "author": "C. S. Lewis"
+      },
+      {
+        "text": "The bad news is time flies. The good news is you’re the pilot.",
+        "author": "Michael Altshuler"
+      },
+      {
+        "text": "There’s only one thing more precious than our time and that’s who we spend it on.",
+        "author": "Leo Christopher"
+      },
+      {
+        "text": "An inch of time is an inch of gold, but you can’t buy that inch of time with an inch of gold.",
+        "author": "Chinese Proverb"
+      },
+      {
+        "text": "There’s never enough time to do it right, but there’s always enough time to do it over.",
+        "author": "Jack Bergman"
+      },
+      {
+        "text": "A man who dares to waste an hour of time has not discovered the value of life.",
+        "author": "Charles Darwin"
+      },
+      {
+        "text": "Time isn’t the main thing. It’s the only thing.",
+        "author": "Miles Davis"
+      },
+      {
+        "text": "I am not particularly interested in saving time; I prefer to enjoy it.",
+        "author": "Eduardo Galeano"
+      },
+      {
+        "text": "Time flies over us, but leaves its shadow behind.",
+        "author": "Nathaniel Hawthorne, The Marble Faun"
+      },
+      {
+        "text": "Time is what keeps everything from happening at once.",
+        "author": "Ray Cummings, The Girl in the Golden Atom"
+      },
+      {
+        "text": "It’s not that we have little time, but more that we waste a good deal of it.",
+        "author": "Seneca"
+      },
+      {
+        "text": "I wish I could turn back the clock and find you sooner so I can love you longer.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Time moves slowly, but passes quickly.",
+        "author": "Alice Walker, The Color Purple"
+      },
+      {
+        "text": "You will never find time for anything. If you want time, you must make it.",
+        "author": "Charles Buxton"
+      },
+      {
+        "text": "There’s never enough time to do all the nothing you want.",
+        "author": "Calvin and Hobbes” by Bill Watterson"
+      },
+      {
+        "text": "They always say time changes things, but you actually have to change them yourself.",
+        "author": "Andy Warhol, The Philosophy of Andy Warhol"
+      },
+      {
+        "text": "Time is a waste of money.",
+        "author": "Oscar Wilde"
+      },
+      {
+        "text": "Time is a great healer, but a poor beautician.",
+        "author": "Lucille S. Harper"
+      },
+      {
+        "text": "No measure of time with you will be long enough. But let’s start with forever.",
+        "author": "Stephenie Meyer, Breaking Dawn"
+      },
+      {
+        "text": "You can’t turn back the clock. But you can wind it up again.",
+        "author": "Bonnie Prudden"
+      },
+      {
+        "text": "Time and tide wait for no man, but time always stands still for a woman of 30.",
+        "author": "Robert Frost"
+      },
+      {
+        "text": "Time has no meaning when you’re in love.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Better three hours too soon than one minute too late.",
+        "author": "William Shakespeare, The Merry Wives of Windsor"
+      },
+      {
+        "text": "There is never a time or place for true love. It happens accidentally, in a heartbeat, in a single flashing, throbbing moment.",
+        "author": "Sarah Dessen, The Truth About Forever"
+      },
+      {
+        "text": "There is a time for work and a time for love. That leaves no other time.",
+        "author": "Coco Chanel"
+      },
+      {
+        "text": "Time is the longest distance between two places.",
+        "author": "Tennessee Williams, The Glass Menagerie"
+      },
+      {
+        "text": "To live is so startling, it leaves little time for anything else.",
+        "author": "Emily Dickinson"
+      },
+      {
+        "text": "Lost time is never found again.",
+        "author": "Benjamin Franklin, Poor Richard’s Almanac"
+      },
+      {
+        "text": "The only reason for time is so that everything doesn’t happen at once.",
+        "author": "Albert Einstein"
+      },
+      {
+        "text": "Time you enjoy wasted was not time wasted.",
+        "author": "John Lennon"
+      },
+      {
+        "text": "Time is precious. Make sure you spend it with the right people.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Who controls the past, controls the future: who controls the present controls the past.",
+        "author": "George Orwell, 1984"
+      },
+      {
+        "text": "Time, which changes people, does not alter the image we have of them.",
+        "author": "Marcel Proust"
+      },
+      {
+        "text": "If you judge people, you have no time to love them.",
+        "author": "Mother Teresa"
+      },
+      {
+        "text": "The few hours I spend with you are worth the thousand hours I spend without you.",
+        "author": "Unknown"
+      },
+      {
+        "text": "If you spend too much time thinking about a thing, you’ll never get it done.",
+        "author": "Bruce Lee"
+      },
+      {
+        "text": "Men talk of killing time, while time quietly kills them.",
+        "author": "Dion Boucicault"
+      },
+      {
+        "text": "Don’t waste your time in anger, regrets, worries, and grudges. Life is too short to be unhappy.",
+        "author": "Roy T. Bennett, The Light in the Heart"
+      },
+      {
+        "text": "It is the time you have wasted for your rose that makes your rose so important.” — Antoine de Saint",
+        "author": "Exupéry, The Little Prince"
+      },
+      {
+        "text": "Own time, or time will own you.",
+        "author": "Brian Norgard"
+      },
+      {
+        "text": "Punctuality is the thief of time.",
+        "author": "Oscar Wilde, The Picture of Dorian Gray"
+      },
+      {
+        "text": "The wisest are the most annoyed at the loss of time.",
+        "author": "Dante Alighieri"
+      }
     ]
   },
   {
     "id": "motivation",
     "label": "Motivation",
     "quotes": [
-      "“What great thing would you attempt, if you knew you could not fail.” – Robert H. Schuller",
-      "“It’s not about money or connections. It’s the willingness to outwork and outlearn everyone when it comes to your business.” – Mark Cuban",
-      "“Success is not final; failure is not fatal; it is the courage to continue that counts.” – Winston Churchill",
-      "“Don’t stop when you’re tired. Stop when you’re done.” – Wesley Snipes",
-      "“Shoot for the moon. Even if you miss, you’ll land among the stars.” – Norman Vincent Peale",
-      "“The journey of a thousand miles begins with one step.” – Lao Tzu",
-      "“Act as if what you do makes a difference.” IT DOES.” – William James",
-      "“Always take another step. If this is to no avail take another, and yet another. One step at a time is not too difficult.” – Og Mandino",
-      "“If you can’t fly, then run, if you can’t run then walk, if you can’t walk then crawl, but whatever you do, you have to keep moving forward.” – Martin Luther King, Jr.",
-      "“Much effort, much prosperity.” – Euripides",
-      "“Much good work is lost for the lack of a little more.” – Edward H. Harriman",
-      "“Your biggest failure is the thing you dreamed of contributing but didn’t find the guts to do.” – Seth Godin",
-      "“That some achieve great success, is proof to all that others can achieve it as well.” – Abraham Lincoln",
-      "“Never let the fear of striking out get in your way.” – Babe Ruth",
-      "“Hustle until you no longer need to introduce yourself.” – Anonymous",
-      "“The heights by great men reached and kept, were not attained by sudden flight, but they, while their companions slept, were toiling upward in the night.” – Henry Wadsworth Longfellow",
-      "“He who would accomplish little must sacrifice little; he who would achieve much must sacrifice much.” – James Allen",
-      "“If you wish to be out front, then act as if you were behind.” – Lao Tzu",
-      "“The key to success is failure.” – Michael Jordan",
-      "“Formula for success: rise early, work hard, strike oil.” – J. Paul Getty",
-      "“Plough deep while sluggards sleep.” – Benjamin Franklin",
-      "“Work hard in silence and let success be your noise.” – Anonymous",
-      "“Don’t stop until you’re proud.” – Anonymous",
-      "“The path to success is to take massive, determined action.” – Tony Robbins",
-      "“If it’s important, you’ll find a way. If it’s not, you’ll find an excuse.” – Ryan Blair",
-      "“Men of action are favored by the goddess of good luck.” – George S. Clason",
-      "“A somebody was once a nobody who wanted to and did.” – John Burroughs",
-      "“Man cannot discover new oceans unless he has the courage to lose sight of the shore.” – Andre Gide",
-      "“If you believe you can do a thing, you can do it.” – Claude M. Bristol",
-      "“Action is the foundational key to all success.” – Pablo Picasso",
-      "“Thought allied fearlessly to purpose becomes creative force.” – James Allen",
-      "“Run your own race. Who cares what others are doing? The only question that matters is, am I progressing?” – Robin Sharma",
-      "“There’s not a person on my team in 16 years that has consistently beat me to the ball every play. That ain’t got anything to do with talent, that’s just got everything to do with effort, and nothing else.” – Ray Lewis",
-      "“Don’t watch the clock; do what it does. Keep going.” – Sam Levonson",
-      "“Winners embrace hard work. They love the discipline of it, the trade-off they’re making to win. Losers, on the other hand, see it as a punishment.",
-      "“Push yourself, because no one else is going to do it for you.” – Anonymous",
-      "“Life shrinks or expands in proportion to one’s courage.” – Anais Nin",
-      "“Nothing in this world is worth having or worth doing unless it means effort, pain, difficulty.” – Theodore Roosevelt",
-      "“In this world you only get what you grab for.” – Giovanni Boccaccio",
-      "“Success means having the courage, the determination, and the will to become the person you believe you were meant to be.” – George A. Sheehan",
-      "“The best way to predict the future is to create it.” – Peter Drucker",
-      "“If you have everything seems under control, you’re just not going fast enough.” – Mario Andretti",
-      "“Do the work. Everyone wants to be successful, but nobody wants to do the work.” – Gary Vaynerchuk",
-      "“Be so good they can’t ignore you.” – Steve Martin",
-      "“Be not afraid of going slowly; be afraid only of standing still.” – Chinese Proverb",
-      "“When we strive to become better than we are, everything around us becomes better too.” – Paulo Coelho",
-      "“With self-discipline, most anything is possible.” – Theodore Roosevelt",
-      "“All the so-called ‘secrets of success’ will not work unless you do.” – Anonymous",
-      "“Your dreams are on the other side of your grit.” – Anonymous"
+      {
+        "text": "What great thing would you attempt, if you knew you could not fail.",
+        "author": "Robert H. Schuller"
+      },
+      {
+        "text": "It’s not about money or connections. It’s the willingness to outwork and outlearn everyone when it comes to your business.",
+        "author": "Mark Cuban"
+      },
+      {
+        "text": "Success is not final; failure is not fatal; it is the courage to continue that counts.",
+        "author": "Winston Churchill"
+      },
+      {
+        "text": "Don’t stop when you’re tired. Stop when you’re done.",
+        "author": "Wesley Snipes"
+      },
+      {
+        "text": "Shoot for the moon. Even if you miss, you’ll land among the stars.",
+        "author": "Norman Vincent Peale"
+      },
+      {
+        "text": "The journey of a thousand miles begins with one step.",
+        "author": "Lao Tzu"
+      },
+      {
+        "text": "Act as if what you do makes a difference. It does.",
+        "author": "William James"
+      },
+      {
+        "text": "Always take another step. If this is to no avail take another, and yet another. One step at a time is not too difficult.",
+        "author": "Og Mandino"
+      },
+      {
+        "text": "If you can’t fly, then run, if you can’t run then walk, if you can’t walk then crawl, but whatever you do, you have to keep moving forward.",
+        "author": "Martin Luther King, Jr."
+      },
+      {
+        "text": "Much effort, much prosperity.",
+        "author": "Euripides"
+      },
+      {
+        "text": "Much good work is lost for the lack of a little more.",
+        "author": "Edward H. Harriman"
+      },
+      {
+        "text": "Your biggest failure is the thing you dreamed of contributing but didn’t find the guts to do.",
+        "author": "Seth Godin"
+      },
+      {
+        "text": "That some achieve great success, is proof to all that others can achieve it as well.",
+        "author": "Abraham Lincoln"
+      },
+      {
+        "text": "Never let the fear of striking out get in your way.",
+        "author": "Babe Ruth"
+      },
+      {
+        "text": "Hustle until you no longer need to introduce yourself.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "The heights by great men reached and kept, were not attained by sudden flight, but they, while their companions slept, were toiling upward in the night.",
+        "author": "Henry Wadsworth Longfellow"
+      },
+      {
+        "text": "He who would accomplish little must sacrifice little; he who would achieve much must sacrifice much.",
+        "author": "James Allen"
+      },
+      {
+        "text": "If you wish to be out front, then act as if you were behind.",
+        "author": "Lao Tzu"
+      },
+      {
+        "text": "The key to success is failure.",
+        "author": "Michael Jordan"
+      },
+      {
+        "text": "Formula for success: rise early, work hard, strike oil.",
+        "author": "J. Paul Getty"
+      },
+      {
+        "text": "Plough deep while sluggards sleep.",
+        "author": "Benjamin Franklin"
+      },
+      {
+        "text": "Work hard in silence and let success be your noise.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "Don’t stop until you’re proud.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "The path to success is to take massive, determined action.",
+        "author": "Tony Robbins"
+      },
+      {
+        "text": "If it’s important, you’ll find a way. If it’s not, you’ll find an excuse.",
+        "author": "Ryan Blair"
+      },
+      {
+        "text": "Men of action are favored by the goddess of good luck.",
+        "author": "George S. Clason"
+      },
+      {
+        "text": "A somebody was once a nobody who wanted to and did.",
+        "author": "John Burroughs"
+      },
+      {
+        "text": "Man cannot discover new oceans unless he has the courage to lose sight of the shore.",
+        "author": "Andre Gide"
+      },
+      {
+        "text": "If you believe you can do a thing, you can do it.",
+        "author": "Claude M. Bristol"
+      },
+      {
+        "text": "Action is the foundational key to all success.",
+        "author": "Pablo Picasso"
+      },
+      {
+        "text": "Thought allied fearlessly to purpose becomes creative force.",
+        "author": "James Allen"
+      },
+      {
+        "text": "Run your own race. Who cares what others are doing? The only question that matters is, am I progressing?",
+        "author": "Robin Sharma"
+      },
+      {
+        "text": "There’s not a person on my team in 16 years that has consistently beat me to the ball every play. That ain’t got anything to do with talent, that’s just got everything to do with effort, and nothing else.",
+        "author": "Ray Lewis"
+      },
+      {
+        "text": "Don’t watch the clock; do what it does. Keep going.",
+        "author": "Sam Levonson"
+      },
+      {
+        "text": "Winners embrace hard work. They love the discipline of it, the trade-off they’re making to win. Losers, on the other hand, see it as a punishment.",
+        "author": "Lou Holtz"
+      },
+      {
+        "text": "Push yourself, because no one else is going to do it for you.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "Life shrinks or expands in proportion to one’s courage.",
+        "author": "Anais Nin"
+      },
+      {
+        "text": "Nothing in this world is worth having or worth doing unless it means effort, pain, difficulty.",
+        "author": "Theodore Roosevelt"
+      },
+      {
+        "text": "In this world you only get what you grab for.",
+        "author": "Giovanni Boccaccio"
+      },
+      {
+        "text": "Success means having the courage, the determination, and the will to become the person you believe you were meant to be.",
+        "author": "George A. Sheehan"
+      },
+      {
+        "text": "The best way to predict the future is to create it.",
+        "author": "Peter Drucker"
+      },
+      {
+        "text": "If you have everything seems under control, you’re just not going fast enough.",
+        "author": "Mario Andretti"
+      },
+      {
+        "text": "Do the work. Everyone wants to be successful, but nobody wants to do the work.",
+        "author": "Gary Vaynerchuk"
+      },
+      {
+        "text": "Be so good they can’t ignore you.",
+        "author": "Steve Martin"
+      },
+      {
+        "text": "Be not afraid of going slowly; be afraid only of standing still.",
+        "author": "Chinese Proverb"
+      },
+      {
+        "text": "When we strive to become better than we are, everything around us becomes better too.",
+        "author": "Paulo Coelho"
+      },
+      {
+        "text": "With self-discipline, most anything is possible.",
+        "author": "Theodore Roosevelt"
+      },
+      {
+        "text": "All the so-called ‘secrets of success’ will not work unless you do.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "Your dreams are on the other side of your grit.",
+        "author": "Anonymous"
+      }
     ]
   },
   {
     "id": "friendship",
     "label": "Friendship",
     "quotes": [
-      "“A real friend is one who walks in when the rest of the world walks out.” — Walter Winchell",
-      "“To like and dislike the same things, that is what makes a solid friendship.” — Sallust",
-      "“My friends and I are crazy. That’s the only thing that keeps us sane.” — Matt Schucker",
-      "“I’ll stick to finding the funny in the ordinary because my life is pretty ordinary and so are the lives of my friends — and my friends are hilarious.” — Issa Rae",
-      "“As much as a BFF can make you go WTF, there’s no denying we’d be a little less rich without them.” — “Gossip Girl”",
-      "“A loyal friend laughs at your jokes when they’re not so good, and sympathizes with your problems when they’re not so bad.” — Arnold H. Glasgow",
-      "“An old friend will help you move. A good friend will help you move a dead body.” — Jim Hayes",
-      "“Whoever says friendship is easy has obviously never had a true friend!” — Bronwyn Polson",
-      "“A day without a friend is like a pot without a single drop of honey left inside.” — Winnie the Pooh",
-      "“How much good inside a day? Depends how good you live ‘em. How much love inside a friend? Depends how much you give ‘em.” — Shel Silverstein",
-      "“A true friend is someone who thinks that you are a good egg even though he knows that you are slightly cracked.” — Bernard Meltzer",
-      "“There is nothing better than a friend, unless it is a friend with chocolate.” — Linda Grayson",
-      "“A true friend never gets in your way unless you happen to be going down.” — Arnold H. Glasgow",
-      "“Friendship is a wildly underrated medication.” — Anna Deavere Smith",
-      "“Friendship is a pretty full-time occupation if you really are friendly with somebody. You can’t have too many friends because then you’re just not really friends.” — Truman Capote",
-      "“True friends are like diamonds — bright, beautiful, valuable, and always in style.” — Nicole Richie",
-      "“Women’s friendships are like a renewable source of power.” — Jane Fonda",
-      "“Friends are those rare people who ask how we are and then wait to hear the answer.” — Ed Cunningham",
-      "“It is one of the blessings of old friends that you can afford to be stupid with them.” — Ralph Waldo Emerson",
-      "“An integral part of any best friend’s job is to immediately clear your computer history if you die.” — Darynda Jones",
-      "“Your friends will know you better in the first minute you meet than your acquaintances will know you in a thousand years.” — Richard Bach",
-      "“When the world is so complicated, the simple gift of friendship is within all of our hands.” — Maria Shriver",
-      "“What draws people to be friends is that they see the same truth. They share it.” — C. S. Lewis",
-      "“Friendship isn’t a big thing — it’s a million little things.” — Paulo Coelho",
-      "“A good friend is like a four-leaf clover; hard to find and lucky to have.” — Irish Proverb",
-      "“Life is an awful, ugly place to not have a best friend.” ― Sarah Dessen, “Someone Like You”",
-      "“If you have one true friend you have more than your share.” ― Thomas Fuller",
-      "“Friendship is the hardest thing in the world to explain. It’s not something you learn in school. But if you haven’t learned the meaning of friendship, you really haven’t learned anything.” — Muhammad Ali",
-      "“A friend is one who knows you and loves you just the same.” — Elbert Hubbard",
-      "“A friend knows the song in my heart and sings it to me when my memory fails.” — Donna Roberts",
-      "“A friend is someone who makes it easy to believe in yourself.” — Heidi Wills",
-      "“Friendship is always a sweet responsibility, never an opportunity.” — Kahlil Gibran",
-      "“Friendships between women, as any woman will tell you, are built of a thousand small kindnesses. . . swapped back and forth and over again,” — Michelle Obama, “Becoming”",
-      "“No friendship is an accident.” — O. Henry",
-      "“Friends are honest with each other. Even if the truth hurts.” — Sarah Dessen, “Along for the Ride”",
-      "“A single rose can be my garden; a single friend, my world.” — Leo Buscaglia",
-      "“A friend may be waiting behind a stranger’s face.” — Maya Angelou, “Letter to My Daughter”",
-      "“Since there is nothing so well worth having as friends, never lose a chance to make them.” — Francesco Guicciardini",
-      "“There’s nothing like a really loyal, dependable, good friend. Nothing.” — Jennifer Aniston",
-      "“Friendship’s the wine of life.” — Edward Young",
-      "“Some people arrive and make such a beautiful impact on your life, you can barely remember what life was like without them.” — Anna Taylor",
-      "“True happiness consists not in the multitude of friends, but in the worth and choice.” — Ben Jonson",
-      "“Fate chooses our relatives, we choose our friends.” — Jacques Delille",
-      "“A friend is one of the nicest things you can have, and one of the best things you can be.” — Douglas Pagels",
-      "“Wishing to be friends is quick work, but friendship is a slow-ripening fruit.” — Aristotle",
-      "“Friendship is the only cement that will ever hold the world together.” — Woodrow Wilson",
-      "“Nearly everything I know about love, I’ve learnt from my long-term friendships with women.” — Dolly Alderton, “Everything I Know About Love”",
-      "“Lots of people want to ride with you in the limo, but what you want is someone who will take the bus with you when the limo breaks down.” — Oprah Winfrey",
-      "“That was what a best friend did: hold up a mirror and show you your heart.” — Kristin Hannah",
-      "“Truly great friends are hard to find, difficult to leave and impossible to forget.” — G. Randolf"
+      {
+        "text": "A real friend is one who walks in when the rest of the world walks out.",
+        "author": "Walter Winchell"
+      },
+      {
+        "text": "To like and dislike the same things, that is what makes a solid friendship.",
+        "author": "Sallust"
+      },
+      {
+        "text": "My friends and I are crazy. That’s the only thing that keeps us sane.",
+        "author": "Matt Schucker"
+      },
+      {
+        "text": "I’ll stick to finding the funny in the ordinary because my life is pretty ordinary and so are the lives of my friends — and my friends are hilarious.",
+        "author": "Issa Rae"
+      },
+      {
+        "text": "As much as a BFF can make you go WTF, there’s no denying we’d be a little less rich without them.",
+        "author": "Gossip Girl"
+      },
+      {
+        "text": "A loyal friend laughs at your jokes when they’re not so good, and sympathizes with your problems when they’re not so bad.",
+        "author": "Arnold H. Glasgow"
+      },
+      {
+        "text": "An old friend will help you move. A good friend will help you move a dead body.",
+        "author": "Jim Hayes"
+      },
+      {
+        "text": "Whoever says friendship is easy has obviously never had a true friend!",
+        "author": "Bronwyn Polson"
+      },
+      {
+        "text": "A day without a friend is like a pot without a single drop of honey left inside.",
+        "author": "Winnie the Pooh"
+      },
+      {
+        "text": "How much good inside a day? Depends how good you live ‘em. How much love inside a friend? Depends how much you give ‘em.",
+        "author": "Shel Silverstein"
+      },
+      {
+        "text": "A true friend is someone who thinks that you are a good egg even though he knows that you are slightly cracked.",
+        "author": "Bernard Meltzer"
+      },
+      {
+        "text": "There is nothing better than a friend, unless it is a friend with chocolate.",
+        "author": "Linda Grayson"
+      },
+      {
+        "text": "A true friend never gets in your way unless you happen to be going down.",
+        "author": "Arnold H. Glasgow"
+      },
+      {
+        "text": "Friendship is a wildly underrated medication.",
+        "author": "Anna Deavere Smith"
+      },
+      {
+        "text": "Friendship is a pretty full-time occupation if you really are friendly with somebody. You can’t have too many friends because then you’re just not really friends.",
+        "author": "Truman Capote"
+      },
+      {
+        "text": "True friends are like diamonds — bright, beautiful, valuable, and always in style.",
+        "author": "Nicole Richie"
+      },
+      {
+        "text": "Women’s friendships are like a renewable source of power.",
+        "author": "Jane Fonda"
+      },
+      {
+        "text": "Friends are those rare people who ask how we are and then wait to hear the answer.",
+        "author": "Ed Cunningham"
+      },
+      {
+        "text": "It is one of the blessings of old friends that you can afford to be stupid with them.",
+        "author": "Ralph Waldo Emerson"
+      },
+      {
+        "text": "An integral part of any best friend’s job is to immediately clear your computer history if you die.",
+        "author": "Darynda Jones"
+      },
+      {
+        "text": "Your friends will know you better in the first minute you meet than your acquaintances will know you in a thousand years.",
+        "author": "Richard Bach"
+      },
+      {
+        "text": "When the world is so complicated, the simple gift of friendship is within all of our hands.",
+        "author": "Maria Shriver"
+      },
+      {
+        "text": "What draws people to be friends is that they see the same truth. They share it.",
+        "author": "C. S. Lewis"
+      },
+      {
+        "text": "Friendship isn’t a big thing — it’s a million little things.",
+        "author": "Paulo Coelho"
+      },
+      {
+        "text": "A good friend is like a four-leaf clover; hard to find and lucky to have.",
+        "author": "Irish Proverb"
+      },
+      {
+        "text": "Life is an awful, ugly place to not have a best friend.",
+        "author": "Sarah Dessen, “Someone Like You"
+      },
+      {
+        "text": "If you have one true friend you have more than your share.",
+        "author": "Thomas Fuller"
+      },
+      {
+        "text": "Friendship is the hardest thing in the world to explain. It’s not something you learn in school. But if you haven’t learned the meaning of friendship, you really haven’t learned anything.",
+        "author": "Muhammad Ali"
+      },
+      {
+        "text": "A friend is one who knows you and loves you just the same.",
+        "author": "Elbert Hubbard"
+      },
+      {
+        "text": "A friend knows the song in my heart and sings it to me when my memory fails.",
+        "author": "Donna Roberts"
+      },
+      {
+        "text": "A friend is someone who makes it easy to believe in yourself.",
+        "author": "Heidi Wills"
+      },
+      {
+        "text": "Friendship is always a sweet responsibility, never an opportunity.",
+        "author": "Kahlil Gibran"
+      },
+      {
+        "text": "Friendships between women, as any woman will tell you, are built of a thousand small kindnesses. . . swapped back and forth and over again,",
+        "author": "Michelle Obama, “Becoming"
+      },
+      {
+        "text": "No friendship is an accident.",
+        "author": "O. Henry"
+      },
+      {
+        "text": "Friends are honest with each other. Even if the truth hurts.",
+        "author": "Sarah Dessen, “Along for the Ride"
+      },
+      {
+        "text": "A single rose can be my garden; a single friend, my world.",
+        "author": "Leo Buscaglia"
+      },
+      {
+        "text": "A friend may be waiting behind a stranger’s face.",
+        "author": "Maya Angelou, “Letter to My Daughter"
+      },
+      {
+        "text": "Since there is nothing so well worth having as friends, never lose a chance to make them.",
+        "author": "Francesco Guicciardini"
+      },
+      {
+        "text": "There’s nothing like a really loyal, dependable, good friend. Nothing.",
+        "author": "Jennifer Aniston"
+      },
+      {
+        "text": "Friendship’s the wine of life.",
+        "author": "Edward Young"
+      },
+      {
+        "text": "Some people arrive and make such a beautiful impact on your life, you can barely remember what life was like without them.",
+        "author": "Anna Taylor"
+      },
+      {
+        "text": "True happiness consists not in the multitude of friends, but in the worth and choice.",
+        "author": "Ben Jonson"
+      },
+      {
+        "text": "Fate chooses our relatives, we choose our friends.",
+        "author": "Jacques Delille"
+      },
+      {
+        "text": "A friend is one of the nicest things you can have, and one of the best things you can be.",
+        "author": "Douglas Pagels"
+      },
+      {
+        "text": "Wishing to be friends is quick work, but friendship is a slow-ripening fruit.",
+        "author": "Aristotle"
+      },
+      {
+        "text": "Friendship is the only cement that will ever hold the world together.",
+        "author": "Woodrow Wilson"
+      },
+      {
+        "text": "Nearly everything I know about love, I’ve learnt from my long-term friendships with women.",
+        "author": "Dolly Alderton, “Everything I Know About Love"
+      },
+      {
+        "text": "Lots of people want to ride with you in the limo, but what you want is someone who will take the bus with you when the limo breaks down.",
+        "author": "Oprah Winfrey"
+      },
+      {
+        "text": "That was what a best friend did: hold up a mirror and show you your heart.",
+        "author": "Kristin Hannah"
+      },
+      {
+        "text": "Truly great friends are hard to find, difficult to leave and impossible to forget.",
+        "author": "G. Randolf"
+      }
     ]
   },
   {
     "id": "music",
     "label": "Music",
     "quotes": [
-      "“Music is like a dream. One that I cannot hear.” ― Ludwig van Beethoven",
-      "“Without music, life would be a mistake” ― Friedrich Nietzsche",
-      "“I can chase you, and I can catch you, but there is nothing I can do to make you mine.” ― Morrissey",
-      "“Music gives a soul to the universe, wings to the mind, flight to the imagination and life to everything.” ― Plato",
-      "“How is it that music can, without words, evoke our laughter, our fears, our highest aspirations?” ― Jane Swan",
-      "“If I were not a physicist, I would probably be a musician. I often think in music. I live my daydreams in music. I see my life in terms of music.” ― Albert Einstein",
-      "“Music is a language that doesn’t speak in particular words. It speaks in emotions, and if it’s in the bones, it’s in the bones.” ― Keith Richards",
-      "“I think music in itself is healing. It’s an explosive expression of humanity. It’s something we are all touched by. No matter what culture we’re from, everyone loves music.” ― Billy Joel",
-      "“One good thing about music, when it hits you, you feel no pain.” ― Bob Marley",
-      "“The only truth is music.” ― Jack Kerouac",
-      "“There are two means of refuge from the miseries of life: music and cats.” ― Albert Schweitzer",
-      "“Music is the shorthand of emotion.” ― Leo Tolstoy",
-      "“Without music, life would be a blank to me.”― Jane Austen",
-      "“If music be the food of love, play on, Give me excess of it; that surfeiting, The appetite may sicken, and so die.” ― William Shakespeare",
-      "“Music was my refuge. I could crawl into the space between the notes and curl my back to loneliness.” ― Maya Angelou",
-      "“After silence, that which comes nearest to expressing the inexpressible is music.” ― Aldous Huxley",
-      "“The most exciting rhythms seem unexpected and complex, the most beautiful melodies simple and inevitable.” ― W. H. Auden",
-      "“Where words fail, music speaks.” ― Hans Christian Andersen",
-      "“Music expresses that which cannot be said and on which it is impossible to be silent.” ― Victor Hugo",
-      "“We are the music makers, and we are the dreamers of dreams.” ― Arthur O’Shaughnessy",
-      "“If I had my life to live over again, I would have made a rule to read some poetry and listen to some music at least once every week.”― Charles Darwin",
-      "“Music produces a kind of pleasure which human nature cannot do without.” ― Confucius",
-      "“Music is … A higher revelation than all Wisdom & Philosophy” ― Ludwig van Beethoven",
-      "“A man should hear a little music, read a little poetry, and see a fine picture every day of his life, in order that worldly cares may not obliterate the sense of the beautiful which God has implanted in the human soul.” ― Johann Wolfgang von Goethe",
-      "“Music is to the soul what words are to the mind.” ― Modest Mouse",
-      "“Music, once admitted to the soul, becomes a sort of spirit, and never dies.” ― Edward Bulwer-Lytton",
-      "“Music touches us emotionally, where words alone can’t.” ― Johnny Depp",
-      "“Virtually every writer I know would rather be a musician.” ― Kurt Vonnegut",
-      "“A painter paints pictures on canvas. But musicians paint their pictures on silence.” ― Leopold Stokowski",
-      "“Music . . . can name the unnameable and communicate the unknowable.” ― Leonard Bernstein",
-      "“I like beautiful melodies telling me terrible things.” ― Tom Waits",
-      "“When you make music or write or create, it’s really your job to have mind-blowing, irresponsible, condomless sex with whatever idea it is you’re writing about at the time.” ― Lady Gaga",
-      "“If being an egomaniac means I believe in what I do and in my art or music, then in that respect you can call me that… I believe in what I do, and I’ll say it.” ― John Lennon",
-      "“Live your truth. Express your love. Share your enthusiasm. Take action towards your dreams. Walk your talk. Dance and sing to your music. Embrace your blessings. Make today worth remembering.” ― Steve Maraboli",
-      "“Information is not knowledge. Knowledge is not wisdom. Wisdom is not truth. Truth is not beauty. Beauty is not love. Love is not music. Music is THE BEST.” ― Frank Zappa",
-      "“Music is the literature of the heart; it commences where speech ends.” ― Alphonse de Lamartine",
-      "“Beethoven tells you what it’s like to be Beethoven and Mozart tells you what it’s like to be human. Bach tells you what it’s like to be the universe.” ― Douglas Adams",
-      "“The music is not in the notes, but in the silence between.” ― Wolfgang Amadeus Mozart",
-      "“Music makes one feel so romantic – at least it always gets on one’s nerves – which is the same thing nowadays.”― Oscar Wilde",
-      "“Without music to decorate it, time is just a bunch of boring production deadlines or dates by which bills must be paid.” ― Frank Zappa",
-      "“If you cannot teach me to fly, teach me to sing.” ― J. M. Barrie, Peter Pan",
-      "“Music is the strongest form of magic.” ― Marilyn Manson",
-      "“Music is the wine that fills the cup of silence.” ― Robert Fripp",
-      "“Music is the language of the spirit. It opens the secret of life bringing peace, abolishing strife.” ― Kahlil Gibran",
-      "“Music in the soul can be heard by the universe.” ― Lao Tzu",
-      "“Music acts like a magic key, to which the most tightly closed heart opens.” ― Maria Augusta von Trapp",
-      "“Music… will help dissolve your perplexities and purify your character and sensibilities, and in time of care and sorrow, will keep a fountain of joy alive in you.” ― Dietrich Bonhoeffer",
-      "“Music is an outburst of the soul.” ― Frederick Delius",
-      "“My personal hobbies are reading, listening to music, and silence.” ― Edith Sitwell",
-      "“Music is the great uniter. An incredible force. Something that people who differ on everything and anything else can have in common.” ― Sarah Dessen"
+      {
+        "text": "Music is like a dream. One that I cannot hear.",
+        "author": "Ludwig van Beethoven"
+      },
+      {
+        "text": "Without music, life would be a mistake",
+        "author": "Friedrich Nietzsche"
+      },
+      {
+        "text": "I can chase you, and I can catch you, but there is nothing I can do to make you mine.",
+        "author": "Morrissey"
+      },
+      {
+        "text": "Music gives a soul to the universe, wings to the mind, flight to the imagination and life to everything.",
+        "author": "Plato"
+      },
+      {
+        "text": "How is it that music can, without words, evoke our laughter, our fears, our highest aspirations?",
+        "author": "Jane Swan"
+      },
+      {
+        "text": "If I were not a physicist, I would probably be a musician. I often think in music. I live my daydreams in music. I see my life in terms of music.",
+        "author": "Albert Einstein"
+      },
+      {
+        "text": "Music is a language that doesn’t speak in particular words. It speaks in emotions, and if it’s in the bones, it’s in the bones.",
+        "author": "Keith Richards"
+      },
+      {
+        "text": "I think music in itself is healing. It’s an explosive expression of humanity. It’s something we are all touched by. No matter what culture we’re from, everyone loves music.",
+        "author": "Billy Joel"
+      },
+      {
+        "text": "One good thing about music, when it hits you, you feel no pain.",
+        "author": "Bob Marley"
+      },
+      {
+        "text": "The only truth is music.",
+        "author": "Jack Kerouac"
+      },
+      {
+        "text": "There are two means of refuge from the miseries of life: music and cats.",
+        "author": "Albert Schweitzer"
+      },
+      {
+        "text": "Music is the shorthand of emotion.",
+        "author": "Leo Tolstoy"
+      },
+      {
+        "text": "Without music, life would be a blank to me.",
+        "author": "Jane Austen"
+      },
+      {
+        "text": "If music be the food of love, play on, Give me excess of it; that surfeiting, The appetite may sicken, and so die.",
+        "author": "William Shakespeare"
+      },
+      {
+        "text": "Music was my refuge. I could crawl into the space between the notes and curl my back to loneliness.",
+        "author": "Maya Angelou"
+      },
+      {
+        "text": "After silence, that which comes nearest to expressing the inexpressible is music.",
+        "author": "Aldous Huxley"
+      },
+      {
+        "text": "The most exciting rhythms seem unexpected and complex, the most beautiful melodies simple and inevitable.",
+        "author": "W. H. Auden"
+      },
+      {
+        "text": "Where words fail, music speaks.",
+        "author": "Hans Christian Andersen"
+      },
+      {
+        "text": "Music expresses that which cannot be said and on which it is impossible to be silent.",
+        "author": "Victor Hugo"
+      },
+      {
+        "text": "We are the music makers, and we are the dreamers of dreams.",
+        "author": "Arthur O’Shaughnessy"
+      },
+      {
+        "text": "If I had my life to live over again, I would have made a rule to read some poetry and listen to some music at least once every week.",
+        "author": "Charles Darwin"
+      },
+      {
+        "text": "Music produces a kind of pleasure which human nature cannot do without.",
+        "author": "Confucius"
+      },
+      {
+        "text": "Music is … A higher revelation than all Wisdom & Philosophy",
+        "author": "Ludwig van Beethoven"
+      },
+      {
+        "text": "A man should hear a little music, read a little poetry, and see a fine picture every day of his life, in order that worldly cares may not obliterate the sense of the beautiful which God has implanted in the human soul.",
+        "author": "Johann Wolfgang von Goethe"
+      },
+      {
+        "text": "Music is to the soul what words are to the mind.",
+        "author": "Modest Mouse"
+      },
+      {
+        "text": "Music, once admitted to the soul, becomes a sort of spirit, and never dies.",
+        "author": "Edward Bulwer-Lytton"
+      },
+      {
+        "text": "Music touches us emotionally, where words alone can’t.",
+        "author": "Johnny Depp"
+      },
+      {
+        "text": "Virtually every writer I know would rather be a musician.",
+        "author": "Kurt Vonnegut"
+      },
+      {
+        "text": "A painter paints pictures on canvas. But musicians paint their pictures on silence.",
+        "author": "Leopold Stokowski"
+      },
+      {
+        "text": "Music . . . can name the unnameable and communicate the unknowable.",
+        "author": "Leonard Bernstein"
+      },
+      {
+        "text": "I like beautiful melodies telling me terrible things.",
+        "author": "Tom Waits"
+      },
+      {
+        "text": "When you make music or write or create, it’s really your job to have mind-blowing, irresponsible, condomless sex with whatever idea it is you’re writing about at the time.",
+        "author": "Lady Gaga"
+      },
+      {
+        "text": "If being an egomaniac means I believe in what I do and in my art or music, then in that respect you can call me that… I believe in what I do, and I’ll say it.",
+        "author": "John Lennon"
+      },
+      {
+        "text": "Live your truth. Express your love. Share your enthusiasm. Take action towards your dreams. Walk your talk. Dance and sing to your music. Embrace your blessings. Make today worth remembering.",
+        "author": "Steve Maraboli"
+      },
+      {
+        "text": "Information is not knowledge. Knowledge is not wisdom. Wisdom is not truth. Truth is not beauty. Beauty is not love. Love is not music. Music is THE BEST.",
+        "author": "Frank Zappa"
+      },
+      {
+        "text": "Music is the literature of the heart; it commences where speech ends.",
+        "author": "Alphonse de Lamartine"
+      },
+      {
+        "text": "Beethoven tells you what it’s like to be Beethoven and Mozart tells you what it’s like to be human. Bach tells you what it’s like to be the universe.",
+        "author": "Douglas Adams"
+      },
+      {
+        "text": "The music is not in the notes, but in the silence between.",
+        "author": "Wolfgang Amadeus Mozart"
+      },
+      {
+        "text": "Music makes one feel so romantic – at least it always gets on one’s nerves – which is the same thing nowadays.",
+        "author": "Oscar Wilde"
+      },
+      {
+        "text": "Without music to decorate it, time is just a bunch of boring production deadlines or dates by which bills must be paid.",
+        "author": "Frank Zappa"
+      },
+      {
+        "text": "If you cannot teach me to fly, teach me to sing.",
+        "author": "J. M. Barrie, Peter Pan"
+      },
+      {
+        "text": "Music is the strongest form of magic.",
+        "author": "Marilyn Manson"
+      },
+      {
+        "text": "Music is the wine that fills the cup of silence.",
+        "author": "Robert Fripp"
+      },
+      {
+        "text": "Music is the language of the spirit. It opens the secret of life bringing peace, abolishing strife.",
+        "author": "Kahlil Gibran"
+      },
+      {
+        "text": "Music in the soul can be heard by the universe.",
+        "author": "Lao Tzu"
+      },
+      {
+        "text": "Music acts like a magic key, to which the most tightly closed heart opens.",
+        "author": "Maria Augusta von Trapp"
+      },
+      {
+        "text": "Music… will help dissolve your perplexities and purify your character and sensibilities, and in time of care and sorrow, will keep a fountain of joy alive in you.",
+        "author": "Dietrich Bonhoeffer"
+      },
+      {
+        "text": "Music is an outburst of the soul.",
+        "author": "Frederick Delius"
+      },
+      {
+        "text": "My personal hobbies are reading, listening to music, and silence.",
+        "author": "Edith Sitwell"
+      },
+      {
+        "text": "Music is the great uniter. An incredible force. Something that people who differ on everything and anything else can have in common.",
+        "author": "Sarah Dessen"
+      }
     ]
   },
   {
     "id": "travel",
     "label": "Travel",
     "quotes": [
-      "The world is a book, and those who do not travel read only a page. — Unknown",
-      "Take only memories, leave only footprints. — Unknown",
-      "Travel makes one modest. You see what a tiny place you occupy in the world. — Gustave Flaubert",
-      "Not all those who wander are lost. — J. R. R. Tolkien",
-      "Every man dies, but not every man really lives. — William Wallace",
-      "To live is the rarest thing in the world. Most people exist, that is all. — Oscar Wilde",
-      "Life is a journey. Make the most of it. — Unknown",
-      "I’ve traveled every road in this here land… I’ve been everywhere, man, I’ve been everywhere. — Johnny Cash",
-      "Paris is always a good idea. — Audrey Hepburn",
-      "Travel is the only thing you buy that makes you richer. — Unknown",
-      "Collect moments, not things. — Unknown",
-      "Today is your day, your mountain is waiting. So get on your way. — Dr Seuss",
-      "Twenty years from now you will be more disappointed by the things you didn’t do than by the things you did do. So throw off the bowlines. Catch the trade winds in your sails. Explore. Dream. Discover. — Unknown",
-      "I’m shaking the dust of this crummy little town off my feet and I’m gonna see the world. — George Bailey in It’s A Wonderful Life",
-      "It’s a dangerous business, Frodo, going out your door. You step onto the road, and if you don’t keep your feet, there’s no knowing where you might be swept off to. — J. R. R. Tolkien",
-      "Nature is not a place to visit. It is home. — Gary Snyder",
-      "Though we travel the world over to find the beautiful, we must carry it with us or we find it not. — Ralph Waldo Emerson",
-      "The journey of a thousand miles begins with a single step. — Lao Tzu",
-      "In every walk with nature one receives far more than he seeks. — John Muir",
-      "The mountains are calling and I must go. — John Muir",
-      "Climb the mountains and get their good tidings. Nature’s peace will flow into you as sunshine flows into trees. The winds will blow their own freshness into you, and the storms their energy, while cares will drop off like autumn leaves. — John Muir",
-      "“Life is either a daring adventure or nothing at all” – Helen Keller",
-      "“I am not the same, having seen the moon shine on the other side of the world.” – Mary Anne Radmacher",
-      "“Don’t tell me how educated you are, tell me how much you have travelled.” – Mohammed",
-      "“Travel is fatal to prejudice, bigotry, and narrow-mindedness.” –Mark Twain",
-      "“Surely, of all the wonders of the world, the horizon is the greatest.” – Freya Stark",
-      "“Travel isn’t always pretty. It isn’t always comfortable. Sometimes it hurts, it even breaks your heart. But that’s okay. The journey changes you; it should change you. It leaves marks on your memory, on your consciousness, on your heart, and on your body. You take something with you. Hopefully, you leave something good behind.” – Anthony Bourdain",
-      "“A good traveler has no fixed plans, and is not intent on arriving.” – Lao Tzu",
-      "“There are no foreign lands. It is the traveler only who is foreign” – Robert Louis Stevenson",
-      "“The world is a book, and those who do not travel read only one page.” –Saint Augustine",
-      "“Life is meant for good friends and great adventures” – Anonymous",
-      "“I haven’t been everywhere, but it’s on my list.” –Susan Sontag",
-      "“Two roads diverged in a wood, and I – I took the one less traveled by” — Robert Frost",
-      "“Once a year, go somewhere you have never been before.” –Dalai Lama",
-      "“A journey is best measured in friends, rather than miles.” –Tim Cahill",
-      "“Wherever you go becomes a part of you somehow.” – Anita Desai",
-      "“Don’t listen to what they say. Go see.”-Anonymous",
-      "“Take only memories, leave only footprints.” – Chief Seattle",
-      "“Collect Moment, Not Things.”-Anonymous",
-      "“Blessed are the curious for they shall have adventures.” – Lovelle Drachman",
-      "“We wander for distraction, but we travel for fulfilment.” — Hilaire Belloc",
-      "“For my part, I travel not to go anywhere, but to go. I travel for travel’s sake. The great affair is to move.” – Robert Louis Stevenson",
-      "“I’m in love with cities I’ve never been to and people I’ve never met.” ― Melody Truong",
-      "“This wasn’t a strange place; it was a new one.” – Paulo Coelho",
-      "“If we were meant to stay in one place, we’d have roots instead of feet” – Rachel Wolchin",
-      "“Once the travel bug bites there is no known antidote, and I know that I shall be happily infected until the end of my life.” – Michael Palin",
-      "“We travel for romance, we travel for architecture, and we travel to be lost.” – Ray Bradbury",
-      "“Twenty years from now you will be more disappointed by the things you didn’t do than by the ones you did.” ― Mark Twain",
-      "“People don’t take trips, trips take people.” – John Steinbeck",
-      "“Travel is never a matter of money but of courage.” – Paulo Coelho"
+      {
+        "text": "The world is a book, and those who do not travel read only a page.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Take only memories, leave only footprints.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Travel makes one modest. You see what a tiny place you occupy in the world.",
+        "author": "Gustave Flaubert"
+      },
+      {
+        "text": "Not all those who wander are lost.",
+        "author": "J. R. R. Tolkien"
+      },
+      {
+        "text": "Every man dies, but not every man really lives.",
+        "author": "William Wallace"
+      },
+      {
+        "text": "To live is the rarest thing in the world. Most people exist, that is all.",
+        "author": "Oscar Wilde"
+      },
+      {
+        "text": "Life is a journey. Make the most of it.",
+        "author": "Unknown"
+      },
+      {
+        "text": "I’ve traveled every road in this here land… I’ve been everywhere, man, I’ve been everywhere.",
+        "author": "Johnny Cash"
+      },
+      {
+        "text": "Paris is always a good idea.",
+        "author": "Audrey Hepburn"
+      },
+      {
+        "text": "Travel is the only thing you buy that makes you richer.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Collect moments, not things.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Today is your day, your mountain is waiting. So get on your way.",
+        "author": "Dr Seuss"
+      },
+      {
+        "text": "Twenty years from now you will be more disappointed by the things you didn’t do than by the things you did do. So throw off the bowlines. Catch the trade winds in your sails. Explore. Dream. Discover.",
+        "author": "Unknown"
+      },
+      {
+        "text": "I’m shaking the dust of this crummy little town off my feet and I’m gonna see the world.",
+        "author": "George Bailey in It’s A Wonderful Life"
+      },
+      {
+        "text": "It’s a dangerous business, Frodo, going out your door. You step onto the road, and if you don’t keep your feet, there’s no knowing where you might be swept off to.",
+        "author": "J. R. R. Tolkien"
+      },
+      {
+        "text": "Nature is not a place to visit. It is home.",
+        "author": "Gary Snyder"
+      },
+      {
+        "text": "Though we travel the world over to find the beautiful, we must carry it with us or we find it not.",
+        "author": "Ralph Waldo Emerson"
+      },
+      {
+        "text": "The journey of a thousand miles begins with a single step.",
+        "author": "Lao Tzu"
+      },
+      {
+        "text": "In every walk with nature one receives far more than he seeks.",
+        "author": "John Muir"
+      },
+      {
+        "text": "The mountains are calling and I must go.",
+        "author": "John Muir"
+      },
+      {
+        "text": "Climb the mountains and get their good tidings. Nature’s peace will flow into you as sunshine flows into trees. The winds will blow their own freshness into you, and the storms their energy, while cares will drop off like autumn leaves.",
+        "author": "John Muir"
+      },
+      {
+        "text": "Life is either a daring adventure or nothing at all",
+        "author": "Helen Keller"
+      },
+      {
+        "text": "I am not the same, having seen the moon shine on the other side of the world.",
+        "author": "Mary Anne Radmacher"
+      },
+      {
+        "text": "Don’t tell me how educated you are, tell me how much you have travelled.",
+        "author": "Mohammed"
+      },
+      {
+        "text": "Travel is fatal to prejudice, bigotry, and narrow-mindedness.",
+        "author": "Mark Twain"
+      },
+      {
+        "text": "Surely, of all the wonders of the world, the horizon is the greatest.",
+        "author": "Freya Stark"
+      },
+      {
+        "text": "Travel isn’t always pretty. It isn’t always comfortable. Sometimes it hurts, it even breaks your heart. But that’s okay. The journey changes you; it should change you. It leaves marks on your memory, on your consciousness, on your heart, and on your body. You take something with you. Hopefully, you leave something good behind.",
+        "author": "Anthony Bourdain"
+      },
+      {
+        "text": "A good traveler has no fixed plans, and is not intent on arriving.",
+        "author": "Lao Tzu"
+      },
+      {
+        "text": "There are no foreign lands. It is the traveler only who is foreign",
+        "author": "Robert Louis Stevenson"
+      },
+      {
+        "text": "The world is a book, and those who do not travel read only one page.",
+        "author": "Saint Augustine"
+      },
+      {
+        "text": "Life is meant for good friends and great adventures",
+        "author": "Anonymous"
+      },
+      {
+        "text": "I haven’t been everywhere, but it’s on my list.",
+        "author": "Susan Sontag"
+      },
+      {
+        "text": "Two roads diverged in a wood, and I – I took the one less traveled by",
+        "author": "Robert Frost"
+      },
+      {
+        "text": "Once a year, go somewhere you have never been before.",
+        "author": "Dalai Lama"
+      },
+      {
+        "text": "A journey is best measured in friends, rather than miles.",
+        "author": "Tim Cahill"
+      },
+      {
+        "text": "Wherever you go becomes a part of you somehow.",
+        "author": "Anita Desai"
+      },
+      {
+        "text": "Don’t listen to what they say. Go see.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "Take only memories, leave only footprints.",
+        "author": "Chief Seattle"
+      },
+      {
+        "text": "Collect Moment, Not Things.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "Blessed are the curious for they shall have adventures.",
+        "author": "Lovelle Drachman"
+      },
+      {
+        "text": "We wander for distraction, but we travel for fulfilment.",
+        "author": "Hilaire Belloc"
+      },
+      {
+        "text": "For my part, I travel not to go anywhere, but to go. I travel for travel’s sake. The great affair is to move.",
+        "author": "Robert Louis Stevenson"
+      },
+      {
+        "text": "I’m in love with cities I’ve never been to and people I’ve never met.",
+        "author": "Melody Truong"
+      },
+      {
+        "text": "This wasn’t a strange place; it was a new one.",
+        "author": "Paulo Coelho"
+      },
+      {
+        "text": "If we were meant to stay in one place, we’d have roots instead of feet",
+        "author": "Rachel Wolchin"
+      },
+      {
+        "text": "Once the travel bug bites there is no known antidote, and I know that I shall be happily infected until the end of my life.",
+        "author": "Michael Palin"
+      },
+      {
+        "text": "We travel for romance, we travel for architecture, and we travel to be lost.",
+        "author": "Ray Bradbury"
+      },
+      {
+        "text": "Twenty years from now you will be more disappointed by the things you didn’t do than by the ones you did.",
+        "author": "Mark Twain"
+      },
+      {
+        "text": "People don’t take trips, trips take people.",
+        "author": "John Steinbeck"
+      },
+      {
+        "text": "Travel is never a matter of money but of courage.",
+        "author": "Paulo Coelho"
+      }
     ]
   },
   {
     "id": "humor",
     "label": "Humor",
     "quotes": [
-      "I’m sick of following my dreams, man. I’m just going to ask where they’re going and hook up with’em later. -Mitch Hedberg",
-      "A pessimist is a person who has had to listen to too many optimists. -Don Marquis",
-      "“Whoever established the high road and how high it should be should be fired.” — Sandra Bullock",
-      "“Keep calm and carry a wand.” — A. W. Jantha, “Hocus Pocus & The All New Sequel”",
-      "“Have you ever noticed that anybody driving slower than you is an idiot, and anyone going faster than you is a maniac?” — George Carlin",
-      "“If I’m not back in five minutes, just wait longer.” — Ace Ventura, “Ace Ventura: Pet Detective”",
-      "“The suspense is terrible. I hope it’ll last.” — Willy Wonka, “Willy Wonka & the Chocolate Factory”",
-      "“Why do they call it rush hour when nothing moves?” — Robin Williams",
-      "“Don’t be so humble — you are not that great.” ― Golda Meir",
-      "“If you can’t be kind, at least be vague.” ― Judith Martin",
-      "“There is only one thing in the world worse than being talked about, and that is not being talked about.” ― Oscar Wilde, “The Picture of Dorian Gray”",
-      "“Always forgive your enemies; nothing annoys them so much.” ― Oscar Wilde",
-      "“In real life, I assure you, there is no such thing as algebra.” — Fran Lebowitz",
-      "“Instant gratification takes too long.” ― Carrie Fisher",
-      "“Accept who you are. Unless you’re a serial killer.” — Ellen DeGeneres",
-      "“Whoever said that money can’t buy happiness, simply didn’t know where to go shopping.” ― Bo Derek",
-      "“So be wise, because the world needs more wisdom, and if you cannot be wise, pretend to be someone who is wise, and then just behave like they would.” — Neil Gaiman",
-      "“I’m not good at the advice. Can I interest you in a sarcastic comment?” — Chandler Bing, “Friends”",
-      "“I’m sick of following my dreams, man. I’m just going to ask where they’re going and hook up with’em later.” ― Mitch Hedberg",
-      "“I’d love to stand here and talk with you. . . but I’m not going to.” — Phil Connors, “Groundhog Day”",
-      "“All you need is love. But a little chocolate now and then doesn’t hurt.” ― Charles M. Schulz",
-      "“People say that money is not the key to happiness, but I always figured if you have enough money, you can have a key made.” — Joan Rivers",
-      "“I’m not offended by blonde jokes because I know I’m not dumb…and I also know that I’m not blonde.” — Dolly Parton",
-      "“It is useless to try to hold a person to anything he says while he’s madly in love, drunk, or running for office.” — Shirley MacLaine",
-      "“I remember it like it was yesterday. Of course, I don’t really remember yesterday all that well.” — Dory, “Finding Dory”",
-      "“The trouble with having an open mind, of course, is that people will insist on coming along and trying to put things in it.” ― Terry Pratchett, “Diggers”",
-      "“To call you stupid would be an insult to stupid people! I’ve known sheep that could outwit you. I’ve worn dresses with higher IQs.” — Wanda, “A Fish Called Wanda\"",
-      "“Those people who think they know everything are a great annoyance to those of us who do.” ― Isaac Asimov",
-      "“The reason I talk to myself is because I’m the only one whose answers I accept.” ― George Carlin",
-      "“I’m not superstitious…but I am a little stitious.” — Michael Scott, “The Office”",
-      "“Here’s something to think about: How come you never see a headline like ‘Psychic Wins Lottery’?” — Jay Leno",
-      "“I’m sure wherever my Dad is, he’s looking down on us. He’s not dead, just very condescending.” — Jack Whitehall",
-      "“Before you marry a person, you should first make them use a computer with slow Internet to see who they really are.” — Will Ferrell",
-      "“I’d like to have a kid, but I’m not sure I’m ready to spend 10 years of my life constantly asking someone where his shoes are.” — Damien Fahey",
-      "“I want my children to have all the things I couldn’t afford. Then I want to move in with them.” — Phyllis Diller",
-      "“My husband and I fell in love at first sight. Maybe I should have taken a second look.” — Halley Reed, “Crimes and Misdemeanors”",
-      "“When my kids become wild and unruly, I use a nice, safe playpen. When they’re finished, I climb out.” ― Erma Bombeck",
-      "“When I was a kid my parents moved a lot, but I always found them.” ― Rodney Dangerfield",
-      "“As I learned from growing up, you don’t mess with your grandmother.” — Prince William",
-      "“I’m not insane. My mother had me tested.” — Sheldon Cooper, “The Big Bang Theory”",
-      "“I love being married. It’s so great to find that one special person you want to annoy for the rest of your life.” — Rita Rudner",
-      "“Good parenting means investing in your child’s future, which is why I am saving to buy mine a hoverboard someday.” — Lin - Manuel Miranda",
-      "“Everybody knows how to raise children, except the people who have them.” ― P. J. O’Rourke",
-      "“When your children are teenagers, it’s important to have a dog so that someone in the house is happy to see you.” — Nora Ephron",
-      "“You can kid the world, but not your sister.” ― Charlotte Gray",
-      "“I generally avoid temptation unless I can’t resist it.” ― Mae West",
-      "“There is no such thing as fun for the whole family.” — Jerry Seinfeld",
-      "“If you cannot get rid of the family skeleton, you may as well make it dance.” ― George Bernard Shaw, “Immaturity”",
-      "“Love is blind but marriage is a real eye-opener.” — Pauline Thomason",
-      "“Happiness is having a large, loving, caring, close-knit family in another city.” — George Burns"
+      {
+        "text": "I’m sick of following my dreams, man. I’m just going to ask where they’re going and hook up with’em later.",
+        "author": "Mitch Hedberg"
+      },
+      {
+        "text": "A pessimist is a person who has had to listen to too many optimists.",
+        "author": "Don Marquis"
+      },
+      {
+        "text": "Whoever established the high road and how high it should be should be fired.",
+        "author": "Sandra Bullock"
+      },
+      {
+        "text": "Keep calm and carry a wand.",
+        "author": "A. W. Jantha, “Hocus Pocus & The All New Sequel"
+      },
+      {
+        "text": "Have you ever noticed that anybody driving slower than you is an idiot, and anyone going faster than you is a maniac?",
+        "author": "George Carlin"
+      },
+      {
+        "text": "If I’m not back in five minutes, just wait longer.",
+        "author": "Ace Ventura, “Ace Ventura: Pet Detective"
+      },
+      {
+        "text": "The suspense is terrible. I hope it’ll last.",
+        "author": "Willy Wonka, “Willy Wonka & the Chocolate Factory"
+      },
+      {
+        "text": "Why do they call it rush hour when nothing moves?",
+        "author": "Robin Williams"
+      },
+      {
+        "text": "Don’t be so humble — you are not that great.",
+        "author": "Golda Meir"
+      },
+      {
+        "text": "If you can’t be kind, at least be vague.",
+        "author": "Judith Martin"
+      },
+      {
+        "text": "There is only one thing in the world worse than being talked about, and that is not being talked about.",
+        "author": "Oscar Wilde, “The Picture of Dorian Gray"
+      },
+      {
+        "text": "Always forgive your enemies; nothing annoys them so much.",
+        "author": "Oscar Wilde"
+      },
+      {
+        "text": "In real life, I assure you, there is no such thing as algebra.",
+        "author": "Fran Lebowitz"
+      },
+      {
+        "text": "Instant gratification takes too long.",
+        "author": "Carrie Fisher"
+      },
+      {
+        "text": "Accept who you are. Unless you’re a serial killer.",
+        "author": "Ellen DeGeneres"
+      },
+      {
+        "text": "Whoever said that money can’t buy happiness, simply didn’t know where to go shopping.",
+        "author": "Bo Derek"
+      },
+      {
+        "text": "So be wise, because the world needs more wisdom, and if you cannot be wise, pretend to be someone who is wise, and then just behave like they would.",
+        "author": "Neil Gaiman"
+      },
+      {
+        "text": "I’m not good at the advice. Can I interest you in a sarcastic comment?",
+        "author": "Chandler Bing, “Friends"
+      },
+      {
+        "text": "I’m sick of following my dreams, man. I’m just going to ask where they’re going and hook up with’em later.",
+        "author": "Mitch Hedberg"
+      },
+      {
+        "text": "I’d love to stand here and talk with you. . . but I’m not going to.",
+        "author": "Phil Connors, “Groundhog Day"
+      },
+      {
+        "text": "All you need is love. But a little chocolate now and then doesn’t hurt.",
+        "author": "Charles M. Schulz"
+      },
+      {
+        "text": "People say that money is not the key to happiness, but I always figured if you have enough money, you can have a key made.",
+        "author": "Joan Rivers"
+      },
+      {
+        "text": "I’m not offended by blonde jokes because I know I’m not dumb…and I also know that I’m not blonde.",
+        "author": "Dolly Parton"
+      },
+      {
+        "text": "It is useless to try to hold a person to anything he says while he’s madly in love, drunk, or running for office.",
+        "author": "Shirley MacLaine"
+      },
+      {
+        "text": "I remember it like it was yesterday. Of course, I don’t really remember yesterday all that well.",
+        "author": "Dory, “Finding Dory"
+      },
+      {
+        "text": "The trouble with having an open mind, of course, is that people will insist on coming along and trying to put things in it.",
+        "author": "Terry Pratchett, “Diggers"
+      },
+      {
+        "text": "To call you stupid would be an insult to stupid people! I’ve known sheep that could outwit you. I’ve worn dresses with higher IQs.",
+        "author": "Wanda, “A Fish Called Wanda"
+      },
+      {
+        "text": "Those people who think they know everything are a great annoyance to those of us who do.",
+        "author": "Isaac Asimov"
+      },
+      {
+        "text": "The reason I talk to myself is because I’m the only one whose answers I accept.",
+        "author": "George Carlin"
+      },
+      {
+        "text": "I’m not superstitious…but I am a little stitious.",
+        "author": "Michael Scott, “The Office"
+      },
+      {
+        "text": "Here’s something to think about: How come you never see a headline like ‘Psychic Wins Lottery’?",
+        "author": "Jay Leno"
+      },
+      {
+        "text": "I’m sure wherever my Dad is, he’s looking down on us. He’s not dead, just very condescending.",
+        "author": "Jack Whitehall"
+      },
+      {
+        "text": "Before you marry a person, you should first make them use a computer with slow Internet to see who they really are.",
+        "author": "Will Ferrell"
+      },
+      {
+        "text": "I’d like to have a kid, but I’m not sure I’m ready to spend 10 years of my life constantly asking someone where his shoes are.",
+        "author": "Damien Fahey"
+      },
+      {
+        "text": "I want my children to have all the things I couldn’t afford. Then I want to move in with them.",
+        "author": "Phyllis Diller"
+      },
+      {
+        "text": "My husband and I fell in love at first sight. Maybe I should have taken a second look.",
+        "author": "Halley Reed, “Crimes and Misdemeanors"
+      },
+      {
+        "text": "When my kids become wild and unruly, I use a nice, safe playpen. When they’re finished, I climb out.",
+        "author": "Erma Bombeck"
+      },
+      {
+        "text": "When I was a kid my parents moved a lot, but I always found them.",
+        "author": "Rodney Dangerfield"
+      },
+      {
+        "text": "As I learned from growing up, you don’t mess with your grandmother.",
+        "author": "Prince William"
+      },
+      {
+        "text": "I’m not insane. My mother had me tested.",
+        "author": "Sheldon Cooper, “The Big Bang Theory"
+      },
+      {
+        "text": "I love being married. It’s so great to find that one special person you want to annoy for the rest of your life.",
+        "author": "Rita Rudner"
+      },
+      {
+        "text": "Good parenting means investing in your child’s future, which is why I am saving to buy mine a hoverboard someday.” — Lin",
+        "author": "Manuel Miranda"
+      },
+      {
+        "text": "Everybody knows how to raise children, except the people who have them.",
+        "author": "P. J. O’Rourke"
+      },
+      {
+        "text": "When your children are teenagers, it’s important to have a dog so that someone in the house is happy to see you.",
+        "author": "Nora Ephron"
+      },
+      {
+        "text": "You can kid the world, but not your sister.",
+        "author": "Charlotte Gray"
+      },
+      {
+        "text": "I generally avoid temptation unless I can’t resist it.",
+        "author": "Mae West"
+      },
+      {
+        "text": "There is no such thing as fun for the whole family.",
+        "author": "Jerry Seinfeld"
+      },
+      {
+        "text": "If you cannot get rid of the family skeleton, you may as well make it dance.",
+        "author": "George Bernard Shaw, “Immaturity"
+      },
+      {
+        "text": "Love is blind but marriage is a real eye-opener.",
+        "author": "Pauline Thomason"
+      },
+      {
+        "text": "Happiness is having a large, loving, caring, close-knit family in another city.",
+        "author": "George Burns"
+      }
     ]
   },
   {
     "id": "money",
     "label": "Money",
     "quotes": [
-      "“Money without financial intelligence is money soon gone.” – Robert Kiyosaki",
-      "“Money is the harvest of our production.” – Earl Nightingale",
-      "“Successful people make money. It’s not that people who make money become successful, but that successful people attract money. They bring success to what they do.” – Wayne Dyer",
-      "“Too many people spend money they earned to buy things they don’t want, to impress people they don’t like.” – Will Rogers",
-      "“Save money, and money will save you.” – Anonymous",
-      "Never spend your money before you have earned it.” – Thomas Jefferson",
-      "“If you don’t find a way to make money while you sleep, you will work until the day you die.” – Warren Buffett",
-      "“Having money isn’t everything, not having it, is.” – Kanye West",
-      "“A penny saved is a penny earned” – Benjamin Franlkin",
-      "“When money realizes that it is in good hands, it wants to stay and multiply in those hands.” – Idowu Koyenikan",
-      "“Money is a tool. Used properly it makes something beautiful; used wrong, it makes a mess.” – Bradley Vinson",
-      "“You can be young without money, but you can’t be old without it.” – Tennessee Williams",
-      "“Money is a great servant but a bad master.” – Francis Bacon",
-      "“The man who does more than he is paid for will soon be paid for more than he does.” – Napoleon Hill",
-      "“It is a kind of spiritual snobbery that makes people think they can be happy without money.” – Albert Camus",
-      "“There is no shortage of money in this world. Start hustling.” – Grant Cardone",
-      "“Money isn’t everything…but it ranks right up there with oxygen.” – Rita Davenport",
-      "“The man who damns money has obtained it dishonorably; the man who respects it has earned it.” – Ayn Rand",
-      "“Work like you don’t need the money. Dance like no one is watching. And love like you’ve never been hurt.” – Mark Twain",
-      "“The first rule is not to lose money. The second rule is not to forget the first rule.” – Warren Buffett",
-      "“Money looks better in the bank than on your feet.” – Sophia Amorus",
-      "“Not he who has much is rich, but he who gives much.” – Erich Fromm",
-      "“That man is richest whose pleasures are cheapest.” – Henry David Thoreau",
-      "“The money you have gives you freedom; the money you pursue enslaves you.” – Jean-Jacques Rousseau",
-      "“Wealth is the ability to fully experience life.” – Henry David Thoreau",
-      "“I will tell you how to become rich. Close the doors. Be fearful when others are greedy. Be greedy when others are fearful.” – Warren Buffett",
-      "“The key to making money is to stay invested.” – Suze Orman",
-      "“If you cannot control your emotions, you cannot control your money.” – Warren Buffett",
-      "“Money is good for nothing unless you know the value of it by experience.” – P. T Barnum",
-      "“Sloth and prosperity can never be companions.” – James Allen",
-      "“If you would know the value of money, go and try to borrow some; for he that goes a borrowing, goes a sorrowing.” – Benjamin Franklin",
-      "“Tell me how you use your spare time, and how you spend your money, and I will tell you where and what you will be in ten years from now.” – Napoleon Hill",
-      "“Through positive, appreciative attitudes toward money, you can make money your servant, instead of becoming its slave. You should master money rather than be enslaved by it.” – Catherine Ponder",
-      "“Rich people have their money work hard for them. Poor people work hard for their money.” – T. Harv Eker",
-      "“The single biggest financial mistake I’ve made was not thinking big enough. I encourage you to go for more than a million. There is no shortage of money on this planet, only a shortage of people thinking big enough.” – Grant Cardone",
-      "“Happiness is not in the mere possession of money; it lies in the joy of achievement, in the thrill of creative effort.” – Franklin D. Roosevelt",
-      "“Money is not an end in itself. It is merely a tool to help us achieve some particular goal. If the way we handle our money conflicts with our personal values, we are not going to wind up living happy and fulfilled lives.” – David Bach",
-      "“You don’t have time an money because you don’t invest time and money.” – Grant Cardone",
-      "“Most people fail to realize that in life, it’s not how much money you make. It’s how much money you keep.” – Robert Kiyosaki",
-      "“In the United States, where we have more land than people, it is not at all difficult for persons in good health to make money.” – P. T. Barnum",
-      "“The philosophy of the rich and the poor is this: the rich invest their money and spend what is left. The poor spend their money and invest what is left.” – Robert Kiyosaki",
-      "“Money is plentiful for those who understand the simple laws which govern it’s acquisitions.” – George S. Clason",
-      "“While money can’t buy happiness, it certainly lets you choose your own form of misery.” – Groucho Marx",
-      "“Money is really only important if you don’t have any.” – Harrison Ford",
-      "“One penny may seem to you a very insignificant thing, but it is the small seed from which fortunes spring.” – Orison Swett Marden",
-      "“The better you feel about money, the more money you magnetize to yourself.” – Rhonda Byrne",
-      "“The fastest way to double your money is to fold them in half and put them in your pocket.” – Andrew Carnegie",
-      "“Money is usually attracted, no pursued.” – Jim Rohn",
-      "“Money may not buy happiness, but I’d rather cry in a Jaguar than on a bus.” – Françoise Sagan"
+      {
+        "text": "Money without financial intelligence is money soon gone.",
+        "author": "Robert Kiyosaki"
+      },
+      {
+        "text": "Money is the harvest of our production.",
+        "author": "Earl Nightingale"
+      },
+      {
+        "text": "Successful people make money. It’s not that people who make money become successful, but that successful people attract money. They bring success to what they do.",
+        "author": "Wayne Dyer"
+      },
+      {
+        "text": "Too many people spend money they earned to buy things they don’t want, to impress people they don’t like.",
+        "author": "Will Rogers"
+      },
+      {
+        "text": "Save money, and money will save you.",
+        "author": "Anonymous"
+      },
+      {
+        "text": "Never spend your money before you have earned it.",
+        "author": "Thomas Jefferson"
+      },
+      {
+        "text": "If you don’t find a way to make money while you sleep, you will work until the day you die.",
+        "author": "Warren Buffett"
+      },
+      {
+        "text": "Having money isn’t everything, not having it, is.",
+        "author": "Kanye West"
+      },
+      {
+        "text": "A penny saved is a penny earned",
+        "author": "Benjamin Franlkin"
+      },
+      {
+        "text": "When money realizes that it is in good hands, it wants to stay and multiply in those hands.",
+        "author": "Idowu Koyenikan"
+      },
+      {
+        "text": "Money is a tool. Used properly it makes something beautiful; used wrong, it makes a mess.",
+        "author": "Bradley Vinson"
+      },
+      {
+        "text": "You can be young without money, but you can’t be old without it.",
+        "author": "Tennessee Williams"
+      },
+      {
+        "text": "Money is a great servant but a bad master.",
+        "author": "Francis Bacon"
+      },
+      {
+        "text": "The man who does more than he is paid for will soon be paid for more than he does.",
+        "author": "Napoleon Hill"
+      },
+      {
+        "text": "It is a kind of spiritual snobbery that makes people think they can be happy without money.",
+        "author": "Albert Camus"
+      },
+      {
+        "text": "There is no shortage of money in this world. Start hustling.",
+        "author": "Grant Cardone"
+      },
+      {
+        "text": "Money isn’t everything…but it ranks right up there with oxygen.",
+        "author": "Rita Davenport"
+      },
+      {
+        "text": "The man who damns money has obtained it dishonorably; the man who respects it has earned it.",
+        "author": "Ayn Rand"
+      },
+      {
+        "text": "Work like you don’t need the money. Dance like no one is watching. And love like you’ve never been hurt.",
+        "author": "Mark Twain"
+      },
+      {
+        "text": "The first rule is not to lose money. The second rule is not to forget the first rule.",
+        "author": "Warren Buffett"
+      },
+      {
+        "text": "Money looks better in the bank than on your feet.",
+        "author": "Sophia Amorus"
+      },
+      {
+        "text": "Not he who has much is rich, but he who gives much.",
+        "author": "Erich Fromm"
+      },
+      {
+        "text": "That man is richest whose pleasures are cheapest.",
+        "author": "Henry David Thoreau"
+      },
+      {
+        "text": "The money you have gives you freedom; the money you pursue enslaves you.",
+        "author": "Jean-Jacques Rousseau"
+      },
+      {
+        "text": "Wealth is the ability to fully experience life.",
+        "author": "Henry David Thoreau"
+      },
+      {
+        "text": "I will tell you how to become rich. Close the doors. Be fearful when others are greedy. Be greedy when others are fearful.",
+        "author": "Warren Buffett"
+      },
+      {
+        "text": "The key to making money is to stay invested.",
+        "author": "Suze Orman"
+      },
+      {
+        "text": "If you cannot control your emotions, you cannot control your money.",
+        "author": "Warren Buffett"
+      },
+      {
+        "text": "Money is good for nothing unless you know the value of it by experience.",
+        "author": "P. T Barnum"
+      },
+      {
+        "text": "Sloth and prosperity can never be companions.",
+        "author": "James Allen"
+      },
+      {
+        "text": "If you would know the value of money, go and try to borrow some; for he that goes a borrowing, goes a sorrowing.",
+        "author": "Benjamin Franklin"
+      },
+      {
+        "text": "Tell me how you use your spare time, and how you spend your money, and I will tell you where and what you will be in ten years from now.",
+        "author": "Napoleon Hill"
+      },
+      {
+        "text": "Through positive, appreciative attitudes toward money, you can make money your servant, instead of becoming its slave. You should master money rather than be enslaved by it.",
+        "author": "Catherine Ponder"
+      },
+      {
+        "text": "Rich people have their money work hard for them. Poor people work hard for their money.",
+        "author": "T. Harv Eker"
+      },
+      {
+        "text": "The single biggest financial mistake I’ve made was not thinking big enough. I encourage you to go for more than a million. There is no shortage of money on this planet, only a shortage of people thinking big enough.",
+        "author": "Grant Cardone"
+      },
+      {
+        "text": "Happiness is not in the mere possession of money; it lies in the joy of achievement, in the thrill of creative effort.",
+        "author": "Franklin D. Roosevelt"
+      },
+      {
+        "text": "Money is not an end in itself. It is merely a tool to help us achieve some particular goal. If the way we handle our money conflicts with our personal values, we are not going to wind up living happy and fulfilled lives.",
+        "author": "David Bach"
+      },
+      {
+        "text": "You don’t have time an money because you don’t invest time and money.",
+        "author": "Grant Cardone"
+      },
+      {
+        "text": "Most people fail to realize that in life, it’s not how much money you make. It’s how much money you keep.",
+        "author": "Robert Kiyosaki"
+      },
+      {
+        "text": "In the United States, where we have more land than people, it is not at all difficult for persons in good health to make money.",
+        "author": "P. T. Barnum"
+      },
+      {
+        "text": "The philosophy of the rich and the poor is this: the rich invest their money and spend what is left. The poor spend their money and invest what is left.",
+        "author": "Robert Kiyosaki"
+      },
+      {
+        "text": "Money is plentiful for those who understand the simple laws which govern it’s acquisitions.",
+        "author": "George S. Clason"
+      },
+      {
+        "text": "While money can’t buy happiness, it certainly lets you choose your own form of misery.",
+        "author": "Groucho Marx"
+      },
+      {
+        "text": "Money is really only important if you don’t have any.",
+        "author": "Harrison Ford"
+      },
+      {
+        "text": "One penny may seem to you a very insignificant thing, but it is the small seed from which fortunes spring.",
+        "author": "Orison Swett Marden"
+      },
+      {
+        "text": "The better you feel about money, the more money you magnetize to yourself.",
+        "author": "Rhonda Byrne"
+      },
+      {
+        "text": "The fastest way to double your money is to fold them in half and put them in your pocket.",
+        "author": "Andrew Carnegie"
+      },
+      {
+        "text": "Money is usually attracted, no pursued.",
+        "author": "Jim Rohn"
+      },
+      {
+        "text": "Money may not buy happiness, but I’d rather cry in a Jaguar than on a bus.",
+        "author": "Françoise Sagan"
+      }
     ]
   },
   {
     "id": "family",
     "label": "Family",
     "quotes": [
-      "“It didn’t matter how big our house was; it mattered that there was love in it.” — Peter Buffett",
-      "“Call it a clan, call it a network, call it a tribe, call it a family: Whatever you call it, whoever you are, you need one.” — Jane Howard",
-      "“Family means nobody gets left behind or forgotten.” — David Ogden Stiers",
-      "“We may have our differences, but nothing’s more important than family.” – Coco",
-      "\"The bond that links your true family is not one of blood, but of respect and joy in each other’s life.” – Richard Bach",
-      "\"A happy family is but an earlier heaven.\"- George Bernard Shaw",
-      "“Being a family means you are a part of something very wonderful. It means you will love and be loved for the rest of your life.” – Lisa Weed",
-      "“Happiness is having a large, loving, caring, close-knit family in another city.” ― George Burns",
-      "“The strength of a family, like the strength of an army, lies in its loyalty to each other.” – Mario Puzo",
-      "The most important thing in the world is family and love.” – John Wooden",
-      "“When everything goes to hell, the people who stand by you without flinching–they are your family.” – Jim Butcher",
-      "\"To us, family means putting your arms around each other and being there.\" — Barbara Bush",
-      "“In family life, love is the oil that eases friction, the cement that binds closer together, and the music that brings harmony.” – Friedrich Nietzsche",
-      "\"The other night I ate at a real nice family restaurant. Every table had an argument going.\" — George Carlin",
-      "“Family is not an important thing. It’s everything.” –Michael J. Fox",
-      "“Family faces are magic mirrors. Looking at people who belong to us, we see the past, present, and future.” – Gail Lumet Buckley",
-      "“The family is one of nature’s masterpieces.” – George Santayana",
-      "“Families are the compass that guides us. They are the inspiration to reach great heights, and our comfort when we occasionally falter.” – Brad Henry",
-      "\"You are the bows from which your children as living arrows are sent forth. ¨ — Khalil Gibran",
-      "\"So much of what is best in us is bound up in our love of family, that it remains the measure of our stability because it measures our sense of loyalty.\" — Haniel Long",
-      "\"A man should never neglect his family for business.\" — Walt Disney",
-      "“The homemaker has the ultimate career. All other careers exist for one purpose only - and that is to support the ultimate career.” ― C. S. Lewis",
-      "\"Sister is probably the most competitive relationship within the family, but once the sisters are grown, it becomes the strongest relationship.\" — Margaret Mead",
-      "“Everyone needs a house to live in, but a supportive family is what builds a home.” – Anthony Liccione",
-      "\"There is no such thing as fun for the whole family.\" — Jerry Seinfeld",
-      "“The informality of family life is a blessed condition that allows us all to become our best while looking our worst.” – Marge Kennedy",
-      "“The greatest gift of family life is to be intimately acquainted with people you might never even introduce yourself to, had life not done it for you.” — Kendall Hailey",
-      "\"I know all those words, but that sentence makes no sense to me.”― Matt Groening",
-      "“Having a place to go is a home. Having someone to love is a family. Having both is a blessing.” – Donna Hedges",
-      "“Being part of a family means smiling for photos.” –Harry Morgan",
-      "“There’s nothing that makes you more insane than family. Or more happy, or more exasperated, or more secure.” – Jim Butcher",
-      "“Family is family.” – Linda Linney",
-      "“In time of test, family is best.” – Burmese Proverb",
-      "“If the family were a boat, it would be a canoe that makes no progress unless everyone paddles.\"– Letty Cottin Pogrebin",
-      "“One day you will do things for me that you hate. That is what it means to be family.”― Jonathan Safran Foer",
-      "“I am blessed to have so many great things in my life – family, friends, and God. All will be in my thoughts daily.” –Lil’ Kim",
-      "“I have learned that to be with those I like is enough.”― Walt Whitman",
-      "“The family–that dear octopus from whose tentacles we never quite escape, nor, in our inmost hearts, ever quite wish to.” – Dodie Smith",
-      "“The family is the first essential cell of human society.” – Pope John XXIII",
-      "“Rejoice with your family in the beautiful land of life.” – Albert Einstein",
-      "“Let love be genuine. Abhor what is evil; hold fast to what is good.” –Romans 12: 9",
-      "“Sticking with your family is what makes it a family.” – Mitch Albom",
-      "“It’s all about the quality of life and finding a happy balance between work and friends and family.” – Philip Green",
-      "“If you cannot get rid of the family skeleton, you may as well make it dance.”",
-      "“Show me a family of readers, and I will show you the people who move the world.”― Napoleon Bonaparte",
-      "“Family and friendships are two of the greatest facilitators of happiness.” –John C. Maxwell",
-      "“Parents were the only ones obligated to love you; from the rest of the world you had to earn it.”― Ann Brashares",
-      "“Nothing is better than going home to family and eating good food and relaxing.” – Irina Shayk",
-      "“Family and friends are hidden treasures, seek them and enjoy their riches.” – Wanda Hope Carter",
-      "“Friends are the family you choose.”― Jess C. Scott"
+      {
+        "text": "It didn’t matter how big our house was; it mattered that there was love in it.",
+        "author": "Peter Buffett"
+      },
+      {
+        "text": "Call it a clan, call it a network, call it a tribe, call it a family: Whatever you call it, whoever you are, you need one.",
+        "author": "Jane Howard"
+      },
+      {
+        "text": "Family means nobody gets left behind or forgotten.",
+        "author": "David Ogden Stiers"
+      },
+      {
+        "text": "We may have our differences, but nothing’s more important than family.",
+        "author": "Coco"
+      },
+      {
+        "text": "The bond that links your true family is not one of blood, but of respect and joy in each other’s life.",
+        "author": "Richard Bach"
+      },
+      {
+        "text": "A happy family is but an earlier heaven.",
+        "author": "George Bernard Shaw"
+      },
+      {
+        "text": "Being a family means you are a part of something very wonderful. It means you will love and be loved for the rest of your life.",
+        "author": "Lisa Weed"
+      },
+      {
+        "text": "Happiness is having a large, loving, caring, close-knit family in another city.",
+        "author": "George Burns"
+      },
+      {
+        "text": "The strength of a family, like the strength of an army, lies in its loyalty to each other.",
+        "author": "Mario Puzo"
+      },
+      {
+        "text": "The most important thing in the world is family and love.",
+        "author": "John Wooden"
+      },
+      {
+        "text": "When everything goes to hell, the people who stand by you without flinching–they are your family.",
+        "author": "Jim Butcher"
+      },
+      {
+        "text": "To us, family means putting your arms around each other and being there.",
+        "author": "Barbara Bush"
+      },
+      {
+        "text": "In family life, love is the oil that eases friction, the cement that binds closer together, and the music that brings harmony.",
+        "author": "Friedrich Nietzsche"
+      },
+      {
+        "text": "The other night I ate at a real nice family restaurant. Every table had an argument going.",
+        "author": "George Carlin"
+      },
+      {
+        "text": "Family is not an important thing. It’s everything.",
+        "author": "Michael J. Fox"
+      },
+      {
+        "text": "Family faces are magic mirrors. Looking at people who belong to us, we see the past, present, and future.",
+        "author": "Gail Lumet Buckley"
+      },
+      {
+        "text": "The family is one of nature’s masterpieces.",
+        "author": "George Santayana"
+      },
+      {
+        "text": "Families are the compass that guides us. They are the inspiration to reach great heights, and our comfort when we occasionally falter.",
+        "author": "Brad Henry"
+      },
+      {
+        "text": "You are the bows from which your children as living arrows are sent forth.",
+        "author": "Khalil Gibran"
+      },
+      {
+        "text": "So much of what is best in us is bound up in our love of family, that it remains the measure of our stability because it measures our sense of loyalty.",
+        "author": "Haniel Long"
+      },
+      {
+        "text": "A man should never neglect his family for business.",
+        "author": "Walt Disney"
+      },
+      {
+        "text": "The homemaker has the ultimate career. All other careers exist for one purpose only - and that is to support the ultimate career.",
+        "author": "C. S. Lewis"
+      },
+      {
+        "text": "Sister is probably the most competitive relationship within the family, but once the sisters are grown, it becomes the strongest relationship.",
+        "author": "Margaret Mead"
+      },
+      {
+        "text": "Everyone needs a house to live in, but a supportive family is what builds a home.",
+        "author": "Anthony Liccione"
+      },
+      {
+        "text": "There is no such thing as fun for the whole family.",
+        "author": "Jerry Seinfeld"
+      },
+      {
+        "text": "The informality of family life is a blessed condition that allows us all to become our best while looking our worst.",
+        "author": "Marge Kennedy"
+      },
+      {
+        "text": "The greatest gift of family life is to be intimately acquainted with people you might never even introduce yourself to, had life not done it for you.",
+        "author": "Kendall Hailey"
+      },
+      {
+        "text": "I know all those words, but that sentence makes no sense to me.",
+        "author": "Matt Groening"
+      },
+      {
+        "text": "Having a place to go is a home. Having someone to love is a family. Having both is a blessing.",
+        "author": "Donna Hedges"
+      },
+      {
+        "text": "Being part of a family means smiling for photos.",
+        "author": "Harry Morgan"
+      },
+      {
+        "text": "There’s nothing that makes you more insane than family. Or more happy, or more exasperated, or more secure.",
+        "author": "Jim Butcher"
+      },
+      {
+        "text": "Family is family.",
+        "author": "Linda Linney"
+      },
+      {
+        "text": "In time of test, family is best.",
+        "author": "Burmese Proverb"
+      },
+      {
+        "text": "If the family were a boat, it would be a canoe that makes no progress unless everyone paddles.",
+        "author": "Letty Cottin Pogrebin"
+      },
+      {
+        "text": "One day you will do things for me that you hate. That is what it means to be family.",
+        "author": "Jonathan Safran Foer"
+      },
+      {
+        "text": "I am blessed to have so many great things in my life – family, friends, and God. All will be in my thoughts daily.",
+        "author": "Lil’ Kim"
+      },
+      {
+        "text": "I have learned that to be with those I like is enough.",
+        "author": "Walt Whitman"
+      },
+      {
+        "text": "The family–that dear octopus from whose tentacles we never quite escape, nor, in our inmost hearts, ever quite wish to.",
+        "author": "Dodie Smith"
+      },
+      {
+        "text": "The family is the first essential cell of human society.",
+        "author": "Pope John XXIII"
+      },
+      {
+        "text": "Rejoice with your family in the beautiful land of life.",
+        "author": "Albert Einstein"
+      },
+      {
+        "text": "Let love be genuine. Abhor what is evil; hold fast to what is good.",
+        "author": "Romans 12: 9"
+      },
+      {
+        "text": "Sticking with your family is what makes it a family.",
+        "author": "Mitch Albom"
+      },
+      {
+        "text": "It’s all about the quality of life and finding a happy balance between work and friends and family.",
+        "author": "Philip Green"
+      },
+      {
+        "text": "If you cannot get rid of the family skeleton, you may as well make it dance.",
+        "author": "George Bernard Shaw"
+      },
+      {
+        "text": "Show me a family of readers, and I will show you the people who move the world.",
+        "author": "Napoleon Bonaparte"
+      },
+      {
+        "text": "Family and friendships are two of the greatest facilitators of happiness.",
+        "author": "John C. Maxwell"
+      },
+      {
+        "text": "Parents were the only ones obligated to love you; from the rest of the world you had to earn it.",
+        "author": "Ann Brashares"
+      },
+      {
+        "text": "Nothing is better than going home to family and eating good food and relaxing.",
+        "author": "Irina Shayk"
+      },
+      {
+        "text": "Family and friends are hidden treasures, seek them and enjoy their riches.",
+        "author": "Wanda Hope Carter"
+      },
+      {
+        "text": "Friends are the family you choose.",
+        "author": "Jess C. Scott"
+      }
     ]
   },
   {
     "id": "love",
     "label": "Love",
     "quotes": [
-      "“I saw that you were perfect, and so I loved you. Then I saw that you were not perfect and I loved you even more.” — Angelita Lim",
-      "“You know you’re in love when you can’t fall asleep because reality is finally better than your dreams.” — Dr. Seuss",
-      "“Love is that condition in which the happiness of another person is essential to your own.” — Robert A. Heinlein",
-      "\"The best thing to hold onto in life is each other.\"–Audrey Hepburn",
-      "“I need you like a heart needs a beat.” –Unknown",
-      "\"I am who I am because of you. You are every reason, every hope, and every dream I’ve ever had.\" — The Notebook",
-      "“If I had a flower for every time I thought of you. . . I could walk through my garden forever.” — Alfred Tennyson",
-      "\"Take my hand, take my whole life too. For I can’t help falling in love with you.\" — Elvis Presley",
-      "“If you live to be a hundred, I want to live to be a hundred minus one day so I never have to live without you.” –A. A. Milne",
-      "\"You’re the closest to heaven, that I’ll ever be.\" — Goo Goo Dolls",
-      "\"You are the finest, loveliest, tenderest, and most beautiful person I have ever known and even that is an understatement.\" — F. Scott Fitzgerald",
-      "\"I will never stop trying. Because when you find the one. . . you never give up.\" — Crazy, Stupid, Love",
-      "\"It’s always better when we’re together.\" — Jack Johnson",
-      "“I love you for all that you are, all that you have been and all that you will be.” — Unknown",
-      "“I wasn’t expecting you. I didn’t think that we would end up together. The single most extraordinary thing I’ve ever done with my life is fall in love with you. I’ve never been seen so completely, loved so passionately and protected so fiercely.” — This Is Us",
-      "“To the world you may be one person, but to one person you are the world.” — Unknown",
-      "\"Two are better than one.\" — Ecclesiastes 4:9",
-      "“I’ve tried so many times to think of a new way to say it, and it’s still I love you.” — Zelda Fitzgerald",
-      "“When you realize you want to spend the rest of your life with somebody, you want the rest of your life to start as soon as possible.” — When Harry Met Sally",
-      "“I love you and that’s the beginning and end of everything.” — F. Scott Fitzgerald",
-      "\"If I know what love is, it is because of you.\" — Hermann Hesse",
-      "“My soul and your soul are forever tangled.” — N. R. Hart",
-      "“I love you more than I have ever found a way to say to you.” — Ben Folds",
-      "\"I have found the one whom my soul loves.\" — Song of Solomon 3:4",
-      "\"Sometimes all you need is a hug from the right person and all your stress will melt away.\" — Unknown",
-      "\"In all the world, there is no heart for me like yours. In all the world, there is no love for you like mine.\" — Maya Angelou",
-      "“If you remember me, then I don’t care if everyone else forgets.” — Haruki Murakami",
-      "\"Love is when you sit beside someone doing nothing, yet you feel perfectly happy.\" — Unknown",
-      "“You are, and always have been, my dream.”―Nicholas Sparks",
-      "”I love that you are the last person I want to talk to before I go to sleep at night.\" — When Harry Met Sally",
-      "”Love is composed of a single soul inhabiting two bodies.\" — Aristotle",
-      "“What is love? It is the morning and the evening star.” — Sinclair Lewis",
-      "“If you find someone you love in your life, then hang on to that love.” — Princess Diana",
-      "“Come near now, and kiss me.” – Genesis 27:26",
-      "”I need you like a heart needs a beat.\" — One Republic",
-      "“Our love is like the wind. I can’t see it, but I can feel it.” – A Walk to Remember",
-      "”Loving you never was an option. It was a necessity.\" — Truth Devour",
-      "“It’s always better when we’re together.” – Jack Johnson",
-      "“I would rather spend one lifetime with you, than face all the ages of this world alone.” – J. K. K. Tolken",
-      "“My love for you has no depth, its boundaries are ever-expanding.” – Christina White",
-      "“When I see your face, there’s not a thing that I would change,’cause you’re amazing – just the way you are.” – Bruno Mars",
-      "“Because of you, I can feel myself slowly, but surely, becoming the me I have always dreamed of being.” – Tyler Knott Gregson",
-      "”We loved with a love that was more than love.\" — Edgar Allen Poe",
-      "“I saw that you were perfect, and so I loved you. Then I saw that you were not perfect and I loved you even more.” – Angelita Lim",
-      "“I am my beloved’s and my beloved is mine.” – Song of Solomon 6:3",
-      "“And in her smile I see something more beautiful than the stars.” — Across the Universe",
-      "”It was love at first sight, at last sight, at ever and ever sight.\"―Vladimir Nabokov",
-      "“Love does not consist in gazing at each other, but in looking outward together in the same direction.” – Antoine de Saint-Exupery",
-      "“You’re always the first and the last thing on this heart of mine. No matter where I go, or what I do, I’m thinking of you.” – Dierks Bentley",
-      "”When I saw you I fell in love, and you smiled because you knew.\"―Arrigo Boito"
+      {
+        "text": "I saw that you were perfect, and so I loved you. Then I saw that you were not perfect and I loved you even more.",
+        "author": "Angelita Lim"
+      },
+      {
+        "text": "You know you’re in love when you can’t fall asleep because reality is finally better than your dreams.",
+        "author": "Dr. Seuss"
+      },
+      {
+        "text": "Love is that condition in which the happiness of another person is essential to your own.",
+        "author": "Robert A. Heinlein"
+      },
+      {
+        "text": "The best thing to hold onto in life is each other.",
+        "author": "Audrey Hepburn"
+      },
+      {
+        "text": "I need you like a heart needs a beat.",
+        "author": "Unknown"
+      },
+      {
+        "text": "I am who I am because of you. You are every reason, every hope, and every dream I’ve ever had.",
+        "author": "The Notebook"
+      },
+      {
+        "text": "If I had a flower for every time I thought of you. . . I could walk through my garden forever.",
+        "author": "Alfred Tennyson"
+      },
+      {
+        "text": "Take my hand, take my whole life too. For I can’t help falling in love with you.",
+        "author": "Elvis Presley"
+      },
+      {
+        "text": "If you live to be a hundred, I want to live to be a hundred minus one day so I never have to live without you.",
+        "author": "A. A. Milne"
+      },
+      {
+        "text": "You’re the closest to heaven, that I’ll ever be.",
+        "author": "Goo Goo Dolls"
+      },
+      {
+        "text": "You are the finest, loveliest, tenderest, and most beautiful person I have ever known and even that is an understatement.",
+        "author": "F. Scott Fitzgerald"
+      },
+      {
+        "text": "I will never stop trying. Because when you find the one. . . you never give up.",
+        "author": "Crazy, Stupid, Love"
+      },
+      {
+        "text": "It’s always better when we’re together.",
+        "author": "Jack Johnson"
+      },
+      {
+        "text": "I love you for all that you are, all that you have been and all that you will be.",
+        "author": "Unknown"
+      },
+      {
+        "text": "I wasn’t expecting you. I didn’t think that we would end up together. The single most extraordinary thing I’ve ever done with my life is fall in love with you. I’ve never been seen so completely, loved so passionately and protected so fiercely.",
+        "author": "This Is Us"
+      },
+      {
+        "text": "To the world you may be one person, but to one person you are the world.",
+        "author": "Unknown"
+      },
+      {
+        "text": "Two are better than one.",
+        "author": "Ecclesiastes 4:9"
+      },
+      {
+        "text": "I’ve tried so many times to think of a new way to say it, and it’s still I love you.",
+        "author": "Zelda Fitzgerald"
+      },
+      {
+        "text": "When you realize you want to spend the rest of your life with somebody, you want the rest of your life to start as soon as possible.",
+        "author": "When Harry Met Sally"
+      },
+      {
+        "text": "I love you and that’s the beginning and end of everything.",
+        "author": "F. Scott Fitzgerald"
+      },
+      {
+        "text": "If I know what love is, it is because of you.",
+        "author": "Hermann Hesse"
+      },
+      {
+        "text": "My soul and your soul are forever tangled.",
+        "author": "N. R. Hart"
+      },
+      {
+        "text": "I love you more than I have ever found a way to say to you.",
+        "author": "Ben Folds"
+      },
+      {
+        "text": "I have found the one whom my soul loves.",
+        "author": "Song of Solomon 3:4"
+      },
+      {
+        "text": "Sometimes all you need is a hug from the right person and all your stress will melt away.",
+        "author": "Unknown"
+      },
+      {
+        "text": "In all the world, there is no heart for me like yours. In all the world, there is no love for you like mine.",
+        "author": "Maya Angelou"
+      },
+      {
+        "text": "If you remember me, then I don’t care if everyone else forgets.",
+        "author": "Haruki Murakami"
+      },
+      {
+        "text": "Love is when you sit beside someone doing nothing, yet you feel perfectly happy.",
+        "author": "Unknown"
+      },
+      {
+        "text": "You are, and always have been, my dream.",
+        "author": "Nicholas Sparks"
+      },
+      {
+        "text": "I love that you are the last person I want to talk to before I go to sleep at night.",
+        "author": "When Harry Met Sally"
+      },
+      {
+        "text": "Love is composed of a single soul inhabiting two bodies.",
+        "author": "Aristotle"
+      },
+      {
+        "text": "What is love? It is the morning and the evening star.",
+        "author": "Sinclair Lewis"
+      },
+      {
+        "text": "If you find someone you love in your life, then hang on to that love.",
+        "author": "Princess Diana"
+      },
+      {
+        "text": "Come near now, and kiss me.",
+        "author": "Genesis 27:26"
+      },
+      {
+        "text": "I need you like a heart needs a beat.",
+        "author": "One Republic"
+      },
+      {
+        "text": "Our love is like the wind. I can’t see it, but I can feel it.",
+        "author": "A Walk to Remember"
+      },
+      {
+        "text": "Loving you never was an option. It was a necessity.",
+        "author": "Truth Devour"
+      },
+      {
+        "text": "It’s always better when we’re together.",
+        "author": "Jack Johnson"
+      },
+      {
+        "text": "I would rather spend one lifetime with you, than face all the ages of this world alone.",
+        "author": "J. K. K. Tolken"
+      },
+      {
+        "text": "My love for you has no depth, its boundaries are ever-expanding.",
+        "author": "Christina White"
+      },
+      {
+        "text": "When I see your face, there’s not a thing that I would change,’cause you’re amazing – just the way you are.",
+        "author": "Bruno Mars"
+      },
+      {
+        "text": "Because of you, I can feel myself slowly, but surely, becoming the me I have always dreamed of being.",
+        "author": "Tyler Knott Gregson"
+      },
+      {
+        "text": "We loved with a love that was more than love.",
+        "author": "Edgar Allen Poe"
+      },
+      {
+        "text": "I saw that you were perfect, and so I loved you. Then I saw that you were not perfect and I loved you even more.",
+        "author": "Angelita Lim"
+      },
+      {
+        "text": "I am my beloved’s and my beloved is mine.",
+        "author": "Song of Solomon 6:3"
+      },
+      {
+        "text": "And in her smile I see something more beautiful than the stars.",
+        "author": "Across the Universe"
+      },
+      {
+        "text": "It was love at first sight, at last sight, at ever and ever sight.",
+        "author": "Vladimir Nabokov"
+      },
+      {
+        "text": "Love does not consist in gazing at each other, but in looking outward together in the same direction.",
+        "author": "Antoine de Saint-Exupery"
+      },
+      {
+        "text": "You’re always the first and the last thing on this heart of mine. No matter where I go, or what I do, I’m thinking of you.",
+        "author": "Dierks Bentley"
+      },
+      {
+        "text": "When I saw you I fell in love, and you smiled because you knew.",
+        "author": "Arrigo Boito"
+      }
     ]
   },
   {
     "id": "positive",
     "label": "Positive",
     "quotes": [
-      "\"The only person you are destined to become is the person you decide to be.\" — Ralph Waldo Emerson",
-      "\"As we work to create light for others, we naturally light our own way.\" — Mary Anne Radmacher",
-      "\"To live is the rarest thing in the world. Most people exist, that is all.\" — Oscar Wilde",
-      "\"Keep your face to the sunshine and you cannot see a shadow.\" — Helen Keller",
-      "\"When the sun is shining I can do anything; no mountain is too high, no trouble too difficult to overcome.\" — Wilma Rudolph",
-      "\"Be fanatically positive and militantly optimistic. If something is not to your liking, change your liking.\" — Rick Steves",
-      "\"To be yourself in a world that is constantly trying to make you something else is the greatest accomplishment.\" — Ralph Waldo Emerson",
-      "\"We all have two lives. The second one starts when we realize we only have one.\" — Confucius",
-      "\"It is during our darkest moments that we must focus to see the light.\" — Aristotle",
-      "\"For every minute you are angry, you lose sixty seconds of happiness.\" — Ralph Waldo Emerson",
-      "\"All your dreams can come true if we have the courage to pursue them.\" — Walt Disney",
-      "\"Life is never fair, and perhaps it is a good thing for most of us that it is not.\" — Oscar Wilde",
-      "\"Be yourself; everyone else is already taken.\" — Oscar Wilde",
-      "\"You cannot change what you are, only what you do.\" — Philip Pullman",
-      "\"An unexamined life is not worth living.\" — Socrates",
-      "\"Every strike brings me closer to the next home run.\" — Babe Ruth",
-      "\"The happiness of your life depends on the quality of your thoughts.\" — Marcus Aurelius",
-      "\"Before anything else, preparation is the key to success.\" — Alexander Graham Bell",
-      "\"I dwell in possibility.\" — Emily Dickinson",
-      "\"Be happy for this moment. This moment is your life.\" — Omar Khayyam",
-      "\"The power of imagination makes us infinite.\" — John Muir",
-      "\"The next choice is the most important choice.\" — George Wells",
-      "\"Make your life matter and have fun doing it.\" — Aaron Hurst",
-      "\"Anything is possible with sunshine and a little pink.\" — Lilly Pulitzer",
-      "\"Do good and good will come to you.\" — Adam Lowy",
-      "\"You do not find the happy life. You make it.\" — Thomas S. Monson",
-      "\"The most wasted of days is one without laughter.\" — E. E. Cummings",
-      "\"You will face many defeats in life, but never let yourself be defeated.\" — Maya Angelou",
-      "\"Hope is the most exciting thing there is in life.\" — Mandy Moore",
-      "\"No act of kindness, no matter how small, is ever wasted.\" — Aesop",
-      "\"Lead from the heart, not the head.\" — Princess Diana",
-      "\"The only place where success comes before work is in the dictionary.\" — Vidal Sassoon",
-      "\"The most difficult thing is the decision to act, the rest is merely tenacity.\" — Amelia Earhart",
-      "\"The most important thing is to try and inspire people so that they can be great in whatever they want to do.\" — Kobe Bryant"
+      {
+        "text": "The only person you are destined to become is the person you decide to be.",
+        "author": "Ralph Waldo Emerson"
+      },
+      {
+        "text": "As we work to create light for others, we naturally light our own way.",
+        "author": "Mary Anne Radmacher"
+      },
+      {
+        "text": "To live is the rarest thing in the world. Most people exist, that is all.",
+        "author": "Oscar Wilde"
+      },
+      {
+        "text": "Keep your face to the sunshine and you cannot see a shadow.",
+        "author": "Helen Keller"
+      },
+      {
+        "text": "When the sun is shining I can do anything; no mountain is too high, no trouble too difficult to overcome.",
+        "author": "Wilma Rudolph"
+      },
+      {
+        "text": "Be fanatically positive and militantly optimistic. If something is not to your liking, change your liking.",
+        "author": "Rick Steves"
+      },
+      {
+        "text": "To be yourself in a world that is constantly trying to make you something else is the greatest accomplishment.",
+        "author": "Ralph Waldo Emerson"
+      },
+      {
+        "text": "We all have two lives. The second one starts when we realize we only have one.",
+        "author": "Confucius"
+      },
+      {
+        "text": "It is during our darkest moments that we must focus to see the light.",
+        "author": "Aristotle"
+      },
+      {
+        "text": "For every minute you are angry, you lose sixty seconds of happiness.",
+        "author": "Ralph Waldo Emerson"
+      },
+      {
+        "text": "All your dreams can come true if we have the courage to pursue them.",
+        "author": "Walt Disney"
+      },
+      {
+        "text": "Life is never fair, and perhaps it is a good thing for most of us that it is not.",
+        "author": "Oscar Wilde"
+      },
+      {
+        "text": "Be yourself; everyone else is already taken.",
+        "author": "Oscar Wilde"
+      },
+      {
+        "text": "You cannot change what you are, only what you do.",
+        "author": "Philip Pullman"
+      },
+      {
+        "text": "An unexamined life is not worth living.",
+        "author": "Socrates"
+      },
+      {
+        "text": "Every strike brings me closer to the next home run.",
+        "author": "Babe Ruth"
+      },
+      {
+        "text": "The happiness of your life depends on the quality of your thoughts.",
+        "author": "Marcus Aurelius"
+      },
+      {
+        "text": "Before anything else, preparation is the key to success.",
+        "author": "Alexander Graham Bell"
+      },
+      {
+        "text": "I dwell in possibility.",
+        "author": "Emily Dickinson"
+      },
+      {
+        "text": "Be happy for this moment. This moment is your life.",
+        "author": "Omar Khayyam"
+      },
+      {
+        "text": "The power of imagination makes us infinite.",
+        "author": "John Muir"
+      },
+      {
+        "text": "The next choice is the most important choice.",
+        "author": "George Wells"
+      },
+      {
+        "text": "Make your life matter and have fun doing it.",
+        "author": "Aaron Hurst"
+      },
+      {
+        "text": "Anything is possible with sunshine and a little pink.",
+        "author": "Lilly Pulitzer"
+      },
+      {
+        "text": "Do good and good will come to you.",
+        "author": "Adam Lowy"
+      },
+      {
+        "text": "You do not find the happy life. You make it.",
+        "author": "Thomas S. Monson"
+      },
+      {
+        "text": "The most wasted of days is one without laughter.",
+        "author": "E. E. Cummings"
+      },
+      {
+        "text": "You will face many defeats in life, but never let yourself be defeated.",
+        "author": "Maya Angelou"
+      },
+      {
+        "text": "Hope is the most exciting thing there is in life.",
+        "author": "Mandy Moore"
+      },
+      {
+        "text": "No act of kindness, no matter how small, is ever wasted.",
+        "author": "Aesop"
+      },
+      {
+        "text": "Lead from the heart, not the head.",
+        "author": "Princess Diana"
+      },
+      {
+        "text": "The only place where success comes before work is in the dictionary.",
+        "author": "Vidal Sassoon"
+      },
+      {
+        "text": "The most difficult thing is the decision to act, the rest is merely tenacity.",
+        "author": "Amelia Earhart"
+      },
+      {
+        "text": "The most important thing is to try and inspire people so that they can be great in whatever they want to do.",
+        "author": "Kobe Bryant"
+      }
     ]
   },
   {
     "id": "happiness",
     "label": "Happiness",
     "quotes": [
-      "“Happiness depends upon ourselves.” — Aristotle",
-      "“To be kind to all, to like many and love a few, to be needed and wanted by those we love, is certainly the nearest we can come to happiness.” — Mary Stuart",
-      "“Happiness is not something ready - made. It comes from your own actions.” — Dalai Lama",
-      "“If you want happiness for an hour— take a nap. If you want happiness for a day— go fishing. If you want happiness for a year— inherit a fortune. If you want happiness for a lifetime— help someone else.” — Chinese Proverb",
-      "“It’s a helluva start, being able to recognize what makes you happy.” — Lucille Ball",
-      "“Don’t underestimate the value of Doing Nothing, of just going along, listening to all the things you can’t hear, and not bothering.” — Winnie the Pooh",
-      "“Some cause happiness wherever they go; others whenever they go.” — Oscar Wilde",
-      "“Happiness is not in the mere possession of money; it lies in the joy of achievement, in the thrill of creative effort.” — Franklin D. Roosevelt",
-      "“It’s been my experience that you can nearly always enjoy things if you make up your mind firmly that you will.” — L. M. Montgomery",
-      "“Since you get more joy out of giving joy to others, you should put a good deal of thought into the happiness that you are able to give.” — Eleanor Roosevelt"
+      {
+        "text": "Happiness depends upon ourselves.",
+        "author": "Aristotle"
+      },
+      {
+        "text": "To be kind to all, to like many and love a few, to be needed and wanted by those we love, is certainly the nearest we can come to happiness.",
+        "author": "Mary Stuart"
+      },
+      {
+        "text": "Happiness is not something ready - made. It comes from your own actions.",
+        "author": "Dalai Lama"
+      },
+      {
+        "text": "If you want happiness for an hour— take a nap. If you want happiness for a day— go fishing. If you want happiness for a year— inherit a fortune. If you want happiness for a lifetime— help someone else.",
+        "author": "Chinese Proverb"
+      },
+      {
+        "text": "It’s a helluva start, being able to recognize what makes you happy.",
+        "author": "Lucille Ball"
+      },
+      {
+        "text": "Don’t underestimate the value of Doing Nothing, of just going along, listening to all the things you can’t hear, and not bothering.",
+        "author": "Winnie the Pooh"
+      },
+      {
+        "text": "Some cause happiness wherever they go; others whenever they go.",
+        "author": "Oscar Wilde"
+      },
+      {
+        "text": "Happiness is not in the mere possession of money; it lies in the joy of achievement, in the thrill of creative effort.",
+        "author": "Franklin D. Roosevelt"
+      },
+      {
+        "text": "It’s been my experience that you can nearly always enjoy things if you make up your mind firmly that you will.",
+        "author": "L. M. Montgomery"
+      },
+      {
+        "text": "Since you get more joy out of giving joy to others, you should put a good deal of thought into the happiness that you are able to give.",
+        "author": "Eleanor Roosevelt"
+      }
     ]
   }
 ];
-

--- a/apps/quotes/render-all.js
+++ b/apps/quotes/render-all.js
@@ -12,8 +12,12 @@
           label: entry && typeof entry.label === 'string' ? entry.label : '',
           quotes: Array.isArray(entry && entry.quotes)
             ? entry.quotes
-                .map((quote) => (typeof quote === 'string' ? quote.trim() : ''))
-                .filter((quote) => quote.length > 0)
+                .map((quote) => {
+                  const text = quote && typeof quote.text === 'string' ? quote.text.trim() : '';
+                  const author = quote && typeof quote.author === 'string' ? quote.author.trim() : '';
+                  return text && author ? { text, author } : null;
+                })
+                .filter(Boolean)
             : [],
         }))
         .filter((entry) => entry.label && entry.quotes.length > 0)
@@ -22,7 +26,8 @@
   const rows = categories.reduce((list, category) => {
     const items = category.quotes.map((quote) => ({
       category: category.label,
-      quote,
+      text: quote.text,
+      author: quote.author,
     }));
     return list.concat(items);
   }, []);
@@ -47,7 +52,7 @@
   if (!deck.length) {
     const emptyRow = document.createElement('tr');
     const emptyCell = document.createElement('td');
-    emptyCell.colSpan = 2;
+    emptyCell.colSpan = 3;
     emptyCell.textContent = 'No quotes available.';
     emptyRow.appendChild(emptyCell);
     tbody.appendChild(emptyRow);
@@ -64,10 +69,15 @@
 
     const textCell = document.createElement('td');
     textCell.className = 'text-cell';
-    textCell.textContent = entry.quote;
+    textCell.textContent = entry.text;
+
+    const authorCell = document.createElement('td');
+    authorCell.className = 'author-cell';
+    authorCell.textContent = entry.author;
 
     row.appendChild(categoryCell);
     row.appendChild(textCell);
+    row.appendChild(authorCell);
 
     fragment.appendChild(row);
   });

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
       align-items: center;
       background: var(--body-gradient);
       background-color: var(--body-base);
-      padding: clamp(24px, 5vw, 56px);
+      padding: clamp(12px, 2.5vw, 28px);
       color: var(--text-primary);
     }
 
@@ -64,7 +64,7 @@
       box-shadow: var(--surface-shadow);
       backdrop-filter: blur(14px);
       border: 1px solid var(--surface-border);
-      padding: clamp(24px, 4vw, 48px) clamp(32px, 5vw, 60px) clamp(32px, 5vw, 60px);
+      padding: clamp(12px, 2vw, 24px) clamp(16px, 2.5vw, 30px) clamp(16px, 2.5vw, 30px);
       display: flex;
       flex-direction: column;
       gap: clamp(14px, 2.5vw, 22px);
@@ -106,7 +106,7 @@
       display: flex;
       flex-direction: column;
       gap: 14px;
-      padding: 24px;
+      padding: 12px;
       border-radius: 20px;
       background: var(--card-background);
       text-decoration: none;
@@ -175,11 +175,11 @@
 
     @media (max-width: 640px) {
       main {
-        padding: clamp(24px, 8vw, 36px);
+        padding: clamp(12px, 4vw, 18px);
       }
 
       a.app-card {
-        padding: 20px;
+        padding: 10px;
       }
 
       header.site-header h1 {


### PR DESCRIPTION
## Summary
- restructure the quotes dataset so each entry stores separate quote text and author metadata, cleaning malformed records along the way
- update the quotes app scripts and layout to render the author on its own line with refined styling, and surface the author column in the full table view
- reduce landing page padding to continue tightening the home page spacing

## Testing
- node - <<'NODE' … (count quotes)


------
https://chatgpt.com/codex/tasks/task_e_68ceb06b99bc8328a6b68a9dc1426ef8