### PR TITLE
Regenerate jokes and quotes datasets

### DIFF
--- a/apps/jokes/jokes.js
+++ b/apps/jokes/jokes.js
@@ -1,5 +1,2012 @@
 window.jokes = [
         {
+            "joke": "I'm tired of following my dreams.",
+            "punchline": "I'm just going to ask them where they are going and meet up with them later."
+        }, {
+            "joke": "Did you hear about the guy whose whole left side was cut off?",
+            "punchline": "He's all right now."
+        }, {
+            "joke": "Why didn’t the skeleton cross the road?",
+            "punchline": "Because he had no guts."
+        }, {
+            "joke": "What did one nut say as he chased another nut?",
+            "punchline": "I'm a cashew!"
+        }, {
+            "joke": "Where do fish keep their money?",
+            "punchline": "In the riverbank"
+        }, {
+            "joke": "I accidentally took my cats meds last night.",
+            "punchline": "Don’t ask meow."
+        }, {
+            "joke": "Chances are if you' ve seen one shopping center",
+            "punchline": "you've seen a mall."
+        }, {
+            "joke": "Dermatologists are always in a hurry.",
+            "punchline": "They spend all day making rash decisions."
+        }, {
+            "joke": "I knew I shouldn't steal a mixer from work",
+            "punchline": "but it was a whisk I was willing to take."
+        }, {
+            "joke": "I won an argument with a weather forecaster once.",
+            "punchline": "His logic was cloudy..."
+        }, {
+            "joke": "How come the stadium got hot after the game?",
+            "punchline": "Because all of the fans left."
+        }, {
+            "joke": "\"Why do seagulls fly over the ocean?\" \"Because if they flew over the bay",
+            "punchline": "we'd call them bagels.\""
+        }, {
+            "joke": "Why was it called the dark ages?",
+            "punchline": "Because of all the knights."
+        }, {
+            "joke": "Why did the tomato blush?",
+            "punchline": "Because it saw the salad dressing."
+        }, {
+            "joke": "Did you hear the joke about the wandering nun?",
+            "punchline": "She was a roman catholic."
+        }, {
+            "joke": "What creature is smarter than a talking parrot?",
+            "punchline": "A spelling bee."
+        }, {
+            "joke": "I'll tell you what often gets over looked...",
+            "punchline": "garden fences."
+        }, {
+            "joke": "Why did the kid cross the playground?",
+            "punchline": "To get to the other slide."
+        }, {
+            "joke": "Why do birds fly south for the winter?",
+            "punchline": "Because it's too far to walk."
+        }, {
+            "joke": "What is a centipedes's favorite Beatle song?",
+            "punchline": "I want to hold your hand, hand, hand, hand..."
+        }, {
+            "joke": "My first time using an elevator was an uplifting experience.",
+            "punchline": "The second time let me down."
+        }, {
+            "joke": "To be Frank",
+            "punchline": "I'd have to change my name."
+        }, {
+            "joke": "What do you call a female snake.",
+            "punchline": "misssssssss"
+        }, {
+            "joke": "Why does a Moon-rock taste better than an Earth-rock?",
+            "punchline": "Because it's a little meteor."
+        }, {
+            "joke": "I thought my wife was joking when she said she'd leave me if I didn't stop signing \"I'm A Believer\"...",
+            "punchline": "Then I saw her face."
+        }, {
+            "joke": "I’m only familiar with 25 letters in the English language.",
+            "punchline": "I don’t know why."
+        }, {
+            "joke": "What do you call two barracuda fish?",
+            "punchline": "A Pairacuda!"
+        }, {
+            "joke": "What did the father tomato say to the baby tomato whilst on a family walk?",
+            "punchline": "Ketchup."
+        }, {
+            "joke": "Why is Peter Pan always flying?",
+            "punchline": "Because he Neverlands."
+        }, {
+            "joke": "What do you do on a remote island?",
+            "punchline": "Try and find the TV island it belongs to."
+        }, {
+            "joke": "Did you know that protons have mass?",
+            "punchline": "I didn't even know they were catholic."
+        }, {
+            "joke": "I was fired from the keyboard factory yesterday.",
+            "punchline": "I wasn't putting in enough shifts."
+        }, {
+            "joke": "Wife: Honey I’m pregnant. Me: Well…. what do we do now? Wife: Well, I guess we should go to a baby doctor. Me: Hm..",
+            "punchline": "I think I’d be a lot more comfortable going to an adult doctor."
+        }, {
+            "joke": "Have you heard the story about the magic tractor?",
+            "punchline": "It drove down the road and turned into a field."
+        }, {
+            "joke": "When will the little snake arrive?",
+            "punchline": "I don't know but he won't be long..."
+        }, {
+            "joke": "Why was Pavlov's beard so soft?",
+            "punchline": "Because he conditioned it."
+        }, {
+            "joke": "Do I enjoy making courthouse puns?",
+            "punchline": "Guilty"
+        }, {
+            "joke": "Why did the kid throw the clock out the window?",
+            "punchline": "He wanted to see time fly!"
+        }, {
+            "joke": "Hear about the new restaurant called Karma?",
+            "punchline": "There’s no menu: You get what you deserve."
+        }, {
+            "joke": "Why couldn't the kid see the pirate movie?",
+            "punchline": "Because it was rated arrr!"
+        }, {
+            "joke": "It was so cold yesterday my computer froze.",
+            "punchline": "My own fault though, I left too many windows open."
+        }, {
+            "joke": "Man, I really love my furniture...",
+            "punchline": "me and my recliner go way back."
+        }, {
+            "joke": "What did the traffic light say to the car as it passed?",
+            "punchline": "\"Don't look I'm changing!\""
+        }, {
+            "joke": "My son is studying to be a surgeon",
+            "punchline": "I just hope he makes the cut."
+        }, {
+            "joke": "Why did the man run around his bed?",
+            "punchline": "Because he was trying to catch up on his sleep!"
+        }, {
+            "joke": "What did one wall say to the other wall?",
+            "punchline": "I'll meet you at the corner!"
+        }, {
+            "joke": "Sometimes I tuck my knees into my chest and lean forward.",
+            "punchline": "That’s just how I roll."
+        }, {
+            "joke": "How many South Americans does it take to change a lightbulb?",
+            "punchline": "A Brazilian"
+        }, {
+            "joke": "I don't trust stairs.",
+            "punchline": "They're always up to something."
+        }, {
+            "joke": "What do you call two guys hanging out by your window?",
+            "punchline": "Kurt & Rod."
+        }, {
+            "joke": "Why was the robot angry?",
+            "punchline": "Because someone kept pressing his buttons!"
+        }, {
+            "joke": "Which is the fastest growing city in the world?",
+            "punchline": "Dublin'"
+        }, {
+            "joke": "A police officer caught two kids playing with a firework and a car battery.",
+            "punchline": "He charged one and let the other one off."
+        }, {
+            "joke": "What do you call a snake who builds houses?",
+            "punchline": "A boa constructor!"
+        }, {
+            "joke": "What is the difference between ignorance and apathy?",
+            "punchline": "I don't know and I don't care."
+        }, {
+            "joke": "I went to a Foo Fighters Concert once...",
+            "punchline": "It was Everlong..."
+        }, {
+            "joke": "Why did the sentence fail the driving test?",
+            "punchline": "It never came to a full stop."
+        }, {
+            "joke": "Some people eat light bulbs.",
+            "punchline": "They say it's a nice light snack."
+        }, {
+            "joke": "What's the difference between a rooster and a crow?",
+            "punchline": "A rooster can crow but a crow cannot rooster."
+        }, {
+            "joke": "I went to the store to pick up eight cans of sprite...",
+            "punchline": "when I got home I realized I'd only picked seven up"
+        }, {
+            "joke": "I cut my finger chopping cheese",
+            "punchline": "but I think that I may have grater problems."
+        }, {
+            "joke": "Yesterday, I accidentally swallowed some food coloring.",
+            "punchline": "The doctor says I’m okay, but I feel like I’ve dyed a little inside."
+        }, {
+            "joke": "When people are sad, I sometimes let them colour in my tattoos.",
+            "punchline": "Sometimes all they need is a shoulder to crayon."
+        }, {
+            "joke": "Last night me and my girlfriend watched three DVDs back to back.",
+            "punchline": "Luckily I was the one facing the TV."
+        }, {
+            "joke": "I got a reversible jacket for Christmas",
+            "punchline": "I can't wait to see how it turns out."
+        }, {
+            "joke": "What do you get when you cross a pig and a pineapple?",
+            "punchline": "A porky pine"
+        }, {
+            "joke": "What did Romans use to cut pizza before the rolling cutter was invented?",
+            "punchline": "Lil Caesars"
+        }, {
+            "joke": "Why did the banana go to the doctor?",
+            "punchline": "He was not \"peeling\" well."
+        }, {
+            "joke": "My pet mouse 'Elvis' died last night.",
+            "punchline": "He was caught in a trap.."
+        }, {
+            "joke": "Never take advice from electrons.",
+            "punchline": "They are always negative."
+        }, {
+            "joke": "Why are oranges the smartest fruit?",
+            "punchline": "Because they are made to concentrate."
+        }, {
+            "joke": "A girl once asked me what my heart desired, apparently blood",
+            "punchline": "oxygen and neural messages were all wrong answers"
+        }, {
+            "joke": "Why is it always hot in the corner of a room?",
+            "punchline": "Because a corner is 90 degrees."
+        }, {
+            "joke": "What did the beaver say to the tree?",
+            "punchline": "It's been nice gnawing you."
+        }, {
+            "joke": "How do you fix a damaged jack-o-lantern?",
+            "punchline": "You use a pumpkin patch."
+        }, {
+            "joke": "Why do cows not have toes?",
+            "punchline": "They lactose!"
+        }, {
+            "joke": "What did the late tomato say to the early tomato?",
+            "punchline": "I’ll ketch up"
+        }, {
+            "joke": "I have kleptomania, but when it gets bad",
+            "punchline": "I take something for it."
+        }, {
+            "joke": "I used to be addicted to soap",
+            "punchline": "but I'm clean now."
+        }, {
+            "joke": "When is a door not a door?",
+            "punchline": "When it's ajar."
+        }, {
+            "joke": "I made a belt out of watches once...",
+            "punchline": "It was a waist of time."
+        }, {
+            "joke": "Why did Mozart kill all his chickens?",
+            "punchline": "Because when he asked them who the best composer was, they'd all say \"Bach bach bach!\""
+        }, {
+            "joke": "This furniture store keeps emailing me",
+            "punchline": "all I wanted was one night stand!"
+        }, {
+            "joke": "How do you find Will Smith in the snow?",
+            "punchline": "Look for fresh prints."
+        }, {
+            "joke": "My sister bet me $15 that I couldn't build a car out of spaghetti.",
+            "punchline": "You should have seen the look on her face as I drove pasta."
+        }, {
+            "joke": "My boss told me to have a good day...",
+            "punchline": "so I went home."
+        }, {
+            "joke": "I just read a book about Stockholm syndrome.",
+            "punchline": "It was pretty bad at first, but by the end I liked it."
+        }, {
+            "joke": "Why do trees seem suspicious on sunny days?",
+            "punchline": "Dunno, they're just a bit shady."
+        }, {
+            "joke": "If at first you don't succeed",
+            "punchline": "sky diving is not for you!"
+        }, {
+            "joke": "I'd like to start a diet",
+            "punchline": "but I've got too much on my plate right now."
+        }, {
+            "joke": "What did the drummer name her twin daughters?",
+            "punchline": "Anna One, Anna Two..."
+        }, {
+            "joke": "What kind of music do mummy's like?",
+            "punchline": "Rap"
+        }, {
+            "joke": "I remember when I was a kid, I opened my fridge and noticed one of my vegetables were crying.",
+            "punchline": "I guess I have some emotional cabbage."
+        }, {
+            "joke": "What's large, grey, and doesn't matter?",
+            "punchline": "An irrelephant."
+        }, {
+            "joke": "A book just fell on my head.",
+            "punchline": "I only have my shelf to blame."
+        }, {
+            "joke": "What did the dog say to the two trees?",
+            "punchline": "Bark bark."
+        }, {
+            "joke": "I've got a joke about vegetables for you...",
+            "punchline": "but it's a bit corny."
+        }, {
+            "joke": "If a child refuses to sleep during nap time",
+            "punchline": "are they guilty of resisting a rest?"
+        }, {
+            "joke": "Why can't your nose be 12 inches long?",
+            "punchline": "Because then it'd be a foot!"
+        }, {
+            "joke": "Have you ever heard of a music group called Cellophane?",
+            "punchline": "They mostly wrap."
+        }, {
+            "joke": "What do you call a boy who stopped digging holes?",
+            "punchline": "Douglas."
+        }, {
+            "joke": "What did the mountain climber name his son?",
+            "punchline": "Cliff."
+        }, {
+            "joke": "Why should you never trust a pig with a secret?",
+            "punchline": "Because it's bound to squeal."
+        }, {
+            "joke": "Why are mummys scared of vacation?",
+            "punchline": "They're afraid to unwind."
+        }, {
+            "joke": "Whiteboards...",
+            "punchline": "are remarkable."
+        }, {
+            "joke": "What kind of dinosaur loves to sleep?",
+            "punchline": "A stega-snore-us."
+        }, {
+            "joke": "What has three letters and starts with gas?",
+            "punchline": "A Car."
+        }, {
+            "joke": "What’s Forest Gump’s Facebook password?",
+            "punchline": "1forest1"
+        }, {
+            "joke": "What kind of tree fits in your hand?",
+            "punchline": "A palm tree!"
+        }, {
+            "joke": "Whenever the cashier at the grocery store asks my dad if he would like the milk in a bag he replies, ‘No",
+            "punchline": "just leave it in the carton!’"
+        }, {
+            "joke": "I used to be addicted to the hokey pokey",
+            "punchline": "but I turned myself around."
+        }, {
+            "joke": "How many tickles does it take to tickle an octopus?",
+            "punchline": "Ten-tickles!"
+        }, {
+            "joke": "Me: If humans lose the ability to hear high frequency volumes as they get older, can my 4 week old son hear a dog whistle? Doctor: No, humans can never hear that high of a frequency no matter what age they are. Me: Trick question...",
+            "punchline": "dogs can't whistle."
+        }, {
+            "joke": "What musical instrument is found in the bathroom?",
+            "punchline": "A tuba toothpaste."
+        }, {
+            "joke": "I can't take my dog to the pond anymore because the ducks keep attacking him.",
+            "punchline": "That's what I get for buying a pure bread dog."
+        }, {
+            "joke": "My boss told me to attach two pieces of wood together...",
+            "punchline": "I totally nailed it!"
+        }, {
+            "joke": "What was the pumpkin’s favorite sport?",
+            "punchline": "Squash."
+        }, {
+            "joke": "What do you call corn that joins the army?",
+            "punchline": "Kernel."
+        }, {
+            "joke": "I've been trying to come up with a dad joke about momentum...",
+            "punchline": "but I just can't seem to get it going."
+        }, {
+            "joke": "Why don't skeletons ride roller coasters?",
+            "punchline": "They don't have the stomach for it."
+        }, {
+            "joke": "Is there a hole in your shoe?",
+            "punchline": "No… Then how’d you get your foot in it?"
+        }, {
+            "joke": "Every night at 11:11",
+            "punchline": "I make a wish that someone will come fix my broken clock."
+        }, {
+            "joke": "Two muffins were sitting in an oven, and the first looks over to the second, and says, “man, it’s really hot in here”.",
+            "punchline": "The second looks over at the first with a surprised look, and answers, “WHOA, a talking muffin!”"
+        }, {
+            "joke": "What's the difference between a guitar and a fish?",
+            "punchline": "You can tune a guitar but you can't \"tuna\" fish!"
+        }, {
+            "joke": "Did you hear that the police have a warrant out on a midget psychic ripping people off?",
+            "punchline": "It reads “Small medium at large.”"
+        }, {
+            "joke": "Why don't sharks eat clowns?",
+            "punchline": "Because they taste funny."
+        }, {
+            "joke": "Just read a few facts about frogs.",
+            "punchline": "They were ribbiting."
+        }, {
+            "joke": "Two satellites decided to get married.",
+            "punchline": "The wedding wasn't much, but the reception was incredible."
+        }, {
+            "joke": "What do you call a fish with no eyes?",
+            "punchline": "A fsh."
+        }, {
+            "joke": "What do you get if you put a duck in a cement mixer?",
+            "punchline": "Quacks in the pavement."
+        }, {
+            "joke": "They tried to make a diamond shaped like a duck.",
+            "punchline": "It quacked under the pressure."
+        }, {
+            "joke": "Where’s the bin?",
+            "punchline": "Dad: I haven’t been anywhere!"
+        }, {
+            "joke": "My wife said I was immature.",
+            "punchline": "So I told her to get out of my fort."
+        }, {
+            "joke": "Why did the knife dress up in a suit?",
+            "punchline": "Because it wanted to look sharp"
+        }, {
+            "joke": "How do you make a water bed more bouncy.",
+            "punchline": "You use Spring Water"
+        }, {
+            "joke": "I considered building the patio by myself.",
+            "punchline": "But I didn't have the stones."
+        }, {
+            "joke": "In my career as a lumberjack I cut down exactly 52,487 trees.",
+            "punchline": "I know because I kept a log."
+        }, {
+            "joke": "Why do bears have hairy coats?",
+            "punchline": "Fur protection."
+        }, {
+            "joke": "What do you get when you cross a bee and a sheep?",
+            "punchline": "A bah-humbug."
+        }, {
+            "joke": "What did one snowman say to the other snow man?",
+            "punchline": "Do you smell carrot?"
+        }, {
+            "joke": "\"Dad, do you think it's going to snow this winter?\" \"I dont know",
+            "punchline": "its all up in the air\""
+        }, {
+            "joke": "Why do bees hum?",
+            "punchline": "Because they don't know the words."
+        }, {
+            "joke": "What do you call a troublesome Canadian high schooler?",
+            "punchline": "A poutine."
+        }, {
+            "joke": "Don't trust atoms.",
+            "punchline": "They make up everything."
+        }, {
+            "joke": "If you walk into a forest and cut down a tree, but the tree doesn't understand why you cut it down",
+            "punchline": "do you think it's stumped?"
+        }, {
+            "joke": "Where do bees go to the bathroom?",
+            "punchline": "The BP station."
+        }, {
+            "joke": "What is the best way to carve?",
+            "punchline": "Whittle by whittle."
+        }, {
+            "joke": "What's a ninja's favorite type of shoes?",
+            "punchline": "Sneakers!"
+        }, {
+            "joke": "Why did the tree go to the dentist?",
+            "punchline": "It needed a root canal."
+        }, {
+            "joke": "It was raining cats and dogs the other day.",
+            "punchline": "I almost stepped in a poodle."
+        }, {
+            "joke": "Why do bananas have to put on sunscreen before they go to the beach?",
+            "punchline": "Because they might peel!"
+        }, {
+            "joke": "What do you call a bee that lives in America?",
+            "punchline": "A USB."
+        }, {
+            "joke": "I was wondering why the frisbee was getting bigger",
+            "punchline": "then it hit me."
+        }, {
+            "joke": "A farmer had 297 cows, when he rounded them up",
+            "punchline": "he found he had 300"
+        }, {
+            "joke": "What's the difference between a hippo and a zippo?",
+            "punchline": "One is really heavy, the other is a little lighter."
+        }, {
+            "joke": "I’ve got this disease where I can’t stop making airport puns.",
+            "punchline": "The doctor says it terminal."
+        }, {
+            "joke": "What concert costs only 45 cents?",
+            "punchline": "50 cent featuring Nickelback."
+        }, {
+            "joke": "I couldn't figure out how the seat belt worked.",
+            "punchline": "Then it just clicked."
+        }, {
+            "joke": "What did the green grape say to the purple grape?",
+            "punchline": "BREATH!!"
+        }, {
+            "joke": "What do you call a dad that has fallen through the ice?",
+            "punchline": "A Popsicle."
+        }, {
+            "joke": "Two parrots are sitting on a perch.",
+            "punchline": "One turns to the other and asks, \"do you smell fish?\""
+        }, {
+            "joke": "Bad at golf?",
+            "punchline": "Join the club."
+        }, {
+            "joke": "I had a pair of racing snails.",
+            "punchline": "I removed their shells to make them more aerodynamic, but they became sluggish."
+        }, {
+            "joke": "What do you call a pile of cats?",
+            "punchline": "A Meowtain."
+        }, {
+            "joke": "How do hens stay fit?",
+            "punchline": "They always egg-cercise!"
+        }, {
+            "joke": "Can a kangaroo jump higher than the Empire State Building?",
+            "punchline": "Of course. The Empire State Building can't jump."
+        }, {
+            "joke": "What do you give a sick lemon?",
+            "punchline": "Lemonaid."
+        }, {
+            "joke": "What do you call an old snowman?",
+            "punchline": "Water."
+        }, {
+            "joke": "I tried to milk a cow today, but was unsuccessful.",
+            "punchline": "Udder failure."
+        }, {
+            "joke": "I just got fired from a florist",
+            "punchline": "apparently I took too many leaves."
+        }, {
+            "joke": "Why don’t skeletons ever go trick or treating?",
+            "punchline": "Because they have nobody to go with."
+        }, {
+            "joke": "What does a female snake use for support?",
+            "punchline": "A co-Bra!"
+        }, {
+            "joke": "\"Dad, I'm cold.\"",
+            "punchline": "\"Go stand in the corner, I hear it's 90 degrees.\""
+        }, {
+            "joke": "Child: Dad, make me a sandwich. Dad: Poof!",
+            "punchline": "You're a sandwich."
+        }, {
+            "joke": "which flower is most fierce?",
+            "punchline": "Dandelion"
+        }, {
+            "joke": "Why are graveyards so noisy?",
+            "punchline": "Because of all the coffin."
+        }, {
+            "joke": "What kind of bagel can fly?",
+            "punchline": "A plain bagel."
+        }, {
+            "joke": "How many apples grow on a tree?",
+            "punchline": "All of them!"
+        }, {
+            "joke": "What do you call a careful wolf?",
+            "punchline": "Aware wolf."
+        }, {
+            "joke": "I was just looking at my ceiling.",
+            "punchline": "Not sure if it’s the best ceiling in the world, but it’s definitely up there."
+        }, {
+            "joke": "Why do valley girls hang out in odd numbered groups?",
+            "punchline": "Because they can't even."
+        }, {
+            "joke": "What do you call a cow with no legs?",
+            "punchline": "Ground beef."
+        }, {
+            "joke": "Why are snake races so exciting?",
+            "punchline": "They're always neck and neck."
+        }, {
+            "joke": "Why did the half blind man fall in the well?",
+            "punchline": "Because he couldn't see that well!"
+        }, {
+            "joke": "As I suspected, someone has been adding soil to my garden.",
+            "punchline": "The plot thickens."
+        }, {
+            "joke": "What do bees do after they are married?",
+            "punchline": "They go on a honeymoon."
+        }, {
+            "joke": "If I could name myself after any Egyptian god",
+            "punchline": "I'd be Set."
+        }, {
+            "joke": "Why doesn't the Chimney-Sweep call out sick from work?",
+            "punchline": "Because he's used to working with a flue."
+        }, {
+            "joke": "It’s hard to explain puns to kleptomaniacs",
+            "punchline": "because they take everything literally."
+        }, {
+            "joke": "It's difficult to say what my wife does",
+            "punchline": "she sells sea shells by the sea shore."
+        }, {
+            "joke": "Why did Dracula lie in the wrong coffin?",
+            "punchline": "He made a grave mistake."
+        }, {
+            "joke": "What did one plate say to the other plate?",
+            "punchline": "Dinner is on me!"
+        }, {
+            "joke": "what do you call a dog that can do magic tricks?",
+            "punchline": "a labracadabrador"
+        }, {
+            "joke": "Doctor: Do you want to hear the good news or the bad news? Patient: Good news please.",
+            "punchline": "Doctor: we're naming a disease after you."
+        }, {
+            "joke": "I tried to write a chemistry joke",
+            "punchline": "but could never get a reaction."
+        }, {
+            "joke": "I gave my friend 10 puns hoping that one of them would make him laugh.",
+            "punchline": "Sadly, no pun in ten did."
+        }, {
+            "joke": "What do computers and air conditioners have in common?",
+            "punchline": "They both become useless when you open windows."
+        }, {
+            "joke": "What do you call a monkey in a mine field?",
+            "punchline": "A babooooom!"
+        }, {
+            "joke": "Scientists finally did a study on forks.",
+            "punchline": "It's about tine!"
+        }, {
+            "joke": "I cut my finger cutting cheese.",
+            "punchline": "I know it may be a cheesy story but I feel grate now."
+        }, {
+            "joke": "How do you steal a coat?",
+            "punchline": "You jacket."
+        }, {
+            "joke": "Why don't you find hippopotamuses hiding in trees?",
+            "punchline": "They're really good at it."
+        }, {
+            "joke": "what happens when you cross a sheep with a kangaroo?",
+            "punchline": "A woolly jumper!"
+        }, {
+            "joke": "Want to hear a joke about construction?",
+            "punchline": "Nah, I'm still working on it."
+        }, {
+            "joke": "My friend told me that pepper is the best seasoning for a roast",
+            "punchline": "but I took it with a grain of salt."
+        }, {
+            "joke": "Why do choirs keep buckets handy?",
+            "punchline": "So they can carry their tune"
+        }, {
+            "joke": "Did you hear about the kidnapping at school?",
+            "punchline": "It's ok, he woke up."
+        }, {
+            "joke": "I asked my date to go to the gym the other day. They never showed up.",
+            "punchline": "That's when I knew we wouldn't work out."
+        }, {
+            "joke": "You will never guess what Elsa did to the balloon.",
+            "punchline": "She let it go."
+        }, {
+            "joke": "Did you hear about the two thieves who stole a calendar?",
+            "punchline": "They each got six months."
+        }, {
+            "joke": "Why can't eggs have love?",
+            "punchline": "They will break up too soon."
+        }, {
+            "joke": "You can't run through a camp site.",
+            "punchline": "You can only ran, because it's past tents."
+        }, {
+            "joke": "They're making a movie about clocks.",
+            "punchline": "It's about time"
+        }, {
+            "joke": "I’ve just been reading a book about anti-gravity",
+            "punchline": "it’s impossible to put down!"
+        }, {
+            "joke": "Have you ever seen fruit preserves being made?",
+            "punchline": "It's jarring."
+        }, {
+            "joke": "I was going to get a brain transplant",
+            "punchline": "but I changed my mind"
+        }, {
+            "joke": "Have you heard about the owl sanctuary job opening?",
+            "punchline": "It’s all night shifts but they’re all a hoot over there."
+        }, {
+            "joke": "Why can't you use \"Beef stew\" as a password?",
+            "punchline": "Because it's not stroganoff."
+        }, {
+            "joke": "What did the piece of bread say to the knife?",
+            "punchline": "Butter me up."
+        }, {
+            "joke": "Why couldn't the lifeguard save the hippie?",
+            "punchline": "He was too far out, man."
+        }, {
+            "joke": "They say Dodger Stadium can hold up to fifty-six thousand people",
+            "punchline": "but that is just a ballpark figure."
+        }, {
+            "joke": "Some people say that I never got over my obsession with Phil Collins.",
+            "punchline": "But take a look at me now."
+        }, {
+            "joke": "Why did the girl smear peanut butter on the road?",
+            "punchline": "To go with the traffic jam."
+        }, {
+            "joke": "How much does a hipster weigh?",
+            "punchline": "An instagram."
+        }, {
+            "joke": "A woman is on trial for beating her husband to death with his guitar collection. Judge says, ‘First offender?’ She says, ‘No, first a Gibson!",
+            "punchline": "Then a Fender!’"
+        }, {
+            "joke": "I saw an ad in a shop window, \"Television for sale, $1, volume stuck on full\", I thought",
+            "punchline": "\"I can't turn that down\"."
+        }, {
+            "joke": "What kind of dog lives in a particle accelerator?",
+            "punchline": "A Fermilabrador Retriever."
+        }, {
+            "joke": "I always wanted to look into why I procrastinate",
+            "punchline": "but I keep putting it off."
+        }, {
+            "joke": "What's blue and not very heavy?",
+            "punchline": "Light blue."
+        }, {
+            "joke": "Guy told me today he did not know what cloning is.",
+            "punchline": "I told him, \"that makes 2 of us.\""
+        }, {
+            "joke": "I was so proud when I finished the puzzle in six months",
+            "punchline": "when on the side it said three to four years."
+        }, {
+            "joke": "Where did you learn to make ice cream?",
+            "punchline": "Sunday school."
+        }, {
+            "joke": "Coffee has a tough time at my house",
+            "punchline": "every morning it gets mugged."
+        }, {
+            "joke": "A quick shoutout to all of the sidewalks out there...",
+            "punchline": "Thanks for keeping me off the streets."
+        }, {
+            "joke": "Where does Napoleon keep his armies?",
+            "punchline": "In his sleevies."
+        }, {
+            "joke": "What's the difference between roast beef and pea soup.",
+            "punchline": "Anyone can roast beef, but nobody can pee soup."
+        }, {
+            "joke": "What do you get if you cross a turkey with a ghost?",
+            "punchline": "A poultry-geist!"
+        }, {
+            "joke": "What is the tallest building in the world?",
+            "punchline": "The library – it’s got the most stories!"
+        }, {
+            "joke": "What kind of magic do cows believe in?",
+            "punchline": "MOODOO."
+        }, {
+            "joke": "What’s the longest word in the dictionary?",
+            "punchline": "Smiles. Because there’s a mile between the two S’s."
+        }, {
+            "joke": "Why don't eggs tell jokes?",
+            "punchline": "They'd crack each other up"
+        }, {
+            "joke": "I just broke my guitar.",
+            "punchline": "It's okay, I won't fret"
+        }, {
+            "joke": "How many kids with ADD does it take to change a lightbulb?",
+            "punchline": "Let's go ride bikes!"
+        }, {
+            "joke": "Where do hamburgers go to dance?",
+            "punchline": "The meat-ball."
+        }, {
+            "joke": "I invented a new word!",
+            "punchline": "Plagiarism!"
+        }, {
+            "joke": "What do you call a cow with two legs?",
+            "punchline": "Lean beef."
+        }, {
+            "joke": "What did the big flower say to the littler flower?",
+            "punchline": "Hi, bud!"
+        }, {
+            "joke": "I never wanted to believe that my Dad was stealing from his job as a road worker.",
+            "punchline": "But when I got home, all the signs were there."
+        }, {
+            "joke": "Why do pumpkins sit on people’s porches?",
+            "punchline": "They have no hands to knock on the door."
+        }, {
+            "joke": "Who is the coolest Doctor in the hospital?",
+            "punchline": "The hip Doctor!"
+        }, {
+            "joke": "Why was ten scared of seven?",
+            "punchline": "Because seven ate nine."
+        }, {
+            "joke": "What do you get when you cross a rabbit with a water hose?",
+            "punchline": "Hare spray."
+        }, {
+            "joke": "I applied to be a doorman but didn't get the job due to lack of experience.",
+            "punchline": "That surprised me, I thought it was an entry level position."
+        }, {
+            "joke": "I knew a guy who collected candy canes",
+            "punchline": "they were all in mint condition"
+        }, {
+            "joke": "A boy dug three holes in the yard.",
+            "punchline": "When his mother saw, she exclaimed: \"well, well, well\""
+        }, {
+            "joke": "Why do nurses carry around red crayons?",
+            "punchline": "Sometimes they need to draw blood."
+        }, {
+            "joke": "Why was the shirt happy to hang around the tank top?",
+            "punchline": "Because it was armless"
+        }, {
+            "joke": "Why does a chicken coop only have two doors?",
+            "punchline": "Because if it had four doors it would be a chicken sedan."
+        }, {
+            "joke": "\"I'll call you later.\" Don't call me later",
+            "punchline": "call me Dad."
+        }, {
+            "joke": "Why did the teddy bear say “no” to dessert?",
+            "punchline": "Because she was stuffed."
+        }, {
+            "joke": "I don't trust sushi",
+            "punchline": "there's something fishy about it."
+        }, {
+            "joke": "Did you hear the one about the giant pickle?",
+            "punchline": "He was kind of a big dill."
+        }, {
+            "joke": "Breaking news!",
+            "punchline": "Energizer Bunny arrested – charged with battery."
+        }, {
+            "joke": "How many bones are in the human hand?",
+            "punchline": "A handful of them."
+        }, {
+            "joke": "A red and a blue ship have just collided in the Caribbean.",
+            "punchline": "Apparently the survivors are marooned."
+        }, {
+            "joke": "I've just written a song about a tortilla.",
+            "punchline": "Well, it is more of a rap really."
+        }, {
+            "joke": "Can February march?",
+            "punchline": "No, but April may."
+        }, {
+            "joke": "Egyptians claimed to invent the guitar",
+            "punchline": "but they were such lyres."
+        }, {
+            "joke": "What is a witch's favorite subject in school?",
+            "punchline": "Spelling!"
+        }, {
+            "joke": "What do you call a crowd of chess players bragging about their wins in a hotel lobby?",
+            "punchline": "Chess nuts boasting in an open foyer."
+        }, {
+            "joke": "Which side of the chicken has more feathers?",
+            "punchline": "The outside."
+        }, {
+            "joke": "Remember",
+            "punchline": "the best angle to approach a problem from is the \"try\" angle."
+        }, {
+            "joke": "Why are fish easy to weigh?",
+            "punchline": "Because they have their own scales."
+        }, {
+            "joke": "What did the scarf say to the hat?",
+            "punchline": "You go on ahead, I am going to hang around a bit longer."
+        }, {
+            "joke": "Did you hear about the scientist who was lab partners with a pot of boiling water?",
+            "punchline": "He had a very esteemed colleague."
+        }, {
+            "joke": "This morning I was wondering where the sun was",
+            "punchline": "but then it dawned on me."
+        }, {
+            "joke": "What did the sea say to the sand?",
+            "punchline": "\"We have to stop meeting like this.\""
+        }, {
+            "joke": "Why is it so windy inside an arena?",
+            "punchline": "All those fans."
+        }, {
+            "joke": "A panda walks into a bar and says to the bartender “I’ll have a Scotch and.............. Coke thank you”.",
+            "punchline": "“Sure thing” the bartender replies and asks “but what’s with the big pause?” The panda holds up his hands and says “I was born with them”"
+        }, {
+            "joke": "I've started telling everyone about the benefits of eating dried grapes.",
+            "punchline": "It's all about raisin awareness."
+        }, {
+            "joke": "“Doctor",
+            "punchline": "I’ve broken my arm in several places” Doctor “Well don’t go to those places.”"
+        }, {
+            "joke": "Where was the Declaration of Independence signed?",
+            "punchline": "At the bottom!"
+        }, {
+            "joke": "What’s the difference between an African elephant and an Indian elephant?",
+            "punchline": "About 5000 miles."
+        }, {
+            "joke": "Two peanuts were walking down the street.",
+            "punchline": "One was a salted"
+        }, {
+            "joke": "Don’t interrupt someone working intently on a puzzle.",
+            "punchline": "Chances are, you’ll hear some crosswords."
+        }, {
+            "joke": "Today a man knocked on my door and asked for a small donation towards the local swimming pool.",
+            "punchline": "I gave him a glass of water."
+        }, {
+            "joke": "What did the Zen Buddist say to the hotdog vendor?",
+            "punchline": "Make me one with everything."
+        }, {
+            "joke": "Why did the clown have neck pain?",
+            "punchline": "- Because he slept funny"
+        }, {
+            "joke": "What did the digital clock say to the grandfather clock?",
+            "punchline": "Look, no hands!"
+        }, {
+            "joke": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before.",
+            "punchline": "What can I get for you?\" \"Pop,\" goes the weasel."
+        }, {
+            "joke": "How was the snow globe feeling after the storm?",
+            "punchline": "A little shaken."
+        }, {
+            "joke": "Did you hear the one about the guy with the broken hearing aid?",
+            "punchline": "Neither did he."
+        }, {
+            "joke": "Did you hear about the campsite that got visited by Bigfoot?",
+            "punchline": "It got in tents."
+        }, {
+            "joke": "I saw a documentary on TV last night about how they put ships together.",
+            "punchline": "It was rivetting."
+        }, {
+            "joke": "What did the Red light say to the Green light?",
+            "punchline": "Don't look at me I'm changing!"
+        }, {
+            "joke": "What did the ocean say to the beach?",
+            "punchline": "Thanks for all the sediment."
+        }, {
+            "joke": "What did the left eye say to the right eye?",
+            "punchline": "Between us, something smells!"
+        }, {
+            "joke": "What do you call a fly without wings?",
+            "punchline": "A walk."
+        }, {
+            "joke": "Why did the melons plan a big wedding?",
+            "punchline": "Because they cantaloupe!"
+        }, {
+            "joke": "Yesterday I confused the words \"jacuzzi\" and \"yakuza\".",
+            "punchline": "Now I'm in hot water with the Japanese mafia."
+        }, {
+            "joke": "What is the least spoken language in the world?",
+            "punchline": "Sign Language"
+        }, {
+            "joke": "What do birds give out on Halloween?",
+            "punchline": "Tweets."
+        }, {
+            "joke": "I used to think I was indecisive",
+            "punchline": "but now I'm not sure."
+        }, {
+            "joke": "Have you heard the rumor going around about butter?",
+            "punchline": "Never mind, I shouldn't spread it."
+        }, {
+            "joke": "Every morning when I go out, I get hit by bicycle. Every morning!",
+            "punchline": "It's a vicious cycle."
+        }, {
+            "joke": "What happens to a frog's car when it breaks down?",
+            "punchline": "It gets toad."
+        }, {
+            "joke": "I fear for the calendar",
+            "punchline": "its days are numbered."
+        }, {
+            "joke": "I'm glad I know sign language",
+            "punchline": "it's pretty handy."
+        }, {
+            "joke": "The other day, my wife asked me to pass her lipstick but I accidentally passed her a glue stick.",
+            "punchline": "She still isn't talking to me."
+        }, {
+            "joke": "What do you get when you cross a chicken with a skunk?",
+            "punchline": "A fowl smell!"
+        }, {
+            "joke": "Where do you take someone who’s been injured in a peek-a-boo accident?",
+            "punchline": "To the I.C.U."
+        }, {
+            "joke": "As I get older, I think of all the people I lost along the way.",
+            "punchline": "Maybe a career as a tour guide wasn't such a good idea."
+        }, {
+            "joke": "How many hipsters does it take to change a lightbulb?",
+            "punchline": "Oh, it's a really obscure number. You've probably never heard of it."
+        }, {
+            "joke": "Where do sheep go to get their hair cut?",
+            "punchline": "The baa-baa shop."
+        }, {
+            "joke": "Our wedding was so beautiful",
+            "punchline": "even the cake was in tiers."
+        }, {
+            "joke": "Why did the miner get fired from his job?",
+            "punchline": "He took it for granite..."
+        }, {
+            "joke": "What did the hat say to the scarf? You can hang around.",
+            "punchline": "I'll just go on ahead."
+        }, {
+            "joke": "Where do cats write notes?",
+            "punchline": "Scratch Paper!"
+        }, {
+            "joke": "Why is the new Kindle screen textured to look like paper?",
+            "punchline": "So you feel write at home."
+        }, {
+            "joke": "When my wife told me to stop impersonating a flamingo",
+            "punchline": "I had to put my foot down."
+        }, {
+            "joke": "No matter how kind you are",
+            "punchline": "German children are kinder."
+        }, {
+            "joke": "What’s the advantage of living in Switzerland?",
+            "punchline": "Well, the flag is a big plus."
+        }, {
+            "joke": "When I left school, I passed every one of my exams with the exception of Greek Mythology.",
+            "punchline": "It always was my achilles elbow"
+        }, {
+            "joke": "Why did the cookie cry?",
+            "punchline": "It was feeling crumby."
+        }, {
+            "joke": "What did Yoda say when he saw himself in 4K?",
+            "punchline": "\"HDMI\""
+        }, {
+            "joke": "How do you make a 'one' disappear?",
+            "punchline": "You add a 'g' and it's 'gone'"
+        }, {
+            "joke": "Me and my mates are in a band called Duvet.",
+            "punchline": "We're a cover band."
+        }, {
+            "joke": "Where do you learn to make banana splits?",
+            "punchline": "At sundae school."
+        }, {
+            "joke": "Nurse: Doctor, there's a patient that says he's invisible.",
+            "punchline": "Doctor: Well, tell him I can't see him right now!"
+        }, {
+            "joke": "What was a more important invention than the first telephone?",
+            "punchline": "The second one."
+        }, {
+            "joke": "What do you get when you cross a snowman with a vampire?",
+            "punchline": "Frostbite."
+        }, {
+            "joke": "What do you do when your bunny gets wet?",
+            "punchline": "You get your hare dryer."
+        }, {
+            "joke": "Did you know crocodiles could grow up to 15 feet?",
+            "punchline": "But most just have 4."
+        }, {
+            "joke": "There are two types of people in this world",
+            "punchline": "those who can extrapolate from incomplete data..."
+        }, {
+            "joke": "Why did the fireman wear red, white, and blue suspenders?",
+            "punchline": "To hold his pants up."
+        }, {
+            "joke": "In the news a courtroom artist was arrested today, I'm not surprised",
+            "punchline": "he always seemed sketchy."
+        }, {
+            "joke": "What do you call someone with no nose?",
+            "punchline": "Nobody knows."
+        }, {
+            "joke": "What do you call a girl between two posts?",
+            "punchline": "Annette."
+        }, {
+            "joke": "What do you call a criminal going down the stairs?",
+            "punchline": "Condescending"
+        }, {
+            "joke": "What do you call a fat psychic?",
+            "punchline": "A four-chin teller."
+        }, {
+            "joke": "I used to be a banker",
+            "punchline": "but I lost interest."
+        }, {
+            "joke": "Why can't a bicycle stand on its own?",
+            "punchline": "It's two-tired."
+        }, {
+            "joke": "What does a pirate pay for his corn?",
+            "punchline": "A buccaneer!"
+        }, {
+            "joke": "Astronomers got tired watching the moon go around the earth for 24 hours.",
+            "punchline": "They decided to call it a day."
+        }, {
+            "joke": "My dog used to chase people on a bike a lot.",
+            "punchline": "It got so bad I had to take his bike away."
+        }, {
+            "joke": "I ate a clock yesterday.",
+            "punchline": "It was so time consuming."
+        }, {
+            "joke": "Is the pool safe for diving?",
+            "punchline": "It deep ends."
+        }, {
+            "joke": "Why do scuba divers fall backwards into the water?",
+            "punchline": "Because if they fell forwards they’d still be in the boat."
+        }, {
+            "joke": "My wife told me to rub the herbs on the meat for better flavor.",
+            "punchline": "That's sage advice."
+        }, {
+            "joke": "A man was caught stealing in a supermarket today while balanced on the shoulders of a couple of vampires.",
+            "punchline": "He was charged with shoplifting on two counts."
+        }, {
+            "joke": "Ben & Jerry's really need to improve their operation.",
+            "punchline": "The only way to get there is down a rocky road."
+        }, {
+            "joke": "How are false teeth like stars?",
+            "punchline": "They come out at night!"
+        }, {
+            "joke": "What time did the man go to the dentist?",
+            "punchline": "Tooth hurt-y."
+        }, {
+            "joke": "I went to the zoo yesterday and saw a baguette in a cage.",
+            "punchline": "It was bread in captivity."
+        }, {
+            "joke": "Did you hear about the cheese factory that exploded in France?",
+            "punchline": "There was nothing left but de Brie."
+        }, {
+            "joke": "How does a penguin build it’s house?",
+            "punchline": "Igloos it together."
+        }, {
+            "joke": "What is this movie about?",
+            "punchline": "It is about 2 hours long."
+        }, {
+            "joke": "Why are pirates called pirates?",
+            "punchline": "Because they arrr!"
+        }, {
+            "joke": "Where does Fonzie like to go for lunch?",
+            "punchline": "Chick-Fil-Eyyyyyyyy."
+        }, {
+            "joke": "How does a dyslexic poet write?",
+            "punchline": "Inverse."
+        }, {
+            "joke": "Don't tell secrets in corn fields.",
+            "punchline": "Too many ears around."
+        }, {
+            "joke": "What did the pirate say on his 80th birthday?",
+            "punchline": "Aye Matey!"
+        }, {
+            "joke": "Why did the A go to the bathroom and come out as an E?",
+            "punchline": "Because he had a vowel movement."
+        }, {
+            "joke": "Yesterday a clown held a door open for me.",
+            "punchline": "I thought it was a nice jester."
+        }, {
+            "joke": "Why did the opera singer go sailing?",
+            "punchline": "They wanted to hit the high Cs."
+        }, {
+            "joke": "Bought a new jacket suit the other day and it burst into flames.",
+            "punchline": "Well, it was a blazer"
+        }, {
+            "joke": "Whats a penguins favorite relative?",
+            "punchline": "Aunt Arctica."
+        }, {
+            "joke": "Never Trust Someone With Graph Paper...",
+            "punchline": "They're always plotting something."
+        }, {
+            "joke": "What do you call an elephant that doesn’t matter?",
+            "punchline": "An irrelephant."
+        }, {
+            "joke": "What do you call a group of disorganized cats?",
+            "punchline": "A cat-tastrophe."
+        }, {
+            "joke": "What is bread's favorite number?",
+            "punchline": "Leaven."
+        }, {
+            "joke": "Why can’t you hear a pterodactyl go to the bathroom?",
+            "punchline": "The p is silent."
+        }, {
+            "joke": "How do you know if there’s an elephant under your bed?",
+            "punchline": "Your head hits the ceiling!"
+        }, {
+            "joke": "How do you teach a kid to climb stairs?",
+            "punchline": "There is a step by step guide."
+        }, {
+            "joke": "Where do owls go to buy their baby clothes?",
+            "punchline": "The owlet malls."
+        }, {
+            "joke": "Why does Norway have barcodes on their battleships?",
+            "punchline": "So when they get back to port, they can Scandinavian."
+        }, {
+            "joke": "What's the worst part about being a cross-eyed teacher?",
+            "punchline": "They can't control their pupils."
+        }, {
+            "joke": "What do you call a fashionable lawn statue with an excellent sense of rhythmn?",
+            "punchline": "A metro-gnome"
+        }, {
+            "joke": "Someone broke into my house last night and stole my limbo trophy.",
+            "punchline": "How low can you go?"
+        }, {
+            "joke": "Why did the coffee file a police report?",
+            "punchline": "It got mugged."
+        }, {
+            "joke": "Mountains aren't just funny",
+            "punchline": "they are hill areas"
+        }, {
+            "joke": "I was going to learn how to juggle",
+            "punchline": "but I didn't have the balls."
+        }, {
+            "joke": "Why was the strawberry sad?",
+            "punchline": "Its parents were in a jam."
+        }, {
+            "joke": "Why are ghosts bad liars?",
+            "punchline": "Because you can see right through them!"
+        }, {
+            "joke": "Every machine in the coin factory broke down all of a sudden without explanation.",
+            "punchline": "It just doesn’t make any cents."
+        }, {
+            "joke": "Why does it take longer to get from 1st to 2nd base, than it does to get from 2nd to 3rd base?",
+            "punchline": "Because there’s a Shortstop in between!"
+        }, {
+            "joke": "What do you do when you see a space man?",
+            "punchline": "Park your car, man."
+        }, {
+            "joke": "If you want a job in the moisturizer industry",
+            "punchline": "the best advice I can give is to apply daily."
+        }, {
+            "joke": "When you have a bladder infection",
+            "punchline": "urine trouble."
+        }, {
+            "joke": "How do you make Lady Gaga cry?",
+            "punchline": "Poker face."
+        }, {
+            "joke": "What do you call a group of killer whales playing instruments?",
+            "punchline": "An Orca-stra."
+        }, {
+            "joke": "I was in an 80's band called the prevention.",
+            "punchline": "We were better than the cure."
+        }, {
+            "joke": "What did Michael Jackson name his denim store?",
+            "punchline": "Billy Jeans!"
+        }, {
+            "joke": "People saying 'boo!",
+            "punchline": "to their friends has risen by 85% in the last year.... That's a frightening statistic."
+        }, {
+            "joke": "Geology rocks",
+            "punchline": "but Geography is where it's at!"
+        }, {
+            "joke": "Why does Han Solo like gum?",
+            "punchline": "It's chewy!"
+        }, {
+            "joke": "I was at the library and asked if they have any books on \"paranoia\", the librarian replied, \"yes",
+            "punchline": "they are right behind you\""
+        }, {
+            "joke": "Have you heard of the band 1023MB?",
+            "punchline": "They haven't got a gig yet."
+        }, {
+            "joke": "What happens when you anger a brain surgeon?",
+            "punchline": "They will give you a piece of your mind."
+        }, {
+            "joke": "I used to work at a stationery store. But, I didn't feel like I was going anywhere. So, I got a job at a travel agency.",
+            "punchline": "Now, I know I'll be going places."
+        }, {
+            "joke": "I used to work in a shoe recycling shop.",
+            "punchline": "It was sole destroying."
+        }, {
+            "joke": "I used to hate facial hair",
+            "punchline": "but then it grew on me."
+        }, {
+            "joke": "R.I.P. boiled water.",
+            "punchline": "You will be mist."
+        }, {
+            "joke": "Q: What did the spaghetti say to the other spaghetti?",
+            "punchline": "A: Pasta la vista, baby!"
+        }, {
+            "joke": "The first time I got a universal remote control I thought to myself",
+            "punchline": "\"This changes everything\""
+        }, {
+            "joke": "Why is the ocean always blue?",
+            "punchline": "Because the shore never waves back."
+        }, {
+            "joke": "Why did the feline fail the lie detector test?",
+            "punchline": "Because he be lion."
+        }, {
+            "joke": "Why did the man put his money in the freezer?",
+            "punchline": "He wanted cold hard cash!"
+        }, {
+            "joke": "Why do ducks make great detectives?",
+            "punchline": "They always quack the case."
+        }, {
+            "joke": "What does a clock do when it's hungry?",
+            "punchline": "It goes back four seconds!"
+        }, {
+            "joke": "What do I look like?",
+            "punchline": "A JOKE MACHINE!?"
+        }, {
+            "joke": "I bought shoes from a drug dealer once.",
+            "punchline": "I don't know what he laced them with, but I was tripping all day."
+        }, {
+            "joke": "What is a tornado's favorite game to play?",
+            "punchline": "Twister!"
+        }, {
+            "joke": "You know that cemetery up the road?",
+            "punchline": "People are dying to get in there."
+        }, {
+            "joke": "Pie is $2.50 in Jamaica and $3.00 in The Bahamas.",
+            "punchline": "These are the pie-rates of the Caribbean."
+        }, {
+            "joke": "What do you call a fish wearing a bowtie?",
+            "punchline": "Sofishticated."
+        }, {
+            "joke": "Did you hear about the Mexican train killer?",
+            "punchline": "He had loco motives"
+        }, {
+            "joke": "Can I watch the TV?",
+            "punchline": "Dad: Yes, but don’t turn it on."
+        }, {
+            "joke": "What is worse then finding a worm in your Apple?",
+            "punchline": "Finding half a worm in your Apple."
+        }, {
+            "joke": "What do vegetarian zombies eat?",
+            "punchline": "Grrrrrainnnnnssss."
+        }, {
+            "joke": "\"I'm sorry.\" \"Hi sorry",
+            "punchline": "I'm dad\""
+        }, {
+            "joke": "What is the hardest part about sky diving?",
+            "punchline": "The ground."
+        }, {
+            "joke": "Why did the cowboy have a weiner dog?",
+            "punchline": "Somebody told him to get a long little doggy."
+        }, {
+            "joke": "My friend keeps telling me \"Cheer up.",
+            "punchline": "You aren't stuck in a deep hole in the ground, filled with water.\" I know he means well."
+        }, {
+            "joke": "Who did the wizard marry?",
+            "punchline": "His ghoul-friend"
+        }, {
+            "joke": "How many seconds are in a year? 12. January 2nd, February 2nd, March 2nd, April 2nd....",
+            "punchline": "etc"
+        }, {
+            "joke": "I ordered a chicken and an egg from Amazon.",
+            "punchline": "I'll let you know."
+        }, {
+            "joke": "Ever wondered why bees hum?",
+            "punchline": "It's because they don't know the words."
+        }, {
+            "joke": "How many optometrists does it take to change a light bulb? 1 or 2?",
+            "punchline": "1... or 2?"
+        }, {
+            "joke": "There's not really any training for garbagemen.",
+            "punchline": "They just pick things up as they go."
+        }, {
+            "joke": "Did you hear about the cow who jumped over the barbed wire fence?",
+            "punchline": "It was udder destruction."
+        }, {
+            "joke": "I was shocked when I was diagnosed as colorblind...",
+            "punchline": "It came out of the purple."
+        }, {
+            "joke": "Where does astronauts hangout after work?",
+            "punchline": "At the spacebar."
+        }, {
+            "joke": "What do you call a bear with no teeth?",
+            "punchline": "A gummy bear!"
+        }, {
+            "joke": "I’ve deleted the phone numbers of all the Germans I know from my mobile phone.",
+            "punchline": "Now it’s Hans free."
+        }, {
+            "joke": "What do you call your friend who stands in a hole?",
+            "punchline": "Phil."
+        }, {
+            "joke": "A doll was recently found dead in a rice paddy.",
+            "punchline": "It's the only known instance of a nick nack paddy wack."
+        }, {
+            "joke": "How do you tell the difference between a crocodile and an alligator?",
+            "punchline": "You will see one later and one in a while."
+        }, {
+            "joke": "What do you call a fake noodle?",
+            "punchline": "An impasta."
+        }, {
+            "joke": "The word queue is ironic.",
+            "punchline": "It's just q with a bunch of silent letters waiting in line."
+        }, {
+            "joke": "What do you call a droid that takes the long way around?",
+            "punchline": "R2 detour."
+        }, {
+            "joke": "What's the best thing about elevator jokes?",
+            "punchline": "They work on so many levels."
+        }, {
+            "joke": "Where do rabbits go after they get married?",
+            "punchline": "On a bunny-moon."
+        }, {
+            "joke": "Why do cows wear bells?",
+            "punchline": "Because their horns don't work."
+        }, {
+            "joke": "Two fish are in a tank, one turns to the other and says",
+            "punchline": "\"how do you drive this thing?\""
+        }, {
+            "joke": "I finally bought the limited edition Thesaurus that I've always wanted.",
+            "punchline": "When I opened it, all the pages were blank. I have no words to describe how angry I am."
+        }, {
+            "joke": "This is my step ladder.",
+            "punchline": "I never knew my real ladder."
+        }, {
+            "joke": "A man walks into a bar and orders helicopter flavor chips.",
+            "punchline": "The barman replies “sorry mate we only do plain”"
+        }, {
+            "joke": "It's been months since I bought the book \"how to scam people online\".",
+            "punchline": "It still hasn't turned up."
+        }, {
+            "joke": "Why is it a bad idea to iron your four-leaf clover?",
+            "punchline": "Cause you shouldn't press your luck."
+        }, {
+            "joke": "What did the fish say when it swam into a wall?",
+            "punchline": "Damn!"
+        }, {
+            "joke": "I accidentally drank a bottle of invisible ink.",
+            "punchline": "Now I’m in hospital, waiting to be seen."
+        }, {
+            "joke": "Why does Waldo only wear stripes?",
+            "punchline": "Because he doesn't want to be spotted."
+        }, {
+            "joke": "Why did the scarecrow win an award?",
+            "punchline": "Because he was outstanding in his field."
+        }, {
+            "joke": "Americans can't switch from pounds to kilograms overnight.",
+            "punchline": "That would cause mass confusion."
+        }, {
+            "joke": "An apple a day keeps the bullies away.",
+            "punchline": "If you throw it hard enough."
+        }, {
+            "joke": "Why does Superman get invited to dinners?",
+            "punchline": "Because he is a Supperhero."
+        }, {
+            "joke": "Why is no one friends with Dracula?",
+            "punchline": "Because he's a pain in the neck."
+        }, {
+            "joke": "A man got hit in the head with a can of Coke",
+            "punchline": "but he was alright because it was a soft drink."
+        }, {
+            "joke": "What is the leading cause of dry skin?",
+            "punchline": "Towels"
+        }, {
+            "joke": "A man walked in to a bar with some asphalt on his arm.",
+            "punchline": "He said “Two beers please, one for me and one for the road.”"
+        }, {
+            "joke": "Did you know the first French fries weren't actually cooked in France?",
+            "punchline": "They were cooked in Greece."
+        }, {
+            "joke": "I’ll tell you something about German sausages",
+            "punchline": "they’re the wurst"
+        }, {
+            "joke": "Where did Captain Hook get his hook?",
+            "punchline": "From a second hand store."
+        }, {
+            "joke": "I got fired from a florist",
+            "punchline": "apparently I took too many leaves."
+        }, {
+            "joke": "Two silk worms had a race.",
+            "punchline": "They ended up in a tie."
+        }, {
+            "joke": "I got fired from the transmission factor",
+            "punchline": "turns out I didn't put on enough shifts..."
+        }, {
+            "joke": "Where do young cows eat lunch?",
+            "punchline": "In the calf-ateria."
+        }, {
+            "joke": "How does a French skeleton say hello?",
+            "punchline": "Bone-jour."
+        }, {
+            "joke": "Why was the big cat disqualified from the race?",
+            "punchline": "Because it was a cheetah."
+        }, {
+            "joke": "What do prisoners use to call each other?",
+            "punchline": "Cell phones."
+        }, {
+            "joke": "What’s E.T. short for?",
+            "punchline": "He’s only got little legs."
+        }, {
+            "joke": "What kind of award did the dentist receive?",
+            "punchline": "A little plaque."
+        }, {
+            "joke": "Got a new suit recently made entirely of living plants.",
+            "punchline": "I wasn’t sure at first, but it’s grown on me"
+        }, {
+            "joke": "Do you know where you can get chicken broth in bulk?",
+            "punchline": "The stock market."
+        }, {
+            "joke": "What's orange and sounds like a parrot?",
+            "punchline": "A Carrot."
+        }, {
+            "joke": "A Sandwich walks into a bar, the bartender says “Sorry",
+            "punchline": "we don’t serve food here”"
+        }, {
+            "joke": "What do you get hanging from Apple trees?",
+            "punchline": "Sore arms."
+        }, {
+            "joke": "I thought about going on an all-almond diet.",
+            "punchline": "But that's just nuts."
+        }, {
+            "joke": "I don’t play soccer because I enjoy the sport.",
+            "punchline": "I’m just doing it for kicks."
+        }, {
+            "joke": "Today a girl said she recognized me from vegetarian club",
+            "punchline": "but I’m sure I’ve never met herbivore."
+        }, {
+            "joke": "How do you organize a space party?",
+            "punchline": "You planet."
+        }, {
+            "joke": "How do you make holy water?",
+            "punchline": "You boil the hell out of it."
+        }, {
+            "joke": "A man is washing the car with his son. The son asks......",
+            "punchline": "\"Dad, can’t you just use a sponge?\""
+        }, {
+            "joke": "What does an angry pepper do?",
+            "punchline": "It gets jalapeño face."
+        }, {
+            "joke": "Don't buy flowers at a monastery.",
+            "punchline": "Because only you can prevent florist friars."
+        }, {
+            "joke": "Hostess: Do you have a preference of where you sit?",
+            "punchline": "Dad: Down."
+        }, {
+            "joke": "Did you hear about the submarine industry?",
+            "punchline": "It really took a dive..."
+        }, {
+            "joke": "The biggest knight at King Arthur's round table was Sir Cumference.",
+            "punchline": "He acquired his size from eating too much pi."
+        }, {
+            "joke": "How do you get a baby alien to sleep?",
+            "punchline": "You rocket."
+        }, {
+            "joke": "Why do pirates not know the alphabet?",
+            "punchline": "They always get stuck at \"C\"."
+        }, {
+            "joke": "I saw my husband trip and fall while carrying a laundry basket full of ironed clothes.",
+            "punchline": "I watched it all unfold."
+        }, {
+            "joke": "Did you hear about the chameleon who couldn't change color?",
+            "punchline": "They had a reptile dysfunction."
+        }, {
+            "joke": "Why did the house go to the doctor?",
+            "punchline": "It was having window panes."
+        }, {
+            "joke": "I made a playlist for hiking. It has music from Peanuts, The Cranberries, and Eminem.",
+            "punchline": "I call it my Trail Mix."
+        }, {
+            "joke": "What do you call a dictionary on drugs?",
+            "punchline": "High definition."
+        }, {
+            "joke": "How do robots eat guacamole?",
+            "punchline": "With computer chips."
+        }, {
+            "joke": "Today, my son asked \"Can I have a book mark?\" and I burst into tears.",
+            "punchline": "11 years old and he still doesn't know my name is Brian."
+        }, {
+            "joke": "When does a joke become a dad joke?",
+            "punchline": "When it becomes apparent."
+        }, {
+            "joke": "What’s brown and sounds like a bell?",
+            "punchline": "Dung!"
+        }, {
+            "joke": "What has a bed that you can’t sleep in?",
+            "punchline": "A river."
+        }, {
+            "joke": "Why do crabs never give to charity?",
+            "punchline": "Because they’re shellfish."
+        }, {
+            "joke": "What do you call a pig with three eyes?",
+            "punchline": "Piiig"
+        }, {
+            "joke": "How do you make a hankie dance?",
+            "punchline": "Put a little boogie in it."
+        }, {
+            "joke": "Sgt.: Commissar! Commissar! The troops are revolting!",
+            "punchline": "Commissar: Well, you’re pretty repulsive yourself."
+        }, {
+            "joke": "The other day I was listening to a song about superglue",
+            "punchline": "it’s been stuck in my head ever since."
+        }, {
+            "joke": "What don't watermelons get married?",
+            "punchline": "Because they cantaloupe."
+        }, {
+            "joke": "If you’re struggling to think of what to get someone for Christmas.",
+            "punchline": "Get them a fridge and watch their face light up when they open it."
+        }, {
+            "joke": "Did you hear about the cheese who saved the world?",
+            "punchline": "It was Legend-dairy!"
+        }, {
+            "joke": "What do you call cheese by itself?",
+            "punchline": "Provolone."
+        }, {
+            "joke": "How do you fix a broken pizza?",
+            "punchline": "With tomato paste."
+        }, {
+            "joke": "What's red and bad for your teeth?",
+            "punchline": "A Brick."
+        }, {
+            "joke": "I heard there was a new store called Moderation.",
+            "punchline": "They have everything there"
+        }, {
+            "joke": "A beekeeper was indicted after he confessed to years of stealing at work.",
+            "punchline": "They charged him with emBEEzlement"
+        }, {
+            "joke": "I used to work for a soft drink can crusher.",
+            "punchline": "It was soda pressing."
+        }, {
+            "joke": "Why did the chicken get a penalty?",
+            "punchline": "For fowl play."
+        }, {
+            "joke": "My cat was just sick on the carpet",
+            "punchline": "I don’t think it’s feline well."
+        }, {
+            "joke": "Why did the burglar hang his mugshot on the wall?",
+            "punchline": "To prove that he was framed!"
+        }, {
+            "joke": "I dreamed about drowning in an ocean made out of orange soda last night.",
+            "punchline": "It took me a while to work out it was just a Fanta sea."
+        }, {
+            "joke": "I had a dream that I was a muffler last night.",
+            "punchline": "I woke up exhausted!"
+        }, {
+            "joke": "A dad washes his car with his son.",
+            "punchline": "But after a while, the son says, \"why can't you just use a sponge?\""
+        }, {
+            "joke": "Doctor you've got you help me, I'm addicted to twitter.",
+            "punchline": "Doctor: I don't follow you."
+        }, {
+            "joke": "I broke my finger at work today",
+            "punchline": "on the other hand I'm completely fine."
+        }, {
+            "joke": "I went to a book store and asked the saleswoman where the Self Help section was",
+            "punchline": "she said if she told me it would defeat the purpose."
+        }, {
+            "joke": "How does a scientist freshen their breath?",
+            "punchline": "With experi-mints!"
+        }, {
+            "joke": "What has ears but cannot hear?",
+            "punchline": "A field of corn."
+        }, {
+            "joke": "How did Darth Vader know what Luke was getting for Christmas?",
+            "punchline": "He felt his presents."
+        }, {
+            "joke": "What's the difference between a seal and a sea lion?",
+            "punchline": "An ion!"
+        }, {
+            "joke": "What did the Dorito farmer say to the other Dorito farmer?",
+            "punchline": "Cool Ranch!"
+        }, {
+            "joke": "A ghost walks into a bar and asks for a glass of vodka but the bar tender says",
+            "punchline": "“sorry we don’t serve spirits”"
+        }, {
+            "joke": "Why do wizards clean their teeth three times a day?",
+            "punchline": "To prevent bat breath!"
+        }, {
+            "joke": "Someone asked me, what's the ninth letter of the alphabet?",
+            "punchline": "It was a complete guess, but I was right."
+        }, {
+            "joke": "Feeling pretty proud of myself.",
+            "punchline": "The Sesame Street puzzle I bought said 3-5 years, but I finished it in 18 months."
+        }, {
+            "joke": "Why are fish so smart?",
+            "punchline": "Because they live in schools!"
+        }, {
+            "joke": "How does the moon cut his hair?",
+            "punchline": "Eclipse it."
+        }, {
+            "joke": "Why did the worker get fired from the orange juice factory?",
+            "punchline": "Lack of concentration."
+        }, {
+            "joke": "I couldn't get a reservation at the library.",
+            "punchline": "They were completely booked."
+        }, {
+            "joke": "Dad, can you put my shoes on?",
+            "punchline": "I don't think they'll fit me."
+        }, {
+            "joke": "How do you get two whales in a car?",
+            "punchline": "Start in England and drive West."
+        }, {
+            "joke": "What do you call an Argentinian with a rubber toe?",
+            "punchline": "Roberto"
+        }, {
+            "joke": "I tried taking some high resolution photos of local farmland",
+            "punchline": "but they all turned out a bit grainy."
+        }, {
+            "joke": "What did the ocean say to the shore?",
+            "punchline": "Nothing, it just waved."
+        }, {
+            "joke": "I went to the zoo the other day, there was only one dog in it.",
+            "punchline": "It was a shitzu."
+        }, {
+            "joke": "Someone asked me to name two structures that hold water.",
+            "punchline": "I said \"Well dam\""
+        }, {
+            "joke": "I gave all my dead batteries away today",
+            "punchline": "free of charge."
+        }, {
+            "joke": "Did you hear the news?",
+            "punchline": "FedEx and UPS are merging. They’re going to go by the name Fed-Up from now on."
+        }, {
+            "joke": "Why didn't the number 4 get into the nightclub?",
+            "punchline": "Because he is 2 square."
+        }, {
+            "joke": "What do you call a sheep with no legs?",
+            "punchline": "A cloud."
+        }, {
+            "joke": "Why did the m&m go to school?",
+            "punchline": "Because it wanted to be a Smartie!"
+        }, {
+            "joke": "Did you hear that David lost his ID in prague?",
+            "punchline": "Now we just have to call him Dav."
+        }, {
+            "joke": "My wife is on a tropical fruit diet, the house is full of stuff.",
+            "punchline": "It is enough to make a mango crazy."
+        }, {
+            "joke": "Why are basketball players messy eaters?",
+            "punchline": "Because they are always dribbling."
+        }, {
+            "joke": "Why do mathematicians hate the U.S.?",
+            "punchline": "Because it's indivisible."
+        }, {
+            "joke": "I knew i shouldn’t have ate that seafood.",
+            "punchline": "Because now i’m feeling a little… Eel"
+        }, {
+            "joke": "Past, present, and future walked into a bar....",
+            "punchline": "It was tense."
+        }, {
+            "joke": "Did you hear about the bread factory burning down?",
+            "punchline": "They say the business is toast."
+        }, {
+            "joke": "My boss told me that he was going to fire the person with the worst posture.",
+            "punchline": "I have a hunch, it might be me."
+        }, {
+            "joke": "What's black and white and read all over?",
+            "punchline": "The newspaper."
+        }, {
+            "joke": "Why are skeletons so calm?",
+            "punchline": "Because nothing gets under their skin."
+        }, {
+            "joke": "“Hold on",
+            "punchline": "I have something in my shoe” “I’m pretty sure it’s a foot”"
+        }, {
+            "joke": "Have you heard about the film \"Constipation\"",
+            "punchline": "you probably haven't because it's not out yet."
+        }, {
+            "joke": "Did you know Albert Einstein was a real person?",
+            "punchline": "All this time, I thought he was just a theoretical physicist!"
+        }, {
+            "joke": "I hate perforated lines",
+            "punchline": "they're tearable."
+        }, {
+            "joke": "I asked the surgeon if I could administer my own anesthetic, they said: go ahead",
+            "punchline": "knock yourself out."
+        }, {
+            "joke": "Why did the barber win the race?",
+            "punchline": "He took a short cut."
+        }, {
+            "joke": "Why did the octopus beat the shark in a fight?",
+            "punchline": "Because it was well armed."
+        }, {
+            "joke": "What did the doctor say to the gingerbread man who broke his leg?",
+            "punchline": "Try icing it."
+        }, {
+            "joke": "What did the judge say to the dentist?",
+            "punchline": "Do you swear to pull the tooth, the whole tooth and nothing but the tooth?"
+        }, {
+            "joke": "\"What time is it?\" I don't know...",
+            "punchline": "it keeps changing."
+        }, {
+            "joke": "You can't trust a ladder.",
+            "punchline": "It will always let you down"
+        }, {
+            "joke": "I wouldn't buy anything with velcro.",
+            "punchline": "It's a total rip-off."
+        }, {
+            "joke": "What are the strongest days of the week?",
+            "punchline": "Saturday and Sunday...the rest are weekdays."
+        }, {
+            "joke": "I had a rough day, and then somebody went and ripped the front and back pages from my dictionary.",
+            "punchline": "It just goes from bad to worse."
+        }, {
+            "joke": "I adopted my dog from a blacksmith.",
+            "punchline": "As soon as we got home he made a bolt for the door."
+        }, {
+            "joke": "Where does batman go to the bathroom?",
+            "punchline": "The batroom."
+        }, {
+            "joke": "Some people say that comedians who tell one too many light bulb jokes soon burn out, but they don't know watt they are talking about.",
+            "punchline": "They're not that bright."
+        }, {
+            "joke": "A bartender broke up with her boyfriend",
+            "punchline": "but he kept asking her for another shot."
+        }, {
+            "joke": "What do you call a cow on a trampoline?",
+            "punchline": "A milk shake!"
+        }, {
+            "joke": "What do you call a nervous javelin thrower?",
+            "punchline": "Shakespeare."
+        }, {
+            "joke": "What do you call an eagle who can play the piano?",
+            "punchline": "Talonted!"
+        }, {
+            "joke": "What do you call a boomerang that won't come back?",
+            "punchline": "A stick."
+        }, {
+            "joke": "What do you call a duck that gets all A's?",
+            "punchline": "A wise quacker."
+        }, {
+            "joke": "There’s a new type of broom out",
+            "punchline": "it’s sweeping the nation."
+        }, {
+            "joke": "I just wrote a book on reverse psychology.",
+            "punchline": "Do not read it!"
+        }, {
+            "joke": "Why don’t seagulls fly over the bay?",
+            "punchline": "Because then they’d be bay-gulls!"
+        }, {
+            "joke": "Parallel lines have so much in common.",
+            "punchline": "It’s a shame they’ll never meet."
+        }, {
+            "joke": "What do you call a magician who has lost their magic?",
+            "punchline": "Ian."
+        }, {
+            "joke": "Why do fish live in salt water?",
+            "punchline": "Because pepper makes them sneeze!"
+        }, {
+            "joke": "When do doctors get angry?",
+            "punchline": "When they run out of patients."
+        }, {
+            "joke": "A man tried to sell me a coffin today.",
+            "punchline": "I told him that's the last thing I need."
+        }, {
+            "joke": "It doesn't matter how much you push the envelope.",
+            "punchline": "It will still be stationary."
+        }, {
+            "joke": "What did the shy pebble wish for?",
+            "punchline": "That she was a little boulder."
+        }, {
+            "joke": "Why did the belt go to prison?",
+            "punchline": "He held up a pair of pants!"
+        }, {
+            "joke": "Wife told me to take the spider out instead of killing it...",
+            "punchline": "We had some drinks, cool guy, wants to be a web developer."
+        }, {
+            "joke": "What cheese can never be yours?",
+            "punchline": "Nacho cheese."
+        }, {
+            "joke": "What is a vampire's favorite fruit?",
+            "punchline": "A blood orange."
+        }, {
+            "joke": "Why did the cookie cry?",
+            "punchline": "Because his mother was a wafer so long"
+        }, {
+            "joke": "Want to hear my pizza joke?",
+            "punchline": "Never mind, it's too cheesy."
+        }, {
+            "joke": "What did the grape do when he got stepped on?",
+            "punchline": "He let out a little wine."
+        }, {
+            "joke": "What did the 0 say to the 8?",
+            "punchline": "Nice belt."
+        }, {
+            "joke": "Why was the picture sent to prison?",
+            "punchline": "It was framed."
+        }, {
+            "joke": "I burned 2000 calories today",
+            "punchline": "I left my food in the oven for too long."
+        }, {
+            "joke": "Cosmetic surgery used to be such a taboo subject.",
+            "punchline": "Now you can talk about Botox and nobody raises an eyebrow."
+        }, {
+            "joke": "How can you tell a vampire has a cold?",
+            "punchline": "They start coffin."
+        }, {
+            "joke": "At the boxing match, the dad got into the popcorn line and the line for hot dogs",
+            "punchline": "but he wanted to stay out of the punchline."
+        }, {
+            "joke": "\"Hey, dad, did you get a haircut?\" \"No",
+            "punchline": "I got them all cut.\""
+        }, {
+            "joke": "Why is there always a gate around cemeteries?",
+            "punchline": "Because people are always dying to get in."
+        }, {
+            "joke": "I asked a frenchman if he played video games.",
+            "punchline": "He said \"Wii\""
+        }, {
+            "joke": "My dentist is the best",
+            "punchline": "he even has a little plaque!"
+        }, {
+            "joke": "So, I heard this pun about cows, but it’s kinda offensive so I won’t say it.",
+            "punchline": "I don’t want there to be any beef between us."
+        }, {
+            "joke": "What do Alexander the Great and Winnie the Pooh have in common?",
+            "punchline": "Same middle name."
+        }, {
+            "joke": "What kind of music do planets listen to?",
+            "punchline": "Nep-tunes."
+        }, {
+            "joke": "Shout out to my grandma",
+            "punchline": "that's the only way she can hear."
+        }, {
+            "joke": "Why was the broom late for the meeting?",
+            "punchline": "He overswept."
+        }, {
+            "joke": "I went on a date last night with a girl from the zoo. It was great.",
+            "punchline": "She’s a keeper."
+        }, {
+            "joke": "Why do you never see elephants hiding in trees?",
+            "punchline": "Because they're so good at it."
+        }, {
+            "joke": "Mahatma Gandhi, as you know, walked barefoot most of the time, which produced an impressive set of calluses on his feet. He also ate very little, which made him rather frail and with his odd diet, he suffered from bad breath.",
+            "punchline": "This made him a super calloused fragile mystic hexed by halitosis."
+        }, {
+            "joke": "What do you call an alligator in a vest?",
+            "punchline": "An in-vest-igator!"
+        }, {
+            "joke": "What did celery say when he broke up with his girlfriend?",
+            "punchline": "She wasn't right for me, so I really don't carrot all."
+        }, {
+            "joke": "Thanks for explaining the word \"many\" to me.",
+            "punchline": "It means a lot."
+        }, {
+            "joke": "What's brown and sticky?",
+            "punchline": "A stick."
+        }, {
+            "joke": "What biscuit does a short person like?",
+            "punchline": "Shortbread."
+        }, {
+            "joke": "Why was Santa's little helper feeling depressed?",
+            "punchline": "Because he has low elf esteem."
+        }, {
+            "joke": "Why did Sweden start painting barcodes on the sides of their battleships?",
+            "punchline": "So they could Scandinavian."
+        }, {
+            "joke": "Want to hear a chimney joke?",
+            "punchline": "Got stacks of em! First one's on the house"
+        }, {
+            "joke": "What do you call a pig that knows karate?",
+            "punchline": "A pork chop!"
+        }, {
+            "joke": "If two vegans are having an argument",
+            "punchline": "is it still considered beef?"
+        }, {
+            "joke": "For Valentine's day, I decided to get my wife some beads for an abacus.",
+            "punchline": "It's the little things that count."
+        }, {
+            "joke": "What's the worst thing about ancient history class?",
+            "punchline": "The teachers tend to Babylon."
+        }, {
+            "joke": "My new thesaurus is terrible.",
+            "punchline": "In fact, it's so bad, I'd say it's terrible."
+        }, {
+            "joke": "What type of music do balloons hate?",
+            "punchline": "Pop music!"
+        }, {
+            "joke": "Do you want a brief explanation of what an acorn is?",
+            "punchline": "In a nutshell, it's an oak tree."
+        }, {
+            "joke": "How come a man driving a train got struck by lightning?",
+            "punchline": "He was a good conductor."
+        }, {
+            "joke": "Dad died because he couldn't remember his blood type. I will never forget his last words.",
+            "punchline": "Be positive."
+        }, {
+            "joke": "I’m on a whiskey diet.",
+            "punchline": "I’ve lost three days already."
+        }, {
+            "joke": "How does Darth Vader like his toast?",
+            "punchline": "On the dark side."
+        }, {
+            "joke": "Why didn’t the orange win the race?",
+            "punchline": "It ran out of juice."
+        }, {
+            "joke": "Did you hear about the runner who was criticized?",
+            "punchline": "He just took it in stride"
+        }, {
+            "joke": "What animal is always at a game of cricket?",
+            "punchline": "A bat."
+        }, {
+            "joke": "Why did the Clydesdale give the pony a glass of water?",
+            "punchline": "Because he was a little horse!"
+        }, {
+            "joke": "If you think swimming with dolphins is expensive",
+            "punchline": "you should try swimming with sharks--it cost me an arm and a leg!"
+        }, {
+            "joke": "What did the Buffalo say to his little boy when he dropped him off at school?",
+            "punchline": "Bison."
+        }, {
+            "joke": "I am terrified of elevators.",
+            "punchline": "I’m going to start taking steps to avoid them."
+        }, {
+            "joke": "Why do bees have sticky hair?",
+            "punchline": "Because they use honey combs!"
+        }, {
+            "joke": "Did you know you should always take an extra pair of pants golfing?",
+            "punchline": "Just in case you get a hole in one."
+        }, {
+            "joke": "I wish I could clean mirrors for a living.",
+            "punchline": "It's just something I can see myself doing."
+        }, {
+            "joke": "How do the trees get on the internet?",
+            "punchline": "They log on."
+        }, {
+            "joke": "To the guy who invented zero...",
+            "punchline": "thanks for nothing."
+        }, {
+            "joke": "What lies at the bottom of the ocean and twitches?",
+            "punchline": "A nervous wreck."
+        }, {
+            "joke": "What is red and smells like blue paint?",
+            "punchline": "Red paint!"
+        }, {
+            "joke": "*Reversing the car* \"Ah",
+            "punchline": "this takes me back\""
+        }, {
+            "joke": "How do locomotives know where they're going?",
+            "punchline": "Lots of training"
+        }, {
+            "joke": "How did the hipster burn the roof of his mouth?",
+            "punchline": "He ate the pizza before it was cool."
+        }, {
+            "joke": "Did you hear about the new restaurant on the moon?",
+            "punchline": "The food is great, but there’s just no atmosphere."
+        }, {
+            "joke": "What do you call a beehive without the b's?",
+            "punchline": "An eehive."
+        }, {
+            "joke": "What kind of pants do ghosts wear?",
+            "punchline": "Boo jeans."
+        }, {
+            "joke": "Two guys walked into a bar",
+            "punchline": "the third one ducked."
+        }, {
+            "joke": "I really want to buy one of those supermarket checkout dividers",
+            "punchline": "but the cashier keeps putting it back."
+        }, {
+            "joke": "A horse walks into a bar.",
+            "punchline": "The bar tender says \"Hey.\" The horse says \"Sure.\""
+        }, {
+            "joke": "Did you hear about the guy who invented Lifesavers?",
+            "punchline": "They say he made a mint."
+        }, {
+            "joke": "What's the difference between a poorly dressed man on a tricycle and a well dressed man on a bicycle?",
+            "punchline": "Attire."
+        }, {
+            "joke": "Why are giraffes so slow to apologize?",
+            "punchline": "Because it takes them a long time to swallow their pride."
+        }, {
+            "joke": "\"Dad, I'm hungry.\" Hello, Hungry.",
+            "punchline": "I'm Dad."
+        }, {
+            "joke": "I have the heart of a lion...",
+            "punchline": "and a lifetime ban from the San Diego Zoo."
+        }, {
+            "joke": "What do you call a guy lying on your doorstep?",
+            "punchline": "Matt."
+        }, {
+            "joke": "I met this girl on a dating site and, I don't know",
+            "punchline": "we just clicked."
+        }, {
+            "joke": "What did the calculator say to the student?",
+            "punchline": "You can count on me."
+        }, {
+            "joke": "What do you call a gorilla wearing headphones?",
+            "punchline": "Anything you'd like, it can't hear you."
+        }, {
+            "joke": "Have you heard about corduroy pillows?",
+            "punchline": "They're making headlines!"
+        }, {
             "joke": "What did the fish say when it hit the wall?",
             "punchline": "Dam."
         }, {
@@ -18,29 +2025,29 @@ window.jokes = [
             "joke": "How does a train eat?",
             "punchline": "It goes chew, chew"
         }, {
-            "joke": "What do you call a singing Laptop",
+            "joke": "What do you call a singing Laptop?",
             "punchline": "A Dell"
         }, {
             "joke": "How many lips does a flower have?",
             "punchline": "Tulips"
         }, {
-            "joke": "How do you organize an outer space party?",
-            "punchline": "You planet"
-        }, {
             "joke": "What kind of shoes does a thief wear?",
             "punchline": "Sneakers"
         }, {
-            "joke": "Why did the girl sit on the watch?",
-            "punchline": "So she could be on time."
+            "joke": "What's the best time to go to the dentist?",
+            "punchline": "Tooth hurty."
         }, {
-            "joke": "Knock knock. \nWho's there? \nA broken pencil. \nA broken pencil who?",
+            "joke": "Knock knock. Who's there? A broken pencil. A broken pencil who?",
             "punchline": "Never mind. It's pointless."
         }, {
-            "joke": "Knock knock. \nWho's there? \nCows go. \nCows go who?",
+            "joke": "Knock knock. Who's there? Cows go. Cows go who?",
             "punchline": "No, cows go moo."
         }, {
-            "joke": "Knock knock. \nWho's there? \nLittle old lady. \nLittle old lady who?",
+            "joke": "Knock knock. Who's there? Little old lady. Little old lady who?",
             "punchline": "I didn't know you could yodel!"
+        }, {
+            "joke": "Why would a guitarist become a good programmer?",
+            "punchline": "He's adept at riffing in C#."
         }, {
             "joke": "What's the best thing about a Boolean?",
             "punchline": "Even if you're wrong, you're only off by a bit."
@@ -65,9 +2072,6 @@ window.jokes = [
         }, {
             "joke": "What does C.S. Lewis keep at the back of his wardrobe?",
             "punchline": "Narnia business!"
-        }, {
-            "joke": "Why do programmers always mix up Halloween and Christmas?",
-            "punchline": "Because Oct 31 == Dec 25"
         }, {
             "joke": "A SQL query walks into a bar, walks up to two tables and asks...",
             "punchline": "'Can I join you?'"
@@ -99,17 +2103,17 @@ window.jokes = [
             "joke": "Which song would an exception sing?",
             "punchline": "Can't catch me - Avicii"
         }, {
-            "joke": "Knock knock. \nWho's there? \nOpportunity.",
+            "joke": "Knock knock. Who's there? Opportunity.",
             "punchline": "That is impossible. Opportunity doesn’t come knocking twice!"
         }, {
             "joke": "Why do Java programmers wear glasses?",
-            "punchline": "Because they don't C#"
+            "punchline": "Because they don't C#."
         }, {
             "joke": "Why did the mushroom get invited to the party?",
             "punchline": "Because he was a fungi."
         }, {
-            "joke": "Why did the mushroom get invited to the party?",
-            "punchline": "Because he was a fungi."
+            "joke": "Do you know what the word 'was' was initially?",
+            "punchline": "Before was was was was was is."
         }, {
             "joke": "I'm reading a book about anti-gravity...",
             "punchline": "It's impossible to put down"
@@ -117,7 +2121,7 @@ window.jokes = [
             "joke": "If you're American when you go into the bathroom, and American when you come out, what are you when you're in there?",
             "punchline": "European"
         }, {
-            "joke": "Want to hear a joke about a peice of paper?",
+            "joke": "Want to hear a joke about a piece of paper?",
             "punchline": "Never mind...it's tearable"
         }, {
             "joke": "I just watched a documentary about beavers.",
@@ -128,9 +2132,6 @@ window.jokes = [
         }, {
             "joke": "A ham sandwhich walks into a bar and orders a beer. The bartender says...",
             "punchline": "I'm sorry, we don't serve food here"
-        }, {
-            "joke": "Why did the Clydesdale give the pony a glass of water?",
-            "punchline": "Because he was a little horse"
         }, {
             "joke": "If you boil a clown...",
             "punchline": "Do you get a laughing stock?"
@@ -156,28 +2157,19 @@ window.jokes = [
             "joke": "Why did the invisible man turn down the job offer?",
             "punchline": "He couldn't see himself doing it"
         }, {
-            "joke": "How do you make holy water?",
-            "punchline": "You boil the hell out of it"
-        }, {
-            "joke": "I had a dream that I was a muffler last night.",
-            "punchline": "I woke up exhausted!"
-        }, {
-            "joke": "Why is peter pan always flying?",
-            "punchline": "Because he neverlands"
-        }, {
             "joke": "How do you check if a webpage is HTML5?",
             "punchline": "Try it out on Internet Explorer"
-        }, {
-            "joke": "What do you call a cow with no legs?",
-            "punchline": "Ground beef!"
         }, {
             "joke": "I dropped a pear in my car this morning.",
             "punchline": "You should drop another one, then you would have a pair."
         }, {
+            "joke": "Lady: How do I spread love in this cruel world?",
+            "punchline": "Random Dude: [...💘]"
+        }, {
             "joke": "A user interface is like a joke.",
             "punchline": "If you have to explain it then it is not that good."
         }, {
-            "joke": "Knock knock. \nWho's there? \nHatch. \nHatch who?",
+            "joke": "Knock knock. Who's there? Hatch. Hatch who?",
             "punchline": "Bless you!"
         }, {
             "joke": "What do you call sad coffee?",
@@ -192,22 +2184,22 @@ window.jokes = [
             "joke": "Well...",
             "punchline": "That’s a deep subject."
         }, {
-            "joke": "Did You Hear The Story About The Cheese That Saved The World?",
+            "joke": "Did you hear the story about the cheese that saved the world?",
             "punchline": "It was legend dairy."
         }, {
-            "joke": "Did You Watch The New Comic Book Movie?",
+            "joke": "Did you watch the new comic book movie?",
             "punchline": "It was very graphic!"
         }, {
-            "joke": "I Started A New Business Making Yachts In My Attic This Year...",
+            "joke": "I started a new business making yachts in my attic this year...",
             "punchline": "The sails are going through the roof."
         }, {
-            "joke": "I Got Hit In the Head By A Soda Can, But It Didn't Hurt That Much...",
+            "joke": "I got hit in the head by a soda can, but it didn't hurt that much...",
             "punchline": "It was a soft drink."
         }, {
-            "joke": "I Can't Tell If I Like This Blender...",
+            "joke": "I can't tell if i like this blender...",
             "punchline": "It keeps giving me mixed results."
         }, {
-            "joke": "WI Couldn't Get A Reservation At The Library...",
+            "joke": "I couldn't get a reservation at the library...",
             "punchline": "They were fully booked."
         }, {
             "joke": "I was gonna tell you a joke about UDP...",
@@ -222,2164 +2214,277 @@ window.jokes = [
             "joke": "What do you give to a lemon in need?",
             "punchline": "Lemonaid."
         }, {
-            "joke": "Never take advice from electrons.",
-            "punchline": "They are always negative."
-        }, {
-            "joke": "Hey, dad, did you get a haircut?",
-            "punchline": "No, I got them all cut."
-        }, {
-            "joke": "What time is it?",
-            "punchline": "I don't know... it keeps changing."
-        }, {
             "joke": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before. What can I get for you?\"",
             "punchline": "Pop,goes the weasel."
-        }, {
-            "joke": "Bad at golf?",
-            "punchline": "Join the club."
-        }, {
-            "joke": "Can a kangaroo jump higher than the Empire State Building?",
-            "punchline": "Of course. The Empire State Building can't jump."
-        }, {
-            "joke": "Can February march?",
-            "punchline": "No, but April may."
         }, {
             "joke": "Can I watch the TV?",
             "punchline": "Yes, but don’t turn it on."
         }, {
-            "joke": "Dad, can you put my shoes on?",
-            "punchline": "I don't think they'll fit me."
-        }, {
-            "joke": "Did you hear about the bread factory burning down?",
-            "punchline": "They say the business is toast."
-        }, {
-            "joke": "Did you hear about the chameleon who couldn't change color?",
-            "punchline": "They had a reptile dysfunction."
-        }, {
-            "joke": "Did you hear about the cheese factory that exploded in France?",
-            "punchline": "There was nothing left but de Brie."
-        }, {
-            "joke": "Did you hear about the cow who jumped over the barbed wire fence?",
-            "punchline": "It was udder destruction."
-        }, {
-            "joke": "Did you hear about the guy who invented Lifesavers?",
-            "punchline": "They say he made a mint."
-        }, {
-            "joke": "Did you hear about the guy whose whole left side was cut off?",
-            "punchline": "He's all right now."
-        }, {
-            "joke": "Did you hear about the kidnapping at school?",
-            "punchline": "It's ok, he woke up."
-        }, {
-            "joke": "Did you hear about the Mexican train killer?",
-            "punchline": "He had loco motives"
-        }, {
-            "joke": "Did you hear about the new restaurant on the moon?",
-            "punchline": "The food is great, but there’s just no atmosphere."
-        }, {
-            "joke": "Did you hear about the runner who was criticized?",
-            "punchline": "He just took it in stride"
-        }, {
-            "joke": "Did you hear about the scientist who was lab partners with a pot of boiling water?",
-            "punchline": "He had a very esteemed colleague."
-        }, {
-            "joke": "Did you hear about the submarine industry?",
-            "punchline": "It really took a dive..."
-        }, {
-            "joke": "Did you hear that David lost his ID in prague?",
-            "punchline": "Now we just have to call him Dav."
-        }, {
-            "joke": "Did you hear that the police have a warrant out on a midget psychic ripping people off?",
-            "punchline": "It reads \"Small medium at large.\""
-        }, {
-            "joke": "Did you hear the joke about the wandering nun?",
-            "punchline": "She was a roman catholic."
-        }, {
-            "joke": "Did you hear the news?",
-            "punchline": "FedEx and UPS are merging. They’re going to go by the name Fed-Up from now on."
-        }, {
-            "joke": "Did you hear the one about the guy with the broken hearing aid?",
-            "punchline": "Neither did he."
-        }, {
-            "joke": "Did you know crocodiles could grow up to 15 feet?",
-            "punchline": "But most just have 4."
-        }, {
             "joke": "What do ghosts call their true love?",
             "punchline": "Their ghoul-friend"
         }, {
-            "joke": "Did you know that protons have mass?",
-            "punchline": "I didn't even know they were catholic."
-        }, {
-            "joke": "Did you know you should always take an extra pair of pants golfing?",
-            "punchline": "Just in case you get a hole in one."
-        }, {
-            "joke": "Do I enjoy making courthouse puns?",
-            "punchline": "Guilty"
-        }, {
-            "joke": "Do you know where you can get chicken broth in bulk?",
-            "punchline": "The stock market."
-        }, {
-            "joke": "Do you want a brief explanation of what an acorn is?",
-            "punchline": "In a nutshell, it's an oak tree."
-        }, {
-            "joke": "Ever wondered why bees hum?",
-            "punchline": "It's because they don't know the words."
-        }, {
-            "joke": "Have you ever heard of a music group called Cellophane?",
-            "punchline": "They mostly wrap."
-        }, {
-            "joke": "Have you heard of the band 1023MB?",
-            "punchline": "They haven't got a gig yet."
-        }, {
-            "joke": "Have you heard the rumor going around about butter?",
-            "punchline": "Never mind, I shouldn't spread it."
-        }, {
-            "joke": "How are false teeth like stars?",
-            "punchline": "They come out at night!"
-        }, {
-            "joke": "How can you tell a vampire has a cold?",
-            "punchline": "They start coffin."
-        }, {
-            "joke": "How come a man driving a train got struck by lightning?",
-            "punchline": "He was a good conductor."
-        }, {
-            "joke": "How come the stadium got hot after the game?",
-            "punchline": "Because all of the fans left."
-        }, {
-            "joke": "How did Darth Vader know what Luke was getting for Christmas?",
-            "punchline": "He felt his presents."
-        }, {
-            "joke": "How did the hipster burn the roof of his mouth?",
-            "punchline": "He ate the pizza before it was cool."
-        }, {
-            "joke": "How do hens stay fit?",
-            "punchline": "They always egg-cercise!"
-        }, {
-            "joke": "How do locomotives know where they're going?",
-            "punchline": "Lots of training"
-        }, {
-            "joke": "How do the trees get on the internet?",
-            "punchline": "They log on."
-        }, {
-            "joke": "How do you find Will Smith in the snow?",
-            "punchline": "Look for fresh prints."
-        }, {
-            "joke": "How do you fix a broken pizza?",
-            "punchline": "With tomato paste."
-        }, {
-            "joke": "How do you fix a damaged jack-o-lantern?",
-            "punchline": "You use a pumpkin patch."
-        }, {
-            "joke": "How do you get a baby alien to sleep?",
-            "punchline": "You rocket."
-        }, {
-            "joke": "How do you get two whales in a car?",
-            "punchline": "Start in England and drive West."
-        }, {
-            "joke": "How do you know if there’s an elephant under your bed?",
-            "punchline": "Your head hits the ceiling!"
-        }, {
-            "joke": "How do you make a hankie dance?",
-            "punchline": "Put a little boogie in it."
-        }, {
-            "joke": "How do you make holy water?",
-            "punchline": "You boil the hell out of it."
-        }, {
-            "joke": "How do you organize a space party?",
-            "punchline": "You planet."
-        }, {
-            "joke": "How do you steal a coat?",
-            "punchline": "You jacket."
-        }, {
-            "joke": "How do you tell the difference between a crocodile and an alligator?",
-            "punchline": "You will see one later and one in a while."
-        }, {
-            "joke": "How does a dyslexic poet write?",
-            "punchline": "Inverse."
-        }, {
-            "joke": "How does a French skeleton say hello?",
-            "punchline": "Bone-jour."
-        }, {
-            "joke": "How does a penguin build it’s house?",
-            "punchline": "Igloos it together."
-        }, {
-            "joke": "How does a scientist freshen their breath?",
-            "punchline": "With experi-mints!"
-        }, {
-            "joke": "How does the moon cut his hair?",
-            "punchline": "Eclipse it."
-        }, {
-            "joke": "How many apples grow on a tree?",
-            "punchline": "All of them!"
-        }, {
-            "joke": "How many bones are in the human hand?",
-            "punchline": "A handful of them."
-        }, {
-            "joke": "How many hipsters does it take to change a lightbulb?",
-            "punchline": "Oh, it's a really obscure number. You've probably never heard of it."
-        }, {
-            "joke": "How many kids with ADD does it take to change a lightbulb?",
-            "punchline": "Let's go ride bikes!"
-        }, {
-            "joke": "How many optometrists does it take to change a light bulb?",
-            "punchline": "1 or 2? 1... or 2?"
+            "joke": "How good are you at Power Point?",
+            "punchline": "I Excel at it."
         }, {
             "joke": "How many seconds are in a year?",
             "punchline": "12. January 2nd, February 2nd, March 2nd, April 2nd.... etc"
         }, {
-            "joke": "How many South Americans does it take to change a lightbulb?",
-            "punchline": "A Brazilian"
-        }, {
-            "joke": "How many tickles does it take to tickle an octopus?",
-            "punchline": "Ten-tickles!"
-        }, {
-            "joke": "How much does a hipster weigh?",
-            "punchline": "An instagram."
-        }, {
-            "joke": "How was the snow globe feeling after the storm?",
-            "punchline": "A little shaken."
-        }, {
-            "joke": "Is the pool safe for diving?",
-            "punchline": "It deep ends."
-        }, {
-            "joke": "Is there a hole in your shoe?",
-            "punchline": "No… Then how’d you get your foot in it?"
-        }, {
-            "joke": "What did the spaghetti say to the other spaghetti?",
-            "punchline": "Pasta la vista, baby!"
-        }, {
             "joke": "What’s 50 Cent’s name in Zimbabwe?",
             "punchline": "200 Dollars."
-        }, {
-            "joke": "Want to hear a chimney joke?",
-            "punchline": "Got stacks of em! First one's on the house"
-        }, {
-            "joke": "Want to hear a joke about construction?",
-            "punchline": "Nah, I'm still working on it."
-        }, {
-            "joke": "Want to hear my pizza joke?",
-            "punchline": "Never mind, it's too cheesy."
-        }, {
-            "joke": "What animal is always at a game of cricket?",
-            "punchline": "A bat."
-        }, {
-            "joke": "What are the strongest days of the week?",
-            "punchline": "Saturday and Sunday...the rest are weekdays."
-        }, {
-            "joke": "What biscuit does a short person like?",
-            "punchline": "Shortbread. "
-        }, {
-            "joke": "What cheese can never be yours?",
-            "punchline": "Nacho cheese."
-        }, {
-            "joke": "What creature is smarter than a talking parrot?",
-            "punchline": "A spelling bee."
-        }, {
-            "joke": "What did celery say when he broke up with his girlfriend?",
-            "punchline": "She wasn't right for me, so I really don't carrot all."
-        }, {
-            "joke": "What did Michael Jackson name his denim store?",
-            "punchline": "Billy Jeans!"
-        }, {
-            "joke": "What did one nut say as he chased another nut?",
-            "punchline": "I'm a cashew!"
-        }, {
-            "joke": "What did one plate say to the other plate?",
-            "punchline": "Dinner is on me!"
-        }, {
-            "joke": "What did one snowman say to the other snow man?",
-            "punchline": "Do you smell carrot?"
-        }, {
-            "joke": "What did one wall say to the other wall?",
-            "punchline": "I'll meet you at the corner!"
-        }, {
-            "joke": "What did Romans use to cut pizza before the rolling cutter was invented?",
-            "punchline": "Lil Caesars"
-        }, {
-            "joke": "What did the 0 say to the 8?",
-            "punchline": "Nice belt."
-        }, {
-            "joke": "What did the beaver say to the tree?",
-            "punchline": "It's been nice gnawing you."
-        }, {
-            "joke": "What did the big flower say to the littler flower?",
-            "punchline": "Hi, bud!"
-        }, {
-            "joke": "What did the Buffalo say to his little boy when he dropped him off at school?",
-            "punchline": "Bison."
-        }, {
-            "joke": "What did the digital clock say to the grandfather clock?",
-            "punchline": "Look, no hands!"
-        }, {
-            "joke": "What did the dog say to the two trees?",
-            "punchline": "Bark bark."
-        }, {
-            "joke": "What did the Dorito farmer say to the other Dorito farmer?",
-            "punchline": "Cool Ranch!"
-        }, {
-            "joke": "What did the fish say when it swam into a wall?",
-            "punchline": "Damn!"
-        }, {
-            "joke": "What did the grape do when he got stepped on?",
-            "punchline": "He let out a little wine."
-        }, {
-            "joke": "What did the judge say to the dentist?",
-            "punchline": "Do you swear to pull the tooth, the whole tooth and nothing but the tooth?"
-        }, {
-            "joke": "What did the late tomato say to the early tomato?",
-            "punchline": "I’ll ketch up"
-        }, {
-            "joke": "What did the left eye say to the right eye?",
-            "punchline": "Between us, something smells!"
-        }, {
-            "joke": "What did the mountain climber name his son?",
-            "punchline": "Cliff."
-        }, {
-            "joke": "What did the ocean say to the beach?",
-            "punchline": "Thanks for all the sediment."
-        }, {
-            "joke": "What did the ocean say to the shore?",
-            "punchline": "Nothing, it just waved."
-        }, {
-            "joke": "Why don't you find hippopotamuses hiding in trees?",
-            "punchline": "They're really good at it."
-        }, {
-            "joke": "What did the pirate say on his 80th birthday?",
-            "punchline": "Aye Matey!"
-        }, {
-            "joke": "What did the Red light say to the Green light?",
-            "punchline": "Don't look at me I'm changing!"
-        }, {
-            "joke": "What did the scarf say to the hat?",
-            "punchline": "You go on ahead, I am going to hang around a bit longer."
-        }, {
-            "joke": "What did the shy pebble wish for?",
-            "punchline": "That she was a little boulder."
-        }, {
-            "joke": "What did the traffic light say to the car as it passed?",
-            "punchline": "Don't look I'm changing!"
-        }, {
-            "joke": "What did the Zen Buddist say to the hotdog vendor?",
-            "punchline": "Make me one with everything."
-        }, {
-            "joke": "What do birds give out on Halloween?",
-            "punchline": "Tweets."
-        }, {
-            "joke": "What do I look like?",
-            "punchline": "A JOKE MACHINE!?"
-        }, {
-            "joke": "What do prisoners use to call each other?",
-            "punchline": "Cell phones."
-        }, {
-            "joke": "What do vegetarian zombies eat?",
-            "punchline": "Grrrrrainnnnnssss."
-        }, {
-            "joke": "What do you call a bear with no teeth?",
-            "punchline": "A gummy bear!"
-        }, {
-            "joke": "What do you call a bee that lives in America?",
-            "punchline": "A USB."
-        }, {
-            "joke": "What do you call a boomerang that won't come back?",
-            "punchline": "A stick."
-        }, {
-            "joke": "What do you call a careful wolf?",
-            "punchline": "Aware wolf."
-        }, {
-            "joke": "What do you call a cow on a trampoline?",
-            "punchline": "A milk shake!"
-        }, {
-            "joke": "What do you call a cow with no legs?",
-            "punchline": "Ground beef."
-        }, {
-            "joke": "What do you call a cow with two legs?",
-            "punchline": "Lean beef."
-        }, {
-            "joke": "What do you call a crowd of chess players bragging about their wins in a hotel lobby?",
-            "punchline": "Chess nuts boasting in an open foyer."
-        }, {
-            "joke": "What do you call a dad that has fallen through the ice?",
-            "punchline": "A Popsicle."
-        }, {
-            "joke": "What do you call a dictionary on drugs?",
-            "punchline": "High definition."
-        }, {
-            "joke": "what do you call a dog that can do magic tricks?",
-            "punchline": "a labracadabrador"
-        }, {
-            "joke": "What do you call a droid that takes the long way around?",
-            "punchline": "R2 detour."
-        }, {
-            "joke": "What do you call a duck that gets all A's?",
-            "punchline": "A wise quacker."
-        }, {
-            "joke": "What do you call a fake noodle?",
-            "punchline": "An impasta."
-        }, {
-            "joke": "What do you call a fashionable lawn statue with an excellent sense of rhythmn?",
-            "punchline": "A metro-gnome"
-        }, {
-            "joke": "What do you call a fat psychic?",
-            "punchline": "A four-chin teller."
-        }, {
-            "joke": "What do you call a fly without wings?",
-            "punchline": "A walk."
-        }, {
-            "joke": "What do you call a girl between two posts?",
-            "punchline": "Annette."
-        }, {
-            "joke": "What do you call a group of disorganized cats?",
-            "punchline": "A cat-tastrophe."
-        }, {
-            "joke": "What do you call a group of killer whales playing instruments?",
-            "punchline": "An Orca-stra."
-        }, {
-            "joke": "What do you call a monkey in a mine field?",
-            "punchline": "A babooooom!"
-        }, {
-            "joke": "What do you call a nervous javelin thrower?",
-            "punchline": "Shakespeare."
-        }, {
-            "joke": "What do you call a pig that knows karate?",
-            "punchline": "A pork chop!"
-        }, {
-            "joke": "What do you call a pig with three eyes?",
-            "punchline": "Piiig"
-        }, {
-            "joke": "What do you call a pile of cats?",
-            "punchline": "A Meowtain."
-        }, {
-            "joke": "What do you call a sheep with no legs?",
-            "punchline": "A cloud."
-        }, {
-            "joke": "What do you call a troublesome Canadian high schooler?",
-            "punchline": "A poutine."
-        }, {
-            "joke": "What do you call an alligator in a vest?",
-            "punchline": "An in-vest-igator!"
-        }, {
-            "joke": "What do you call an Argentinian with a rubber toe?",
-            "punchline": "Roberto"
-        }, {
-            "joke": "What do you call an eagle who can play the piano?",
-            "punchline": "Talonted!"
-        }, {
-            "joke": "What do you call an elephant that doesn’t matter?",
-            "punchline": "An irrelephant."
-        }, {
-            "joke": "What do you call an old snowman?",
-            "punchline": "Water."
-        }, {
-            "joke": "What do you call cheese by itself?",
-            "punchline": "Provolone."
-        }, {
-            "joke": "What do you call corn that joins the army?",
-            "punchline": "Kernel."
-        }, {
-            "joke": "What do you call someone with no nose?",
-            "punchline": "Nobody knows."
-        }, {
-            "joke": "What do you call two barracuda fish?",
-            "punchline": "A Pairacuda!"
-        }, {
-            "joke": "What do you do on a remote island?",
-            "punchline": "Try and find the TV island it belongs to."
-        }, {
-            "joke": "What do you do when you see a space man?",
-            "punchline": "Park your car, man."
-        }, {
-            "joke": "What do you get hanging from Apple trees?",
-            "punchline": "Sore arms."
-        }, {
-            "joke": "What do you get when you cross a bee and a sheep?",
-            "punchline": "A bah-humbug."
-        }, {
-            "joke": "What do you get when you cross a chicken with a skunk?",
-            "punchline": "A fowl smell!"
-        }, {
-            "joke": "What do you get when you cross a rabbit with a water hose?",
-            "punchline": "Hare spray."
-        }, {
-            "joke": "What do you get when you cross a snowman with a vampire?",
-            "punchline": "Frostbite."
-        }, {
-            "joke": "What do you give a sick lemon?",
-            "punchline": "Lemonaid."
-        }, {
-            "joke": "What does a clock do when it's hungry?",
-            "punchline": "It goes back four seconds!"
-        }, {
-            "joke": "What does a female snake use for support?",
-            "punchline": "A co-Bra!"
-        }, {
-            "joke": "What does a pirate pay for his corn?",
-            "punchline": "A buccaneer!"
-        }, {
-            "joke": "What does an angry pepper do?",
-            "punchline": "It gets jalapeño face."
-        }, {
-            "joke": "What happens to a frog's car when it breaks down?",
-            "punchline": "It gets toad."
-        }, {
-            "joke": "What happens when you anger a brain surgeon?",
-            "punchline": "They will give you a piece of your mind."
-        }, {
-            "joke": "What has ears but cannot hear?",
-            "punchline": "A field of corn."
-        }, {
-            "joke": "What is a centipedes's favorite Beatle song?",
-            "punchline": "I want to hold your hand, hand, hand, hand..."
-        }, {
-            "joke": "What is a tornado's favorite game to play?",
-            "punchline": "Twister!"
-        }, {
-            "joke": "What is a vampire's favorite fruit?",
-            "punchline": "A blood orange."
-        }, {
-            "joke": "What is a witch's favorite subject in school?",
-            "punchline": "Spelling!"
-        }, {
-            "joke": "What is red and smells like blue paint?",
-            "punchline": "Red paint!"
-        }, {
-            "joke": "What is the difference between ignorance and apathy?",
-            "punchline": "I don't know and I don't care."
-        }, {
-            "joke": "What is the hardest part about sky diving?",
-            "punchline": "The ground."
-        }, {
-            "joke": "What is the leading cause of dry skin?",
-            "punchline": "Towels"
-        }, {
-            "joke": "What is the least spoken language in the world?",
-            "punchline": "Sign Language"
-        }, {
-            "joke": "What is the tallest building in the world?",
-            "punchline": "The library, it’s got the most stories!"
-        }, {
-            "joke": "What is this movie about?",
-            "punchline": "It is about 2 hours long."
-        }, {
-            "joke": "What kind of award did the dentist receive?",
-            "punchline": "A little plaque."
-        }, {
-            "joke": "What kind of bagel can fly?",
-            "punchline": "A plain bagel."
-        }, {
-            "joke": "What kind of dinosaur loves to sleep?",
-            "punchline": "A stega-snore-us."
-        }, {
-            "joke": "What kind of dog lives in a particle accelerator?",
-            "punchline": "A Fermilabrador Retriever."
-        }, {
-            "joke": "What kind of magic do cows believe in?",
-            "punchline": "MOODOO."
-        }, {
-            "joke": "What kind of music do planets listen to?",
-            "punchline": "Nep-tunes."
-        }, {
-            "joke": "What kind of pants do ghosts wear?",
-            "punchline": "Boo jeans."
-        }, {
-            "joke": "What kind of tree fits in your hand?",
-            "punchline": "A palm tree!"
-        }, {
-            "joke": "What lies at the bottom of the ocean and twitches?",
-            "punchline": "A nervous wreck."
-        }, {
-            "joke": "What musical instrument is found in the bathroom?",
-            "punchline": "A tuba toothpaste."
-        }, {
-            "joke": "What time did the man go to the dentist?",
-            "punchline": "Tooth hurt-y."
-        }, {
-            "joke": "What type of music do balloons hate?",
-            "punchline": "Pop music!"
-        }, {
-            "joke": "What was a more important invention than the first telephone?",
-            "punchline": "The second one."
-        }, {
-            "joke": "What was the pumpkin’s favorite sport?",
-            "punchline": "Squash."
-        }, {
-            "joke": "What's black and white and read all over?",
-            "punchline": "The newspaper."
-        }, {
-            "joke": "What's blue and not very heavy?",
-            "punchline": "Light blue."
-        }, {
-            "joke": "What's brown and sticky?",
-            "punchline": "A stick."
-        }, {
-            "joke": "What's orange and sounds like a parrot?",
-            "punchline": "A Carrot."
-        }, {
-            "joke": "What's red and bad for your teeth?",
-            "punchline": "A Brick."
-        }, {
-            "joke": "What's the best thing about elevator jokes?",
-            "punchline": "They work on so many levels."
-        }, {
-            "joke": "What's the difference between a guitar and a fish?",
-            "punchline": "You can tune a guitar but you can't \"tuna\"fish!"
-        }, {
-            "joke": "What's the difference between a hippo and a zippo?",
-            "punchline": "One is really heavy, the other is a little lighter."
-        }, {
-            "joke": "What's the difference between a seal and a sea lion?",
-            "punchline": "An ion! "
-        }, {
-            "joke": "What's the worst part about being a cross-eyed teacher?",
-            "punchline": "They can't control their pupils."
-        }, {
-            "joke": "What's the worst thing about ancient history class?",
-            "punchline": "The teachers tend to Babylon."
-        }, {
-            "joke": "What’s brown and sounds like a bell?",
-            "punchline": "Dung!"
-        }, {
-            "joke": "What’s E.T. short for?",
-            "punchline": "He’s only got little legs."
-        }, {
-            "joke": "What’s Forest Gump’s Facebook password?",
-            "punchline": "1forest1"
-        }, {
-            "joke": "What’s the advantage of living in Switzerland?",
-            "punchline": "Well, the flag is a big plus."
-        }, {
-            "joke": "What’s the difference between an African elephant and an Indian elephant?",
-            "punchline": "About 5000 miles."
-        }, {
-            "joke": "When do doctors get angry?",
-            "punchline": "When they run out of patients."
-        }, {
-            "joke": "When does a joke become a dad joke?",
-            "punchline": "When it becomes apparent."
-        }, {
-            "joke": "When is a door not a door?",
-            "punchline": "When it's ajar."
-        }, {
-            "joke": "Where did you learn to make ice cream?",
-            "punchline": "Sunday school."
-        }, {
-            "joke": "Where do bees go to the bathroom?",
-            "punchline": "The BP station."
-        }, {
-            "joke": "Where do hamburgers go to dance?",
-            "punchline": "The meat-ball."
-        }, {
-            "joke": "Where do rabbits go after they get married?",
-            "punchline": "On a bunny-moon."
-        }, {
-            "joke": "Where do sheep go to get their hair cut?",
-            "punchline": "The baa-baa shop."
-        }, {
-            "joke": "Where do you learn to make banana splits?",
-            "punchline": "At sundae school."
-        }, {
-            "joke": "Where do young cows eat lunch?",
-            "punchline": "In the calf-ateria."
-        }, {
-            "joke": "Where does batman go to the bathroom?",
-            "punchline": "The batroom."
-        }, {
-            "joke": "Where does Fonzie like to go for lunch?",
-            "punchline": "Chick-Fil-Eyyyyyyyy."
-        }, {
-            "joke": "Where does Napoleon keep his armies?",
-            "punchline": "In his sleevies."
-        }, {
-            "joke": "Where was the Declaration of Independence signed?",
-            "punchline": "At the bottom! "
         }, {
             "joke": "Where’s the bin?",
             "punchline": "I haven’t been anywhere!"
         }, {
-            "joke": "Which side of the chicken has more feathers?",
-            "punchline": "The outside."
+            "joke": "Knock-knock.",
+            "punchline": "A race condition. Who is there?"
         }, {
-            "joke": "Who did the wizard marry?",
-            "punchline": "His ghoul-friend"
+            "joke": "What's the best part about TCP jokes?",
+            "punchline": "I get to keep telling them until you get them."
         }, {
-            "joke": "Who is the coolest Doctor in the hospital?",
-            "punchline": "The hip Doctor!"
+            "joke": "A programmer puts two glasses on his bedside table before going to sleep.",
+            "punchline": "A full one, in case he gets thirsty, and an empty one, in case he doesn’t."
         }, {
-            "joke": "Why are fish easy to weigh?",
-            "punchline": "Because they have their own scales."
+            "joke": "Two guys walk into a bar...",
+            "punchline": "The first guy says \"Ouch!\" and the second says \"Yeah, I didn't see it either.\""
         }, {
-            "joke": "Why are fish so smart?",
-            "punchline": "Because they live in schools!"
+            "joke": "What did the router say to the doctor?",
+            "punchline": "It hurts when IP."
         }, {
-            "joke": "Why are ghosts bad liars?",
-            "punchline": "Because you can see right through them!"
+            "joke": "An IPv6 packet is walking out of the house.",
+            "punchline": "He goes nowhere."
         }, {
-            "joke": "Why are graveyards so noisy?",
-            "punchline": "Because of all the coffin."
+            "joke": "A DHCP packet walks into a bar and asks for a beer.",
+            "punchline": "Bartender says, \"here, but I’ll need that back in an hour!\""
         }, {
-            "joke": "Why are mummys scared of vacation?",
-            "punchline": "They're afraid to unwind."
+            "joke": "3 SQL statements walk into a NoSQL bar. Soon, they walk out",
+            "punchline": "They couldn't find a table."
         }, {
-            "joke": "Why are oranges the smartest fruit?",
-            "punchline": "Because they are made to concentrate. "
+            "joke": "I saw a nice stereo on Craigslist for $1. Seller says the volume is stuck on ‘high’",
+            "punchline": "I couldn’t turn it down."
         }, {
-            "joke": "Why are pirates called pirates?",
-            "punchline": "Because they arrr!"
+            "joke": "What do you call a bee that can't make up its mind?",
+            "punchline": "A maybe."
         }, {
-            "joke": "Why are skeletons so calm?",
-            "punchline": "Because nothing gets under their skin."
+            "joke": "Why was Cinderalla thrown out of the football team?",
+            "punchline": "Because she ran away from the ball."
         }, {
-            "joke": "Why can't a bicycle stand on its own?",
-            "punchline": "It's two-tired."
+            "joke": "What kind of music do welders like?",
+            "punchline": "Heavy metal."
         }, {
-            "joke": "Why can't you use \"Beef stew\" as a password?",
-            "punchline": "Because it's not stroganoff."
+            "joke": "Why are “Dad Jokes” so good?",
+            "punchline": "Because the punchline is apparent."
         }, {
-            "joke": "Why can't your nose be 12 inches long?",
-            "punchline": "Because then it'd be a foot!"
+            "joke": "Why dot net developers don't wear glasses?",
+            "punchline": "Because they see sharp."
         }, {
-            "joke": "Why can’t you hear a pterodactyl go to the bathroom?",
-            "punchline": "The p is silent."
+            "joke": "Why is seven bigger than nine?",
+            "punchline": "Because seven ate nine."
         }, {
-            "joke": "Why couldn't the kid see the pirate movie?",
-            "punchline": "Because it was rated arrr!"
+            "joke": "Why do fathers take an extra pair of socks when they go golfing?",
+            "punchline": "In case they get a hole in one!"
         }, {
-            "joke": "Why couldn't the lifeguard save the hippie?",
-            "punchline": "He was too far out, man."
+            "joke": "What do you call a suspicious looking laptop?",
+            "punchline": "Asus"
         }, {
-            "joke": "Why did Dracula lie in the wrong coffin?",
-            "punchline": "He made a grave mistake."
+            "joke": "What did the Java code say to the C code?",
+            "punchline": "You've got no class."
         }, {
-            "joke": "Why did Sweden start painting barcodes on the sides of their battleships?",
-            "punchline": "So they could Scandinavian."
+            "joke": "What is the most used language in programming?",
+            "punchline": "Profanity."
         }, {
-            "joke": "Why did the A go to the bathroom and come out as an E?",
-            "punchline": "Because he had a vowel movement."
+            "joke": "Why do programmers always get Christmas and Halloween mixed up?",
+            "punchline": "Because DEC 25 = OCT 31"
         }, {
-            "joke": "Why did the barber win the race?",
-            "punchline": "He took a short cut."
+            "joke": "What goes after USA?",
+            "punchline": "USB."
         }, {
-            "joke": "Why did the belt go to prison?",
-            "punchline": "He held up a pair of pants!"
+            "joke": "Why don't eggs tell jokes?",
+            "punchline": "Because they would crack each other up."
         }, {
-            "joke": "Why did the burglar hang his mugshot on the wall?",
-            "punchline": "To prove that he was framed!"
+            "joke": "How do you make the number one disappear?",
+            "punchline": "Add the letter G and it’s “gone”!"
         }, {
-            "joke": "Why did the chicken get a penalty?",
-            "punchline": "For fowl play."
+            "joke": "My older brother always tore the last pages of my comic books, and never told me why.",
+            "punchline": "I had to draw my own conclusions."
         }, {
-            "joke": "Why did the Clydesdale give the pony a glass of water?",
-            "punchline": "Because he was a little horse!"
+            "joke": "The Sergeant-Major growled at the young soldier: I didn’t see you at camouflage training this morning.",
+            "punchline": "Thank you very much, sir."
         }, {
-            "joke": "Why did the coffee file a police report?",
-            "punchline": "It got mugged."
+            "joke": "Why did the kid throw the watch out the window?",
+            "punchline": "So time would fly."
         }, {
-            "joke": "Why did the cookie cry?",
-            "punchline": "Because his mother was a wafer so long"
+            "joke": "Where did the API go to eat?",
+            "punchline": "To the RESTaurant."
         }, {
-            "joke": "Why did the cookie cry?",
-            "punchline": "It was feeling crumby."
+            "joke": "Why did the rooster cross the road?",
+            "punchline": "He heard that the chickens at KFC were pretty hot."
         }, {
-            "joke": "Why did the cowboy have a weiner dog?",
-            "punchline": "Somebody told him to get a long little doggy."
+            "joke": "Did you hear about the Viking who was reincarnated?",
+            "punchline": "He was Bjorn again"
         }, {
-            "joke": "Why did the fireman wear red, white, and blue suspenders?",
-            "punchline": "To hold his pants up."
+            "joke": "What does the mermaid wear to math class?",
+            "punchline": "Algae-bra."
         }, {
-            "joke": "Why did the girl smear peanut butter on the road?",
-            "punchline": "To go with the traffic jam."
+            "joke": "Did you hear about the crime in the parking garage?",
+            "punchline": "It was wrong on so many levels."
         }, {
-            "joke": "Why did the half blind man fall in the well?",
-            "punchline": "Because he couldn't see that well!"
+            "joke": "Hey, wanna hear a joke?",
+            "punchline": "Parsing HTML with regex."
         }, {
-            "joke": "Why did the house go to the doctor?",
-            "punchline": "It was having window panes."
+            "joke": "Why didn't the skeleton go for prom?",
+            "punchline": "Because it had nobody."
         }, {
-            "joke": "Why did the kid cross the playground?",
-            "punchline": "To get to the other slide."
+            "joke": "A grocery store cashier asked if I would like my milk in a bag.",
+            "punchline": "I told her 'No, thanks. The carton works fine.'"
         }, {
-            "joke": "Why did the man put his money in the freezer?",
-            "punchline": "He wanted cold hard cash!"
+            "joke": "99.9% of the people are dumb!",
+            "punchline": "Fortunately I belong to the remaining 1%"
         }, {
-            "joke": "Why did the man run around his bed?",
-            "punchline": "Because he was trying to catch up on his sleep!"
+            "joke": "I just got fired from my job at the keyboard factory.",
+            "punchline": "They told me I wasn't putting in enough shifts."
         }, {
-            "joke": "Why did the melons plan a big wedding?",
-            "punchline": "Because they cantaloupe!"
+            "joke": "You see, mountains aren't just funny.",
+            "punchline": "They are hill areas."
         }, {
-            "joke": "Why did the octopus beat the shark in a fight?",
-            "punchline": "Because it was well armed."
+            "joke": "What do elves post on Social Media?",
+            "punchline": "Elf-ies."
         }, {
-            "joke": "Why did the opera singer go sailing?",
-            "punchline": "They wanted to hit the high Cs."
+            "joke": "While I was sleeping my friends decided to write math equations on me.",
+            "punchline": "You should have seen the expression on my face when I woke up."
         }, {
-            "joke": "Why did the scarecrow win an award?",
-            "punchline": "Because he was outstanding in his field."
+            "joke": "Due to complaints, Hawaii passed a law where you're not allowed to laugh above a certain decibel.",
+            "punchline": "You can only use a low ha."
         }, {
-            "joke": "Why did the tomato blush?",
-            "punchline": "Because it saw the salad dressing."
+            "joke": "Why are football stadiums so cool?",
+            "punchline": "Because every seat has a fan in it."
         }, {
-            "joke": "Why did the tree go to the dentist?",
-            "punchline": "It needed a root canal."
+            "joke": "How do you generate a random string?",
+            "punchline": "Put a Windows user in front of Vim and tell them to exit."
         }, {
-            "joke": "Why did the worker get fired from the orange juice factory?",
-            "punchline": "Lack of concentration."
+            "joke": "Why did the functions stop calling each other?",
+            "punchline": "Because they had constant arguments."
         }, {
-            "joke": "Why didn't the number 4 get into the nightclub?",
-            "punchline": "Because he is 2 square."
+            "joke": "Why did the private classes break up?",
+            "punchline": "Because they never saw each other."
         }, {
-            "joke": "Why didn’t the orange win the race?",
-            "punchline": "It ran out of juice."
+            "joke": "Why did the developer quit his job?",
+            "punchline": "Because he didn't get arrays."
         }, {
-            "joke": "Why didn’t the skeleton cross the road?",
-            "punchline": "Because he had no guts."
+            "joke": "How many React developers does it take to change a lightbulb?",
+            "punchline": "None, they prefer dark mode."
         }, {
-            "joke": "Why do bananas have to put on sunscreen before they go to the beach?",
-            "punchline": "Because they might peel!"
+            "joke": "Why don't React developers like nature?",
+            "punchline": "They prefer the virtual DOM."
         }, {
-            "joke": "Why do bears have hairy coats?",
-            "punchline": "Fur protection."
+            "joke": "What do you get when you cross a React developer with a mathematician?",
+            "punchline": "A function component."
         }, {
-            "joke": "Why do bees have sticky hair?",
-            "punchline": "Because they use honey combs!"
+            "joke": "Why did the developer go broke buying Bitcoin?",
+            "punchline": "He kept calling it bytecoin and didn't get any."
         }, {
-            "joke": "Why do bees hum?",
-            "punchline": "Because they don't know the words."
+            "joke": "Why did the programmer go to art school?",
+            "punchline": "He wanted to learn how to code outside the box."
         }, {
-            "joke": "Why do birds fly south for the winter?",
-            "punchline": "Because it's too far to walk."
+            "joke": "Why did the programmer's wife leave him?",
+            "punchline": "He didn't know how to commit."
         }, {
-            "joke": "Why do choirs keep buckets handy?",
-            "punchline": "So they can carry their tune"
+            "joke": "Why do programmers prefer dark chocolate?",
+            "punchline": "Because it's bitter like their code."
         }, {
-            "joke": "Why do crabs never give to charity?",
-            "punchline": "Because they’re shellfish."
+            "joke": "Why did the programmer go broke?",
+            "punchline": "He used up all his cache"
         }, {
-            "joke": "Why do ducks make great detectives?",
-            "punchline": "They always quack the case."
+            "joke": "Why did the programmer always mix up Halloween and Christmas?",
+            "punchline": "Because Oct 31 equals Dec 25."
         }, {
-            "joke": "Why do mathematicians hate the U.S.?",
-            "punchline": "Because it's indivisible."
+            "joke": "Why don't programmers like nature?",
+            "punchline": "There's too many bugs."
         }, {
-            "joke": "Why do pirates not know the alphabet?",
-            "punchline": "They always get stuck at \"C\"."
-        }, {
-            "joke": "Why do pumpkins sit on people’s porches?",
-            "punchline": "They have no hands to knock on the door."
-        }, {
-            "joke": "Why do scuba divers fall backwards into the water?",
-            "punchline": "Because if they fell forwards they’d still be in the boat."
-        }, {
-            "joke": "Why do trees seem suspicious on sunny days?",
-            "punchline": "Dunno, they're just a bit shady."
-        }, {
-            "joke": "Why do valley girls hang out in odd numbered groups?",
-            "punchline": "Because they can't even."
-        }, {
-            "joke": "Why do wizards clean their teeth three times a day?",
-            "punchline": "To prevent bat breath!"
-        }, {
-            "joke": "Why do you never see elephants hiding in trees?",
-            "punchline": "Because they're so good at it."
-        }, {
-            "joke": "Why does a chicken coop only have two doors?",
-            "punchline": "Because if it had four doors it would be a chicken sedan."
-        }, {
-            "joke": "Why does a Moon-rock taste better than an Earth-rock?",
-            "punchline": "Because it's a little meteor."
-        }, {
-            "joke": "Why does it take longer to get from 1st to 2nd base, than it does to get from 2nd to 3rd base?",
-            "punchline": "Because there’s a Shortstop in between!"
-        }, {
-            "joke": "Why does Norway have barcodes on their battleships?",
-            "punchline": "So when they get back to port, they can Scandinavian."
-        }, {
-            "joke": "Why does Superman get invited to dinners?",
-            "punchline": "Because he is a Supperhero."
-        }, {
-            "joke": "Why does Waldo only wear stripes?",
-            "punchline": "Because he doesn't want to be spotted."
-        }, {
-            "joke": "Dad, can you put my shoes on?",
-            "punchline": "No, I don't think they'll fit me."
-        }, {
-            "joke": "Dad, did you get a haircut?",
-            "punchline": "No I got them all cut."
-        }, {
-            "joke": "Did I tell you the time I fell in love during a backflip?",
-            "punchline": "I was heels over head."
-        }, {
-            "joke": "Did you hear about the circus fire?",
-            "punchline": "It was in tents!"
-        }, {
-            "joke": "Did you hear about the fire at the circus?",
-            "punchline": "IT WAS IN TENTS."
-        }, {
-            "joke": "Did you hear about the guy whose whole left side was cut off?",
-            "punchline": "He's all right now."
-        }, {
-            "joke": "Did you hear about the Hyena who drank a pint of gravy?",
-            "punchline": "He was a laughing stock!"
-        }, {
-            "joke": "Did you hear about the kidnapping at school?",
-            "punchline": "It's fine, he woke up."
-        }, {
-            "joke": "Did you hear about the new restaurant on the moon?",
-            "punchline": "The food is great, but there's just no atmosphere."
-        }, {
-            "joke": "Did you hear about the red ship and the blue ship that collided?",
-            "punchline": "Both crews were marooned."
-        }, {
-            "joke": "Did you hear about the restaurant on the moon?",
-            "punchline": "Great food, no atmosphere."
-        }, {
-            "joke": "Did you hear that the police have a warrant out on a midget psychic ripping people off?",
-            "punchline": "It reads 'Small medium at large.'"
-        }, {
-            "joke": "Did you know the first French fries weren't actually cooked in France?",
-            "punchline": "They were cooked in grease."
-        }, {
-            "joke": "Did you see they made round bails of hay illegal in Wisconsin?",
-            "punchline": "It's because the cows weren't getting a square meal."
-        }, {
-            "joke": "Have you heard the one about the Corduroy pillow?",
-            "punchline": "It's making HEADLINES!"
-        }, {
-            "joke": "How did Darth Vader know what Luke got him for Christmas?",
-            "punchline": "He felt his presents!"
-        }, {
-            "joke": "How do you count cows?",
-            "punchline": "A 'Cow'culator."
-        }, {
-            "joke": "How do you find Will Smith in the snow?",
-            "punchline": "You look for the fresh prints."
-        }, {
-            "joke": "How do you fix a broken tuba?",
-            "punchline": "With a tuba glue!"
-        }, {
-            "joke": "How do you make a tissue dance?",
-            "punchline": "Put a little boogie in it!"
-        }, {
-            "joke": "How do you make toast in the jungle?",
-            "punchline": "Pop your bread under a g'rilla."
-        }, {
-            "joke": "How do you turn a duck into a soul singer?",
-            "punchline": "Put it in a microwave until its bill withers."
-        }, {
-            "joke": "How does a burglar get into your house?",
-            "punchline": "Intruder window."
-        }, {
-            "joke": "How does a lion like his meat?",
-            "punchline": "ROAR!"
-        }, {
-            "joke": "How does a penguin build it's house?",
-            "punchline": "Igloos it together."
-        }, {
-            "joke": "How does an octopus go to war?",
-            "punchline": "WELL-ARMED!"
-        }, {
-            "joke": "How does Hitler tie his shoes?",
-            "punchline": "with little Nazis!"
-        }, {
-            "joke": "How does the man in the moon cut his hair?",
-            "punchline": "ECLIPSE IT!"
-        }, {
-            "joke": "How many apples grow on a tree?",
-            "punchline": "All of them."
-        }, {
-            "joke": "How many tickles does it take to make an octopus laugh?",
-            "punchline": "Ten-tickles."
-        }, {
-            "joke": "How much does a pirate pay for corn?",
-            "punchline": "A buccaneer!"
-        }, {
-            "joke": "Want to hear a joke about construction?",
-            "punchline": "I'm still working on it."
-        }, {
-            "joke": "Want to hear a joke about paper?",
-            "punchline": "Nevermind, it's tearable."
-        }, {
-            "joke": "What did 0 say to 8?",
-            "punchline": "Nice belt!"
-        }, {
-            "joke": "what did one hat say to another?",
-            "punchline": "You stay here, I'll go on a head!"
-        }, {
-            "joke": "What did one shark say to the other while eating a clownfish?",
-            "punchline": "This tastes funny."
-        }, {
-            "joke": "What did one snowman say to the other?",
-            "punchline": "Do you smell carrots?"
-        }, {
-            "joke": "What did the baby say to its mother after breastfeeding?",
-            "punchline": "Thanks for the mammaries!"
-        }, {
-            "joke": "What did the big bucket say to the little bucket?",
-            "punchline": "You look a little pail!"
-        }, {
-            "joke": "What did the Buddhist say to the hot dog vendor?",
-            "punchline": "Make me one with everything!"
-        }, {
-            "joke": "What did the buffalo say to his son when he dropped him off at school?",
-            "punchline": "Bison."
-        }, {
-            "joke": "What did the cobbler say when a cat wandered into his shop?",
-            "punchline": "Shoe!"
-        }, {
-            "joke": "What did the elder chimney say to the younger chimney?",
-            "punchline": "You're too young to smoke!"
-        }, {
-            "joke": "What did the fish say when he ran into the wall?",
-            "punchline": "Dam."
-        }, {
-            "joke": "What did the ghost say to the bee?",
-            "punchline": "BOO-BEE!"
-        }, {
-            "joke": "What did the grape do when he got stepped on?",
-            "punchline": "He let out a little wine."
-        }, {
-            "joke": "What did the grape say after the elephant sat on it?",
-            "punchline": "Nothing, it just let out a little whine!"
-        }, {
-            "joke": "What did the green grape say to the purple grape?",
-            "punchline": "Breathe, you fool, breathe!"
-        }, {
-            "joke": "What did the monkey say when he caught his tail in the revolving door?",
-            "punchline": "It won't be long now."
-        }, {
-            "joke": "What did the mother Buffalo say when her boy left for college?",
-            "punchline": "BYE-SON!"
-        }, {
-            "joke": "What did the pirate say on his 80th birthday?",
-            "punchline": "Aye matey."
-        }, {
-            "joke": "What did the policeman say to his tummy?",
-            "punchline": "I've got you under a vest!"
-        }, {
-            "joke": "What did the psychiatrist say when a man wearing nothing but saran wrap walked into his office?",
-            "punchline": "I can clearly see you're nuts!"
-        }, {
-            "joke": "What did the traffic light say to the car?",
-            "punchline": "Don't look, I'm changing."
-        }, {
-            "joke": "What did the worker at the rubber band factory say when he lost his job?",
-            "punchline": "OH SNAP!"
-        }, {
-            "joke": "What do calendars eat?",
-            "punchline": "DATES!"
-        }, {
-            "joke": "What do cats eat for breakfast?",
-            "punchline": "Mice Krispies!"
-        }, {
-            "joke": "What do clouds wear under their shorts?",
-            "punchline": "THUNDERPANTS!"
-        }, {
-            "joke": "What do Eskimos get from sitting on the ice too long?",
-            "punchline": "Polaroids."
-        }, {
-            "joke": "What do prisoners use to call each other?",
-            "punchline": "Cell phones."
-        }, {
-            "joke": "What do sharks say when something radical happens?",
-            "punchline": "JAWESOME!"
-        }, {
-            "joke": "What do you call a bear with no teeth?",
-            "punchline": "A gummy bear."
-        }, {
-            "joke": "What do you call a Bee who is having a bad hair day?",
-            "punchline": "A FRISBEE!"
-        }, {
-            "joke": "What do you call a cow with two legs?",
-            "punchline": "Lean beef, if the cow has no legs, then it's ground beef."
-        }, {
-            "joke": "What do you call a deer with no eye?",
-            "punchline": "NO IDEAR!"
-        }, {
-            "joke": "What do you call a dog that can do magic?",
-            "punchline": "A Labracadabrador."
-        }, {
-            "joke": "What do you call a factory that sells passable products?",
-            "punchline": "A satisfactory."
-        }, {
-            "joke": "What do you call a fake noodle?",
-            "punchline": "An impasta."
-        }, {
-            "joke": "What do you call a fat psychic?",
-            "punchline": "A four-chin teller."
-        }, {
-            "joke": "What do you call a fat psychic?",
-            "punchline": "A four-chin teller."
-        }, {
-            "joke": "What do you call a fish with no eyes?",
-            "punchline": "Fsh."
-        }, {
-            "joke": "What do you call a fish with two knees?",
-            "punchline": "A two-knee fish"
-        }, {
-            "joke": "What do you call a guy who never farts in public?",
-            "punchline": "A PRIVATE TUTOR!"
-        }, {
-            "joke": "What do you call a guy with a rubber toe?",
-            "punchline": "Roberto."
-        }, {
-            "joke": "What do you call a lonely cheese?",
-            "punchline": "Provolone."
-        }, {
-            "joke": "What do you call a man with a rubber toe?",
-            "punchline": "Roberto."
-        }, {
-            "joke": "What do you call a man with a rug on his head?",
-            "punchline": "Matt."
-        }, {
-            "joke": "What do you call a man with no arms and no legs in a pool?",
-            "punchline": "Bob."
-        }, {
-            "joke": "What do you call a man with no arms and no legs playing in the leaves?",
-            "punchline": "Russell."
-        }, {
-            "joke": "What do you call a man with no arms or legs who gets into a fight with his cat?",
-            "punchline": "Claude."
-        }, {
-            "joke": "What do you call a Mexican who has lost his car?",
-            "punchline": "Carlos."
-        }, {
-            "joke": "What do you call a nosy pepper?",
-            "punchline": "JALAPENO BUSINESS!"
-        }, {
-            "joke": "What do you call a pig that does karate?",
-            "punchline": "A PORK CHOP!"
-        }, {
-            "joke": "What do you call a pony's cough?",
-            "punchline": "A LITTLE HOARSE!"
-        }, {
-            "joke": "what do you call a psychic midget who has escaped from prison?",
-            "punchline": "A SMALL MEDIUM AT LARGE!"
-        }, {
-            "joke": "What do you call a sheep with no legs?",
-            "punchline": "A cloud."
-        }, {
-            "joke": "What do you call a sketchy Italian neighbourhood?",
-            "punchline": "The Spaghetto."
-        }, {
-            "joke": "What do you call an elephant that doesn't matter?",
-            "punchline": "An irrelephant."
-        }, {
-            "joke": "What do you call cheese that isn't yours?",
-            "punchline": "Nacho cheese."
-        }, {
-            "joke": "What do you call it when a dinosaur crashes his car?",
-            "punchline": "Tyrannosaurus Wrecks."
-        }, {
-            "joke": "What do you call it when you feed a stick of dynamite to a steer?",
-            "punchline": "Abominable! (say it out loud, slowly)"
-        }, {
-            "joke": "What do you call someone with no body and no nose?",
-            "punchline": "Nobody knows."
-        }, {
-            "joke": "What do you do when you see a spaceman?",
-            "punchline": "PARK YOUR CAR, MAN!"
-        }, {
-            "joke": "What do you do with a sick boat?",
-            "punchline": "TAKE IT TO THE DOC!"
-        }, {
-            "joke": "what do you do with epileptic lettuce?",
-            "punchline": "You make a seizure salad!"
-        }, {
-            "joke": "What do you get hanging off banana trees?",
-            "punchline": "Sore arms."
-        }, {
-            "joke": "What do you get if you cross the Atlantic with the Titanic?",
-            "punchline": "About halfway."
-        }, {
-            "joke": "What do you get if you divide the circumference of a pumpkin by its diameter?",
-            "punchline": "PUMPKIN PI!"
-        }, {
-            "joke": "What do you get if you drop a piano down a coal shaft?",
-            "punchline": "A flat minor."
-        }, {
-            "joke": "What do you get when you cross a sheep and a bee?",
-            "punchline": "A bah-humbug."
-        }, {
-            "joke": "What do you get when you cross a snowman with a vampire?",
-            "punchline": "Frostbite."
-        }, {
-            "joke": "What do you get when you cross a tyrannosaurus rex with fireworks?",
-            "punchline": "DINO-MITE!"
-        }, {
-            "joke": "What do you get when you cross an elephant with a rhino?",
-            "punchline": "Elephino."
-        }, {
-            "joke": "What do you get when you run over a bird with your lawnmower?",
-            "punchline": "Shredded tweet."
-        }, {
-            "joke": "What does a cannibal do after dumping his girlfriend?",
-            "punchline": "Wipes his butt."
-        }, {
-            "joke": "What does a ghost wear when it's raining outside?",
-            "punchline": "Boooooooooooooooooooooooooooots!"
-        }, {
-            "joke": "What does a vegan zombie eat?",
-            "punchline": "Graaaaaaaaaaaaaaaaaaaaaaaains!"
-        }, {
-            "joke": "What does an angry pepper do?",
-            "punchline": "It gets jalapeno your face."
-        }, {
-            "joke": "What happened when the butcher backed into his meat grinder?",
-            "punchline": "HE GOT A LITTLE BEHIND IN HIS WORK!"
-        }, {
-            "joke": "What happens to Pastors who eat chili dogs?",
-            "punchline": "They have to sit in their own pew."
-        }, {
-            "joke": "What has twenty legs and flies?",
-            "punchline": "Five dead Horses."
-        }, {
-            "joke": "What has twenty legs and flies?",
-            "punchline": "Ten pairs of pants."
-        }, {
-            "joke": "What is a shark's favorite illegal substance?",
-            "punchline": "Reefer!"
-        }, {
-            "joke": "What is Beethoven's favorite fruit?",
-            "punchline": "A ba-na-na-na."
-        }, {
-            "joke": "What is Bruce Lee's favorite drink?",
-            "punchline": "WATAAAAARR!"
-        }, {
-            "joke": "What is invisible and smells like carrots?",
-            "punchline": "Rabbit farts."
-        }, {
-            "joke": "What is the definition of a good farmer?",
-            "punchline": "A MAN OUTSTANDING IN HIS FIELD!"
-        }, {
-            "joke": "What is the richest country in the world?",
-            "punchline": "Ireland, its capital is always Dublin."
-        }, {
-            "joke": "What kind of flower is on your face?",
-            "punchline": "Tulips!"
-        }, {
-            "joke": "What kind of guns do bees use?",
-            "punchline": "BeeBee guns."
-        }, {
-            "joke": "What kind of horses go out after dusk?",
-            "punchline": "Nightmares!"
-        }, {
-            "joke": "What kind of music do chiropractors listen to?",
-            "punchline": "HIP-POP!"
-        }, {
-            "joke": "What lies on the ocean floor and shivers?",
-            "punchline": "A nervous wreck."
-        }, {
-            "joke": "What time did the man go to the dentist?",
-            "punchline": "Tooth hurt-y."
-        }, {
-            "joke": "What time did the man go to the dentist?",
-            "punchline": "Tooth hurt-y."
-        }, {
-            "joke": "What type of music do mummies listen to?",
-            "punchline": "WRAP MUSIC!"
-        }, {
-            "joke": "What was Beethoven's favorite fruit?",
-            "punchline": "BANANANAAAAAA!"
-        }, {
-            "joke": "What was Beethoven's fifth favorite fruit?",
-            "punchline": "Ba-na-na-na."
-        }, {
-            "joke": "What was T-Rex's favorite number?",
-            "punchline": "Ate!"
-        }, {
-            "joke": "What washes up on tiny beaches?",
-            "punchline": "MICROWAVES!"
-        }, {
-            "joke": "What's a pirate's favorite letter?",
-            "punchline": "It be the Sea."
-        }, {
-            "joke": "What's big, red, and eats rocks?",
-            "punchline": "A big, red, rock-eater."
-        }, {
-            "joke": "What's brown and sticky?",
-            "punchline": "A stick."
-        }, {
-            "joke": "What's Forrest Gump's password?",
-            "punchline": "1forrest1."
-        }, {
-            "joke": "What's it called when you lend money to a bison?",
-            "punchline": "A BUFFA-LOAN!"
-        }, {
-            "joke": "What's the advantage of living in Switzerland?",
-            "punchline": "Well, the flag is a big plus."
-        }, {
-            "joke": "What's the best part about living in Switzerland?",
-            "punchline": "I don't know, but the flag is a big plus."
-        }, {
-            "joke": "What's the best way to carve wood?",
-            "punchline": "Whittle by whittle."
-        }, {
-            "joke": "What's the difference between a hippo and a Zippo?",
-            "punchline": "One is heavy, and the other is a little lighter."
-        }, {
-            "joke": "What's the difference between a jeweller and a prison warden?",
-            "punchline": "One sells watches, and the other watches cells."
-        }, {
-            "joke": "What's the difference between a well dressed man on a a bicycle and a poorly dressed man on a tricycle?",
-            "punchline": "Attire!"
-        }, {
-            "joke": "What's the last thing that goes through a bug's mind when it hits a windshield?",
-            "punchline": "Its butt."
-        }, {
-            "joke": "What's worse than finding a worm in your apple?",
-            "punchline": "Finding half a worm."
-        }, {
-            "joke": "Where are average things built?",
-            "punchline": "In the satisfactory."
-        }, {
-            "joke": "Where are the Andes?",
-            "punchline": "At the end of your armies."
-        }, {
-            "joke": "Where did Napoleon keep his armies?",
-            "punchline": "Up his sleevies."
-        }, {
-            "joke": "Where does George Washington keep his armies?",
-            "punchline": "In his sleevies."
-        }, {
-            "joke": "Which side of a cheetah has the most spots?",
-            "punchline": "THE OUTSIDE!"
-        }, {
-            "joke": "Who does a pharaoh talk to when he's sad?",
-            "punchline": "His mummy."
-        }, {
-            "joke": "Who is the quickest draw in the ocean?",
-            "punchline": "Billy the Squid."
-        }, {
-            "joke": "Why are all the frogs around here dead?",
-            "punchline": "'Cause they keep croaking!"
-        }, {
-            "joke": "Why can't you hear a pterodactyl go to the bathroom?",
-            "punchline": "Because the pee is silent."
-        }, {
-            "joke": "Why can't you hear a pterodactyl using the bathroom?",
-            "punchline": "Because the P is silent."
-        }, {
-            "joke": "Why couldn't Dracula's wife get to sleep?",
-            "punchline": "Because of his coffin."
+            "joke": "Why was the JavaScript developer sad?",
+            "punchline": "He didn't know how to null his feelings."
         }, {
             "joke": "Why couldn't the bicycle stand up by itself?",
-            "punchline": "It was two tired."
+            "punchline": "It was two-tired."
         }, {
-            "joke": "Why couldn't the bike standup by itself?",
-            "punchline": "It was two tired."
+            "joke": "Why did the math book look sad?",
+            "punchline": "Because it had too many problems."
         }, {
-            "joke": "Why did Cinderella get kicked off the softball team?",
-            "punchline": "Because she ran away from the ball!"
+            "joke": "What's a computer's favorite snack?",
+            "punchline": "Microchips."
         }, {
-            "joke": "Why did Simba's father die?",
-            "punchline": "Because he couldn't Mufasa!"
+            "joke": "What did the janitor say when he jumped out of the closet?",
+            "punchline": "Supplies!"
         }, {
-            "joke": "Why did the banana go to the doctors'?",
-            "punchline": "He wasn't peeling very well."
+            "joke": "What did one ocean say to the other ocean?",
+            "punchline": "Nothing, they just waved."
         }, {
-            "joke": "Why did the Clydesdale give the pony a glass of water?",
-            "punchline": "Because he was a little horse!"
-        }, {
-            "joke": "Why did the coffee file a police report?",
-            "punchline": "It got mugged."
-        }, {
-            "joke": "Why did the cookie cry?",
-            "punchline": "Because his mother was a wafer so long!"
-        }, {
-            "joke": "Why did the cookie go to the hospital?",
-            "punchline": "Be cause he felt crummy."
-        }, {
-            "joke": "Why did the cowboy adopt a weiner dog?",
-            "punchline": "He wanted to get a long little doggy!"
-        }, {
-            "joke": "Why did the crab never share?",
-            "punchline": "Because he's shellfish."
-        }, {
-            "joke": "Why did the elephants get kicked out of the public pool?",
-            "punchline": "THEY KEPT DROPPING THEIR TRUNKS!"
+            "joke": "What's the best thing about Switzerland?",
+            "punchline": "I don't know, but their flag is a big plus."
         }, {
             "joke": "Why did the golfer bring two pairs of pants?",
-            "punchline": "In case he got a hole-in-one."
+            "punchline": "In case he got a hole in one."
         }, {
-            "joke": "Why did the invisible man turn down the job offer?",
-            "punchline": "He couldn't see himself doing it."
+            "joke": "Why did the chicken cross the playground?",
+            "punchline": "To get to the other slide."
         }, {
-            "joke": "Why did the man dump ground beef on his head?",
-            "punchline": "He wanted a meatier shower!"
+            "joke": "Why don't scientists trust atoms?",
+            "punchline": "Because they make up everything."
         }, {
-            "joke": "Why did the octopus beat the shark in a fight?",
-            "punchline": "Because it was well armed."
-        }, {
-            "joke": "Why did the pirate go to the Caribbean?",
-            "punchline": "He wanted some arr and arr."
-        }, {
-            "joke": "Why did the police officer smell?",
-            "punchline": "Because he was on duty."
-        }, {
-            "joke": "Why did the rapper carry an umbrella?",
-            "punchline": "Fo' drizzle."
-        }, {
-            "joke": "Why did the scarecrow win an award?",
-            "punchline": "Because he was outstanding in his field."
-        }, {
-            "joke": "Why did the skeleton go to the party alone?",
-            "punchline": "He had no body to go with him!"
-        }, {
-            "joke": "Why did the teddy bear say 'no' to dessert?",
-            "punchline": "Because she was stuffed."
-        }, {
-            "joke": "Why didn't the melons get married?",
-            "punchline": "Because they cantaloupe!"
-        }, {
-            "joke": "Why didn't the vampire attack Taylor Swift?",
-            "punchline": "She had bad blood."
-        }, {
-            "joke": "Why do bakers work so hard?",
-            "punchline": "They knead the dough."
-        }, {
-            "joke": "Why do chicken coops only have two doors?",
-            "punchline": "Because if they had four, they would be chicken sedans!"
-        }, {
-            "joke": "Why do chicken coops only have two doors?",
-            "punchline": "Because if they had four, they would be chicken sedans."
-        }, {
-            "joke": "Why do crabs never give to charity?",
+            "joke": "Why don't oysters give to charity?",
             "punchline": "Because they're shellfish."
         }, {
-            "joke": "Why do milking stools only have three legs?",
-            "punchline": "'Cause the cow's got the udder!"
+            "joke": "Why did the cookie go to the doctor?",
+            "punchline": "Because it was feeling crumbly."
         }, {
-            "joke": "Why do you never see elephants hiding in trees?",
-            "punchline": "Because they're so good at it."
+            "joke": "What do you call a computer mouse that swears a lot?",
+            "punchline": "A cursor!"
         }, {
-            "joke": "Why does a Moon-rock taste better than an Earth-rock?",
-            "punchline": "Because it's a little meteor."
+            "joke": "Why did the designer break up with their font?",
+            "punchline": "Because it wasn't their type."
         }, {
-            "joke": "Why don't blind people go skydiving?",
-            "punchline": "Because it scares the bejesus out of the dogs!"
+            "joke": "Why did the programmer quit their job?",
+            "punchline": "They didn't get arrays."
         }, {
-            "joke": "Why is the ocean blue?",
-            "punchline": "Because all the little fish go blu, blu blu."
+            "joke": "Why did the developer go broke?",
+            "punchline": "They kept spending all their cache."
         }, {
-            "joke": "no gam bling in Africa?",
-            "punchline": "Too many Cheetahs!"
+            "joke": "How do you comfort a designer?",
+            "punchline": "You give them some space... between the elements."
         }, {
-            "joke": "Why shouldn't you write with a broken pencil?",
-            "punchline": "BECAUSE IT'S POINTLESS!"
+            "joke": "Why don't programmers like nature?",
+            "punchline": "Too many bugs."
         }, {
-            "joke": "Why was the sa nd wet?",
-            "punchline": "Because the sea weed!"
+            "joke": "Why did the programmer bring a ladder to work?",
+            "punchline": "They heard the code needed to be debugged from a higher level."
         }, {
-            "joke": "Why wouldn't the shrimp share his treasure?",
-            "punchline": "Because he was a little shellfish."
+            "joke": "Why was the developer always calm?",
+            "punchline": "Because they knew how to handle exceptions."
         }, {
-            "joke": "Dad, can you put the cat out?",
-            "punchline": "I didn't know it was on fire."
+            "joke": "Why was the font always tired?",
+            "punchline": "It was always bold."
         }, {
-            "joke": "What's a total rip-off?",
-            "punchline": "Velcro."
+            "joke": "Why did the developer go to therapy?",
+            "punchline": "They had too many unresolved issues."
         }, {
-            "joke": "Cashier: Would like the milk in a bag?",
-            "punchline": "No, just leave it in the carton!"
+            "joke": "Why was the designer always cold?",
+            "punchline": "Because they always used too much ice-olation."
         }, {
-            "joke": "What did Elsa do to the balloon?",
-            "punchline": "She let it go."
+            "joke": "Why did the programmer bring a broom to work?",
+            "punchline": "To clean up all the bugs."
         }, {
-            "joke": "How do I look?",
-            "punchline": "With your eyes."
+            "joke": "Why did the developer break up with their keyboard?",
+            "punchline": "It just wasn't their type anymore."
         }, {
-            "joke": "Slept like a log last night.",
-            "punchline": "Woke up in the fireplace."
+            "joke": "Why did the programmer always carry a pencil?",
+            "punchline": "They preferred to write in C#."
         }, {
-            "joke": "So, I heard this pun about cows, but it's kinda offensive so I won't say it.",
-            "punchline": "I don't want there to be any beef between us."
+            "joke": "Why don't skeletons fight each other?",
+            "punchline": "They don't have the guts."
         }, {
-            "joke": "I'll call you later.",
-            "punchline": "Don't call me later, call me Dad."
+            "joke": "What do you call fake spaghetti?",
+            "punchline": "An impasta."
         }, {
-            "joke": "I'm sorry.",
-            "punchline": "Hi sorry, I'm dad"
-        }, {
-            "joke": "A beekeeper was indicted after he confessed to years of stealing at work.",
-            "punchline": "They charged him with emBEEzlement."
-        }, {
-            "joke": "A book just fell on my head.",
-            "punchline": "I only have my shelf to blame."
-        }, {
-            "joke": "A doll was recentlyfound dead in a rice paddy.",
-            "punchline": "It's the only known instance of a nick nack paddy wack."
-        }, {
-            "joke": "A furniture store keeps calling me.",
-            "punchline": "All I wanted was one night stand."
-        }, {
-            "joke": "A ham sandwich walks into a bar and orders a beer.",
-            "punchline": "The bartender looks at him and says, \"Sorry we don't serve food here."
-        }, {
-            "joke": "A horse walks into a bar.",
-            "punchline": "The bar tender says 'Hey', The horse says 'Sure.'"
-        }, {
-            "joke": "A magician was driving down the road..",
-            "punchline": "then he turned into a drive way."
-        }, {
-            "joke": "A man is washing the car with his son.",
-            "punchline": "The son asks, \"Dad, can't you just use a sponge?\""
-        }, {
-            "joke": "A man tried to sell me a coffin today.",
-            "punchline": "I told him that's the last thing I need."
-        }, {
-            "joke": "A man walked in to a bar with some asphalt on his arm.",
-            "punchline": "He said 'Two beers please, one for me and one for the road.'"
-        }, {
-            "joke": "A man walks into a bar and orders helicopter flavor chips.",
-            "punchline": "The barman replies 'sorry mate we only do plain'."
-        }, {
-            "joke": "A man was caught stealing in a supermarket today while balanced on the shoulders of a couple of vampires.",
-            "punchline": "He was charged with shoplifting on two counts."
-        }, {
-            "joke": "A police officer caught two kids playing with a firework and a car battery.",
-            "punchline": "He charged one and let the other one off."
-        }, {
-            "joke": "A quick shoutout to all of the sidewalks out there...",
-            "punchline": "Thanks for keeping me off the streets."
-        }, {
-            "joke": "A red and a blue ship have just collided in the Caribbean.",
-            "punchline": "Apparently the survivors are marooned."
-        }, {
-            "joke": "Americans can't switch from pounds to kilograms overnight.",
-            "punchline": "That would cause mass confusion."
-        }, {
-            "joke": "An apple a day keeps the bullies away.",
-            "punchline": "If you throw it ha rd enough."
-        }, {
-            "joke": "Cosmetic surgery used to be such a taboo subject.",
-            "punchline": "Now you can talk about Botox and nobody raises an eyebrow."
-        }, {
-            "joke": "Don't buy flowers at a monastery.",
-            "punchline": "Because only you can prevent florist friars."
-        }, {
-            "joke": "Don't tell secrets in corn fields.",
-            "punchline": "Too many ears around."
-        }, {
-            "joke": "Don't trust atoms.",
-            "punchline": "They make up everything! "
-        }, {
-            "joke": "Don't interrupt someone working intently on a puzzle.",
-            "punchline": "Chances are, you'll hear some crosswords."
-        }, {
-            "joke": "Every machine in the coin factory broke down all of a sudden without explanation.",
-            "punchline": "It just doesn't make any cents."
-        }, {
-            "joke": "Feeling pretty proud of myself.",
-            "punchline": "The Sesame Street puzzle I bought said 3-5 years, but I finished it in 18 months."
-        }, {
-            "joke": "Found out I was colour blind the other day...",
-            "punchline": "That one came right out the purple."
-        }, {
-            "joke": "Guy walks into a bar with a slab of asphalt under arm.",
-            "punchline": "Says to the bartender: \"I'll take a beer, and one for the road.\""
-        }, {
-            "joke": "I am terrified of elevators.",
-            "punchline": "I'm going to start taking steps to avoid them."
-        }, {
-            "joke": "I applied to be a doorman but didn't get the job due to lack of experience.",
-            "punchline": "That surprised me, I thought it was an entry level position."
-        }, {
-            "joke": "I asked the checkout girl for a date.",
-            "punchline": "She said \"They're in the fruit aisle next to the bananas\"."
-        }, {
-            "joke": "I ate a clock yesterday.",
-            "punchline": "It was so time consuming."
-        }, {
-            "joke": "I bought shoes from a drug dealer once.",
-            "punchline": "I don't know what he laced them with, but I was tripping all day."
-        }, {
-            "joke": "I couldn't figure out how the seat belt worked.",
-            "punchline": "Then it just clicked."
-        }, {
-            "joke": "I couldn't get a reservation at the library.",
-            "punchline": "They were booked. "
-        }, {
-            "joke": "I cut my finger cutting cheese.",
-            "punchline": "I know it may be a cheesy story but I feel grate now."
-        }, {
-            "joke": "I decided to sell my Hoover...",
-            "punchline": "well it was just collecting dust."
-        }, {
-            "joke": "I don't trust stairs.",
-            "punchline": "They're always up to something."
-        }, {
-            "joke": "I don't play soccer because I enjoy the sport.",
-            "punchline": "I'm just doing it for kicks."
-        }, {
-            "joke": "I had a dream that I was a muffler last night.",
-            "punchline": "I woke up exhausted!"
-        }, {
-            "joke": "I just swapped our bed for a trampoline.",
-            "punchline": "My wife hit the roof."
-        }, {
-            "joke": "I just watched a documentary about beavers.",
-            "punchline": "It was the best dam show I've ever seen."
-        }, {
-            "joke": "I made a belt out of watches once...",
-            "punchline": "It was a waist of time."
-        }, {
-            "joke": "I thought my wife was joking when she said she'd leave me if I didn't stop signing \"I'm A Believer\"...",
-            "punchline": "Then I saw her face."
-        }, {
-            "joke": "I used to work in a shoe recycling shop.",
-            "punchline": "It was sole destroying."
-        }, {
-            "joke": "I was fired from the keyboard factory yesterday.",
-            "punchline": "I wasn't putting in enough shifts."
-        }, {
-            "joke": "I was interrogated over the theft of a grilled cheese sandwich.",
-            "punchline": "Man, they really grilled me."
-        }, {
-            "joke": "I was just looking at my ceiling.",
-            "punchline": "Not sure if it's the best ceiling in the world, but it's definitely up there."
-        }, {
-            "joke": "I wish I could clean mirrors for a living.",
-            "punchline": "It's just something I can see myself doing"
-        }, {
-            "joke": "I would avoid the sushi if I was you.",
-            "punchline": "It's a little fishy."
-        }, {
-            "joke": "I'll call you later.",
-            "punchline": "Don't call me later, call me Dad."
-        }, {
-            "joke": "I'll tell you what often gets over looked...",
-            "punchline": "garden fences."
-        }, {
-            "joke": "I've deleted the phone numbers of all the Germans I know from my mobile phone.",
-            "punchline": "Now it's Hans free."
-        }, {
-            "joke": "I've just written a song about a tortilla.",
-            "punchline": "Well, it is more of a rap really."
-        }, {
-            "joke": "I've never gone to a gun range before.",
-            "punchline": "I decided to give it a shot!"
-        }, {
-            "joke": "I'm on a whiskey diet.",
-            "punchline": "I've lost three days already."
-        }, {
-            "joke": "I've deleted the phone numbers of all the Germans I know from my mobile phone.",
-            "punchline": "Now it's Hans free."
-        }, {
-            "joke": "If you're struggling to think of what to get someone for Christmas.",
-            "punchline": "Get them a fridge, and watch their face light up when they open it."
-        }, {
-            "joke": "It doesn't matter how much you push the envelope.",
-            "punchline": "It will still be stationary."
-        }, {
-            "joke": "It was raining catsand dogs the other day.",
-            "punchline": "I almost stepped in a poodle."
-        }, {
-            "joke": "Just read a few facts about frogs.",
-            "punchline": "They were ribbiting."
-        }, {
-            "joke": "Last night me and my girlfriend watched three movies back to back.",
-            "punchline": "Luckily I was the one facing the TV."
-        }, {
-            "joke": "Milk is also the fastest liquid on earth.",
-            "punchline": "It's pasteurized before you even see it."
-        }, {
-            "joke": "My boss told me that he was going to fire the person with the worst posture.",
-            "punchline": "I have a hunch, it might be me."
-        }, {
-            "joke": "My boss told me to attach two pieces of wood together...",
-            "punchline": "I totally nailed it!"
-        }, {
-            "joke": "My cat just threw up on the carpet.",
-            "punchline": "I don't think it's feline well."
-        }, {
-            "joke": "My first time using an elevator was an uplifting experience.",
-            "punchline": "The second time let me down."
-        }, {
-            "joke": "My new thesaurus is terrible.",
-            "punchline": "In fact, it's so bad, I'd say it's terrible."
-        }, {
-            "joke": "My son asked me to stop singing Oasis songs in public.",
-            "punchline": "I said maybe."
-        }, {
-            "joke": "My wife told me to rub the herbs on the meat for better flavor.",
-            "punchline": "That's sage advice."
-        }, {
-            "joke": "Never take advice from electrons.",
-            "punchline": "They are always negative."
-        }, {
-            "joke": "People don't like having to bend over to get their drinks.",
-            "punchline": "We really need to raise the bar."
-        }, {
-            "joke": "RIP boiled water.",
-            "punchline": "You will be mist."
-        }, {
-            "joke": "Singin gin the shower is all fun and games until you get shampoo in your mouth.",
-            "punchline": "Then it's a soap opera."
-        }, {
-            "joke": "The word queue is ironic.",
-            "punchline": "It's just q with a bunch of silent letters waiting in line."
-        }, {
-            "joke": "There's not really any training for garbagemen.",
-            "punchline": "They just pick things up as they go."
-        }, {
-            "joke": "They tried to make a diamond shaped like a duck.",
-            "punchline": "It quacked under the pressure."
-        }, {
-            "joke": "To the man in the wheelchair that stole my camouflage jacket...",
-            "punchline": "You can hide but you can't run."
-        }, {
-            "joke": "This is my step ladder.",
-            "punchline": "I never knew my real ladder."
-        }, {
-            "joke": "Today a man knocked on my door and asked for a small donation towards the local swimming pool.",
-            "punchline": "I gave him a glass of water."
-        }, {
-            "joke": "Two satell ites decided to get married.",
-            "punchline": "The wedding wasn't much, but the reception was incredible."
-        }, {
-            "joke": "You can't run through a camp site.",
-            "punchline": "You can only ran, because it's past tents."
-        }, {
-            "joke": "You can't trust a ladder.",
-            "punchline": "It will always let you down."
-        }, {
-            "joke": "Put the cat out.",
-            "punchline": "I didn't realize it was on fire."
-        }, {
-            "joke": "I've broken my arm in several places.",
-            "punchline": "Well don't go to those places."
-        }, {
-            "joke": "As I suspected, someone has been adding soil to my garden.",
-            "punchline": "The plot thickens."
-        }, {
-            "joke": "I had a rough day, and then somebody went and ripped the front and back pages from my dictionary.",
-            "punchline": "It just goes from bad to worse."
-        }, {
-            "joke": "I went to the zoo the other day, there was only one dog in it.",
-            "punchline": "It was a shitzu."
-        }, {
-            "joke": "Man, I really love my furniture...",
-            "punchline": "me and my recliner go way back."
-        }, {
-            "joke": "My wife is on a tropical fruit diet, the house is full of stuff.",
-            "punchline": "It is enough to make a mango crazy."
-        }, {
-            "joke": "Past, present, and future walked into a bar....",
-            "punchline": "It was tense."
-        }, {
-            "joke": "Some people say that comedians who tell one too many light bulb jokes soon burn out, but they don't know watt they are talking about.",
-            "punchline": "They're not that bright."
-        }, {
-            "joke": "The other day I was listening to a song about superglue.",
-            "punchline": "It's been stuck in my head ever since."
-        }, {
-            "joke": "The other day, my wife asked me to pass her lipstick but I accidentally passed her a glue stick.",
-            "punchline": "She still isn't talking to me."
-        }, {
-            "joke": "I was in an 80's band called the prevention.",
-            "punchline": "We were better than the cure."
-        }, {
-            "joke": "I'm only familiar with 25 letters in the English language.",
-            "punchline": "I don't know why."
-        }, {
-            "joke": "Hostess: Do you have a preference of where you sit?",
-            "punchline": "Dad: Down."
-        }, {
-            "joke": "Mom: I'm going to jump in the shower.",
-            "punchline": "Dad: It's probably safer if you just stand."
-        }, {
-            "joke": "Nurse: Doctor, there's a patient that says he's invisible.",
-            "punchline": "Doctor: Well, tell him I can't see him right now!"
-        }, {
-            "joke": "There's two fish in a tank.",
-            "punchline": "One turns to thend says'You man the guns, I'll drive'"
-        }, {
-            "joke": "Child :Dad, make me a sandwich.",
-            "punchline": "Dad: Poof, You're a sandwich."
-        }, {
-            "joke": "I knew I shouldn't have ate that seafood.",
-            "punchline": "Because now I'm feeling a little, Eel."
-        }, {
-            "joke": "I went to a Foo Fighters Concert once...",
-            "punchline": "It was Everlong."
-        }, {
-            "joke": "They're making a movie about clocks.",
-            "punchline": "It's about time."
-        }, {
-            "joke": "Dad died because he couldn't remember his blood type.",
-            "punchline": "I will never forget his last words, 'Be positive.'"
-        }, {
-            "joke": "Two goldfish are in a tank.",
-            "punchline": "One says to the other, 'do you know how to drive this thing?'"
-        }, {
-            "joke": "People saying 'boo to their friends has risen by 85% in the last year.",
-            "punchline": "That's a frightening statistic."
-        }, {
-            "joke": "Ben and Jerry's really need to improve their operation.",
-            "punchline": "The only way to get there is down a rocky road."
-        }, {
-            "joke": "I was at the library and asked if they have any books on 'paranoia.'",
-            "punchline": "The librarian replied, 'yes, they are right behind you.'"
-        }, {
-            "joke": "My friend said to me 'What rhymes with orange?'",
-            "punchline": "I said: 'no it doesn't'."
-        }, {
-            "joke": "A panda walks into a bar and says to the bartender \"I'll have a Scotch and . .(wait for a moment) . . . a Coke thank you.\".The bartender replies and asks \"Sure thing, but what's with the big pause?\"",
-            "punchline": "The panda holds up his hands and says \"I was born with them\""
-        }, {
-            "joke": "A woman is on trial for beating her husband to death with his guitar collection. Judge says, 'First offender?'",
-            "punchline": "She says, 'No, first a Gibson! Then a Fender!'"
-        }, {
-            "joke": "Doctor: Do you want to hear the good news or the bad news? Patient: Good news please.",
-            "punchline": "Doctor: we're naming a disease after you."
-        }, {
-            "joke": "My dog has no nose.  Really? How does he smell?",
-            "punchline": "Terrible"
-        }, {
-            "joke": "Wife: Honey I'm pregnant. Me: Well... what do we do now?  Wife: Well, I guess we should go to a baby doctor.",
-            "punchline": "Me: Hm..I think I'd be a lot more comfortable going to an adult doctor."
-        }, {
-            "joke": "Sgt.: Commissar!C ommissar! The troops are revolting!",
-            "punchline": "Commissar: Well, you're pretty repulsive yourself."
-        }, {
-            "joke": "What did the Island Gobbling Sea Monster say?",
-            "punchline": "These islands aren't Philippine me up. I need Samoa Tahiti!"
-        }, {
-            "joke": "Me : If humans lose the ability to hear high frequency volumes as they get older, can my 4 week old son hear a dog whistle?",
-            "punchline": "Doctor: No, humans can never hear that high of a frequency no matter what age they are. Me: Trick question... dogs can't whistle."
-        }, {
-            "joke": "A bartender broke up with her boyfriend, but he kept asking her for another shot.",
-            "punchline": null
-        }, {
-            "joke": "A butcher accidentally backed into his meat grinder and got a little behind in his work that day.",
-            "punchline": null
-        }, {
-            "joke": "A cannibal is someone who is fed up with people.",
-            "punchline": null
-        }, {
-            "joke": "A cannibal went for a walk and he passed his brother.",
-            "punchline": null
-        }, {
-            "joke": "People are making apocalypse jokes like there's no tomorrow.",
-            "punchline": null
-        }, {
-            "joke": "A drum and a cymbal fall off a cliff...",
-            "punchline": null
-        }, {
-            "joke": "A magician was driving down the street and then he turned into a driveway.",
-            "punchline": null
-        }, {
-            "joke": "A man got hit in the head with a can of Coke, but he was alright because it was a soft drink.",
-            "punchline": null
-        }, {
-            "joke": "Astronomers got tired of watching the moon go round the earth for 24 hours, so they decided to call it a day.",
-            "punchline": null
-        }, {
-            "joke": "Atheism is a non-prophet organisation.",
-            "punchline": null
-        }, {
-            "joke": "Doorbells, don't knock 'em.",
-            "punchline": null
-        }, {
-            "joke": "Why do so many people with laser hair want to get it removed?",
-            "punchline": null
-        }, {
-            "joke": "Geology rocks, but Geography is where it's at!",
-            "punchline": null
-        }, {
-            "joke": "Have you heard about the film \"Constipation\", you probably haven't because it's not out yet.",
-            "punchline": null
-        }, {
-            "joke": "I broke my finger at work today, on the other hand I'm completely fine.",
-            "punchline": null
-        }, {
-            "joke": "I cut my finger chopping cheese, but I think that I may have grater problems.",
-            "punchline": null
-        }, {
-            "joke": "I gave all my dead batteries away today, free of charge.",
-            "punchline": null
-        }, {
-            "joke": "I got a reversible jacket for Christmas, I can't wait to see how it turns out.",
-            "punchline": null
-        }, {
-            "joke": "I got fired from a florist, apparently I took too many leaves.",
-            "punchline": null
-        }, {
-            "joke": "I hate perforated lines, they're tearable.",
-            "punchline": null
-        }, {
-            "joke": "I just got fired from a florist, apparently I took too many leaves.",
-            "punchline": null
-        }, {
-            "joke": "I knew I shouldn't steal a mixer from work, but it was a whisk I was willing to take.",
-            "punchline": null
-        }, {
-            "joke": "I needed a password eight characters long so I picked Snow White and the Seven Dwarfs.",
-            "punchline": null
-        }, {
-            "joke": "I really want to buy one of those supermarket checkout dividers, but the cashier keeps putting it back.",
-            "punchline": null
-        }, {
-            "joke": "I tried taking some high resolution photos of local farmland, but they all turned out a bit grainy.",
-            "punchline": null
-        }, {
-            "joke": "I used to be a banker, but I lost interest.",
-            "punchline": null
-        }, {
-            "joke": "I used to be addicted to soap, but I'm clean now.",
-            "punchline": null
-        }, {
-            "joke": "I used to be addicted to the hokey pokey, but Iturned myself around.",
-            "punchline": null
-        }, {
-            "joke": "I used to hate facial hair, but then it grew on me.",
-            "punchline": null
-        }, {
-            "joke": "I used to have a job at a calendar factory but I got the sack because I took a couple of days off.",
-            "punchline": null
-        }, {
-            "joke": "I used to think I was indecisive, but now I'm not sure.",
-            "punchline": null
-        }, {
-            "joke": "I was going to learn how to juggle, but I didn't have the balls.",
-            "punchline": null
-        }, {
-            "joke": "I was so proud when I finished the puzzle in six months, when on the side it said three to four years.",
-            "punchline": null
-        }, {
-            "joke": "I was thinking about moving to Moscow but there is no point Russian into things.",
-            "punchline": null
-        }, {
-            "joke": "I was wondering why the frisbee was getting bigger, then it hit me.",
-            "punchline": null
-        }, {
-            "joke": "I wear a stethoscope so that in a medical emergency I can teach people a valuable lesson about assumptions.",
-            "punchline": null
-        }, {
-            "joke": "I went to a book store and asked the saleswoman where the Self Help section was, she said if she told me it would defeat the purpose.",
-            "punchline": null
-        }, {
-            "joke": "I went to the doctor today and he told me I had type A blood, but it was a type O.",
-            "punchline": null
-        }, {
-            "joke": "I'm glad I know sign language, it's pretty handy.",
-            "punchline": null
-        }, {
-            "joke": "If at first you don't succeed, sky diving is not for you!",
-            "punchline": null
-        }, {
-            "joke": "If you want a job in the moisturizer industry, the best advice I can give is to apply daily.",
-            "punchline": null
-        }, {
-            "joke": "It's difficult to say what my wife does, she sells sea shells by the sea shore.",
-            "punchline": null
-        }, {
-            "joke": "Leather is great for sneaking around because it's made of hide.",
-            "punchline": null
-        }, {
-            "joke": "My New Years resolution is to stop leaving things so late.",
-            "punchline": null
-        }, {
-            "joke": "My sea sickness comes in waves.",
-            "punchline": null
-        }, {
-            "joke": "Our wedding was so beautiful, even the cake was in tiers.",
-            "punchline": null
-        }, {
-            "joke": "People keep making apocalypse jokes like there's no tomorrow.",
-            "punchline": null
-        }, {
-            "joke": "People who don't eat gluten are really going against the grain.",
-            "punchline": null
-        }, {
-            "joke": "Recent survey revealed 6 out of 7 dwarf's aren't happy.",
-            "punchline": null
-        }, {
-            "joke": "Remember, the best angle to approach a problem from is the \"try\" angle.",
-            "punchline": null
-        }, {
-            "joke": "Shout out to my grandma, that's the only way she can hear.",
-            "punchline": null
-        }, {
-            "joke": "Sore throats are a pain in the neck!",
-            "punchline": null
-        }, {
-            "joke": "The great thing about stationery shops is they're always in the same place...",
-            "punchline": null
-        }, {
-            "joke": "The rotation of earth really makes my day.",
-            "punchline": null
-        }, {
-            "joke": "The shovel was a ground-breaking invention.",
-            "punchline": null
-        }, {
-            "joke": "This furniture store keeps emailing me, all I wanted was one night stand!",
-            "punchline": null
-        }, {
-            "joke": "This morning I was wondering where the sun was, but then it dawned on me.",
-            "punchline": null
-        }, {
-            "joke": "To be Frank, I'd have to change my name.",
-            "punchline": null
-        }, {
-            "joke": "Toasters were the first form of pop-up notifications.",
-            "punchline": null
-        }, {
-            "joke": "Today a girl said she recognized me from vegetarian club, but I'm sure I've never met herbivore.",
-            "punchline": null
-        }, {
-            "joke": "Two dyslexics walk into a bra.",
-            "punchline": null
-        }, {
-            "joke": "Two guys walked into a bar, the third one ducked.",
-            "punchline": null
-        }, {
-            "joke": "When Dad drops a pea off of his plate, 'oh dear I've pee'd on the table!'",
-            "punchline": null
-        }, {
-            "joke": "When my wife told me to stop impersonating a flamingo, I had to put my foot down.",
-            "punchline": null
-        }, {
-            "joke": "When the window fell into the incinerator, it was a pane in the ash to retrieve.",
-            "punchline": null
-        }, {
-            "joke": "When you have a bladder infection, urine trouble.",
-            "punchline": null
-        }, {
-            "joke": "Whenever I want to start eating healthy, a chocolate bar looks at me and Snickers.",
-            "punchline": null
-        }, {
-            "joke": "Whiteboards are remarkable.",
-            "punchline": null
-        }, {
-            "joke": "Whoever invented the knock-knock joke should get a no bell prize.",
-            "punchline": null
-        }, {
-            "joke": "Without geometry life is pointless.",
-            "punchline": null
-        }, {
-            "joke": "Writing with a broken pencil is pointless.",
-            "punchline": null
-        }, {
-            "joke": "You know what they say about cliffhangers...",
-            "punchline": null
-        }, {
-            "joke": "A baby seal walks into a club... ",
-            "punchline": null
-        }, {
-            "joke": "A ghost walks into a bar and asks for a glass of vodka but the bar tender says",
-            "punchline": "sorry we don't serve spirits"
-        }, {
-            "joke": "A neutron walks into a bar and asks \"How much for a beer?\" The bartender says;",
-            "punchline": "for you? no charge."
-        }, {
-            "joke": "A Sandwich walks into a bar, the bartender says \"Sorry, we don't serve food here\"",
-            "punchline": null
-        }, {
-            "joke": "Doctor you've got to help me, I'm addicted to Twitter. Doctor: I don't follow you.",
-            "punchline": null
-        }, {
-            "joke": "Egyptians claimed to invent the guitar, but they were such lyres.",
-            "punchline": null
-        }, {
-            "joke": "Every night at 11:11, I make a wish that someone will come fix my broken clock.",
-            "punchline": null
-        }, {
-            "joke": "I fear for the calendar, it's days are numbered.",
-            "punchline": null
-        }, {
-            "joke": "I got an A on my origami assignment when I turned my paper into my teacher",
-            "punchline": null
-        }, {
-            "joke": "I knew a guy who collected candy canes, they were all in mint condition",
-            "punchline": null
-        }, {
-            "joke": "I thought about going on an all-almond diet. But that's just nuts.",
-            "punchline": null
-        }, {
-            "joke": "I used to be a banker but I lost interest",
-            "punchline": null
-        }, {
-            "joke": "I was going to get a brain transplant, but I changed my mind",
-            "punchline": null
-        }, {
-            "joke": "I'll tell you something about German sausages, they're the wurst",
-            "punchline": null
-        }, {
-            "joke": "I've just been reading a book about anti-gravity, it's impossible to put down!",
-            "punchline": null
-        }, {
-            "joke": "If two vegans are having an argument, is it still considered beef?",
-            "punchline": null
-        }, {
-            "joke": "If you see a robbery at an Apple Store does that make you an iWitness?",
-            "punchline": null
-        }, {
-            "joke": "If you walk into a forest and cut down a tree, but the tree doesn't understand why you cut it down, do you think it's stumped?",
-            "punchline": null
-        }, {
-            "joke": "It's hard to explain puns to kleptomaniacs, because they take everything literally.",
-            "punchline": null
-        }, {
-            "joke": "Mountains aren't just funny, they are hill areas",
-            "punchline": null
-        }, {
-            "joke": "The first time I got a universal remote control I thought to myself;",
-            "punchline": "This changes everything."
-        }, {
-            "joke": "The invention of the wheel was what got things rolling",
-            "punchline": null
-        }, {
-            "joke": "There's a new type of broom out, it's sweeping the nation.",
-            "punchline": null
-        }, {
-            "joke": "Two fish are in a tank, one turns to the other and says, \"How do you drive this thing?\"",
-            "punchline": null
-        }, {
-            "joke": "5/4 of people admit that they're bad with fractions.",
-            "punchline": null
-        }, {
-            "joke": "*Reversing the car*",
-            "punchline": "Ah, this takes me back"
-        }, {
-            "joke": "A Mexican magician says he'll disappear on the count of 3; \"Uno... dos... poof...\".",
-            "punchline": "He disappeared without a tres."
-        }, {
-            "joke": "Conjunctivitis.com",
-            "punchline": "Now that's a site for sore eyes.",
-        }, {
-            "joke": "I'm reading a book on the history of glue",
-            "punchline": "Can't put it down."
-        }, {
-            "joke": "So a duck walks into a pharmacy and says \"Give me some chap-stick\"",
-            "punchline": "and put it on my bill"
-        }, {
-            "joke": "Two muffins were sitting in an oven, and the first looks over to the second, and says, \"Man, it's really hot in here.\"",
-            "punchline": "The second looks over at the first with a surprised look, and answers, \"WHOA, a talking muffin!\""
-        }, {
-            "joke": "When an ambulance zips past with its siren blaring",
-            "punchline": "They won't sell much ice cream driving that fast."
-        }, {
-            "joke": "In ServiceNow, what kind of business rule can you wash your hands in?",
-            "punchline": "Async"
-        }, {
-            "joke": "What kind of coding makes you stronger?",
-            "punchline": "Hard coding"
-        }, {
-            "joke": "Where to dads keep their dad jokes?",
-            "punchline": "In the dad-a-base."//we miss you randy jones
-        }, {
-            "joke": "What do you call a snake that is 3.14 feet long?",
-            "punchline": "A Pie-thon"
-        }, {
-            "joke": "What do you call ghost poop?",
-            "punchline": "Boo-Boo"
-        }, {
-            "joke": "What did the blanket say when it fell off the bed?",
-            "punchline": "Oh sheet!"
-        }, {
-            "joke": "Did you hear about the lumberjack who got fired?",
-            "punchline": "He axed for it."
-        }, {
-            "joke": "What do you call two mexicans playing basketball?",
-            "punchline": "Juan on Juan"
+            "joke": "What do you call a thieving alligator?",
+            "punchline": "A crookodile!"
         }
     ];

--- a/data/curated-quotes.json
+++ b/data/curated-quotes.json
@@ -1,4 +1,4 @@
-window.quotesData = [
+[
   {
     "id": "creativity",
     "label": "Creativity",
@@ -539,4 +539,4 @@ window.quotesData = [
       }
     ]
   }
-];
+]

--- a/data/icanhazdadjokes-split.json
+++ b/data/icanhazdadjokes-split.json
@@ -1,0 +1,4222 @@
+[
+  {
+    "id": "0189hNRf2g",
+    "setup": "I'm tired of following my dreams.",
+    "punchline": "I'm just going to ask them where they are going and meet up with them later."
+  },
+  {
+    "id": "08EQZ8EQukb",
+    "setup": "Did you hear about the guy whose whole left side was cut off?",
+    "punchline": "He's all right now."
+  },
+  {
+    "id": "08xHQCdx5Ed",
+    "setup": "Why didn’t the skeleton cross the road?",
+    "punchline": "Because he had no guts."
+  },
+  {
+    "id": "0DQKB51oGlb",
+    "setup": "What did one nut say as he chased another nut?",
+    "punchline": "I'm a cashew!"
+  },
+  {
+    "id": "0DdFQZgyXnb",
+    "setup": "Where do fish keep their money?",
+    "punchline": "In the riverbank"
+  },
+  {
+    "id": "0DdaxAX0orc",
+    "setup": "I accidentally took my cats meds last night.",
+    "punchline": "Don’t ask meow."
+  },
+  {
+    "id": "0DtrrOZDlyd",
+    "setup": "Chances are if you' ve seen one shopping center",
+    "punchline": "you've seen a mall."
+  },
+  {
+    "id": "0L6MexPukjb",
+    "setup": "Dermatologists are always in a hurry.",
+    "punchline": "They spend all day making rash decisions."
+  },
+  {
+    "id": "0LuXvkq4Muc",
+    "setup": "I knew I shouldn't steal a mixer from work",
+    "punchline": "but it was a whisk I was willing to take."
+  },
+  {
+    "id": "0gFdFBsWDd",
+    "setup": "I won an argument with a weather forecaster once.",
+    "punchline": "His logic was cloudy..."
+  },
+  {
+    "id": "0ga2EdN7prc",
+    "setup": "How come the stadium got hot after the game?",
+    "punchline": "Because all of the fans left."
+  },
+  {
+    "id": "0ga2wsPZgib",
+    "setup": "\"Why do seagulls fly over the ocean?\" \"Because if they flew over the bay",
+    "punchline": "we'd call them bagels.\""
+  },
+  {
+    "id": "0oO71TSv4Ed",
+    "setup": "Why was it called the dark ages?",
+    "punchline": "Because of all the knights."
+  },
+  {
+    "id": "0ozAXv4Mmjb",
+    "setup": "Why did the tomato blush?",
+    "punchline": "Because it saw the salad dressing."
+  },
+  {
+    "id": "0wcFBQfiGBd",
+    "setup": "Did you hear the joke about the wandering nun?",
+    "punchline": "She was a roman catholic."
+  },
+  {
+    "id": "189xHQ7pOuc",
+    "setup": "What creature is smarter than a talking parrot?",
+    "punchline": "A spelling bee."
+  },
+  {
+    "id": "18Elj3EIYvc",
+    "setup": "I'll tell you what often gets over looked...",
+    "punchline": "garden fences."
+  },
+  {
+    "id": "18h3wcU8xAd",
+    "setup": "Why did the kid cross the playground?",
+    "punchline": "To get to the other slide."
+  },
+  {
+    "id": "1DIRSfx51Dd",
+    "setup": "Why do birds fly south for the winter?",
+    "punchline": "Because it's too far to walk."
+  },
+  {
+    "id": "1DQZDY0gVnb",
+    "setup": "What is a centipedes's favorite Beatle song?",
+    "punchline": "I want to hold your hand, hand, hand, hand..."
+  },
+  {
+    "id": "1DQZvXvX8Ed",
+    "setup": "My first time using an elevator was an uplifting experience.",
+    "punchline": "The second time let me down."
+  },
+  {
+    "id": "1DQZvcFBdib",
+    "setup": "To be Frank",
+    "punchline": "I'd have to change my name."
+  },
+  {
+    "id": "1LmOKBIJYob",
+    "setup": "What do you call a female snake.",
+    "punchline": "misssssssss"
+  },
+  {
+    "id": "1T01LBXLuzd",
+    "setup": "Why does a Moon-rock taste better than an Earth-rock?",
+    "punchline": "Because it's a little meteor."
+  },
+  {
+    "id": "1T0gqOZT0g",
+    "setup": "I thought my wife was joking when she said she'd leave me if I didn't stop signing \"I'm A Believer\"...",
+    "punchline": "Then I saw her face."
+  },
+  {
+    "id": "1TfNRKexAd",
+    "setup": "I’m only familiar with 25 letters in the English language.",
+    "punchline": "I don’t know why."
+  },
+  {
+    "id": "1gyI6EIRKBd",
+    "setup": "What do you call two barracuda fish?",
+    "punchline": "A Pairacuda!"
+  },
+  {
+    "id": "1gyskqz51ob",
+    "setup": "What did the father tomato say to the baby tomato whilst on a family walk?",
+    "punchline": "Ketchup."
+  },
+  {
+    "id": "1oGYLu4T7Ed",
+    "setup": "Why is Peter Pan always flying?",
+    "punchline": "Because he Neverlands."
+  },
+  {
+    "id": "1oOfFlOfaxc",
+    "setup": "What do you do on a remote island?",
+    "punchline": "Try and find the TV island it belongs to."
+  },
+  {
+    "id": "1wkqrcNCljb",
+    "setup": "Did you know that protons have mass?",
+    "punchline": "I didn't even know they were catholic."
+  },
+  {
+    "id": "218xkq49prc",
+    "setup": "I was fired from the keyboard factory yesterday.",
+    "punchline": "I wasn't putting in enough shifts."
+  },
+  {
+    "id": "29ElG6p49pb",
+    "setup": "Wife: Honey I’m pregnant. Me: Well…. what do we do now? Wife: Well, I guess we should go to a baby doctor. Me: Hm..",
+    "punchline": "I think I’d be a lot more comfortable going to an adult doctor."
+  },
+  {
+    "id": "2Luc21TSnb",
+    "setup": "Have you heard the story about the magic tractor?",
+    "punchline": "It drove down the road and turned into a field."
+  },
+  {
+    "id": "2TnrHtcNuc",
+    "setup": "When will the little snake arrive?",
+    "punchline": "I don't know but he won't be long..."
+  },
+  {
+    "id": "2TvX0wX89h",
+    "setup": "Why was Pavlov's beard so soft?",
+    "punchline": "Because he conditioned it."
+  },
+  {
+    "id": "2gFIBX82Etc",
+    "setup": "Do I enjoy making courthouse puns?",
+    "punchline": "Guilty"
+  },
+  {
+    "id": "2gaMZLBszsc",
+    "setup": "Why did the kid throw the clock out the window?",
+    "punchline": "He wanted to see time fly!"
+  },
+  {
+    "id": "2giGYLeiGe",
+    "setup": "Hear about the new restaurant called Karma?",
+    "punchline": "There’s no menu: You get what you deserve."
+  },
+  {
+    "id": "2gii3LeN7Ed",
+    "setup": "Why couldn't the kid see the pirate movie?",
+    "punchline": "Because it was rated arrr!"
+  },
+  {
+    "id": "2o4MZ8pjNuc",
+    "setup": "It was so cold yesterday my computer froze.",
+    "punchline": "My own fault though, I left too many windows open."
+  },
+  {
+    "id": "2wP711DAdFd",
+    "setup": "Man, I really love my furniture...",
+    "punchline": "me and my recliner go way back."
+  },
+  {
+    "id": "2wkykjyIYDd",
+    "setup": "What did the traffic light say to the car as it passed?",
+    "punchline": "\"Don't look I'm changing!\""
+  },
+  {
+    "id": "31wHeNJB5ob",
+    "setup": "My son is studying to be a surgeon",
+    "punchline": "I just hope he makes the cut."
+  },
+  {
+    "id": "39Etc2orc",
+    "setup": "Why did the man run around his bed?",
+    "punchline": "Because he was trying to catch up on his sleep!"
+  },
+  {
+    "id": "3E6MuHtH6h",
+    "setup": "What did one wall say to the other wall?",
+    "punchline": "I'll meet you at the corner!"
+  },
+  {
+    "id": "3E6U8UKmbFd",
+    "setup": "Sometimes I tuck my knees into my chest and lean forward.",
+    "punchline": "That’s just how I roll."
+  },
+  {
+    "id": "3LRCIJY82wc",
+    "setup": "How many South Americans does it take to change a lightbulb?",
+    "punchline": "A Brazilian"
+  },
+  {
+    "id": "3LmyXvsPfqc",
+    "setup": "I don't trust stairs.",
+    "punchline": "They're always up to something."
+  },
+  {
+    "id": "3gNRuHY89Ed",
+    "setup": "What do you call two guys hanging out by your window?",
+    "punchline": "Kurt & Rod."
+  },
+  {
+    "id": "3gibFB5Muzd",
+    "setup": "Why was the robot angry?",
+    "punchline": "Because someone kept pressing his buttons!"
+  },
+  {
+    "id": "3oG6UvX82g",
+    "setup": "Which is the fastest growing city in the world?",
+    "punchline": "Dublin'"
+  },
+  {
+    "id": "3w5wAIRZTnb",
+    "setup": "A police officer caught two kids playing with a firework and a car battery.",
+    "punchline": "He charged one and let the other one off."
+  },
+  {
+    "id": "3wPfFYorWvc",
+    "setup": "What do you call a snake who builds houses?",
+    "punchline": "A boa constructor!"
+  },
+  {
+    "id": "41LeN7EImjb",
+    "setup": "What is the difference between ignorance and apathy?",
+    "punchline": "I don't know and I don't care."
+  },
+  {
+    "id": "49xPmW82g",
+    "setup": "I went to a Foo Fighters Concert once...",
+    "punchline": "It was Everlong..."
+  },
+  {
+    "id": "4EBXnjiVKBd",
+    "setup": "Why did the sentence fail the driving test?",
+    "punchline": "It never came to a full stop."
+  },
+  {
+    "id": "4EBsPZvP7h",
+    "setup": "Some people eat light bulbs.",
+    "punchline": "They say it's a nice light snack."
+  },
+  {
+    "id": "4Elysrzs4wc",
+    "setup": "What's the difference between a rooster and a crow?",
+    "punchline": "A rooster can crow but a crow cannot rooster."
+  },
+  {
+    "id": "4ElyszXDdxc",
+    "setup": "I went to the store to pick up eight cans of sprite...",
+    "punchline": "when I got home I realized I'd only picked seven up"
+  },
+  {
+    "id": "4MmjbFlbah",
+    "setup": "I cut my finger chopping cheese",
+    "punchline": "but I think that I may have grater problems."
+  },
+  {
+    "id": "4TKukj3gyAd",
+    "setup": "Yesterday, I accidentally swallowed some food coloring.",
+    "punchline": "The doctor says I’m okay, but I feel like I’ve dyed a little inside."
+  },
+  {
+    "id": "4orc2TCtzAd",
+    "setup": "When people are sad, I sometimes let them colour in my tattoos.",
+    "punchline": "Sometimes all they need is a shoulder to crayon."
+  },
+  {
+    "id": "4wHB51ws4Ed",
+    "setup": "Last night me and my girlfriend watched three DVDs back to back.",
+    "punchline": "Luckily I was the one facing the TV."
+  },
+  {
+    "id": "4wciyk3EBAd",
+    "setup": "I got a reversible jacket for Christmas",
+    "punchline": "I can't wait to see how it turns out."
+  },
+  {
+    "id": "4wszdpW8pjb",
+    "setup": "What do you get when you cross a pig and a pineapple?",
+    "punchline": "A porky pine"
+  },
+  {
+    "id": "51DAA5Tfaxc",
+    "setup": "What did Romans use to cut pizza before the rolling cutter was invented?",
+    "punchline": "Lil Caesars"
+  },
+  {
+    "id": "5EBlOKBQSvc",
+    "setup": "Why did the banana go to the doctor?",
+    "punchline": "He was not \"peeling\" well."
+  },
+  {
+    "id": "5M7hF6EItzd",
+    "setup": "My pet mouse 'Elvis' died last night.",
+    "punchline": "He was caught in a trap.."
+  },
+  {
+    "id": "5T08U8M79pb",
+    "setup": "Never take advice from electrons.",
+    "punchline": "They are always negative."
+  },
+  {
+    "id": "5TS7pbxcpb",
+    "setup": "Why are oranges the smartest fruit?",
+    "punchline": "Because they are made to concentrate."
+  },
+  {
+    "id": "5TSnys4wPuc",
+    "setup": "A girl once asked me what my heart desired, apparently blood",
+    "punchline": "oxygen and neural messages were all wrong answers"
+  },
+  {
+    "id": "5TvXSf2TKBd",
+    "setup": "Why is it always hot in the corner of a room?",
+    "punchline": "Because a corner is 90 degrees."
+  },
+  {
+    "id": "5h399pWLmyd",
+    "setup": "What did the beaver say to the tree?",
+    "punchline": "It's been nice gnawing you."
+  },
+  {
+    "id": "5hNJexX8prc",
+    "setup": "How do you fix a damaged jack-o-lantern?",
+    "punchline": "You use a pumpkin patch."
+  },
+  {
+    "id": "5hNuz5w5Me",
+    "setup": "Why do cows not have toes?",
+    "punchline": "They lactose!"
+  },
+  {
+    "id": "5hVDAAIRKuc",
+    "setup": "What did the late tomato say to the early tomato?",
+    "punchline": "I’ll ketch up"
+  },
+  {
+    "id": "5hyP79pOCd",
+    "setup": "I have kleptomania, but when it gets bad",
+    "punchline": "I take something for it."
+  },
+  {
+    "id": "5oGYLZo4Tvc",
+    "setup": "I used to be addicted to soap",
+    "punchline": "but I'm clean now."
+  },
+  {
+    "id": "5oWLeFdxkjb",
+    "setup": "When is a door not a door?",
+    "punchline": "When it's ajar."
+  },
+  {
+    "id": "5wHexPC5hib",
+    "setup": "I made a belt out of watches once...",
+    "punchline": "It was a waist of time."
+  },
+  {
+    "id": "69xAsrHYDAd",
+    "setup": "Why did Mozart kill all his chickens?",
+    "punchline": "Because when he asked them who the best composer was, they'd all say \"Bach bach bach!\""
+  },
+  {
+    "id": "6EYLBscN7wc",
+    "setup": "This furniture store keeps emailing me",
+    "punchline": "all I wanted was one night stand!"
+  },
+  {
+    "id": "6EdFBAsrcpb",
+    "setup": "How do you find Will Smith in the snow?",
+    "punchline": "Look for fresh prints."
+  },
+  {
+    "id": "6MCYoGB5Tf",
+    "setup": "My sister bet me $15 that I couldn't build a car out of spaghetti.",
+    "punchline": "You should have seen the look on her face as I drove pasta."
+  },
+  {
+    "id": "6MR79MJ6h",
+    "setup": "My boss told me to have a good day...",
+    "punchline": "so I went home."
+  },
+  {
+    "id": "6MZobUfVKuc",
+    "setup": "I just read a book about Stockholm syndrome.",
+    "punchline": "It was pretty bad at first, but by the end I liked it."
+  },
+  {
+    "id": "6MZor4T79pb",
+    "setup": "Why do trees seem suspicious on sunny days?",
+    "punchline": "Dunno, they're just a bit shady."
+  },
+  {
+    "id": "6U0DIBAlbxc",
+    "setup": "If at first you don't succeed",
+    "punchline": "sky diving is not for you!"
+  },
+  {
+    "id": "6USSCQnyd",
+    "setup": "I'd like to start a diet",
+    "punchline": "but I've got too much on my plate right now."
+  },
+  {
+    "id": "6UnrOmrzImb",
+    "setup": "What did the drummer name her twin daughters?",
+    "punchline": "Anna One, Anna Two..."
+  },
+  {
+    "id": "6hqHJmyPmyd",
+    "setup": "What kind of music do mummy's like?",
+    "punchline": "Rap"
+  },
+  {
+    "id": "6hy5EQCtHtc",
+    "setup": "I remember when I was a kid, I opened my fridge and noticed one of my vegetables were crying.",
+    "punchline": "I guess I have some emotional cabbage."
+  },
+  {
+    "id": "6prjykbFd",
+    "setup": "What's large, grey, and doesn't matter?",
+    "punchline": "An irrelephant."
+  },
+  {
+    "id": "71gF6wHBsrc",
+    "setup": "A book just fell on my head.",
+    "punchline": "I only have my shelf to blame."
+  },
+  {
+    "id": "71wsPKeF6h",
+    "setup": "What did the dog say to the two trees?",
+    "punchline": "Bark bark."
+  },
+  {
+    "id": "7E69M792Tvc",
+    "setup": "I've got a joke about vegetables for you...",
+    "punchline": "but it's a bit corny."
+  },
+  {
+    "id": "7MRuzIYgaFd",
+    "setup": "If a child refuses to sleep during nap time",
+    "punchline": "are they guilty of resisting a rest?"
+  },
+  {
+    "id": "7MZ0LR7UfFd",
+    "setup": "Why can't your nose be 12 inches long?",
+    "punchline": "Because then it'd be a foot!"
+  },
+  {
+    "id": "7U89MJeFdib",
+    "setup": "Have you ever heard of a music group called Cellophane?",
+    "punchline": "They mostly wrap."
+  },
+  {
+    "id": "7USvkbaahFd",
+    "setup": "What do you call a boy who stopped digging holes?",
+    "punchline": "Douglas."
+  },
+  {
+    "id": "7Ufi31gydFd",
+    "setup": "What did the mountain climber name his son?",
+    "punchline": "Cliff."
+  },
+  {
+    "id": "7UnjNRfapzd",
+    "setup": "Why should you never trust a pig with a secret?",
+    "punchline": "Because it's bound to squeal."
+  },
+  {
+    "id": "7Uvc29hFIBd",
+    "setup": "Why are mummys scared of vacation?",
+    "punchline": "They're afraid to unwind."
+  },
+  {
+    "id": "7h3oGtrOfxc",
+    "setup": "Whiteboards...",
+    "punchline": "are remarkable."
+  },
+  {
+    "id": "7hNuz5MeVnb",
+    "setup": "What kind of dinosaur loves to sleep?",
+    "punchline": "A stega-snore-us."
+  },
+  {
+    "id": "7p41Lmbpjqc",
+    "setup": "What has three letters and starts with gas?",
+    "punchline": "A Car."
+  },
+  {
+    "id": "7wciy59MJe",
+    "setup": "What’s Forest Gump’s Facebook password?",
+    "punchline": "1forest1"
+  },
+  {
+    "id": "82LBXSfaFlb",
+    "setup": "What kind of tree fits in your hand?",
+    "punchline": "A palm tree!"
+  },
+  {
+    "id": "82TnORSK6wc",
+    "setup": "Whenever the cashier at the grocery store asks my dad if he would like the milk in a bag he replies, ‘No",
+    "punchline": "just leave it in the carton!’"
+  },
+  {
+    "id": "82gqciGBdFd",
+    "setup": "I used to be addicted to the hokey pokey",
+    "punchline": "but I turned myself around."
+  },
+  {
+    "id": "82wAAI6pbh",
+    "setup": "How many tickles does it take to tickle an octopus?",
+    "punchline": "Ten-tickles!"
+  },
+  {
+    "id": "82wHlbaapzd",
+    "setup": "Me: If humans lose the ability to hear high frequency volumes as they get older, can my 4 week old son hear a dog whistle? Doctor: No, humans can never hear that high of a frequency no matter what age they are. Me: Trick question...",
+    "punchline": "dogs can't whistle."
+  },
+  {
+    "id": "892EImW0Dlb",
+    "setup": "What musical instrument is found in the bathroom?",
+    "punchline": "A tuba toothpaste."
+  },
+  {
+    "id": "89MZLmWnWvc",
+    "setup": "I can't take my dog to the pond anymore because the ducks keep attacking him.",
+    "punchline": "That's what I get for buying a pure bread dog."
+  },
+  {
+    "id": "89pzsHtW8pb",
+    "setup": "My boss told me to attach two pieces of wood together...",
+    "punchline": "I totally nailed it!"
+  },
+  {
+    "id": "8U0TClqOZDd",
+    "setup": "What was the pumpkin’s favorite sport?",
+    "punchline": "Squash."
+  },
+  {
+    "id": "8UDdUnrzkyd",
+    "setup": "What do you call corn that joins the army?",
+    "punchline": "Kernel."
+  },
+  {
+    "id": "8USSSfVn3ob",
+    "setup": "I've been trying to come up with a dad joke about momentum...",
+    "punchline": "but I just can't seem to get it going."
+  },
+  {
+    "id": "8hFYojqz5h",
+    "setup": "Why don't skeletons ride roller coasters?",
+    "punchline": "They don't have the stomach for it."
+  },
+  {
+    "id": "8hVnbxcp4wc",
+    "setup": "Is there a hole in your shoe?",
+    "punchline": "No… Then how’d you get your foot in it?"
+  },
+  {
+    "id": "8p49pWvcxAd",
+    "setup": "Every night at 11:11",
+    "punchline": "I make a wish that someone will come fix my broken clock."
+  },
+  {
+    "id": "8pWvzkjN7Ed",
+    "setup": "Two muffins were sitting in an oven, and the first looks over to the second, and says, “man, it’s really hot in here”.",
+    "punchline": "The second looks over at the first with a surprised look, and answers, “WHOA, a talking muffin!”"
+  },
+  {
+    "id": "8prWvkOf2Ed",
+    "setup": "What's the difference between a guitar and a fish?",
+    "punchline": "You can tune a guitar but you can't \"tuna\" fish!"
+  },
+  {
+    "id": "92oOKusHBd",
+    "setup": "Did you hear that the police have a warrant out on a midget psychic ripping people off?",
+    "punchline": "It reads “Small medium at large.”"
+  },
+  {
+    "id": "99MZvHJJtzd",
+    "setup": "Why don't sharks eat clowns?",
+    "punchline": "Because they taste funny."
+  },
+  {
+    "id": "99U0T7hVDlb",
+    "setup": "Just read a few facts about frogs.",
+    "punchline": "They were ribbiting."
+  },
+  {
+    "id": "99UDQZgyIBd",
+    "setup": "Two satellites decided to get married.",
+    "punchline": "The wedding wasn't much, but the reception was incredible."
+  },
+  {
+    "id": "9EBljqWDAsc",
+    "setup": "What do you call a fish with no eyes?",
+    "punchline": "A fsh."
+  },
+  {
+    "id": "9Mus4wkqzd",
+    "setup": "What do you get if you put a duck in a cement mixer?",
+    "punchline": "Quacks in the pavement."
+  },
+  {
+    "id": "9hiGeNZ0Tnb",
+    "setup": "They tried to make a diamond shaped like a duck.",
+    "punchline": "It quacked under the pressure."
+  },
+  {
+    "id": "9hyAsrzAItc",
+    "setup": "Where’s the bin?",
+    "punchline": "Dad: I haven’t been anywhere!"
+  },
+  {
+    "id": "9hydxXgiiqc",
+    "setup": "My wife said I was immature.",
+    "punchline": "So I told her to get out of my fort."
+  },
+  {
+    "id": "9pGJRSnbMCd",
+    "setup": "Why did the knife dress up in a suit?",
+    "punchline": "Because it wanted to look sharp"
+  },
+  {
+    "id": "9pOR7pzItrc",
+    "setup": "How do you make a water bed more bouncy.",
+    "punchline": "You use Spring Water"
+  },
+  {
+    "id": "9pW8xXgiiqc",
+    "setup": "I considered building the patio by myself.",
+    "punchline": "But I didn't have the stones."
+  },
+  {
+    "id": "9pjqj3gqWDd",
+    "setup": "In my career as a lumberjack I cut down exactly 52,487 trees.",
+    "punchline": "I know because I kept a log."
+  },
+  {
+    "id": "9prWnjyImyd",
+    "setup": "Why do bears have hairy coats?",
+    "punchline": "Fur protection."
+  },
+  {
+    "id": "9xA51L6Uvc",
+    "setup": "What do you get when you cross a bee and a sheep?",
+    "punchline": "A bah-humbug."
+  },
+  {
+    "id": "9xPCt411ojb",
+    "setup": "What did one snowman say to the other snow man?",
+    "punchline": "Do you smell carrot?"
+  },
+  {
+    "id": "A5189xcFIBd",
+    "setup": "\"Dad, do you think it's going to snow this winter?\" \"I dont know",
+    "punchline": "its all up in the air\""
+  },
+  {
+    "id": "A5MCY821gib",
+    "setup": "Why do bees hum?",
+    "punchline": "Because they don't know the words."
+  },
+  {
+    "id": "A5ozsH6pWnb",
+    "setup": "What do you call a troublesome Canadian high schooler?",
+    "punchline": "A poutine."
+  },
+  {
+    "id": "AAXnyImyPCd",
+    "setup": "Don't trust atoms.",
+    "punchline": "They make up everything."
+  },
+  {
+    "id": "AAdFBXnGlyd",
+    "setup": "If you walk into a forest and cut down a tree, but the tree doesn't understand why you cut it down",
+    "punchline": "do you think it's stumped?"
+  },
+  {
+    "id": "AI6hiGtzAd",
+    "setup": "Where do bees go to the bathroom?",
+    "punchline": "The BP station."
+  },
+  {
+    "id": "AI6pbUSnbh",
+    "setup": "What is the best way to carve?",
+    "punchline": "Whittle by whittle."
+  },
+  {
+    "id": "AIRSSfi3Le",
+    "setup": "What's a ninja's favorite type of shoes?",
+    "punchline": "Sneakers!"
+  },
+  {
+    "id": "AIm3w5hiyd",
+    "setup": "Why did the tree go to the dentist?",
+    "punchline": "It needed a root canal."
+  },
+  {
+    "id": "AQn3wPKeqrc",
+    "setup": "It was raining cats and dogs the other day.",
+    "punchline": "I almost stepped in a poodle."
+  },
+  {
+    "id": "AXnrrcNmyAd",
+    "setup": "Why do bananas have to put on sunscreen before they go to the beach?",
+    "punchline": "Because they might peel!"
+  },
+  {
+    "id": "AXvHeVvHeib",
+    "setup": "What do you call a bee that lives in America?",
+    "punchline": "A USB."
+  },
+  {
+    "id": "Albp49Mmjyd",
+    "setup": "I was wondering why the frisbee was getting bigger",
+    "punchline": "then it hit me."
+  },
+  {
+    "id": "AljqO7hFBd",
+    "setup": "A farmer had 297 cows, when he rounded them up",
+    "punchline": "he found he had 300"
+  },
+  {
+    "id": "As4wsHtzd",
+    "setup": "What's the difference between a hippo and a zippo?",
+    "punchline": "One is really heavy, the other is a little lighter."
+  },
+  {
+    "id": "AsHQSSKeapb",
+    "setup": "I’ve got this disease where I can’t stop making airport puns.",
+    "punchline": "The doctor says it terminal."
+  },
+  {
+    "id": "AsrrcprjNCd",
+    "setup": "What concert costs only 45 cents?",
+    "punchline": "50 cent featuring Nickelback."
+  },
+  {
+    "id": "B5h311TS7h",
+    "setup": "I couldn't figure out how the seat belt worked.",
+    "punchline": "Then it just clicked."
+  },
+  {
+    "id": "B5hNeNJYgFd",
+    "setup": "What did the green grape say to the purple grape?",
+    "punchline": "BREATH!!"
+  },
+  {
+    "id": "BAdU0DAlVvc",
+    "setup": "What do you call a dad that has fallen through the ice?",
+    "punchline": "A Popsicle."
+  },
+  {
+    "id": "BAscNus4ozd",
+    "setup": "Two parrots are sitting on a perch.",
+    "punchline": "One turns to the other and asks, \"do you smell fish?\""
+  },
+  {
+    "id": "BI699EY08Ed",
+    "setup": "Bad at golf?",
+    "punchline": "Join the club."
+  },
+  {
+    "id": "BQKZTnOCIe",
+    "setup": "I had a pair of racing snails.",
+    "punchline": "I removed their shells to make them more aerodynamic, but they became sluggish."
+  },
+  {
+    "id": "BQfaxsHBsrc",
+    "setup": "What do you call a pile of cats?",
+    "punchline": "A Meowtain."
+  },
+  {
+    "id": "BQnyImOCIBd",
+    "setup": "How do hens stay fit?",
+    "punchline": "They always egg-cercise!"
+  },
+  {
+    "id": "BdxHQZ0TCd",
+    "setup": "Can a kangaroo jump higher than the Empire State Building?",
+    "punchline": "Of course. The Empire State Building can't jump."
+  },
+  {
+    "id": "BsHtcN7hiqc",
+    "setup": "What do you give a sick lemon?",
+    "punchline": "Lemonaid."
+  },
+  {
+    "id": "C59hNRCdUnb",
+    "setup": "What do you call an old snowman?",
+    "punchline": "Water."
+  },
+  {
+    "id": "C5TKmb21ojb",
+    "setup": "I tried to milk a cow today, but was unsuccessful.",
+    "punchline": "Udder failure."
+  },
+  {
+    "id": "CAlG6MRnWnb",
+    "setup": "I just got fired from a florist",
+    "punchline": "apparently I took too many leaves."
+  },
+  {
+    "id": "CIt49pjG6wc",
+    "setup": "Why don’t skeletons ever go trick or treating?",
+    "punchline": "Because they have nobody to go with."
+  },
+  {
+    "id": "CQSKeaFIBsc",
+    "setup": "What does a female snake use for support?",
+    "punchline": "A co-Bra!"
+  },
+  {
+    "id": "CYvsHtWDAlb",
+    "setup": "\"Dad, I'm cold.\"",
+    "punchline": "\"Go stand in the corner, I hear it's 90 degrees.\""
+  },
+  {
+    "id": "Cd2gFdFQKuc",
+    "setup": "Child: Dad, make me a sandwich. Dad: Poof!",
+    "punchline": "You're a sandwich."
+  },
+  {
+    "id": "CdUnOKeiqzd",
+    "setup": "which flower is most fierce?",
+    "punchline": "Dandelion"
+  },
+  {
+    "id": "ClGY8xc2EBd",
+    "setup": "Why are graveyards so noisy?",
+    "punchline": "Because of all the coffin."
+  },
+  {
+    "id": "CtWgqjbMeib",
+    "setup": "What kind of bagel can fly?",
+    "punchline": "A plain bagel."
+  },
+  {
+    "id": "D5E6USfNmb",
+    "setup": "How many apples grow on a tree?",
+    "punchline": "All of them!"
+  },
+  {
+    "id": "D5wAA5o4TCd",
+    "setup": "What do you call a careful wolf?",
+    "punchline": "Aware wolf."
+  },
+  {
+    "id": "DAskq4oWSvc",
+    "setup": "I was just looking at my ceiling.",
+    "punchline": "Not sure if it’s the best ceiling in the world, but it’s definitely up there."
+  },
+  {
+    "id": "DIeFtkVvHlb",
+    "setup": "Why do valley girls hang out in odd numbered groups?",
+    "punchline": "Because they can't even."
+  },
+  {
+    "id": "DImrciqWSCd",
+    "setup": "What do you call a cow with no legs?",
+    "punchline": "Ground beef."
+  },
+  {
+    "id": "DQ7MZLZoWnb",
+    "setup": "Why are snake races so exciting?",
+    "punchline": "They're always neck and neck."
+  },
+  {
+    "id": "DY8UvkqHexc",
+    "setup": "Why did the half blind man fall in the well?",
+    "punchline": "Because he couldn't see that well!"
+  },
+  {
+    "id": "DYLukyIY8Ed",
+    "setup": "As I suspected, someone has been adding soil to my garden.",
+    "punchline": "The plot thickens."
+  },
+  {
+    "id": "Dd2EY018Me",
+    "setup": "What do bees do after they are married?",
+    "punchline": "They go on a honeymoon."
+  },
+  {
+    "id": "DdaFtrrOZvc",
+    "setup": "If I could name myself after any Egyptian god",
+    "punchline": "I'd be Set."
+  },
+  {
+    "id": "DlOmrj3gaFd",
+    "setup": "Why doesn't the Chimney-Sweep call out sick from work?",
+    "punchline": "Because he's used to working with a flue."
+  },
+  {
+    "id": "Dt4hNJJmykb",
+    "setup": "It’s hard to explain puns to kleptomaniacs",
+    "punchline": "because they take everything literally."
+  },
+  {
+    "id": "DtWSnydN7h",
+    "setup": "It's difficult to say what my wife does",
+    "punchline": "she sells sea shells by the sea shore."
+  },
+  {
+    "id": "DtcaMmWDImb",
+    "setup": "Why did Dracula lie in the wrong coffin?",
+    "punchline": "He made a grave mistake."
+  },
+  {
+    "id": "EBAsPfiNuzd",
+    "setup": "What did one plate say to the other plate?",
+    "punchline": "Dinner is on me!"
+  },
+  {
+    "id": "EBQfiyXD5ob",
+    "setup": "what do you call a dog that can do magic tricks?",
+    "punchline": "a labracadabrador"
+  },
+  {
+    "id": "EIJmGY8Etrc",
+    "setup": "Doctor: Do you want to hear the good news or the bad news? Patient: Good news please.",
+    "punchline": "Doctor: we're naming a disease after you."
+  },
+  {
+    "id": "EYo4TCAdUf",
+    "setup": "I tried to write a chemistry joke",
+    "punchline": "but could never get a reaction."
+  },
+  {
+    "id": "EYojGtPRusc",
+    "setup": "I gave my friend 10 puns hoping that one of them would make him laugh.",
+    "punchline": "Sadly, no pun in ten did."
+  },
+  {
+    "id": "EYoz51DtHtc",
+    "setup": "What do computers and air conditioners have in common?",
+    "punchline": "They both become useless when you open windows."
+  },
+  {
+    "id": "EdpjyXSfNCd",
+    "setup": "What do you call a monkey in a mine field?",
+    "punchline": "A babooooom!"
+  },
+  {
+    "id": "Elb2wkbx5wc",
+    "setup": "Scientists finally did a study on forks.",
+    "punchline": "It's about tine!"
+  },
+  {
+    "id": "ElbaF6wHlyd",
+    "setup": "I cut my finger cutting cheese.",
+    "punchline": "I know it may be a cheesy story but I feel grate now."
+  },
+  {
+    "id": "ElyXS0gFBAd",
+    "setup": "How do you steal a coat?",
+    "punchline": "You jacket."
+  },
+  {
+    "id": "EtzscNuk3Ed",
+    "setup": "Why don't you find hippopotamuses hiding in trees?",
+    "punchline": "They're really good at it."
+  },
+  {
+    "id": "F6M7ElOZTvc",
+    "setup": "what happens when you cross a sheep with a kangaroo?",
+    "punchline": "A woolly jumper!"
+  },
+  {
+    "id": "FBQ7wskbMmb",
+    "setup": "Want to hear a joke about construction?",
+    "punchline": "Nah, I'm still working on it."
+  },
+  {
+    "id": "FBQK6MexPuc",
+    "setup": "My friend told me that pepper is the best seasoning for a roast",
+    "punchline": "but I took it with a grain of salt."
+  },
+  {
+    "id": "FIY8992wskb",
+    "setup": "Why do choirs keep buckets handy?",
+    "punchline": "So they can carry their tune"
+  },
+  {
+    "id": "FImyA5EIBAd",
+    "setup": "Did you hear about the kidnapping at school?",
+    "punchline": "It's ok, he woke up."
+  },
+  {
+    "id": "FQfxk39EBd",
+    "setup": "I asked my date to go to the gym the other day. They never showed up.",
+    "punchline": "That's when I knew we wouldn't work out."
+  },
+  {
+    "id": "FYTv41LmbFd",
+    "setup": "You will never guess what Elsa did to the balloon.",
+    "punchline": "She let it go."
+  },
+  {
+    "id": "FYobM71o4ob",
+    "setup": "Did you hear about the two thieves who stole a calendar?",
+    "punchline": "They each got six months."
+  },
+  {
+    "id": "FdN7hiG6Uvc",
+    "setup": "Why can't eggs have love?",
+    "punchline": "They will break up too soon."
+  },
+  {
+    "id": "FdN7przPCtc",
+    "setup": "You can't run through a camp site.",
+    "punchline": "You can only ran, because it's past tents."
+  },
+  {
+    "id": "FdN7wcxAskb",
+    "setup": "They're making a movie about clocks.",
+    "punchline": "It's about time"
+  },
+  {
+    "id": "FdNZTnWvHBd",
+    "setup": "I’ve just been reading a book about anti-gravity",
+    "punchline": "it’s impossible to put down!"
+  },
+  {
+    "id": "FlbUKuPZob",
+    "setup": "Have you ever seen fruit preserves being made?",
+    "punchline": "It's jarring."
+  },
+  {
+    "id": "FtHBXvXL6h",
+    "setup": "I was going to get a brain transplant",
+    "punchline": "but I changed my mind"
+  },
+  {
+    "id": "FtHJmGJ61wc",
+    "setup": "Have you heard about the owl sanctuary job opening?",
+    "punchline": "It’s all night shifts but they’re all a hoot over there."
+  },
+  {
+    "id": "G6EtkOZD5h",
+    "setup": "Why can't you use \"Beef stew\" as a password?",
+    "punchline": "Because it's not stroganoff."
+  },
+  {
+    "id": "G6pr4EQfiqc",
+    "setup": "What did the piece of bread say to the knife?",
+    "punchline": "Butter me up."
+  },
+  {
+    "id": "GBscNZg3gib",
+    "setup": "Why couldn't the lifeguard save the hippie?",
+    "punchline": "He was too far out, man."
+  },
+  {
+    "id": "GJeaF6pOKmb",
+    "setup": "They say Dodger Stadium can hold up to fifty-six thousand people",
+    "punchline": "but that is just a ballpark figure."
+  },
+  {
+    "id": "GQuzAAXgah",
+    "setup": "Some people say that I never got over my obsession with Phil Collins.",
+    "punchline": "But take a look at me now."
+  },
+  {
+    "id": "GYDY8xXLmyd",
+    "setup": "Why did the girl smear peanut butter on the road?",
+    "punchline": "To go with the traffic jam."
+  },
+  {
+    "id": "GlGBIY0wAAd",
+    "setup": "How much does a hipster weigh?",
+    "punchline": "An instagram."
+  },
+  {
+    "id": "GlbxXg3TClb",
+    "setup": "A woman is on trial for beating her husband to death with his guitar collection. Judge says, ‘First offender?’ She says, ‘No, first a Gibson!",
+    "punchline": "Then a Fender!’"
+  },
+  {
+    "id": "GlbxkyPRKuc",
+    "setup": "I saw an ad in a shop window, \"Television for sale, $1, volume stuck on full\", I thought",
+    "punchline": "\"I can't turn that down\"."
+  },
+  {
+    "id": "GtH6E6UD5Ed",
+    "setup": "What kind of dog lives in a particle accelerator?",
+    "punchline": "A Fermilabrador Retriever."
+  },
+  {
+    "id": "H6EY0Dljiyd",
+    "setup": "I always wanted to look into why I procrastinate",
+    "punchline": "but I keep putting it off."
+  },
+  {
+    "id": "H6Elb2LBdxc",
+    "setup": "What's blue and not very heavy?",
+    "punchline": "Light blue."
+  },
+  {
+    "id": "H6pWvHQKJe",
+    "setup": "Guy told me today he did not know what cloning is.",
+    "punchline": "I told him, \"that makes 2 of us.\""
+  },
+  {
+    "id": "HBszX8MJ6h",
+    "setup": "I was so proud when I finished the puzzle in six months",
+    "punchline": "when on the side it said three to four years."
+  },
+  {
+    "id": "HJJY0LR7hyd",
+    "setup": "Where did you learn to make ice cream?",
+    "punchline": "Sunday school."
+  },
+  {
+    "id": "HQZorO7pWnb",
+    "setup": "Coffee has a tough time at my house",
+    "punchline": "every morning it gets mugged."
+  },
+  {
+    "id": "HQfNZDIRSnb",
+    "setup": "A quick shoutout to all of the sidewalks out there...",
+    "punchline": "Thanks for keeping me off the streets."
+  },
+  {
+    "id": "HQuXvkjqcpb",
+    "setup": "Where does Napoleon keep his armies?",
+    "punchline": "In his sleevies."
+  },
+  {
+    "id": "HY08E6U0Dtc",
+    "setup": "What's the difference between roast beef and pea soup.",
+    "punchline": "Anyone can roast beef, but nobody can pee soup."
+  },
+  {
+    "id": "HYTfVf21ob",
+    "setup": "What do you get if you cross a turkey with a ghost?",
+    "punchline": "A poultry-geist!"
+  },
+  {
+    "id": "HYoGYTvX0g",
+    "setup": "What is the tallest building in the world?",
+    "punchline": "The library – it’s got the most stories!"
+  },
+  {
+    "id": "HeaFdiyIJe",
+    "setup": "What kind of magic do cows believe in?",
+    "punchline": "MOODOO."
+  },
+  {
+    "id": "HeiqcaMRKBd",
+    "setup": "What’s the longest word in the dictionary?",
+    "punchline": "Smiles. Because there’s a mile between the two S’s."
+  },
+  {
+    "id": "HlGlbFdiqjb",
+    "setup": "Why don't eggs tell jokes?",
+    "punchline": "They'd crack each other up"
+  },
+  {
+    "id": "HlbFQ71wkyd",
+    "setup": "I just broke my guitar.",
+    "punchline": "It's okay, I won't fret"
+  },
+  {
+    "id": "HtcNuHJBQCd",
+    "setup": "How many kids with ADD does it take to change a lightbulb?",
+    "punchline": "Let's go ride bikes!"
+  },
+  {
+    "id": "I6h3ozAIYDd",
+    "setup": "Where do hamburgers go to dance?",
+    "punchline": "The meat-ball."
+  },
+  {
+    "id": "IBszdxXDAsc",
+    "setup": "I invented a new word!",
+    "punchline": "Plagiarism!"
+  },
+  {
+    "id": "IJBAsrrzPmb",
+    "setup": "What do you call a cow with two legs?",
+    "punchline": "Lean beef."
+  },
+  {
+    "id": "IJYvcFIBAlb",
+    "setup": "What did the big flower say to the littler flower?",
+    "punchline": "Hi, bud!"
+  },
+  {
+    "id": "IRKJBQ7p4wc",
+    "setup": "I never wanted to believe that my Dad was stealing from his job as a road worker.",
+    "punchline": "But when I got home, all the signs were there."
+  },
+  {
+    "id": "IRZDtWSnWDd",
+    "setup": "Why do pumpkins sit on people’s porches?",
+    "punchline": "They have no hands to knock on the door."
+  },
+  {
+    "id": "IRuX8U8EImb",
+    "setup": "Who is the coolest Doctor in the hospital?",
+    "punchline": "The hip Doctor!"
+  },
+  {
+    "id": "IYT082EQukb",
+    "setup": "Why was ten scared of seven?",
+    "punchline": "Because seven ate nine."
+  },
+  {
+    "id": "IYgiyIR7hib",
+    "setup": "What do you get when you cross a rabbit with a water hose?",
+    "punchline": "Hare spray."
+  },
+  {
+    "id": "IeiyIRSnbxc",
+    "setup": "I applied to be a doorman but didn't get the job due to lack of experience.",
+    "punchline": "That surprised me, I thought it was an entry level position."
+  },
+  {
+    "id": "IexXD5TnGBd",
+    "setup": "I knew a guy who collected candy canes",
+    "punchline": "they were all in mint condition"
+  },
+  {
+    "id": "Im31ozkVnjb",
+    "setup": "A boy dug three holes in the yard.",
+    "punchline": "When his mother saw, she exclaimed: \"well, well, well\""
+  },
+  {
+    "id": "Imjb2gN7hib",
+    "setup": "Why do nurses carry around red crayons?",
+    "punchline": "Sometimes they need to draw blood."
+  },
+  {
+    "id": "ImydN7hy5h",
+    "setup": "Why was the shirt happy to hang around the tank top?",
+    "punchline": "Because it was armless"
+  },
+  {
+    "id": "It4Etrjiqrc",
+    "setup": "Why does a chicken coop only have two doors?",
+    "punchline": "Because if it had four doors it would be a chicken sedan."
+  },
+  {
+    "id": "ItWLR792Ed",
+    "setup": "\"I'll call you later.\" Don't call me later",
+    "punchline": "call me Dad."
+  },
+  {
+    "id": "ItWSnbUfVnb",
+    "setup": "Why did the teddy bear say “no” to dessert?",
+    "punchline": "Because she was stuffed."
+  },
+  {
+    "id": "J69x5hNZvzd",
+    "setup": "I don't trust sushi",
+    "punchline": "there's something fishy about it."
+  },
+  {
+    "id": "JBIBImbMe",
+    "setup": "Did you hear the one about the giant pickle?",
+    "punchline": "He was kind of a big dill."
+  },
+  {
+    "id": "JBs4T79Edpb",
+    "setup": "Breaking news!",
+    "punchline": "Energizer Bunny arrested – charged with battery."
+  },
+  {
+    "id": "JJ61L61Lusc",
+    "setup": "How many bones are in the human hand?",
+    "punchline": "A handful of them."
+  },
+  {
+    "id": "JeF69xAQSnb",
+    "setup": "A red and a blue ship have just collided in the Caribbean.",
+    "punchline": "Apparently the survivors are marooned."
+  },
+  {
+    "id": "JeVDI6EBIe",
+    "setup": "I've just written a song about a tortilla.",
+    "punchline": "Well, it is more of a rap really."
+  },
+  {
+    "id": "JeaxXvkyPf",
+    "setup": "Can February march?",
+    "punchline": "No, but April may."
+  },
+  {
+    "id": "JmjbxkGJBAd",
+    "setup": "Egyptians claimed to invent the guitar",
+    "punchline": "but they were such lyres."
+  },
+  {
+    "id": "K6UKmykqrjb",
+    "setup": "What is a witch's favorite subject in school?",
+    "punchline": "Spelling!"
+  },
+  {
+    "id": "K6USKBXvcib",
+    "setup": "What do you call a crowd of chess players bragging about their wins in a hotel lobby?",
+    "punchline": "Chess nuts boasting in an open foyer."
+  },
+  {
+    "id": "K6UvXD5Mexc",
+    "setup": "Which side of the chicken has more feathers?",
+    "punchline": "The outside."
+  },
+  {
+    "id": "KBsWnO711Dd",
+    "setup": "Remember",
+    "punchline": "the best angle to approach a problem from is the \"try\" angle."
+  },
+  {
+    "id": "KBsrz5ws4Ed",
+    "setup": "Why are fish easy to weigh?",
+    "punchline": "Because they have their own scales."
+  },
+  {
+    "id": "KJJtPuPKJe",
+    "setup": "What did the scarf say to the hat?",
+    "punchline": "You go on ahead, I am going to hang around a bit longer."
+  },
+  {
+    "id": "KJmW8h3oWnb",
+    "setup": "Did you hear about the scientist who was lab partners with a pot of boiling water?",
+    "punchline": "He had a very esteemed colleague."
+  },
+  {
+    "id": "KJmrOKeNexc",
+    "setup": "This morning I was wondering where the sun was",
+    "punchline": "but then it dawned on me."
+  },
+  {
+    "id": "KZLBXvPZDd",
+    "setup": "What did the sea say to the sand?",
+    "punchline": "\"We have to stop meeting like this.\""
+  },
+  {
+    "id": "KeqOmOZDYDd",
+    "setup": "Why is it so windy inside an arena?",
+    "punchline": "All those fans."
+  },
+  {
+    "id": "KmW8hFlV0ob",
+    "setup": "A panda walks into a bar and says to the bartender “I’ll have a Scotch and.............. Coke thank you”.",
+    "punchline": "“Sure thing” the bartender replies and asks “but what’s with the big pause?” The panda holds up his hands and says “I was born with them”"
+  },
+  {
+    "id": "KmbMJtrjbxc",
+    "setup": "I've started telling everyone about the benefits of eating dried grapes.",
+    "punchline": "It's all about raisin awareness."
+  },
+  {
+    "id": "L6UnyP7Unyd",
+    "setup": "“Doctor",
+    "punchline": "I’ve broken my arm in several places” Doctor “Well don’t go to those places.”"
+  },
+  {
+    "id": "LB5wHQSvzAd",
+    "setup": "Where was the Declaration of Independence signed?",
+    "punchline": "At the bottom!"
+  },
+  {
+    "id": "LBAQ79MJmb",
+    "setup": "What’s the difference between an African elephant and an Indian elephant?",
+    "punchline": "About 5000 miles."
+  },
+  {
+    "id": "LBdUvcFB5h",
+    "setup": "Two peanuts were walking down the street.",
+    "punchline": "One was a salted"
+  },
+  {
+    "id": "LRf2obFBskb",
+    "setup": "Don’t interrupt someone working intently on a puzzle.",
+    "punchline": "Chances are, you’ll hear some crosswords."
+  },
+  {
+    "id": "LRnGeVfiNe",
+    "setup": "Today a man knocked on my door and asked for a small donation towards the local swimming pool.",
+    "punchline": "I gave him a glass of water."
+  },
+  {
+    "id": "Lmjqzsr49pb",
+    "setup": "What did the Zen Buddist say to the hotdog vendor?",
+    "punchline": "Make me one with everything."
+  },
+  {
+    "id": "LucahqjGQuc",
+    "setup": "Why did the clown have neck pain?",
+    "punchline": "- Because he slept funny"
+  },
+  {
+    "id": "LuciNmbaMmb",
+    "setup": "What did the digital clock say to the grandfather clock?",
+    "punchline": "Look, no hands!"
+  },
+  {
+    "id": "M7EBXgVSCAd",
+    "setup": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before.",
+    "punchline": "What can I get for you?\" \"Pop,\" goes the weasel."
+  },
+  {
+    "id": "M7ElyAQCAd",
+    "setup": "How was the snow globe feeling after the storm?",
+    "punchline": "A little shaken."
+  },
+  {
+    "id": "M7wPC5wPKBd",
+    "setup": "Did you hear the one about the guy with the broken hearing aid?",
+    "punchline": "Neither did he."
+  },
+  {
+    "id": "MCImjqrWvzd",
+    "setup": "Did you hear about the campsite that got visited by Bigfoot?",
+    "punchline": "It got in tents."
+  },
+  {
+    "id": "MCYLZ0wAsc",
+    "setup": "I saw a documentary on TV last night about how they put ships together.",
+    "punchline": "It was rivetting."
+  },
+  {
+    "id": "MCt4wX8pb",
+    "setup": "What did the Red light say to the Green light?",
+    "punchline": "Don't look at me I'm changing!"
+  },
+  {
+    "id": "MJB511wAXvc",
+    "setup": "What did the ocean say to the beach?",
+    "punchline": "Thanks for all the sediment."
+  },
+  {
+    "id": "MRC5hNCAXg",
+    "setup": "What did the left eye say to the right eye?",
+    "punchline": "Between us, something smells!"
+  },
+  {
+    "id": "MRZ0LJtHQCd",
+    "setup": "What do you call a fly without wings?",
+    "punchline": "A walk."
+  },
+  {
+    "id": "MZ82EIB5hFd",
+    "setup": "Why did the melons plan a big wedding?",
+    "punchline": "Because they cantaloupe!"
+  },
+  {
+    "id": "MZDtW0gi3g",
+    "setup": "Yesterday I confused the words \"jacuzzi\" and \"yakuza\".",
+    "punchline": "Now I'm in hot water with the Japanese mafia."
+  },
+  {
+    "id": "MZga2gFlysc",
+    "setup": "What is the least spoken language in the world?",
+    "punchline": "Sign Language"
+  },
+  {
+    "id": "MZoOCQ7wcpb",
+    "setup": "What do birds give out on Halloween?",
+    "punchline": "Tweets."
+  },
+  {
+    "id": "MZvsrzXgyd",
+    "setup": "I used to think I was indecisive",
+    "punchline": "but now I'm not sure."
+  },
+  {
+    "id": "MeaFYLBAQuc",
+    "setup": "Have you heard the rumor going around about butter?",
+    "punchline": "Never mind, I shouldn't spread it."
+  },
+  {
+    "id": "MeqOZgV8MCd",
+    "setup": "Every morning when I go out, I get hit by bicycle. Every morning!",
+    "punchline": "It's a vicious cycle."
+  },
+  {
+    "id": "N7pWvcxsHBd",
+    "setup": "What happens to a frog's car when it breaks down?",
+    "punchline": "It gets toad."
+  },
+  {
+    "id": "NCAIYLeNe",
+    "setup": "I fear for the calendar",
+    "punchline": "its days are numbered."
+  },
+  {
+    "id": "NCQfqHYgaFd",
+    "setup": "I'm glad I know sign language",
+    "punchline": "it's pretty handy."
+  },
+  {
+    "id": "NJBl3TnrHlb",
+    "setup": "The other day, my wife asked me to pass her lipstick but I accidentally passed her a glue stick.",
+    "punchline": "She still isn't talking to me."
+  },
+  {
+    "id": "NJJ6wH6hNCd",
+    "setup": "What do you get when you cross a chicken with a skunk?",
+    "punchline": "A fowl smell!"
+  },
+  {
+    "id": "NRZTSnykqjb",
+    "setup": "Where do you take someone who’s been injured in a peek-a-boo accident?",
+    "punchline": "To the I.C.U."
+  },
+  {
+    "id": "NRfxXvkbFtc",
+    "setup": "As I get older, I think of all the people I lost along the way.",
+    "punchline": "Maybe a career as a tour guide wasn't such a good idea."
+  },
+  {
+    "id": "NRuHJYgaUDd",
+    "setup": "How many hipsters does it take to change a lightbulb?",
+    "punchline": "Oh, it's a really obscure number. You've probably never heard of it."
+  },
+  {
+    "id": "NZDlb299Uf",
+    "setup": "Where do sheep go to get their hair cut?",
+    "punchline": "The baa-baa shop."
+  },
+  {
+    "id": "NmbFtH69hFd",
+    "setup": "Our wedding was so beautiful",
+    "punchline": "even the cake was in tiers."
+  },
+  {
+    "id": "NmjNJJR7wc",
+    "setup": "Why did the miner get fired from his job?",
+    "punchline": "He took it for granite..."
+  },
+  {
+    "id": "NucUfVvXLBd",
+    "setup": "What did the hat say to the scarf? You can hang around.",
+    "punchline": "I'll just go on ahead."
+  },
+  {
+    "id": "O7haxA5Tfxc",
+    "setup": "Where do cats write notes?",
+    "punchline": "Scratch Paper!"
+  },
+  {
+    "id": "OCtWnGJtPuc",
+    "setup": "Why is the new Kindle screen textured to look like paper?",
+    "punchline": "So you feel write at home."
+  },
+  {
+    "id": "ORK6UDA5hqc",
+    "setup": "When my wife told me to stop impersonating a flamingo",
+    "punchline": "I had to put my foot down."
+  },
+  {
+    "id": "ORKmyAIYvzd",
+    "setup": "No matter how kind you are",
+    "punchline": "German children are kinder."
+  },
+  {
+    "id": "OZLuP7UDtkb",
+    "setup": "What’s the advantage of living in Switzerland?",
+    "punchline": "Well, the flag is a big plus."
+  },
+  {
+    "id": "OfNRfaaUSf",
+    "setup": "When I left school, I passed every one of my exams with the exception of Greek Mythology.",
+    "punchline": "It always was my achilles elbow"
+  },
+  {
+    "id": "OfNmyI6Ed",
+    "setup": "Why did the cookie cry?",
+    "punchline": "It was feeling crumby."
+  },
+  {
+    "id": "OmOfqW821Dd",
+    "setup": "What did Yoda say when he saw himself in 4K?",
+    "punchline": "\"HDMI\""
+  },
+  {
+    "id": "OukjGeNmWDd",
+    "setup": "How do you make a 'one' disappear?",
+    "punchline": "You add a 'g' and it's 'gone'"
+  },
+  {
+    "id": "P71TnyI6prc",
+    "setup": "Me and my mates are in a band called Duvet.",
+    "punchline": "We're a cover band."
+  },
+  {
+    "id": "PC5TCQuXnrc",
+    "setup": "Where do you learn to make banana splits?",
+    "punchline": "At sundae school."
+  },
+  {
+    "id": "PRZ8xHtcprc",
+    "setup": "Nurse: Doctor, there's a patient that says he's invisible.",
+    "punchline": "Doctor: Well, tell him I can't see him right now!"
+  },
+  {
+    "id": "PZDAXL6pOCd",
+    "setup": "What was a more important invention than the first telephone?",
+    "punchline": "The second one."
+  },
+  {
+    "id": "PZgyPmjb2ob",
+    "setup": "What do you get when you cross a snowman with a vampire?",
+    "punchline": "Frostbite."
+  },
+  {
+    "id": "PfaMusPucFd",
+    "setup": "What do you do when your bunny gets wet?",
+    "punchline": "You get your hare dryer."
+  },
+  {
+    "id": "PmyXSfxHBd",
+    "setup": "Did you know crocodiles could grow up to 15 feet?",
+    "punchline": "But most just have 4."
+  },
+  {
+    "id": "PucUS0L6Ed",
+    "setup": "There are two types of people in this world",
+    "punchline": "those who can extrapolate from incomplete data..."
+  },
+  {
+    "id": "PucUvXSvkqc",
+    "setup": "Why did the fireman wear red, white, and blue suspenders?",
+    "punchline": "To hold his pants up."
+  },
+  {
+    "id": "PuskbxcpWnb",
+    "setup": "In the news a courtroom artist was arrested today, I'm not surprised",
+    "punchline": "he always seemed sketchy."
+  },
+  {
+    "id": "Q7pGY0Dt4Ed",
+    "setup": "What do you call someone with no nose?",
+    "punchline": "Nobody knows."
+  },
+  {
+    "id": "QKJR79EIYDd",
+    "setup": "What do you call a girl between two posts?",
+    "punchline": "Annette."
+  },
+  {
+    "id": "QfiyAAlbpzd",
+    "setup": "What do you call a criminal going down the stairs?",
+    "punchline": "Condescending"
+  },
+  {
+    "id": "Qn31o49Musc",
+    "setup": "What do you call a fat psychic?",
+    "punchline": "A four-chin teller."
+  },
+  {
+    "id": "Qn3EIRZorrc",
+    "setup": "I used to be a banker",
+    "punchline": "but I lost interest."
+  },
+  {
+    "id": "QnWnWSfiqc",
+    "setup": "Why can't a bicycle stand on its own?",
+    "punchline": "It's two-tired."
+  },
+  {
+    "id": "QuscibaMClb",
+    "setup": "What does a pirate pay for his corn?",
+    "punchline": "A buccaneer!"
+  },
+  {
+    "id": "Qusrcahiib",
+    "setup": "Astronomers got tired watching the moon go around the earth for 24 hours.",
+    "punchline": "They decided to call it a day."
+  },
+  {
+    "id": "R7UfaahVfFd",
+    "setup": "My dog used to chase people on a bike a lot.",
+    "punchline": "It got so bad I had to take his bike away."
+  },
+  {
+    "id": "R7hFtWv49h",
+    "setup": "I ate a clock yesterday.",
+    "punchline": "It was so time consuming."
+  },
+  {
+    "id": "RZv4h3gV0g",
+    "setup": "Is the pool safe for diving?",
+    "punchline": "It deep ends."
+  },
+  {
+    "id": "RfiGei3E6Ed",
+    "setup": "Why do scuba divers fall backwards into the water?",
+    "punchline": "Because if they fell forwards they’d still be in the boat."
+  },
+  {
+    "id": "RuHYTSvzsrc",
+    "setup": "My wife told me to rub the herbs on the meat for better flavor.",
+    "punchline": "That's sage advice."
+  },
+  {
+    "id": "S0TvXvzPfFd",
+    "setup": "A man was caught stealing in a supermarket today while balanced on the shoulders of a couple of vampires.",
+    "punchline": "He was charged with shoplifting on two counts."
+  },
+  {
+    "id": "S7MCtHBQuc",
+    "setup": "Ben & Jerry's really need to improve their operation.",
+    "punchline": "The only way to get there is down a rocky road."
+  },
+  {
+    "id": "S7wHQKJe2wc",
+    "setup": "How are false teeth like stars?",
+    "punchline": "They come out at night!"
+  },
+  {
+    "id": "SKeqOucNeFd",
+    "setup": "What time did the man go to the dentist?",
+    "punchline": "Tooth hurt-y."
+  },
+  {
+    "id": "SKexPmbhapb",
+    "setup": "I went to the zoo yesterday and saw a baguette in a cage.",
+    "punchline": "It was bread in captivity."
+  },
+  {
+    "id": "SSCQCdi39Ed",
+    "setup": "Did you hear about the cheese factory that exploded in France?",
+    "punchline": "There was nothing left but de Brie."
+  },
+  {
+    "id": "SSnW8xsrrjb",
+    "setup": "How does a penguin build it’s house?",
+    "punchline": "Igloos it together."
+  },
+  {
+    "id": "Sn39Elb2LBd",
+    "setup": "What is this movie about?",
+    "punchline": "It is about 2 hours long."
+  },
+  {
+    "id": "SnOf2gqjiqc",
+    "setup": "Why are pirates called pirates?",
+    "punchline": "Because they arrr!"
+  },
+  {
+    "id": "SnrcpbhVKBd",
+    "setup": "Where does Fonzie like to go for lunch?",
+    "punchline": "Chick-Fil-Eyyyyyyyy."
+  },
+  {
+    "id": "SvPRCIeiNuc",
+    "setup": "How does a dyslexic poet write?",
+    "punchline": "Inverse."
+  },
+  {
+    "id": "SvXDImbMe",
+    "setup": "Don't tell secrets in corn fields.",
+    "punchline": "Too many ears around."
+  },
+  {
+    "id": "SvzIBAQS0Dd",
+    "setup": "What did the pirate say on his 80th birthday?",
+    "punchline": "Aye Matey!"
+  },
+  {
+    "id": "TC5TCt49prc",
+    "setup": "Why did the A go to the bathroom and come out as an E?",
+    "punchline": "Because he had a vowel movement."
+  },
+  {
+    "id": "TCA59hiiVvc",
+    "setup": "Yesterday a clown held a door open for me.",
+    "punchline": "I thought it was a nice jester."
+  },
+  {
+    "id": "TCY0LmGQnb",
+    "setup": "Why did the opera singer go sailing?",
+    "punchline": "They wanted to hit the high Cs."
+  },
+  {
+    "id": "TCYLBX0ozAd",
+    "setup": "Bought a new jacket suit the other day and it burst into flames.",
+    "punchline": "Well, it was a blazer"
+  },
+  {
+    "id": "TKRSCIBIBsc",
+    "setup": "Whats a penguins favorite relative?",
+    "punchline": "Aunt Arctica."
+  },
+  {
+    "id": "TKZD592LZob",
+    "setup": "Never Trust Someone With Graph Paper...",
+    "punchline": "They're always plotting something."
+  },
+  {
+    "id": "TKmbUDI6UDd",
+    "setup": "What do you call an elephant that doesn’t matter?",
+    "punchline": "An irrelephant."
+  },
+  {
+    "id": "TS0gFlqr4ob",
+    "setup": "What do you call a group of disorganized cats?",
+    "punchline": "A cat-tastrophe."
+  },
+  {
+    "id": "TS7U0oWnjyd",
+    "setup": "What is bread's favorite number?",
+    "punchline": "Leaven."
+  },
+  {
+    "id": "TSfFYT7EBd",
+    "setup": "Why can’t you hear a pterodactyl go to the bathroom?",
+    "punchline": "The p is silent."
+  },
+  {
+    "id": "TfVvX0wscib",
+    "setup": "How do you know if there’s an elephant under your bed?",
+    "punchline": "Your head hits the ceiling!"
+  },
+  {
+    "id": "TnWnbpbU8pb",
+    "setup": "How do you teach a kid to climb stairs?",
+    "punchline": "There is a step by step guide."
+  },
+  {
+    "id": "Tv4wkVS0gib",
+    "setup": "Where do owls go to buy their baby clothes?",
+    "punchline": "The owlet malls."
+  },
+  {
+    "id": "TvPf2gyAdxc",
+    "setup": "Why does Norway have barcodes on their battleships?",
+    "punchline": "So when they get back to port, they can Scandinavian."
+  },
+  {
+    "id": "TvPfV8prOuc",
+    "setup": "What's the worst part about being a cross-eyed teacher?",
+    "punchline": "They can't control their pupils."
+  },
+  {
+    "id": "Tvcah31oWvc",
+    "setup": "What do you call a fashionable lawn statue with an excellent sense of rhythmn?",
+    "punchline": "A metro-gnome"
+  },
+  {
+    "id": "TvzdxXSCdFd",
+    "setup": "Someone broke into my house last night and stole my limbo trophy.",
+    "punchline": "How low can you go?"
+  },
+  {
+    "id": "UKeFB59EQf",
+    "setup": "Why did the coffee file a police report?",
+    "punchline": "It got mugged."
+  },
+  {
+    "id": "UKeiNeVnrc",
+    "setup": "Mountains aren't just funny",
+    "punchline": "they are hill areas"
+  },
+  {
+    "id": "UKuXvzAlOuc",
+    "setup": "I was going to learn how to juggle",
+    "punchline": "but I didn't have the balls."
+  },
+  {
+    "id": "UfiGljVKusc",
+    "setup": "Why was the strawberry sad?",
+    "punchline": "Its parents were in a jam."
+  },
+  {
+    "id": "UfxAIm3wkjb",
+    "setup": "Why are ghosts bad liars?",
+    "punchline": "Because you can see right through them!"
+  },
+  {
+    "id": "UnWS0wcF6Ed",
+    "setup": "Every machine in the coin factory broke down all of a sudden without explanation.",
+    "punchline": "It just doesn’t make any cents."
+  },
+  {
+    "id": "V0gyPusWSCd",
+    "setup": "Why does it take longer to get from 1st to 2nd base, than it does to get from 2nd to 3rd base?",
+    "punchline": "Because there’s a Shortstop in between!"
+  },
+  {
+    "id": "V0orcFdFIBd",
+    "setup": "What do you do when you see a space man?",
+    "punchline": "Park your car, man."
+  },
+  {
+    "id": "V0wkbprcprc",
+    "setup": "If you want a job in the moisturizer industry",
+    "punchline": "the best advice I can give is to apply daily."
+  },
+  {
+    "id": "VDYgib2T7wc",
+    "setup": "When you have a bladder infection",
+    "punchline": "urine trouble."
+  },
+  {
+    "id": "VDdxcp4ob",
+    "setup": "How do you make Lady Gaga cry?",
+    "punchline": "Poker face."
+  },
+  {
+    "id": "VKe2gNCQnb",
+    "setup": "What do you call a group of killer whales playing instruments?",
+    "punchline": "An Orca-stra."
+  },
+  {
+    "id": "VKexkV0LeFd",
+    "setup": "I was in an 80's band called the prevention.",
+    "punchline": "We were better than the cure."
+  },
+  {
+    "id": "VSn3oOmyPmb",
+    "setup": "What did Michael Jackson name his denim store?",
+    "punchline": "Billy Jeans!"
+  },
+  {
+    "id": "VfFlGJmOmb",
+    "setup": "People saying 'boo!",
+    "punchline": "to their friends has risen by 85% in the last year.... That's a frightening statistic."
+  },
+  {
+    "id": "VnysHtWvkqc",
+    "setup": "Geology rocks",
+    "punchline": "but Geography is where it's at!"
+  },
+  {
+    "id": "Vv4hNZDQZg",
+    "setup": "Why does Han Solo like gum?",
+    "punchline": "It's chewy!"
+  },
+  {
+    "id": "VvP7U0D5TCd",
+    "setup": "I was at the library and asked if they have any books on \"paranoia\", the librarian replied, \"yes",
+    "punchline": "they are right behind you\""
+  },
+  {
+    "id": "W018xscFIe",
+    "setup": "Have you heard of the band 1023MB?",
+    "punchline": "They haven't got a gig yet."
+  },
+  {
+    "id": "W82EtW01wkb",
+    "setup": "What happens when you anger a brain surgeon?",
+    "punchline": "They will give you a piece of your mind."
+  },
+  {
+    "id": "WD5oWLuXgFd",
+    "setup": "I used to work at a stationery store. But, I didn't feel like I was going anywhere. So, I got a job at a travel agency.",
+    "punchline": "Now, I know I'll be going places."
+  },
+  {
+    "id": "WLJJRKJeqjb",
+    "setup": "I used to work in a shoe recycling shop.",
+    "punchline": "It was sole destroying."
+  },
+  {
+    "id": "WSKe2ojiNe",
+    "setup": "I used to hate facial hair",
+    "punchline": "but then it grew on me."
+  },
+  {
+    "id": "WgFY82ozsrc",
+    "setup": "R.I.P. boiled water.",
+    "punchline": "You will be mist."
+  },
+  {
+    "id": "WgV0T0wk3ob",
+    "setup": "Q: What did the spaghetti say to the other spaghetti?",
+    "punchline": "A: Pasta la vista, baby!"
+  },
+  {
+    "id": "WvHJJ611wAd",
+    "setup": "The first time I got a universal remote control I thought to myself",
+    "punchline": "\"This changes everything\""
+  },
+  {
+    "id": "WvHJJ61obFd",
+    "setup": "Why is the ocean always blue?",
+    "punchline": "Because the shore never waves back."
+  },
+  {
+    "id": "WvPZTvsWDd",
+    "setup": "Why did the feline fail the lie detector test?",
+    "punchline": "Because he be lion."
+  },
+  {
+    "id": "WvsHlyszkyd",
+    "setup": "Why did the man put his money in the freezer?",
+    "punchline": "He wanted cold hard cash!"
+  },
+  {
+    "id": "X0wkGJtPKuc",
+    "setup": "Why do ducks make great detectives?",
+    "punchline": "They always quack the case."
+  },
+  {
+    "id": "X8pWSKJRZg",
+    "setup": "What does a clock do when it's hungry?",
+    "punchline": "It goes back four seconds!"
+  },
+  {
+    "id": "X8xAlq4E6Ed",
+    "setup": "What do I look like?",
+    "punchline": "A JOKE MACHINE!?"
+  },
+  {
+    "id": "XDImr41obh",
+    "setup": "I bought shoes from a drug dealer once.",
+    "punchline": "I don't know what he laced them with, but I was tripping all day."
+  },
+  {
+    "id": "XLRfNuPZDAd",
+    "setup": "What is a tornado's favorite game to play?",
+    "punchline": "Twister!"
+  },
+  {
+    "id": "XgVnOK6USnb",
+    "setup": "You know that cemetery up the road?",
+    "punchline": "People are dying to get in there."
+  },
+  {
+    "id": "XgaMuPucNe",
+    "setup": "Pie is $2.50 in Jamaica and $3.00 in The Bahamas.",
+    "punchline": "These are the pie-rates of the Caribbean."
+  },
+  {
+    "id": "XgiydUKu4Ed",
+    "setup": "What do you call a fish wearing a bowtie?",
+    "punchline": "Sofishticated."
+  },
+  {
+    "id": "Xn3wX8hi3Ed",
+    "setup": "Did you hear about the Mexican train killer?",
+    "punchline": "He had loco motives"
+  },
+  {
+    "id": "Xny5MZvHQCd",
+    "setup": "Can I watch the TV?",
+    "punchline": "Dad: Yes, but don’t turn it on."
+  },
+  {
+    "id": "Y0LZ0Ddxcib",
+    "setup": "What is worse then finding a worm in your Apple?",
+    "punchline": "Finding half a worm in your Apple."
+  },
+  {
+    "id": "YLm39E6pjqc",
+    "setup": "What do vegetarian zombies eat?",
+    "punchline": "Grrrrrainnnnnssss."
+  },
+  {
+    "id": "Yg3orWS7wkb",
+    "setup": "\"I'm sorry.\" \"Hi sorry",
+    "punchline": "I'm dad\""
+  },
+  {
+    "id": "YvHQnW8U8pb",
+    "setup": "What is the hardest part about sky diving?",
+    "punchline": "The ground."
+  },
+  {
+    "id": "YvkV8xXnjyd",
+    "setup": "Why did the cowboy have a weiner dog?",
+    "punchline": "Somebody told him to get a long little doggy."
+  },
+  {
+    "id": "Z82wXvsrrzd",
+    "setup": "My friend keeps telling me \"Cheer up.",
+    "punchline": "You aren't stuck in a deep hole in the ground, filled with water.\" I know he means well."
+  },
+  {
+    "id": "Z8UDIRuXLmb",
+    "setup": "Who did the wizard marry?",
+    "punchline": "His ghoul-friend"
+  },
+  {
+    "id": "Z8p4MeaaFBd",
+    "setup": "How many seconds are in a year? 12. January 2nd, February 2nd, March 2nd, April 2nd....",
+    "punchline": "etc"
+  },
+  {
+    "id": "Z8xHBQZ0Lmb",
+    "setup": "I ordered a chicken and an egg from Amazon.",
+    "punchline": "I'll let you know."
+  },
+  {
+    "id": "ZDAIRn39prc",
+    "setup": "Ever wondered why bees hum?",
+    "punchline": "It's because they don't know the words."
+  },
+  {
+    "id": "ZDAlOZgydxc",
+    "setup": "How many optometrists does it take to change a light bulb? 1 or 2?",
+    "punchline": "1... or 2?"
+  },
+  {
+    "id": "ZDIYvPKBQuc",
+    "setup": "There's not really any training for garbagemen.",
+    "punchline": "They just pick things up as they go."
+  },
+  {
+    "id": "ZDtzdFlqOf",
+    "setup": "Did you hear about the cow who jumped over the barbed wire fence?",
+    "punchline": "It was udder destruction."
+  },
+  {
+    "id": "Zg31orrz5Ed",
+    "setup": "I was shocked when I was diagnosed as colorblind...",
+    "punchline": "It came out of the purple."
+  },
+  {
+    "id": "ZgahF6MZDd",
+    "setup": "Where does astronauts hangout after work?",
+    "punchline": "At the spacebar."
+  },
+  {
+    "id": "ZgyPZDtkbFd",
+    "setup": "What do you call a bear with no teeth?",
+    "punchline": "A gummy bear!"
+  },
+  {
+    "id": "Zo4E6pbFIBd",
+    "setup": "I’ve deleted the phone numbers of all the Germans I know from my mobile phone.",
+    "punchline": "Now it’s Hans free."
+  },
+  {
+    "id": "ZoGQuXgV0ob",
+    "setup": "What do you call your friend who stands in a hole?",
+    "punchline": "Phil."
+  },
+  {
+    "id": "ZobU08UKBd",
+    "setup": "A doll was recently found dead in a rice paddy.",
+    "punchline": "It's the only known instance of a nick nack paddy wack."
+  },
+  {
+    "id": "Zv4wHQuXgyd",
+    "setup": "How do you tell the difference between a crocodile and an alligator?",
+    "punchline": "You will see one later and one in a while."
+  },
+  {
+    "id": "ZvHBQC59Muc",
+    "setup": "What do you call a fake noodle?",
+    "punchline": "An impasta."
+  },
+  {
+    "id": "ZvPfFQukVvc",
+    "setup": "The word queue is ironic.",
+    "punchline": "It's just q with a bunch of silent letters waiting in line."
+  },
+  {
+    "id": "ZvzkyXnWLuc",
+    "setup": "What do you call a droid that takes the long way around?",
+    "punchline": "R2 detour."
+  },
+  {
+    "id": "a218pbMmOmb",
+    "setup": "What's the best thing about elevator jokes?",
+    "punchline": "They work on so many levels."
+  },
+  {
+    "id": "a29pbp4haFd",
+    "setup": "Where do rabbits go after they get married?",
+    "punchline": "On a bunny-moon."
+  },
+  {
+    "id": "aFQZo49haxc",
+    "setup": "Why do cows wear bells?",
+    "punchline": "Because their horns don't work."
+  },
+  {
+    "id": "aFtzPRSnbxc",
+    "setup": "Two fish are in a tank, one turns to the other and says",
+    "punchline": "\"how do you drive this thing?\""
+  },
+  {
+    "id": "aMmbaFYTKBd",
+    "setup": "I finally bought the limited edition Thesaurus that I've always wanted.",
+    "punchline": "When I opened it, all the pages were blank. I have no words to describe how angry I am."
+  },
+  {
+    "id": "aaUKeahqWvc",
+    "setup": "This is my step ladder.",
+    "punchline": "I never knew my real ladder."
+  },
+  {
+    "id": "ap4orcpGtrc",
+    "setup": "A man walks into a bar and orders helicopter flavor chips.",
+    "punchline": "The barman replies “sorry mate we only do plain”"
+  },
+  {
+    "id": "apO7pW08pzd",
+    "setup": "It's been months since I bought the book \"how to scam people online\".",
+    "punchline": "It still hasn't turned up."
+  },
+  {
+    "id": "apjVK6pr4wc",
+    "setup": "Why is it a bad idea to iron your four-leaf clover?",
+    "punchline": "Cause you shouldn't press your luck."
+  },
+  {
+    "id": "axPR79MZvc",
+    "setup": "What did the fish say when it swam into a wall?",
+    "punchline": "Damn!"
+  },
+  {
+    "id": "b21gqORfNe",
+    "setup": "I accidentally drank a bottle of invisible ink.",
+    "punchline": "Now I’m in hospital, waiting to be seen."
+  },
+  {
+    "id": "bMus4MZDAlb",
+    "setup": "Why does Waldo only wear stripes?",
+    "punchline": "Because he doesn't want to be spotted."
+  },
+  {
+    "id": "bprz5wXSSvc",
+    "setup": "Why did the scarecrow win an award?",
+    "punchline": "Because he was outstanding in his field."
+  },
+  {
+    "id": "bxXLeqzP7wc",
+    "setup": "Americans can't switch from pounds to kilograms overnight.",
+    "punchline": "That would cause mass confusion."
+  },
+  {
+    "id": "c2LJR7Ed2ob",
+    "setup": "An apple a day keeps the bullies away.",
+    "punchline": "If you throw it hard enough."
+  },
+  {
+    "id": "c2TSfxXgqrc",
+    "setup": "Why does Superman get invited to dinners?",
+    "punchline": "Because he is a Supperhero."
+  },
+  {
+    "id": "cFd21gNClyd",
+    "setup": "Why is no one friends with Dracula?",
+    "punchline": "Because he's a pain in the neck."
+  },
+  {
+    "id": "cNRZTfFtrjb",
+    "setup": "A man got hit in the head with a can of Coke",
+    "punchline": "but he was alright because it was a soft drink."
+  },
+  {
+    "id": "cUnWLRZ01wc",
+    "setup": "What is the leading cause of dry skin?",
+    "punchline": "Towels"
+  },
+  {
+    "id": "cUvsHt41gFd",
+    "setup": "A man walked in to a bar with some asphalt on his arm.",
+    "punchline": "He said “Two beers please, one for me and one for the road.”"
+  },
+  {
+    "id": "caxscaMRnjb",
+    "setup": "Did you know the first French fries weren't actually cooked in France?",
+    "punchline": "They were cooked in Greece."
+  },
+  {
+    "id": "ci311DtH6h",
+    "setup": "I’ll tell you something about German sausages",
+    "punchline": "they’re the wurst"
+  },
+  {
+    "id": "ciiNuXDY0wc",
+    "setup": "Where did Captain Hook get his hook?",
+    "punchline": "From a second hand store."
+  },
+  {
+    "id": "cp4TCdahqc",
+    "setup": "I got fired from a florist",
+    "punchline": "apparently I took too many leaves."
+  },
+  {
+    "id": "cpWnWg3TKmb",
+    "setup": "Two silk worms had a race.",
+    "punchline": "They ended up in a tie."
+  },
+  {
+    "id": "cxHYg3gFQf",
+    "setup": "I got fired from the transmission factor",
+    "punchline": "turns out I didn't put on enough shifts..."
+  },
+  {
+    "id": "cxXv4Elj3wc",
+    "setup": "Where do young cows eat lunch?",
+    "punchline": "In the calf-ateria."
+  },
+  {
+    "id": "d21DAXSCljb",
+    "setup": "How does a French skeleton say hello?",
+    "punchline": "Bone-jour."
+  },
+  {
+    "id": "daaUfibh",
+    "setup": "Why was the big cat disqualified from the race?",
+    "punchline": "Because it was a cheetah."
+  },
+  {
+    "id": "daxcxciqHe",
+    "setup": "What do prisoners use to call each other?",
+    "punchline": "Cell phones."
+  },
+  {
+    "id": "diGeqOfiqc",
+    "setup": "What’s E.T. short for?",
+    "punchline": "He’s only got little legs."
+  },
+  {
+    "id": "dibUSv4ojyd",
+    "setup": "What kind of award did the dentist receive?",
+    "punchline": "A little plaque."
+  },
+  {
+    "id": "dp4Tfqciiib",
+    "setup": "Got a new suit recently made entirely of living plants.",
+    "punchline": "I wasn’t sure at first, but it’s grown on me"
+  },
+  {
+    "id": "dpGtcxPKuzd",
+    "setup": "Do you know where you can get chicken broth in bulk?",
+    "punchline": "The stock market."
+  },
+  {
+    "id": "dpWvHtW0Tnb",
+    "setup": "What's orange and sounds like a parrot?",
+    "punchline": "A Carrot."
+  },
+  {
+    "id": "dprjbhyAAAd",
+    "setup": "A Sandwich walks into a bar, the bartender says “Sorry",
+    "punchline": "we don’t serve food here”"
+  },
+  {
+    "id": "dx5ojVK61wc",
+    "setup": "What do you get hanging from Apple trees?",
+    "punchline": "Sore arms."
+  },
+  {
+    "id": "e2obFd2oOf",
+    "setup": "I thought about going on an all-almond diet.",
+    "punchline": "But that's just nuts."
+  },
+  {
+    "id": "eFlVnrOClyd",
+    "setup": "I don’t play soccer because I enjoy the sport.",
+    "punchline": "I’m just doing it for kicks."
+  },
+  {
+    "id": "eNmyXDtzkqc",
+    "setup": "Today a girl said she recognized me from vegetarian club",
+    "punchline": "but I’m sure I’ve never met herbivore."
+  },
+  {
+    "id": "eNuHJBQCdFd",
+    "setup": "How do you organize a space party?",
+    "punchline": "You planet."
+  },
+  {
+    "id": "eNuPm3Etzkb",
+    "setup": "How do you make holy water?",
+    "punchline": "You boil the hell out of it."
+  },
+  {
+    "id": "eVKRZTKeiib",
+    "setup": "A man is washing the car with his son. The son asks......",
+    "punchline": "\"Dad, can’t you just use a sponge?\""
+  },
+  {
+    "id": "ea2wkyscah",
+    "setup": "What does an angry pepper do?",
+    "punchline": "It gets jalapeño face."
+  },
+  {
+    "id": "eaMCQKRZ0ob",
+    "setup": "Don't buy flowers at a monastery.",
+    "punchline": "Because only you can prevent florist friars."
+  },
+  {
+    "id": "ei3T08EQZob",
+    "setup": "Hostess: Do you have a preference of where you sit?",
+    "punchline": "Dad: Down."
+  },
+  {
+    "id": "eiiVvH6MCd",
+    "setup": "Did you hear about the submarine industry?",
+    "punchline": "It really took a dive..."
+  },
+  {
+    "id": "eiyAXnWS0g",
+    "setup": "The biggest knight at King Arthur's round table was Sir Cumference.",
+    "punchline": "He acquired his size from eating too much pi."
+  },
+  {
+    "id": "exH6pOuzXDd",
+    "setup": "How do you get a baby alien to sleep?",
+    "punchline": "You rocket."
+  },
+  {
+    "id": "exXSCtkOKe",
+    "setup": "Why do pirates not know the alphabet?",
+    "punchline": "They always get stuck at \"C\"."
+  },
+  {
+    "id": "exc2w5MmOCd",
+    "setup": "I saw my husband trip and fall while carrying a laundry basket full of ironed clothes.",
+    "punchline": "I watched it all unfold."
+  },
+  {
+    "id": "f211DdFBdxc",
+    "setup": "Did you hear about the chameleon who couldn't change color?",
+    "punchline": "They had a reptile dysfunction."
+  },
+  {
+    "id": "fNZTCdFBImb",
+    "setup": "Why did the house go to the doctor?",
+    "punchline": "It was having window panes."
+  },
+  {
+    "id": "fNeVDI6USnb",
+    "setup": "I made a playlist for hiking. It has music from Peanuts, The Cranberries, and Eminem.",
+    "punchline": "I call it my Trail Mix."
+  },
+  {
+    "id": "fNmOm3Ediyd",
+    "setup": "What do you call a dictionary on drugs?",
+    "punchline": "High definition."
+  },
+  {
+    "id": "fVv4MRuHBsc",
+    "setup": "How do robots eat guacamole?",
+    "punchline": "With computer chips."
+  },
+  {
+    "id": "fii3Tv4hFd",
+    "setup": "Today, my son asked \"Can I have a book mark?\" and I burst into tears.",
+    "punchline": "11 years old and he still doesn't know my name is Brian."
+  },
+  {
+    "id": "fiyPR7wPZDd",
+    "setup": "When does a joke become a dad joke?",
+    "punchline": "When it becomes apparent."
+  },
+  {
+    "id": "fiydpr4EQnb",
+    "setup": "What’s brown and sounds like a bell?",
+    "punchline": "Dung!"
+  },
+  {
+    "id": "fqOmr4MeaFd",
+    "setup": "What has a bed that you can’t sleep in?",
+    "punchline": "A river."
+  },
+  {
+    "id": "fqWgFt4Edxc",
+    "setup": "Why do crabs never give to charity?",
+    "punchline": "Because they’re shellfish."
+  },
+  {
+    "id": "g3LZTCYDYg",
+    "setup": "What do you call a pig with three eyes?",
+    "punchline": "Piiig"
+  },
+  {
+    "id": "gFtrHYoWnjb",
+    "setup": "How do you make a hankie dance?",
+    "punchline": "Put a little boogie in it."
+  },
+  {
+    "id": "gNRnWvzdiib",
+    "setup": "Sgt.: Commissar! Commissar! The troops are revolting!",
+    "punchline": "Commissar: Well, you’re pretty repulsive yourself."
+  },
+  {
+    "id": "gNZTCQnWSf",
+    "setup": "The other day I was listening to a song about superglue",
+    "punchline": "it’s been stuck in my head ever since."
+  },
+  {
+    "id": "gaM7pbpWnrc",
+    "setup": "What don't watermelons get married?",
+    "punchline": "Because they cantaloupe."
+  },
+  {
+    "id": "gaUfNJ6hapb",
+    "setup": "If you’re struggling to think of what to get someone for Christmas.",
+    "punchline": "Get them a fridge and watch their face light up when they open it."
+  },
+  {
+    "id": "h39UfibMJBd",
+    "setup": "Did you hear about the cheese who saved the world?",
+    "punchline": "It was Legend-dairy!"
+  },
+  {
+    "id": "hNu4oORnOmb",
+    "setup": "What do you call cheese by itself?",
+    "punchline": "Provolone."
+  },
+  {
+    "id": "haMJRfF6hFd",
+    "setup": "How do you fix a broken pizza?",
+    "punchline": "With tomato paste."
+  },
+  {
+    "id": "haahVKZDtrc",
+    "setup": "What's red and bad for your teeth?",
+    "punchline": "A Brick."
+  },
+  {
+    "id": "hiVSCdUvXg",
+    "setup": "I heard there was a new store called Moderation.",
+    "punchline": "They have everything there"
+  },
+  {
+    "id": "hqjGlyImrzd",
+    "setup": "A beekeeper was indicted after he confessed to years of stealing at work.",
+    "punchline": "They charged him with emBEEzlement"
+  },
+  {
+    "id": "hyPmOZLBIBd",
+    "setup": "I used to work for a soft drink can crusher.",
+    "punchline": "It was soda pressing."
+  },
+  {
+    "id": "i31LeNRuzAd",
+    "setup": "Why did the chicken get a penalty?",
+    "punchline": "For fowl play."
+  },
+  {
+    "id": "iGJeVKmWDlb",
+    "setup": "My cat was just sick on the carpet",
+    "punchline": "I don’t think it’s feline well."
+  },
+  {
+    "id": "iGQZDAIRZDd",
+    "setup": "Why did the burglar hang his mugshot on the wall?",
+    "punchline": "To prove that he was framed!"
+  },
+  {
+    "id": "iGlOClqrrrc",
+    "setup": "I dreamed about drowning in an ocean made out of orange soda last night.",
+    "punchline": "It took me a while to work out it was just a Fanta sea."
+  },
+  {
+    "id": "iV0DQ7pjGlb",
+    "setup": "I had a dream that I was a muffler last night.",
+    "punchline": "I woke up exhausted!"
+  },
+  {
+    "id": "iVSClyXDQf",
+    "setup": "A dad washes his car with his son.",
+    "punchline": "But after a while, the son says, \"why can't you just use a sponge?\""
+  },
+  {
+    "id": "iq4hVD599pb",
+    "setup": "Doctor you've got you help me, I'm addicted to twitter.",
+    "punchline": "Doctor: I don't follow you."
+  },
+  {
+    "id": "jNCtkyIeNuc",
+    "setup": "I broke my finger at work today",
+    "punchline": "on the other hand I'm completely fine."
+  },
+  {
+    "id": "jNmykbUSSvc",
+    "setup": "I went to a book store and asked the saleswoman where the Self Help section was",
+    "punchline": "she said if she told me it would defeat the purpose."
+  },
+  {
+    "id": "jVKBQS0o4h",
+    "setup": "How does a scientist freshen their breath?",
+    "punchline": "With experi-mints!"
+  },
+  {
+    "id": "jbU0LmyPKBd",
+    "setup": "What has ears but cannot hear?",
+    "punchline": "A field of corn."
+  },
+  {
+    "id": "jyPCYTKuskb",
+    "setup": "How did Darth Vader know what Luke was getting for Christmas?",
+    "punchline": "He felt his presents."
+  },
+  {
+    "id": "jyPf2giqHlb",
+    "setup": "What's the difference between a seal and a sea lion?",
+    "punchline": "An ion!"
+  },
+  {
+    "id": "kOfaUvP7Muc",
+    "setup": "What did the Dorito farmer say to the other Dorito farmer?",
+    "punchline": "Cool Ranch!"
+  },
+  {
+    "id": "kbUv4T0Ddxc",
+    "setup": "A ghost walks into a bar and asks for a glass of vodka but the bar tender says",
+    "punchline": "“sorry we don’t serve spirits”"
+  },
+  {
+    "id": "kqjNmbM7wsc",
+    "setup": "Why do wizards clean their teeth three times a day?",
+    "punchline": "To prevent bat breath!"
+  },
+  {
+    "id": "kqrjNmbxcxc",
+    "setup": "Someone asked me, what's the ninth letter of the alphabet?",
+    "punchline": "It was a complete guess, but I was right."
+  },
+  {
+    "id": "lG6pjibpbxc",
+    "setup": "Feeling pretty proud of myself.",
+    "punchline": "The Sesame Street puzzle I bought said 3-5 years, but I finished it in 18 months."
+  },
+  {
+    "id": "lGe2Tvskyd",
+    "setup": "Why are fish so smart?",
+    "punchline": "Because they live in schools!"
+  },
+  {
+    "id": "lGlbhqjGJBd",
+    "setup": "How does the moon cut his hair?",
+    "punchline": "Eclipse it."
+  },
+  {
+    "id": "lV8hqHexHBd",
+    "setup": "Why did the worker get fired from the orange juice factory?",
+    "punchline": "Lack of concentration."
+  },
+  {
+    "id": "lbU01DljGtc",
+    "setup": "I couldn't get a reservation at the library.",
+    "punchline": "They were completely booked."
+  },
+  {
+    "id": "ljGB5o49Elb",
+    "setup": "Dad, can you put my shoes on?",
+    "punchline": "I don't think they'll fit me."
+  },
+  {
+    "id": "ljqzkVKJtrc",
+    "setup": "How do you get two whales in a car?",
+    "punchline": "Start in England and drive West."
+  },
+  {
+    "id": "lqWgFlyPusc",
+    "setup": "What do you call an Argentinian with a rubber toe?",
+    "punchline": "Roberto"
+  },
+  {
+    "id": "ly5hNR7w5Ed",
+    "setup": "I tried taking some high resolution photos of local farmland",
+    "punchline": "but they all turned out a bit grainy."
+  },
+  {
+    "id": "lyPZgVn3Le",
+    "setup": "What did the ocean say to the shore?",
+    "punchline": "Nothing, it just waved."
+  },
+  {
+    "id": "lyk3EIBQfxc",
+    "setup": "I went to the zoo the other day, there was only one dog in it.",
+    "punchline": "It was a shitzu."
+  },
+  {
+    "id": "m3182oz5TCd",
+    "setup": "Someone asked me to name two structures that hold water.",
+    "punchline": "I said \"Well dam\""
+  },
+  {
+    "id": "m3E69pbhaFd",
+    "setup": "I gave all my dead batteries away today",
+    "punchline": "free of charge."
+  },
+  {
+    "id": "m3wPZoz51ob",
+    "setup": "Did you hear the news?",
+    "punchline": "FedEx and UPS are merging. They’re going to go by the name Fed-Up from now on."
+  },
+  {
+    "id": "mG61giiy5wc",
+    "setup": "Why didn't the number 4 get into the nightclub?",
+    "punchline": "Because he is 2 square."
+  },
+  {
+    "id": "mGeFlykbFBd",
+    "setup": "What do you call a sheep with no legs?",
+    "punchline": "A cloud."
+  },
+  {
+    "id": "mGlbFtk3Tvc",
+    "setup": "Why did the m&m go to school?",
+    "punchline": "Because it wanted to be a Smartie!"
+  },
+  {
+    "id": "mGtHtcUfqjb",
+    "setup": "Did you hear that David lost his ID in prague?",
+    "punchline": "Now we just have to call him Dav."
+  },
+  {
+    "id": "mO7hqWvsPCd",
+    "setup": "My wife is on a tropical fruit diet, the house is full of stuff.",
+    "punchline": "It is enough to make a mango crazy."
+  },
+  {
+    "id": "mOR7h392TCd",
+    "setup": "Why are basketball players messy eaters?",
+    "punchline": "Because they are always dribbling."
+  },
+  {
+    "id": "mOfqzdx51wc",
+    "setup": "Why do mathematicians hate the U.S.?",
+    "punchline": "Because it's indivisible."
+  },
+  {
+    "id": "mW01DA511ob",
+    "setup": "I knew i shouldn’t have ate that seafood.",
+    "punchline": "Because now i’m feeling a little… Eel"
+  },
+  {
+    "id": "mWS7hVKRSnb",
+    "setup": "Past, present, and future walked into a bar....",
+    "punchline": "It was tense."
+  },
+  {
+    "id": "mbpbapbhiyd",
+    "setup": "Did you hear about the bread factory burning down?",
+    "punchline": "They say the business is toast."
+  },
+  {
+    "id": "mrHQKBA5MCd",
+    "setup": "My boss told me that he was going to fire the person with the worst posture.",
+    "punchline": "I have a hunch, it might be me."
+  },
+  {
+    "id": "n3gVSC5oOmb",
+    "setup": "What's black and white and read all over?",
+    "punchline": "The newspaper."
+  },
+  {
+    "id": "n3o4orjiysc",
+    "setup": "Why are skeletons so calm?",
+    "punchline": "Because nothing gets under their skin."
+  },
+  {
+    "id": "nOfV0gVKBd",
+    "setup": "“Hold on",
+    "punchline": "I have something in my shoe” “I’m pretty sure it’s a foot”"
+  },
+  {
+    "id": "nWDdFdFYLuc",
+    "setup": "Have you heard about the film \"Constipation\"",
+    "punchline": "you probably haven't because it's not out yet."
+  },
+  {
+    "id": "nWSfiNeVKBd",
+    "setup": "Did you know Albert Einstein was a real person?",
+    "punchline": "All this time, I thought he was just a theoretical physicist!"
+  },
+  {
+    "id": "nWvXSvHBd",
+    "setup": "I hate perforated lines",
+    "punchline": "they're tearable."
+  },
+  {
+    "id": "nWvcUD5orrc",
+    "setup": "I asked the surgeon if I could administer my own anesthetic, they said: go ahead",
+    "punchline": "knock yourself out."
+  },
+  {
+    "id": "nbFBdiydxkb",
+    "setup": "Why did the barber win the race?",
+    "punchline": "He took a short cut."
+  },
+  {
+    "id": "nrrj3TfFdxc",
+    "setup": "Why did the octopus beat the shark in a fight?",
+    "punchline": "Because it was well armed."
+  },
+  {
+    "id": "nrz5oWnyPuc",
+    "setup": "What did the doctor say to the gingerbread man who broke his leg?",
+    "punchline": "Try icing it."
+  },
+  {
+    "id": "o4MexXSClb",
+    "setup": "What did the judge say to the dentist?",
+    "punchline": "Do you swear to pull the tooth, the whole tooth and nothing but the tooth?"
+  },
+  {
+    "id": "oGBIRKuPukb",
+    "setup": "\"What time is it?\" I don't know...",
+    "punchline": "it keeps changing."
+  },
+  {
+    "id": "oGY0wsWnysc",
+    "setup": "You can't trust a ladder.",
+    "punchline": "It will always let you down"
+  },
+  {
+    "id": "oOR7hFdx5Ed",
+    "setup": "I wouldn't buy anything with velcro.",
+    "punchline": "It's a total rip-off."
+  },
+  {
+    "id": "oORfVv4oOCd",
+    "setup": "What are the strongest days of the week?",
+    "punchline": "Saturday and Sunday...the rest are weekdays."
+  },
+  {
+    "id": "obahq4MJtzd",
+    "setup": "I had a rough day, and then somebody went and ripped the front and back pages from my dictionary.",
+    "punchline": "It just goes from bad to worse."
+  },
+  {
+    "id": "obhFBljb2g",
+    "setup": "I adopted my dog from a blacksmith.",
+    "punchline": "As soon as we got home he made a bolt for the door."
+  },
+  {
+    "id": "ozPf21LJJtc",
+    "setup": "Where does batman go to the bathroom?",
+    "punchline": "The batroom."
+  },
+  {
+    "id": "ozPmbFtWDlb",
+    "setup": "Some people say that comedians who tell one too many light bulb jokes soon burn out, but they don't know watt they are talking about.",
+    "punchline": "They're not that bright."
+  },
+  {
+    "id": "ozsPmORZvzd",
+    "setup": "A bartender broke up with her boyfriend",
+    "punchline": "but he kept asking her for another shot."
+  },
+  {
+    "id": "p4oWvPClVnb",
+    "setup": "What do you call a cow on a trampoline?",
+    "punchline": "A milk shake!"
+  },
+  {
+    "id": "pGe2EYozAsc",
+    "setup": "What do you call a nervous javelin thrower?",
+    "punchline": "Shakespeare."
+  },
+  {
+    "id": "pOuzPmyIYob",
+    "setup": "What do you call an eagle who can play the piano?",
+    "punchline": "Talonted!"
+  },
+  {
+    "id": "pWLRK6pWDtc",
+    "setup": "What do you call a boomerang that won't come back?",
+    "punchline": "A stick."
+  },
+  {
+    "id": "pWn31TCQ7pb",
+    "setup": "What do you call a duck that gets all A's?",
+    "punchline": "A wise quacker."
+  },
+  {
+    "id": "pjyA59MRusc",
+    "setup": "There’s a new type of broom out",
+    "punchline": "it’s sweeping the nation."
+  },
+  {
+    "id": "prWDIBdiGlb",
+    "setup": "I just wrote a book on reverse psychology.",
+    "punchline": "Do not read it!"
+  },
+  {
+    "id": "pzXvHl3EYg",
+    "setup": "Why don’t seagulls fly over the bay?",
+    "punchline": "Because then they’d be bay-gulls!"
+  },
+  {
+    "id": "pzkbpORS7wc",
+    "setup": "Parallel lines have so much in common.",
+    "punchline": "It’s a shame they’ll never meet."
+  },
+  {
+    "id": "q4hVKRnOmjb",
+    "setup": "What do you call a magician who has lost their magic?",
+    "punchline": "Ian."
+  },
+  {
+    "id": "q4hiGJBXLe",
+    "setup": "Why do fish live in salt water?",
+    "punchline": "Because pepper makes them sneeze!"
+  },
+  {
+    "id": "qOK61Tvs4Ed",
+    "setup": "When do doctors get angry?",
+    "punchline": "When they run out of patients."
+  },
+  {
+    "id": "qOmyPmO79h",
+    "setup": "A man tried to sell me a coffin today.",
+    "punchline": "I told him that's the last thing I need."
+  },
+  {
+    "id": "qWDlOZozXDd",
+    "setup": "It doesn't matter how much you push the envelope.",
+    "punchline": "It will still be stationary."
+  },
+  {
+    "id": "qjV8EIRfVnb",
+    "setup": "What did the shy pebble wish for?",
+    "punchline": "That she was a little boulder."
+  },
+  {
+    "id": "qjbF6E6wHlb",
+    "setup": "Why did the belt go to prison?",
+    "punchline": "He held up a pair of pants!"
+  },
+  {
+    "id": "qjyszskjNCd",
+    "setup": "Wife told me to take the spider out instead of killing it...",
+    "punchline": "We had some drinks, cool guy, wants to be a web developer."
+  },
+  {
+    "id": "qrHJ69M7hFd",
+    "setup": "What cheese can never be yours?",
+    "punchline": "Nacho cheese."
+  },
+  {
+    "id": "qrHeiqHJmrc",
+    "setup": "What is a vampire's favorite fruit?",
+    "punchline": "A blood orange."
+  },
+  {
+    "id": "rHBQuXLR7h",
+    "setup": "Why did the cookie cry?",
+    "punchline": "Because his mother was a wafer so long"
+  },
+  {
+    "id": "rc2E6EdiNe",
+    "setup": "Want to hear my pizza joke?",
+    "punchline": "Never mind, it's too cheesy."
+  },
+  {
+    "id": "rcxk3TSKusc",
+    "setup": "What did the grape do when he got stepped on?",
+    "punchline": "He let out a little wine."
+  },
+  {
+    "id": "rjiyXLZTSf",
+    "setup": "What did the 0 say to the 8?",
+    "punchline": "Nice belt."
+  },
+  {
+    "id": "rjqOZoO7pb",
+    "setup": "Why was the picture sent to prison?",
+    "punchline": "It was framed."
+  },
+  {
+    "id": "s49h3ElVnrc",
+    "setup": "I burned 2000 calories today",
+    "punchline": "I left my food in the oven for too long."
+  },
+  {
+    "id": "s4Me29U0gqc",
+    "setup": "Cosmetic surgery used to be such a taboo subject.",
+    "punchline": "Now you can talk about Botox and nobody raises an eyebrow."
+  },
+  {
+    "id": "sHlqrjyPf",
+    "setup": "How can you tell a vampire has a cold?",
+    "punchline": "They start coffin."
+  },
+  {
+    "id": "sPRnOfiyAAd",
+    "setup": "At the boxing match, the dad got into the popcorn line and the line for hot dogs",
+    "punchline": "but he wanted to stay out of the punchline."
+  },
+  {
+    "id": "sPfqWDlq4Ed",
+    "setup": "\"Hey, dad, did you get a haircut?\" \"No",
+    "punchline": "I got them all cut.\""
+  },
+  {
+    "id": "sWSSnbaUfqc",
+    "setup": "Why is there always a gate around cemeteries?",
+    "punchline": "Because people are always dying to get in."
+  },
+  {
+    "id": "scUvsrORKe",
+    "setup": "I asked a frenchman if he played video games.",
+    "punchline": "He said \"Wii\""
+  },
+  {
+    "id": "scaFQfFlqjb",
+    "setup": "My dentist is the best",
+    "punchline": "he even has a little plaque!"
+  },
+  {
+    "id": "scaUn3TfNe",
+    "setup": "So, I heard this pun about cows, but it’s kinda offensive so I won’t say it.",
+    "punchline": "I don’t want there to be any beef between us."
+  },
+  {
+    "id": "scpGtcNJJBd",
+    "setup": "What do Alexander the Great and Winnie the Pooh have in common?",
+    "punchline": "Same middle name."
+  },
+  {
+    "id": "skGtHlORfFd",
+    "setup": "What kind of music do planets listen to?",
+    "punchline": "Nep-tunes."
+  },
+  {
+    "id": "srjbpzs4h",
+    "setup": "Shout out to my grandma",
+    "punchline": "that's the only way she can hear."
+  },
+  {
+    "id": "szItcaFQnjb",
+    "setup": "Why was the broom late for the meeting?",
+    "punchline": "He overswept."
+  },
+  {
+    "id": "szXDA59U0wc",
+    "setup": "I went on a date last night with a girl from the zoo. It was great.",
+    "punchline": "She’s a keeper."
+  },
+  {
+    "id": "t4MJRuXDIe",
+    "setup": "Why do you never see elephants hiding in trees?",
+    "punchline": "Because they're so good at it."
+  },
+  {
+    "id": "tHJtrrzP7wc",
+    "setup": "Mahatma Gandhi, as you know, walked barefoot most of the time, which produced an impressive set of calluses on his feet. He also ate very little, which made him rather frail and with his odd diet, he suffered from bad breath.",
+    "punchline": "This made him a super calloused fragile mystic hexed by halitosis."
+  },
+  {
+    "id": "tPuPm3EYDAd",
+    "setup": "What do you call an alligator in a vest?",
+    "punchline": "An in-vest-igator!"
+  },
+  {
+    "id": "tWL618U8Ed",
+    "setup": "What did celery say when he broke up with his girlfriend?",
+    "punchline": "She wasn't right for me, so I really don't carrot all."
+  },
+  {
+    "id": "tWL6U01obpb",
+    "setup": "Thanks for explaining the word \"many\" to me.",
+    "punchline": "It means a lot."
+  },
+  {
+    "id": "tcFBIm3gyd",
+    "setup": "What's brown and sticky?",
+    "punchline": "A stick."
+  },
+  {
+    "id": "tkji39992Ed",
+    "setup": "What biscuit does a short person like?",
+    "punchline": "Shortbread."
+  },
+  {
+    "id": "trjG61Dlqzd",
+    "setup": "Why was Santa's little helper feeling depressed?",
+    "punchline": "Because he has low elf esteem."
+  },
+  {
+    "id": "u4Tvkba21wc",
+    "setup": "Why did Sweden start painting barcodes on the sides of their battleships?",
+    "punchline": "So they could Scandinavian."
+  },
+  {
+    "id": "uPu4MRZLmrc",
+    "setup": "Want to hear a chimney joke?",
+    "punchline": "Got stacks of em! First one's on the house"
+  },
+  {
+    "id": "ucapjGQZTf",
+    "setup": "What do you call a pig that knows karate?",
+    "punchline": "A pork chop!"
+  },
+  {
+    "id": "ucxPZDAlGlb",
+    "setup": "If two vegans are having an argument",
+    "punchline": "is it still considered beef?"
+  },
+  {
+    "id": "usWLJeaUvc",
+    "setup": "For Valentine's day, I decided to get my wife some beads for an abacus.",
+    "punchline": "It's the little things that count."
+  },
+  {
+    "id": "usrcaMuszd",
+    "setup": "What's the worst thing about ancient history class?",
+    "punchline": "The teachers tend to Babylon."
+  },
+  {
+    "id": "uszdNZ8MRCd",
+    "setup": "My new thesaurus is terrible.",
+    "punchline": "In fact, it's so bad, I'd say it's terrible."
+  },
+  {
+    "id": "v4wAlO7USf",
+    "setup": "What type of music do balloons hate?",
+    "punchline": "Pop music!"
+  },
+  {
+    "id": "vPmy5EtPKuc",
+    "setup": "Do you want a brief explanation of what an acorn is?",
+    "punchline": "In a nutshell, it's an oak tree."
+  },
+  {
+    "id": "vPuzAd299pb",
+    "setup": "How come a man driving a train got struck by lightning?",
+    "punchline": "He was a good conductor."
+  },
+  {
+    "id": "vX8MeFdUDlb",
+    "setup": "Dad died because he couldn't remember his blood type. I will never forget his last words.",
+    "punchline": "Be positive."
+  },
+  {
+    "id": "vXgNZ0wcxAd",
+    "setup": "I’m on a whiskey diet.",
+    "punchline": "I’ve lost three days already."
+  },
+  {
+    "id": "vcNJRnrcNCd",
+    "setup": "How does Darth Vader like his toast?",
+    "punchline": "On the dark side."
+  },
+  {
+    "id": "vk31LJB5Elb",
+    "setup": "Why didn’t the orange win the race?",
+    "punchline": "It ran out of juice."
+  },
+  {
+    "id": "vkV0L6wcFlb",
+    "setup": "Did you hear about the runner who was criticized?",
+    "punchline": "He just took it in stride"
+  },
+  {
+    "id": "wA5wX0wXLmb",
+    "setup": "What animal is always at a game of cricket?",
+    "punchline": "A bat."
+  },
+  {
+    "id": "wHJtHeFY8h",
+    "setup": "Why did the Clydesdale give the pony a glass of water?",
+    "punchline": "Because he was a little horse!"
+  },
+  {
+    "id": "wHlOu4o41g",
+    "setup": "If you think swimming with dolphins is expensive",
+    "punchline": "you should try swimming with sharks--it cost me an arm and a leg!"
+  },
+  {
+    "id": "wX0gNuXgVnb",
+    "setup": "What did the Buffalo say to his little boy when he dropped him off at school?",
+    "punchline": "Bison."
+  },
+  {
+    "id": "wcxHJBl3gFd",
+    "setup": "I am terrified of elevators.",
+    "punchline": "I’m going to start taking steps to avoid them."
+  },
+  {
+    "id": "wcxPRu41wc",
+    "setup": "Why do bees have sticky hair?",
+    "punchline": "Because they use honey combs!"
+  },
+  {
+    "id": "wsPKZozsc",
+    "setup": "Did you know you should always take an extra pair of pants golfing?",
+    "punchline": "Just in case you get a hole in one."
+  },
+  {
+    "id": "x5M799Ufib",
+    "setup": "I wish I could clean mirrors for a living.",
+    "punchline": "It's just something I can see myself doing."
+  },
+  {
+    "id": "xAlOZ8pOmjb",
+    "setup": "How do the trees get on the internet?",
+    "punchline": "They log on."
+  },
+  {
+    "id": "xHQucUvszd",
+    "setup": "To the guy who invented zero...",
+    "punchline": "thanks for nothing."
+  },
+  {
+    "id": "xHY8xsHYTnb",
+    "setup": "What lies at the bottom of the ocean and twitches?",
+    "punchline": "A nervous wreck."
+  },
+  {
+    "id": "xXSv492wPmb",
+    "setup": "What is red and smells like blue paint?",
+    "punchline": "Red paint!"
+  },
+  {
+    "id": "xXg3LZLZDd",
+    "setup": "*Reversing the car* \"Ah",
+    "punchline": "this takes me back\""
+  },
+  {
+    "id": "xXvzXga21wc",
+    "setup": "How do locomotives know where they're going?",
+    "punchline": "Lots of training"
+  },
+  {
+    "id": "xc21Lmbxcib",
+    "setup": "How did the hipster burn the roof of his mouth?",
+    "punchline": "He ate the pizza before it was cool."
+  },
+  {
+    "id": "xkGB5oWSKmb",
+    "setup": "Did you hear about the new restaurant on the moon?",
+    "punchline": "The food is great, but there’s just no atmosphere."
+  },
+  {
+    "id": "xkVDIBsPRCd",
+    "setup": "What do you call a beehive without the b's?",
+    "punchline": "An eehive."
+  },
+  {
+    "id": "xs4o49hF6pb",
+    "setup": "What kind of pants do ghosts wear?",
+    "punchline": "Boo jeans."
+  },
+  {
+    "id": "xscaxH6M7h",
+    "setup": "Two guys walked into a bar",
+    "punchline": "the third one ducked."
+  },
+  {
+    "id": "y59pGlbhyAd",
+    "setup": "I really want to buy one of those supermarket checkout dividers",
+    "punchline": "but the cashier keeps putting it back."
+  },
+  {
+    "id": "yItzAdUKBd",
+    "setup": "A horse walks into a bar.",
+    "punchline": "The bar tender says \"Hey.\" The horse says \"Sure.\""
+  },
+  {
+    "id": "yP7MRucFQCd",
+    "setup": "Did you hear about the guy who invented Lifesavers?",
+    "punchline": "They say he made a mint."
+  },
+  {
+    "id": "yX821Lusrrc",
+    "setup": "What's the difference between a poorly dressed man on a tricycle and a well dressed man on a bicycle?",
+    "punchline": "Attire."
+  },
+  {
+    "id": "ykb2TSKRSnb",
+    "setup": "Why are giraffes so slow to apologize?",
+    "punchline": "Because it takes them a long time to swallow their pride."
+  },
+  {
+    "id": "ysHQZvcpbFd",
+    "setup": "\"Dad, I'm hungry.\" Hello, Hungry.",
+    "punchline": "I'm Dad."
+  },
+  {
+    "id": "zPRCljGQ7Ed",
+    "setup": "I have the heart of a lion...",
+    "punchline": "and a lifetime ban from the San Diego Zoo."
+  },
+  {
+    "id": "zPZ0TClqrc",
+    "setup": "What do you call a guy lying on your doorstep?",
+    "punchline": "Matt."
+  },
+  {
+    "id": "zdpjyXnjbFd",
+    "setup": "I met this girl on a dating site and, I don't know",
+    "punchline": "we just clicked."
+  },
+  {
+    "id": "zkO7wHJmrc",
+    "setup": "What did the calculator say to the student?",
+    "punchline": "You can count on me."
+  },
+  {
+    "id": "zkysrzkVfqc",
+    "setup": "What do you call a gorilla wearing headphones?",
+    "punchline": "Anything you'd like, it can't hear you."
+  },
+  {
+    "id": "zsHBljyk3wc",
+    "setup": "Have you heard about corduroy pillows?",
+    "punchline": "They're making headlines!"
+  },
+  {
+    "id": "official-general-001",
+    "setup": "What did the fish say when it hit the wall?",
+    "punchline": "Dam."
+  },
+  {
+    "id": "official-general-002",
+    "setup": "How do you make a tissue dance?",
+    "punchline": "You put a little boogie on it."
+  },
+  {
+    "id": "official-general-003",
+    "setup": "What's Forrest Gump's password?",
+    "punchline": "1Forrest1"
+  },
+  {
+    "id": "official-general-004",
+    "setup": "What do you call a belt made out of watches?",
+    "punchline": "A waist of time."
+  },
+  {
+    "id": "official-general-005",
+    "setup": "Why can't bicycles stand on their own?",
+    "punchline": "They are two tired"
+  },
+  {
+    "id": "official-general-006",
+    "setup": "How does a train eat?",
+    "punchline": "It goes chew, chew"
+  },
+  {
+    "id": "official-general-007",
+    "setup": "What do you call a singing Laptop?",
+    "punchline": "A Dell"
+  },
+  {
+    "id": "official-general-008",
+    "setup": "How many lips does a flower have?",
+    "punchline": "Tulips"
+  },
+  {
+    "id": "official-general-009",
+    "setup": "What kind of shoes does a thief wear?",
+    "punchline": "Sneakers"
+  },
+  {
+    "id": "official-general-010",
+    "setup": "What's the best time to go to the dentist?",
+    "punchline": "Tooth hurty."
+  },
+  {
+    "id": "official-knock-knock-011",
+    "setup": "Knock knock. Who's there? A broken pencil. A broken pencil who?",
+    "punchline": "Never mind. It's pointless."
+  },
+  {
+    "id": "official-knock-knock-012",
+    "setup": "Knock knock. Who's there? Cows go. Cows go who?",
+    "punchline": "No, cows go moo."
+  },
+  {
+    "id": "official-knock-knock-013",
+    "setup": "Knock knock. Who's there? Little old lady. Little old lady who?",
+    "punchline": "I didn't know you could yodel!"
+  },
+  {
+    "id": "official-programming-014",
+    "setup": "Why would a guitarist become a good programmer?",
+    "punchline": "He's adept at riffing in C#."
+  },
+  {
+    "id": "official-programming-015",
+    "setup": "What's the best thing about a Boolean?",
+    "punchline": "Even if you're wrong, you're only off by a bit."
+  },
+  {
+    "id": "official-programming-016",
+    "setup": "What's the object-oriented way to become wealthy?",
+    "punchline": "Inheritance"
+  },
+  {
+    "id": "official-programming-017",
+    "setup": "Where do programmers like to hangout?",
+    "punchline": "The Foo Bar."
+  },
+  {
+    "id": "official-programming-018",
+    "setup": "Why did the programmer quit his job?",
+    "punchline": "Because he didn't get arrays."
+  },
+  {
+    "id": "official-general-019",
+    "setup": "Did you hear about the two silk worms in a race?",
+    "punchline": "It ended in a tie."
+  },
+  {
+    "id": "official-general-020",
+    "setup": "What do you call a laughing motorcycle?",
+    "punchline": "A Yamahahahaha."
+  },
+  {
+    "id": "official-general-021",
+    "setup": "A termite walks into a bar and says...",
+    "punchline": "'Where is the bar tended?'"
+  },
+  {
+    "id": "official-general-022",
+    "setup": "What does C.S. Lewis keep at the back of his wardrobe?",
+    "punchline": "Narnia business!"
+  },
+  {
+    "id": "official-programming-023",
+    "setup": "A SQL query walks into a bar, walks up to two tables and asks...",
+    "punchline": "'Can I join you?'"
+  },
+  {
+    "id": "official-programming-024",
+    "setup": "How many programmers does it take to change a lightbulb?",
+    "punchline": "None that's a hardware problem"
+  },
+  {
+    "id": "official-programming-025",
+    "setup": "If you put a million monkeys at a million keyboards, one of them will eventually write a Java program",
+    "punchline": "the rest of them will write Perl"
+  },
+  {
+    "id": "official-programming-026",
+    "setup": "['hip', 'hip']",
+    "punchline": "(hip hip array)"
+  },
+  {
+    "id": "official-programming-027",
+    "setup": "To understand what recursion is...",
+    "punchline": "You must first understand what recursion is"
+  },
+  {
+    "id": "official-programming-028",
+    "setup": "There are 10 types of people in this world...",
+    "punchline": "Those who understand binary and those who don't"
+  },
+  {
+    "id": "official-general-029",
+    "setup": "What did the duck say when he bought lipstick?",
+    "punchline": "Put it on my bill"
+  },
+  {
+    "id": "official-general-030",
+    "setup": "What happens to a frog's car when it breaks down?",
+    "punchline": "It gets toad away"
+  },
+  {
+    "id": "official-general-031",
+    "setup": "did you know the first French fries weren't cooked in France?",
+    "punchline": "they were cooked in Greece"
+  },
+  {
+    "id": "official-programming-032",
+    "setup": "Which song would an exception sing?",
+    "punchline": "Can't catch me - Avicii"
+  },
+  {
+    "id": "official-knock-knock-033",
+    "setup": "Knock knock. Who's there? Opportunity.",
+    "punchline": "That is impossible. Opportunity doesn’t come knocking twice!"
+  },
+  {
+    "id": "official-programming-034",
+    "setup": "Why do Java programmers wear glasses?",
+    "punchline": "Because they don't C#."
+  },
+  {
+    "id": "official-general-035",
+    "setup": "Why did the mushroom get invited to the party?",
+    "punchline": "Because he was a fungi."
+  },
+  {
+    "id": "official-general-036",
+    "setup": "Do you know what the word 'was' was initially?",
+    "punchline": "Before was was was was was is."
+  },
+  {
+    "id": "official-general-037",
+    "setup": "I'm reading a book about anti-gravity...",
+    "punchline": "It's impossible to put down"
+  },
+  {
+    "id": "official-general-038",
+    "setup": "If you're American when you go into the bathroom, and American when you come out, what are you when you're in there?",
+    "punchline": "European"
+  },
+  {
+    "id": "official-general-039",
+    "setup": "Want to hear a joke about a piece of paper?",
+    "punchline": "Never mind...it's tearable"
+  },
+  {
+    "id": "official-general-040",
+    "setup": "I just watched a documentary about beavers.",
+    "punchline": "It was the best dam show I ever saw"
+  },
+  {
+    "id": "official-general-041",
+    "setup": "If you see a robbery at an Apple Store...",
+    "punchline": "Does that make you an iWitness?"
+  },
+  {
+    "id": "official-general-042",
+    "setup": "A ham sandwhich walks into a bar and orders a beer. The bartender says...",
+    "punchline": "I'm sorry, we don't serve food here"
+  },
+  {
+    "id": "official-general-043",
+    "setup": "Why did the Clydesdale give the pony a glass of water?",
+    "punchline": "Because he was a little horse"
+  },
+  {
+    "id": "official-general-044",
+    "setup": "If you boil a clown...",
+    "punchline": "Do you get a laughing stock?"
+  },
+  {
+    "id": "official-general-045",
+    "setup": "Finally realized why my plant sits around doing nothing all day...",
+    "punchline": "He loves his pot."
+  },
+  {
+    "id": "official-general-046",
+    "setup": "Don't look at the eclipse through a colander.",
+    "punchline": "You'll strain your eyes."
+  },
+  {
+    "id": "official-general-047",
+    "setup": "I bought some shoes from a drug dealer.",
+    "punchline": "I don't know what he laced them with, but I was tripping all day!"
+  },
+  {
+    "id": "official-general-048",
+    "setup": "Why do chicken coops only have two doors?",
+    "punchline": "Because if they had four, they would be chicken sedans"
+  },
+  {
+    "id": "official-general-049",
+    "setup": "What do you call a factory that sells passable products?",
+    "punchline": "A satisfactory"
+  },
+  {
+    "id": "official-general-050",
+    "setup": "When a dad drives past a graveyard: Did you know that's a popular cemetery?",
+    "punchline": "Yep, people are just dying to get in there"
+  },
+  {
+    "id": "official-general-051",
+    "setup": "Why did the invisible man turn down the job offer?",
+    "punchline": "He couldn't see himself doing it"
+  },
+  {
+    "id": "official-general-052",
+    "setup": "How do you make holy water?",
+    "punchline": "You boil the hell out of it"
+  },
+  {
+    "id": "official-general-054",
+    "setup": "Why is peter pan always flying?",
+    "punchline": "Because he neverlands"
+  },
+  {
+    "id": "official-programming-055",
+    "setup": "How do you check if a webpage is HTML5?",
+    "punchline": "Try it out on Internet Explorer"
+  },
+  {
+    "id": "official-general-056",
+    "setup": "What do you call a cow with no legs?",
+    "punchline": "Ground beef!"
+  },
+  {
+    "id": "official-general-057",
+    "setup": "I dropped a pear in my car this morning.",
+    "punchline": "You should drop another one, then you would have a pair."
+  },
+  {
+    "id": "official-programming-058",
+    "setup": "Lady: How do I spread love in this cruel world?",
+    "punchline": "Random Dude: [...💘]"
+  },
+  {
+    "id": "official-programming-059",
+    "setup": "A user interface is like a joke.",
+    "punchline": "If you have to explain it then it is not that good."
+  },
+  {
+    "id": "official-knock-knock-060",
+    "setup": "Knock knock. Who's there? Hatch. Hatch who?",
+    "punchline": "Bless you!"
+  },
+  {
+    "id": "official-general-061",
+    "setup": "What do you call sad coffee?",
+    "punchline": "Despresso."
+  },
+  {
+    "id": "official-general-062",
+    "setup": "Why did the butcher work extra hours at the shop?",
+    "punchline": "To make ends meat."
+  },
+  {
+    "id": "official-general-063",
+    "setup": "Did you hear about the hungry clock?",
+    "punchline": "It went back four seconds."
+  },
+  {
+    "id": "official-general-064",
+    "setup": "Well...",
+    "punchline": "That’s a deep subject."
+  },
+  {
+    "id": "official-general-065",
+    "setup": "Did you hear the story about the cheese that saved the world?",
+    "punchline": "It was legend dairy."
+  },
+  {
+    "id": "official-general-066",
+    "setup": "Did you watch the new comic book movie?",
+    "punchline": "It was very graphic!"
+  },
+  {
+    "id": "official-general-067",
+    "setup": "I started a new business making yachts in my attic this year...",
+    "punchline": "The sails are going through the roof."
+  },
+  {
+    "id": "official-general-068",
+    "setup": "I got hit in the head by a soda can, but it didn't hurt that much...",
+    "punchline": "It was a soft drink."
+  },
+  {
+    "id": "official-general-069",
+    "setup": "I can't tell if i like this blender...",
+    "punchline": "It keeps giving me mixed results."
+  },
+  {
+    "id": "official-general-070",
+    "setup": "I couldn't get a reservation at the library...",
+    "punchline": "They were fully booked."
+  },
+  {
+    "id": "official-programming-071",
+    "setup": "I was gonna tell you a joke about UDP...",
+    "punchline": "...but you might not get it."
+  },
+  {
+    "id": "official-programming-072",
+    "setup": "The punchline often arrives before the set-up.",
+    "punchline": "Do you know the problem with UDP jokes?"
+  },
+  {
+    "id": "official-programming-073",
+    "setup": "Why do C# and Java developers keep breaking their keyboards?",
+    "punchline": "Because they use a strongly typed language."
+  },
+  {
+    "id": "official-general-074",
+    "setup": "What do you give to a lemon in need?",
+    "punchline": "Lemonaid."
+  },
+  {
+    "id": "official-general-076",
+    "setup": "Hey, dad, did you get a haircut?",
+    "punchline": "No, I got them all cut."
+  },
+  {
+    "id": "official-general-077",
+    "setup": "What time is it?",
+    "punchline": "I don't know... it keeps changing."
+  },
+  {
+    "id": "official-general-078",
+    "setup": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before. What can I get for you?\"",
+    "punchline": "Pop,goes the weasel."
+  },
+  {
+    "id": "official-general-082",
+    "setup": "Can I watch the TV?",
+    "punchline": "Yes, but don’t turn it on."
+  },
+  {
+    "id": "official-general-097",
+    "setup": "Did you hear that the police have a warrant out on a midget psychic ripping people off?",
+    "punchline": "It reads \"Small medium at large.\""
+  },
+  {
+    "id": "official-general-102",
+    "setup": "What do ghosts call their true love?",
+    "punchline": "Their ghoul-friend"
+  },
+  {
+    "id": "official-general-128",
+    "setup": "How good are you at Power Point?",
+    "punchline": "I Excel at it."
+  },
+  {
+    "id": "official-general-141",
+    "setup": "How many optometrists does it take to change a light bulb?",
+    "punchline": "1 or 2? 1... or 2?"
+  },
+  {
+    "id": "official-general-142",
+    "setup": "How many seconds are in a year?",
+    "punchline": "12. January 2nd, February 2nd, March 2nd, April 2nd.... etc"
+  },
+  {
+    "id": "official-general-148",
+    "setup": "What did the spaghetti say to the other spaghetti?",
+    "punchline": "Pasta la vista, baby!"
+  },
+  {
+    "id": "official-general-149",
+    "setup": "What’s 50 Cent’s name in Zimbabwe?",
+    "punchline": "200 Dollars."
+  },
+  {
+    "id": "official-general-185",
+    "setup": "What did the traffic light say to the car as it passed?",
+    "punchline": "Don't look I'm changing!"
+  },
+  {
+    "id": "official-general-248",
+    "setup": "What is the tallest building in the world?",
+    "punchline": "The library, it’s got the most stories!"
+  },
+  {
+    "id": "official-general-270",
+    "setup": "What's the difference between a guitar and a fish?",
+    "punchline": "You can tune a guitar but you can't \"tuna\"fish!"
+  },
+  {
+    "id": "official-general-294",
+    "setup": "Where’s the bin?",
+    "punchline": "I haven’t been anywhere!"
+  },
+  {
+    "id": "official-general-307",
+    "setup": "Why can't you use \"Beef stew\"as a password?",
+    "punchline": "Because it's not stroganoff."
+  },
+  {
+    "id": "official-programming-362",
+    "setup": "Knock-knock.",
+    "punchline": "A race condition. Who is there?"
+  },
+  {
+    "id": "official-programming-363",
+    "setup": "What's the best part about TCP jokes?",
+    "punchline": "I get to keep telling them until you get them."
+  },
+  {
+    "id": "official-programming-364",
+    "setup": "A programmer puts two glasses on his bedside table before going to sleep.",
+    "punchline": "A full one, in case he gets thirsty, and an empty one, in case he doesn’t."
+  },
+  {
+    "id": "official-general-365",
+    "setup": "Two guys walk into a bar...",
+    "punchline": "The first guy says \"Ouch!\" and the second says \"Yeah, I didn't see it either.\""
+  },
+  {
+    "id": "official-programming-366",
+    "setup": "What did the router say to the doctor?",
+    "punchline": "It hurts when IP."
+  },
+  {
+    "id": "official-programming-367",
+    "setup": "An IPv6 packet is walking out of the house.",
+    "punchline": "He goes nowhere."
+  },
+  {
+    "id": "official-programming-368",
+    "setup": "A DHCP packet walks into a bar and asks for a beer.",
+    "punchline": "Bartender says, \"here, but I’ll need that back in an hour!\""
+  },
+  {
+    "id": "official-programming-369",
+    "setup": "3 SQL statements walk into a NoSQL bar. Soon, they walk out",
+    "punchline": "They couldn't find a table."
+  },
+  {
+    "id": "official-general-370",
+    "setup": "I saw a nice stereo on Craigslist for $1. Seller says the volume is stuck on ‘high’",
+    "punchline": "I couldn’t turn it down."
+  },
+  {
+    "id": "official-programming-371",
+    "setup": "What’s the object-oriented way to become wealthy?",
+    "punchline": "Inheritance."
+  },
+  {
+    "id": "official-general-372",
+    "setup": "What do you call a bee that can't make up its mind?",
+    "punchline": "A maybe."
+  },
+  {
+    "id": "official-general-373",
+    "setup": "Why was Cinderalla thrown out of the football team?",
+    "punchline": "Because she ran away from the ball."
+  },
+  {
+    "id": "official-general-374",
+    "setup": "What kind of music do welders like?",
+    "punchline": "Heavy metal."
+  },
+  {
+    "id": "official-general-375",
+    "setup": "Why are “Dad Jokes” so good?",
+    "punchline": "Because the punchline is apparent."
+  },
+  {
+    "id": "official-programming-376",
+    "setup": "Why dot net developers don't wear glasses?",
+    "punchline": "Because they see sharp."
+  },
+  {
+    "id": "official-general-377",
+    "setup": "Why is seven bigger than nine?",
+    "punchline": "Because seven ate nine."
+  },
+  {
+    "id": "official-dad-378",
+    "setup": "Why do fathers take an extra pair of socks when they go golfing?",
+    "punchline": "In case they get a hole in one!"
+  },
+  {
+    "id": "official-general-379",
+    "setup": "What do you call a suspicious looking laptop?",
+    "punchline": "Asus"
+  },
+  {
+    "id": "official-programming-380",
+    "setup": "What did the Java code say to the C code?",
+    "punchline": "You've got no class."
+  },
+  {
+    "id": "official-programming-381",
+    "setup": "What is the most used language in programming?",
+    "punchline": "Profanity."
+  },
+  {
+    "id": "official-programming-382",
+    "setup": "Why do programmers always get Christmas and Halloween mixed up?",
+    "punchline": "Because DEC 25 = OCT 31"
+  },
+  {
+    "id": "official-programming-383",
+    "setup": "What goes after USA?",
+    "punchline": "USB."
+  },
+  {
+    "id": "official-dad-384",
+    "setup": "Why don't eggs tell jokes?",
+    "punchline": "Because they would crack each other up."
+  },
+  {
+    "id": "official-general-385",
+    "setup": "How do you make the number one disappear?",
+    "punchline": "Add the letter G and it’s “gone”!"
+  },
+  {
+    "id": "official-general-386",
+    "setup": "My older brother always tore the last pages of my comic books, and never told me why.",
+    "punchline": "I had to draw my own conclusions."
+  },
+  {
+    "id": "official-general-387",
+    "setup": "The Sergeant-Major growled at the young soldier: I didn’t see you at camouflage training this morning.",
+    "punchline": "Thank you very much, sir."
+  },
+  {
+    "id": "official-general-389",
+    "setup": "Why did the kid throw the watch out the window?",
+    "punchline": "So time would fly."
+  },
+  {
+    "id": "official-programming-390",
+    "setup": "Where did the API go to eat?",
+    "punchline": "To the RESTaurant."
+  },
+  {
+    "id": "official-general-391",
+    "setup": "Why did the rooster cross the road?",
+    "punchline": "He heard that the chickens at KFC were pretty hot."
+  },
+  {
+    "id": "official-general-392",
+    "setup": "Did you hear about the Viking who was reincarnated?",
+    "punchline": "He was Bjorn again"
+  },
+  {
+    "id": "official-general-393",
+    "setup": "What does the mermaid wear to math class?",
+    "punchline": "Algae-bra."
+  },
+  {
+    "id": "official-general-394",
+    "setup": "Did you hear about the crime in the parking garage?",
+    "punchline": "It was wrong on so many levels."
+  },
+  {
+    "id": "official-programming-395",
+    "setup": "Hey, wanna hear a joke?",
+    "punchline": "Parsing HTML with regex."
+  },
+  {
+    "id": "official-general-396",
+    "setup": "Why didn't the skeleton go for prom?",
+    "punchline": "Because it had nobody."
+  },
+  {
+    "id": "official-general-397",
+    "setup": "A grocery store cashier asked if I would like my milk in a bag.",
+    "punchline": "I told her 'No, thanks. The carton works fine.'"
+  },
+  {
+    "id": "official-general-398",
+    "setup": "99.9% of the people are dumb!",
+    "punchline": "Fortunately I belong to the remaining 1%"
+  },
+  {
+    "id": "official-programming-399",
+    "setup": "I just got fired from my job at the keyboard factory.",
+    "punchline": "They told me I wasn't putting in enough shifts."
+  },
+  {
+    "id": "official-general-400",
+    "setup": "You see, mountains aren't just funny.",
+    "punchline": "They are hill areas."
+  },
+  {
+    "id": "official-general-401",
+    "setup": "What do elves post on Social Media?",
+    "punchline": "Elf-ies."
+  },
+  {
+    "id": "official-general-402",
+    "setup": "While I was sleeping my friends decided to write math equations on me.",
+    "punchline": "You should have seen the expression on my face when I woke up."
+  },
+  {
+    "id": "official-general-403",
+    "setup": "Due to complaints, Hawaii passed a law where you're not allowed to laugh above a certain decibel.",
+    "punchline": "You can only use a low ha."
+  },
+  {
+    "id": "official-general-404",
+    "setup": "Why are football stadiums so cool?",
+    "punchline": "Because every seat has a fan in it."
+  },
+  {
+    "id": "official-programming-405",
+    "setup": "How do you generate a random string?",
+    "punchline": "Put a Windows user in front of Vim and tell them to exit."
+  },
+  {
+    "id": "official-programming-406",
+    "setup": "Why did the functions stop calling each other?",
+    "punchline": "Because they had constant arguments."
+  },
+  {
+    "id": "official-programming-407",
+    "setup": "Why did the private classes break up?",
+    "punchline": "Because they never saw each other."
+  },
+  {
+    "id": "official-programming-408",
+    "setup": "Why did the developer quit his job?",
+    "punchline": "Because he didn't get arrays."
+  },
+  {
+    "id": "official-programming-410",
+    "setup": "How many React developers does it take to change a lightbulb?",
+    "punchline": "None, they prefer dark mode."
+  },
+  {
+    "id": "official-programming-411",
+    "setup": "Why don't React developers like nature?",
+    "punchline": "They prefer the virtual DOM."
+  },
+  {
+    "id": "official-programming-412",
+    "setup": "What do you get when you cross a React developer with a mathematician?",
+    "punchline": "A function component."
+  },
+  {
+    "id": "official-programming-413",
+    "setup": "Why did the developer go broke buying Bitcoin?",
+    "punchline": "He kept calling it bytecoin and didn't get any."
+  },
+  {
+    "id": "official-programming-414",
+    "setup": "Why did the programmer go to art school?",
+    "punchline": "He wanted to learn how to code outside the box."
+  },
+  {
+    "id": "official-programming-415",
+    "setup": "Why did the programmer's wife leave him?",
+    "punchline": "He didn't know how to commit."
+  },
+  {
+    "id": "official-programming-416",
+    "setup": "Why do programmers prefer dark chocolate?",
+    "punchline": "Because it's bitter like their code."
+  },
+  {
+    "id": "official-programming-417",
+    "setup": "Why did the programmer go broke?",
+    "punchline": "He used up all his cache"
+  },
+  {
+    "id": "official-programming-418",
+    "setup": "Why did the programmer always mix up Halloween and Christmas?",
+    "punchline": "Because Oct 31 equals Dec 25."
+  },
+  {
+    "id": "official-programming-419",
+    "setup": "Why don't programmers like nature?",
+    "punchline": "There's too many bugs."
+  },
+  {
+    "id": "official-programming-420",
+    "setup": "Why was the JavaScript developer sad?",
+    "punchline": "He didn't know how to null his feelings."
+  },
+  {
+    "id": "official-general-421",
+    "setup": "Why couldn't the bicycle stand up by itself?",
+    "punchline": "It was two-tired."
+  },
+  {
+    "id": "official-general-422",
+    "setup": "Why did the math book look sad?",
+    "punchline": "Because it had too many problems."
+  },
+  {
+    "id": "official-general-423",
+    "setup": "What's a computer's favorite snack?",
+    "punchline": "Microchips."
+  },
+  {
+    "id": "official-general-424",
+    "setup": "What did the janitor say when he jumped out of the closet?",
+    "punchline": "Supplies!"
+  },
+  {
+    "id": "official-general-425",
+    "setup": "What did one ocean say to the other ocean?",
+    "punchline": "Nothing, they just waved."
+  },
+  {
+    "id": "official-general-426",
+    "setup": "What's the best thing about Switzerland?",
+    "punchline": "I don't know, but their flag is a big plus."
+  },
+  {
+    "id": "official-general-427",
+    "setup": "Why did the golfer bring two pairs of pants?",
+    "punchline": "In case he got a hole in one."
+  },
+  {
+    "id": "official-general-428",
+    "setup": "Why did the chicken cross the playground?",
+    "punchline": "To get to the other slide."
+  },
+  {
+    "id": "official-general-429",
+    "setup": "Why don't scientists trust atoms?",
+    "punchline": "Because they make up everything."
+  },
+  {
+    "id": "official-general-432",
+    "setup": "Why don't oysters give to charity?",
+    "punchline": "Because they're shellfish."
+  },
+  {
+    "id": "official-general-433",
+    "setup": "Why did the golfer wear two pairs of pants?",
+    "punchline": "In case he got a hole in one."
+  },
+  {
+    "id": "official-general-434",
+    "setup": "Why did the cookie go to the doctor?",
+    "punchline": "Because it was feeling crumbly."
+  },
+  {
+    "id": "official-programming-435",
+    "setup": "What do you call a computer mouse that swears a lot?",
+    "punchline": "A cursor!"
+  },
+  {
+    "id": "official-programming-436",
+    "setup": "Why did the designer break up with their font?",
+    "punchline": "Because it wasn't their type."
+  },
+  {
+    "id": "official-programming-437",
+    "setup": "Why did the programmer quit their job?",
+    "punchline": "They didn't get arrays."
+  },
+  {
+    "id": "official-programming-438",
+    "setup": "Why did the developer go broke?",
+    "punchline": "They kept spending all their cache."
+  },
+  {
+    "id": "official-programming-439",
+    "setup": "How do you comfort a designer?",
+    "punchline": "You give them some space... between the elements."
+  },
+  {
+    "id": "official-programming-440",
+    "setup": "Why don't programmers like nature?",
+    "punchline": "Too many bugs."
+  },
+  {
+    "id": "official-programming-441",
+    "setup": "Why did the programmer bring a ladder to work?",
+    "punchline": "They heard the code needed to be debugged from a higher level."
+  },
+  {
+    "id": "official-general-442",
+    "setup": "Why was the developer always calm?",
+    "punchline": "Because they knew how to handle exceptions."
+  },
+  {
+    "id": "official-programming-443",
+    "setup": "Why was the font always tired?",
+    "punchline": "It was always bold."
+  },
+  {
+    "id": "official-programming-444",
+    "setup": "Why did the developer go to therapy?",
+    "punchline": "They had too many unresolved issues."
+  },
+  {
+    "id": "official-programming-445",
+    "setup": "Why was the designer always cold?",
+    "punchline": "Because they always used too much ice-olation."
+  },
+  {
+    "id": "official-programming-446",
+    "setup": "Why did the programmer bring a broom to work?",
+    "punchline": "To clean up all the bugs."
+  },
+  {
+    "id": "official-programming-447",
+    "setup": "Why did the developer break up with their keyboard?",
+    "punchline": "It just wasn't their type anymore."
+  },
+  {
+    "id": "official-programming-448",
+    "setup": "Why did the programmer always carry a pencil?",
+    "punchline": "They preferred to write in C#."
+  },
+  {
+    "id": "official-general-449",
+    "setup": "Why don't skeletons fight each other?",
+    "punchline": "They don't have the guts."
+  },
+  {
+    "id": "official-general-450",
+    "setup": "What do you call fake spaghetti?",
+    "punchline": "An impasta."
+  },
+  {
+    "id": "official-general-451",
+    "setup": "What do you call a thieving alligator?",
+    "punchline": "A crookodile!"
+  }
+]

--- a/data/official-jokes-index.json
+++ b/data/official-jokes-index.json
@@ -1,0 +1,2257 @@
+[
+  {
+    "type": "general",
+    "setup": "What did the fish say when it hit the wall?",
+    "punchline": "Dam."
+  },
+  {
+    "type": "general",
+    "setup": "How do you make a tissue dance?",
+    "punchline": "You put a little boogie on it."
+  },
+  {
+    "type": "general",
+    "setup": "What's Forrest Gump's password?",
+    "punchline": "1Forrest1"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a belt made out of watches?",
+    "punchline": "A waist of time."
+  },
+  {
+    "type": "general",
+    "setup": "Why can't bicycles stand on their own?",
+    "punchline": "They are two tired"
+  },
+  {
+    "type": "general",
+    "setup": "How does a train eat?",
+    "punchline": "It goes chew, chew"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a singing Laptop?",
+    "punchline": "A Dell"
+  },
+  {
+    "type": "general",
+    "setup": "How many lips does a flower have?",
+    "punchline": "Tulips"
+  },
+  {
+    "type": "general",
+    "setup": "What kind of shoes does a thief wear?",
+    "punchline": "Sneakers"
+  },
+  {
+    "type": "general",
+    "setup": "What's the best time to go to the dentist?",
+    "punchline": "Tooth hurty."
+  },
+  {
+    "type": "knock-knock",
+    "setup": "Knock knock. \n Who's there? \n A broken pencil. \n A broken pencil who?",
+    "punchline": "Never mind. It's pointless."
+  },
+  {
+    "type": "knock-knock",
+    "setup": "Knock knock. \n Who's there? \n Cows go. \n Cows go who?",
+    "punchline": "No, cows go moo."
+  },
+  {
+    "type": "knock-knock",
+    "setup": "Knock knock. \n Who's there? \n Little old lady. \n Little old lady who?",
+    "punchline": "I didn't know you could yodel!"
+  },
+  {
+    "type": "programming",
+    "setup": "Why would a guitarist become a good programmer?",
+    "punchline": "He's adept at riffing in C#."
+  },
+  {
+    "type": "programming",
+    "setup": "What's the best thing about a Boolean?",
+    "punchline": "Even if you're wrong, you're only off by a bit."
+  },
+  {
+    "type": "programming",
+    "setup": "What's the object-oriented way to become wealthy?",
+    "punchline": "Inheritance"
+  },
+  {
+    "type": "programming",
+    "setup": "Where do programmers like to hangout?",
+    "punchline": "The Foo Bar."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the programmer quit his job?",
+    "punchline": "Because he didn't get arrays."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the two silk worms in a race?",
+    "punchline": "It ended in a tie."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a laughing motorcycle?",
+    "punchline": "A Yamahahahaha."
+  },
+  {
+    "type": "general",
+    "setup": "A termite walks into a bar and says...",
+    "punchline": "'Where is the bar tended?'"
+  },
+  {
+    "type": "general",
+    "setup": "What does C.S. Lewis keep at the back of his wardrobe?",
+    "punchline": "Narnia business!"
+  },
+  {
+    "type": "programming",
+    "setup": "A SQL query walks into a bar, walks up to two tables and asks...",
+    "punchline": "'Can I join you?'"
+  },
+  {
+    "type": "programming",
+    "setup": "How many programmers does it take to change a lightbulb?",
+    "punchline": "None that's a hardware problem"
+  },
+  {
+    "type": "programming",
+    "setup": "If you put a million monkeys at a million keyboards, one of them will eventually write a Java program",
+    "punchline": "the rest of them will write Perl"
+  },
+  {
+    "type": "programming",
+    "setup": "['hip', 'hip']",
+    "punchline": "(hip hip array)"
+  },
+  {
+    "type": "programming",
+    "setup": "To understand what recursion is...",
+    "punchline": "You must first understand what recursion is"
+  },
+  {
+    "type": "programming",
+    "setup": "There are 10 types of people in this world...",
+    "punchline": "Those who understand binary and those who don't"
+  },
+  {
+    "type": "general",
+    "setup": "What did the duck say when he bought lipstick?",
+    "punchline": "Put it on my bill"
+  },
+  {
+    "type": "general",
+    "setup": "What happens to a frog's car when it breaks down?",
+    "punchline": "It gets toad away"
+  },
+  {
+    "type": "general",
+    "setup": "did you know the first French fries weren't cooked in France?",
+    "punchline": "they were cooked in Greece"
+  },
+  {
+    "type": "programming",
+    "setup": "Which song would an exception sing?",
+    "punchline": "Can't catch me - Avicii"
+  },
+  {
+    "type": "knock-knock",
+    "setup": "Knock knock. \n Who's there? \n Opportunity.",
+    "punchline": "That is impossible. Opportunity doesn’t come knocking twice!"
+  },
+  {
+    "type": "programming",
+    "setup": "Why do Java programmers wear glasses?",
+    "punchline": "Because they don't C#."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the mushroom get invited to the party?",
+    "punchline": "Because he was a fungi."
+  },
+  {
+    "type": "general",
+    "setup": "Do you know what the word 'was' was initially?",
+    "punchline": "Before was was was was was is."
+  },
+  {
+    "type": "general",
+    "setup": "I'm reading a book about anti-gravity...",
+    "punchline": "It's impossible to put down"
+  },
+  {
+    "type": "general",
+    "setup": "If you're American when you go into the bathroom, and American when you come out, what are you when you're in there?",
+    "punchline": "European"
+  },
+  {
+    "type": "general",
+    "setup": "Want to hear a joke about a piece of paper?",
+    "punchline": "Never mind...it's tearable"
+  },
+  {
+    "type": "general",
+    "setup": "I just watched a documentary about beavers.",
+    "punchline": "It was the best dam show I ever saw"
+  },
+  {
+    "type": "general",
+    "setup": "If you see a robbery at an Apple Store...",
+    "punchline": "Does that make you an iWitness?"
+  },
+  {
+    "type": "general",
+    "setup": "A ham sandwhich walks into a bar and orders a beer. The bartender says...",
+    "punchline": "I'm sorry, we don't serve food here"
+  },
+  {
+    "type": "general",
+    "setup": "Why did the Clydesdale give the pony a glass of water?",
+    "punchline": "Because he was a little horse"
+  },
+  {
+    "type": "general",
+    "setup": "If you boil a clown...",
+    "punchline": "Do you get a laughing stock?"
+  },
+  {
+    "type": "general",
+    "setup": "Finally realized why my plant sits around doing nothing all day...",
+    "punchline": "He loves his pot."
+  },
+  {
+    "type": "general",
+    "setup": "Don't look at the eclipse through a colander.",
+    "punchline": "You'll strain your eyes."
+  },
+  {
+    "type": "general",
+    "setup": "I bought some shoes from a drug dealer.",
+    "punchline": "I don't know what he laced them with, but I was tripping all day!"
+  },
+  {
+    "type": "general",
+    "setup": "Why do chicken coops only have two doors?",
+    "punchline": "Because if they had four, they would be chicken sedans"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a factory that sells passable products?",
+    "punchline": "A satisfactory"
+  },
+  {
+    "type": "general",
+    "setup": "When a dad drives past a graveyard: Did you know that's a popular cemetery?",
+    "punchline": "Yep, people are just dying to get in there"
+  },
+  {
+    "type": "general",
+    "setup": "Why did the invisible man turn down the job offer?",
+    "punchline": "He couldn't see himself doing it"
+  },
+  {
+    "type": "general",
+    "setup": "How do you make holy water?",
+    "punchline": "You boil the hell out of it"
+  },
+  {
+    "type": "general",
+    "setup": "I had a dream that I was a muffler last night.",
+    "punchline": "I woke up exhausted!"
+  },
+  {
+    "type": "general",
+    "setup": "Why is peter pan always flying?",
+    "punchline": "Because he neverlands"
+  },
+  {
+    "type": "programming",
+    "setup": "How do you check if a webpage is HTML5?",
+    "punchline": "Try it out on Internet Explorer"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a cow with no legs?",
+    "punchline": "Ground beef!"
+  },
+  {
+    "type": "general",
+    "setup": "I dropped a pear in my car this morning.",
+    "punchline": "You should drop another one, then you would have a pair."
+  },
+  {
+    "type": "programming",
+    "setup": "Lady: How do I spread love in this cruel world?",
+    "punchline": "Random Dude: [...💘]"
+  },
+  {
+    "type": "programming",
+    "setup": "A user interface is like a joke.",
+    "punchline": "If you have to explain it then it is not that good."
+  },
+  {
+    "type": "knock-knock",
+    "setup": "Knock knock. \n Who's there? \n Hatch. \n Hatch who?",
+    "punchline": "Bless you!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call sad coffee?",
+    "punchline": "Despresso."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the butcher work extra hours at the shop?",
+    "punchline": "To make ends meat."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the hungry clock?",
+    "punchline": "It went back four seconds."
+  },
+  {
+    "type": "general",
+    "setup": "Well...",
+    "punchline": "That’s a deep subject."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear the story about the cheese that saved the world?",
+    "punchline": "It was legend dairy."
+  },
+  {
+    "type": "general",
+    "setup": "Did you watch the new comic book movie?",
+    "punchline": "It was very graphic!"
+  },
+  {
+    "type": "general",
+    "setup": "I started a new business making yachts in my attic this year...",
+    "punchline": "The sails are going through the roof."
+  },
+  {
+    "type": "general",
+    "setup": "I got hit in the head by a soda can, but it didn't hurt that much...",
+    "punchline": "It was a soft drink."
+  },
+  {
+    "type": "general",
+    "setup": "I can't tell if i like this blender...",
+    "punchline": "It keeps giving me mixed results."
+  },
+  {
+    "type": "general",
+    "setup": "I couldn't get a reservation at the library...",
+    "punchline": "They were fully booked."
+  },
+  {
+    "type": "programming",
+    "setup": "I was gonna tell you a joke about UDP...",
+    "punchline": "...but you might not get it."
+  },
+  {
+    "type": "programming",
+    "setup": "The punchline often arrives before the set-up.",
+    "punchline": "Do you know the problem with UDP jokes?"
+  },
+  {
+    "type": "programming",
+    "setup": "Why do C# and Java developers keep breaking their keyboards?",
+    "punchline": "Because they use a strongly typed language."
+  },
+  {
+    "type": "general",
+    "setup": "What do you give to a lemon in need?",
+    "punchline": "Lemonaid."
+  },
+  {
+    "type": "general",
+    "setup": "Never take advice from electrons.",
+    "punchline": "They are always negative."
+  },
+  {
+    "type": "general",
+    "setup": "Hey, dad, did you get a haircut?",
+    "punchline": "No, I got them all cut."
+  },
+  {
+    "type": "general",
+    "setup": "What time is it?",
+    "punchline": "I don't know... it keeps changing."
+  },
+  {
+    "type": "general",
+    "setup": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before. What can I get for you?\"",
+    "punchline": "Pop,goes the weasel."
+  },
+  {
+    "type": "general",
+    "setup": "Bad at golf?",
+    "punchline": "Join the club."
+  },
+  {
+    "type": "general",
+    "setup": "Can a kangaroo jump higher than the Empire State Building?",
+    "punchline": "Of course. The Empire State Building can't jump."
+  },
+  {
+    "type": "general",
+    "setup": "Can February march?",
+    "punchline": "No, but April may."
+  },
+  {
+    "type": "general",
+    "setup": "Can I watch the TV?",
+    "punchline": "Yes, but don’t turn it on."
+  },
+  {
+    "type": "general",
+    "setup": "Dad, can you put my shoes on?",
+    "punchline": "I don't think they'll fit me."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the bread factory burning down?",
+    "punchline": "They say the business is toast."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the chameleon who couldn't change color?",
+    "punchline": "They had a reptile dysfunction."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the cheese factory that exploded in France?",
+    "punchline": "There was nothing left but de Brie."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the cow who jumped over the barbed wire fence?",
+    "punchline": "It was udder destruction."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the guy who invented Lifesavers?",
+    "punchline": "They say he made a mint."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the guy whose whole left side was cut off?",
+    "punchline": "He's all right now."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the kidnapping at school?",
+    "punchline": "It's ok, he woke up."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the Mexican train killer?",
+    "punchline": "He had loco motives"
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the new restaurant on the moon?",
+    "punchline": "The food is great, but there’s just no atmosphere."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the runner who was criticized?",
+    "punchline": "He just took it in stride"
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the scientist who was lab partners with a pot of boiling water?",
+    "punchline": "He had a very esteemed colleague."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the submarine industry?",
+    "punchline": "It really took a dive..."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear that David lost his ID in prague?",
+    "punchline": "Now we just have to call him Dav."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear that the police have a warrant out on a midget psychic ripping people off?",
+    "punchline": "It reads \"Small medium at large.\""
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear the joke about the wandering nun?",
+    "punchline": "She was a roman catholic."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear the news?",
+    "punchline": "FedEx and UPS are merging. They’re going to go by the name Fed-Up from now on."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear the one about the guy with the broken hearing aid?",
+    "punchline": "Neither did he."
+  },
+  {
+    "type": "general",
+    "setup": "Did you know crocodiles could grow up to 15 feet?",
+    "punchline": "But most just have 4."
+  },
+  {
+    "type": "general",
+    "setup": "What do ghosts call their true love?",
+    "punchline": "Their ghoul-friend"
+  },
+  {
+    "type": "general",
+    "setup": "Did you know that protons have mass?",
+    "punchline": "I didn't even know they were catholic."
+  },
+  {
+    "type": "general",
+    "setup": "Did you know you should always take an extra pair of pants golfing?",
+    "punchline": "Just in case you get a hole in one."
+  },
+  {
+    "type": "general",
+    "setup": "Do I enjoy making courthouse puns?",
+    "punchline": "Guilty"
+  },
+  {
+    "type": "general",
+    "setup": "Do you know where you can get chicken broth in bulk?",
+    "punchline": "The stock market."
+  },
+  {
+    "type": "general",
+    "setup": "Do you want a brief explanation of what an acorn is?",
+    "punchline": "In a nutshell, it's an oak tree."
+  },
+  {
+    "type": "general",
+    "setup": "Ever wondered why bees hum?",
+    "punchline": "It's because they don't know the words."
+  },
+  {
+    "type": "general",
+    "setup": "Have you ever heard of a music group called Cellophane?",
+    "punchline": "They mostly wrap."
+  },
+  {
+    "type": "general",
+    "setup": "Have you heard of the band 1023MB?",
+    "punchline": "They haven't got a gig yet."
+  },
+  {
+    "type": "general",
+    "setup": "Have you heard the rumor going around about butter?",
+    "punchline": "Never mind, I shouldn't spread it."
+  },
+  {
+    "type": "general",
+    "setup": "How are false teeth like stars?",
+    "punchline": "They come out at night!"
+  },
+  {
+    "type": "general",
+    "setup": "How can you tell a vampire has a cold?",
+    "punchline": "They start coffin."
+  },
+  {
+    "type": "general",
+    "setup": "How come a man driving a train got struck by lightning?",
+    "punchline": "He was a good conductor."
+  },
+  {
+    "type": "general",
+    "setup": "How come the stadium got hot after the game?",
+    "punchline": "Because all of the fans left."
+  },
+  {
+    "type": "general",
+    "setup": "How did Darth Vader know what Luke was getting for Christmas?",
+    "punchline": "He felt his presents."
+  },
+  {
+    "type": "general",
+    "setup": "How did the hipster burn the roof of his mouth?",
+    "punchline": "He ate the pizza before it was cool."
+  },
+  {
+    "type": "general",
+    "setup": "How do hens stay fit?",
+    "punchline": "They always egg-cercise!"
+  },
+  {
+    "type": "general",
+    "setup": "How do locomotives know where they're going?",
+    "punchline": "Lots of training"
+  },
+  {
+    "type": "general",
+    "setup": "How do the trees get on the internet?",
+    "punchline": "They log on."
+  },
+  {
+    "type": "general",
+    "setup": "How do you find Will Smith in the snow?",
+    "punchline": "Look for fresh prints."
+  },
+  {
+    "type": "general",
+    "setup": "How do you fix a broken pizza?",
+    "punchline": "With tomato paste."
+  },
+  {
+    "type": "general",
+    "setup": "How do you fix a damaged jack-o-lantern?",
+    "punchline": "You use a pumpkin patch."
+  },
+  {
+    "type": "general",
+    "setup": "How do you get a baby alien to sleep?",
+    "punchline": "You rocket."
+  },
+  {
+    "type": "general",
+    "setup": "How do you get two whales in a car?",
+    "punchline": "Start in England and drive West."
+  },
+  {
+    "type": "general",
+    "setup": "How do you know if there’s an elephant under your bed?",
+    "punchline": "Your head hits the ceiling!"
+  },
+  {
+    "type": "general",
+    "setup": "How do you make a hankie dance?",
+    "punchline": "Put a little boogie in it."
+  },
+  {
+    "type": "general",
+    "setup": "How good are you at Power Point?",
+    "punchline": "I Excel at it."
+  },
+  {
+    "type": "general",
+    "setup": "How do you organize a space party?",
+    "punchline": "You planet."
+  },
+  {
+    "type": "general",
+    "setup": "How do you steal a coat?",
+    "punchline": "You jacket."
+  },
+  {
+    "type": "general",
+    "setup": "How do you tell the difference between a crocodile and an alligator?",
+    "punchline": "You will see one later and one in a while."
+  },
+  {
+    "type": "general",
+    "setup": "How does a dyslexic poet write?",
+    "punchline": "Inverse."
+  },
+  {
+    "type": "general",
+    "setup": "How does a French skeleton say hello?",
+    "punchline": "Bone-jour."
+  },
+  {
+    "type": "general",
+    "setup": "How does a penguin build it’s house?",
+    "punchline": "Igloos it together."
+  },
+  {
+    "type": "general",
+    "setup": "How does a scientist freshen their breath?",
+    "punchline": "With experi-mints!"
+  },
+  {
+    "type": "general",
+    "setup": "How does the moon cut his hair?",
+    "punchline": "Eclipse it."
+  },
+  {
+    "type": "general",
+    "setup": "How many apples grow on a tree?",
+    "punchline": "All of them!"
+  },
+  {
+    "type": "general",
+    "setup": "How many bones are in the human hand?",
+    "punchline": "A handful of them."
+  },
+  {
+    "type": "general",
+    "setup": "How many hipsters does it take to change a lightbulb?",
+    "punchline": "Oh, it's a really obscure number. You've probably never heard of it."
+  },
+  {
+    "type": "general",
+    "setup": "How many kids with ADD does it take to change a lightbulb?",
+    "punchline": "Let's go ride bikes!"
+  },
+  {
+    "type": "general",
+    "setup": "How many optometrists does it take to change a light bulb?",
+    "punchline": "1 or 2? 1... or 2?"
+  },
+  {
+    "type": "general",
+    "setup": "How many seconds are in a year?",
+    "punchline": "12. January 2nd, February 2nd, March 2nd, April 2nd.... etc"
+  },
+  {
+    "type": "general",
+    "setup": "How many tickles does it take to tickle an octopus?",
+    "punchline": "Ten-tickles!"
+  },
+  {
+    "type": "general",
+    "setup": "How much does a hipster weigh?",
+    "punchline": "An instagram."
+  },
+  {
+    "type": "general",
+    "setup": "How was the snow globe feeling after the storm?",
+    "punchline": "A little shaken."
+  },
+  {
+    "type": "general",
+    "setup": "Is the pool safe for diving?",
+    "punchline": "It deep ends."
+  },
+  {
+    "type": "general",
+    "setup": "Is there a hole in your shoe?",
+    "punchline": "No… Then how’d you get your foot in it?"
+  },
+  {
+    "type": "general",
+    "setup": "What did the spaghetti say to the other spaghetti?",
+    "punchline": "Pasta la vista, baby!"
+  },
+  {
+    "type": "general",
+    "setup": "What’s 50 Cent’s name in Zimbabwe?",
+    "punchline": "200 Dollars."
+  },
+  {
+    "type": "general",
+    "setup": "Want to hear a chimney joke?",
+    "punchline": "Got stacks of em! First one's on the house"
+  },
+  {
+    "type": "general",
+    "setup": "Want to hear a joke about construction?",
+    "punchline": "Nah, I'm still working on it."
+  },
+  {
+    "type": "general",
+    "setup": "Want to hear my pizza joke?",
+    "punchline": "Never mind, it's too cheesy."
+  },
+  {
+    "type": "general",
+    "setup": "What animal is always at a game of cricket?",
+    "punchline": "A bat."
+  },
+  {
+    "type": "general",
+    "setup": "What are the strongest days of the week?",
+    "punchline": "Saturday and Sunday...the rest are weekdays."
+  },
+  {
+    "type": "general",
+    "setup": "What biscuit does a short person like?",
+    "punchline": "Shortbread. "
+  },
+  {
+    "type": "general",
+    "setup": "What cheese can never be yours?",
+    "punchline": "Nacho cheese."
+  },
+  {
+    "type": "general",
+    "setup": "What creature is smarter than a talking parrot?",
+    "punchline": "A spelling bee."
+  },
+  {
+    "type": "general",
+    "setup": "What did celery say when he broke up with his girlfriend?",
+    "punchline": "She wasn't right for me, so I really don't carrot all."
+  },
+  {
+    "type": "general",
+    "setup": "What did Michael Jackson name his denim store?",
+    "punchline": "Billy Jeans!"
+  },
+  {
+    "type": "general",
+    "setup": "What did one nut say as he chased another nut?",
+    "punchline": "I'm a cashew!"
+  },
+  {
+    "type": "general",
+    "setup": "What did one plate say to the other plate?",
+    "punchline": "Dinner is on me!"
+  },
+  {
+    "type": "general",
+    "setup": "What did one snowman say to the other snow man?",
+    "punchline": "Do you smell carrot?"
+  },
+  {
+    "type": "general",
+    "setup": "What did one wall say to the other wall?",
+    "punchline": "I'll meet you at the corner!"
+  },
+  {
+    "type": "general",
+    "setup": "What did Romans use to cut pizza before the rolling cutter was invented?",
+    "punchline": "Lil Caesars"
+  },
+  {
+    "type": "general",
+    "setup": "What did the 0 say to the 8?",
+    "punchline": "Nice belt."
+  },
+  {
+    "type": "general",
+    "setup": "What did the beaver say to the tree?",
+    "punchline": "It's been nice gnawing you."
+  },
+  {
+    "type": "general",
+    "setup": "What did the big flower say to the littler flower?",
+    "punchline": "Hi, bud!"
+  },
+  {
+    "type": "general",
+    "setup": "What did the Buffalo say to his little boy when he dropped him off at school?",
+    "punchline": "Bison."
+  },
+  {
+    "type": "general",
+    "setup": "What did the digital clock say to the grandfather clock?",
+    "punchline": "Look, no hands!"
+  },
+  {
+    "type": "general",
+    "setup": "What did the dog say to the two trees?",
+    "punchline": "Bark bark."
+  },
+  {
+    "type": "general",
+    "setup": "What did the Dorito farmer say to the other Dorito farmer?",
+    "punchline": "Cool Ranch!"
+  },
+  {
+    "type": "general",
+    "setup": "What did the fish say when it swam into a wall?",
+    "punchline": "Damn!"
+  },
+  {
+    "type": "general",
+    "setup": "What did the grape do when he got stepped on?",
+    "punchline": "He let out a little wine."
+  },
+  {
+    "type": "general",
+    "setup": "What did the judge say to the dentist?",
+    "punchline": "Do you swear to pull the tooth, the whole tooth and nothing but the tooth?"
+  },
+  {
+    "type": "general",
+    "setup": "What did the late tomato say to the early tomato?",
+    "punchline": "I’ll ketch up"
+  },
+  {
+    "type": "general",
+    "setup": "What did the left eye say to the right eye?",
+    "punchline": "Between us, something smells!"
+  },
+  {
+    "type": "general",
+    "setup": "What did the mountain climber name his son?",
+    "punchline": "Cliff."
+  },
+  {
+    "type": "general",
+    "setup": "What did the ocean say to the beach?",
+    "punchline": "Thanks for all the sediment."
+  },
+  {
+    "type": "general",
+    "setup": "What did the ocean say to the shore?",
+    "punchline": "Nothing, it just waved."
+  },
+  {
+    "type": "general",
+    "setup": "Why don't you find hippopotamuses hiding in trees?",
+    "punchline": "They're really good at it."
+  },
+  {
+    "type": "general",
+    "setup": "What did the pirate say on his 80th birthday?",
+    "punchline": "Aye Matey!"
+  },
+  {
+    "type": "general",
+    "setup": "What did the Red light say to the Green light?",
+    "punchline": "Don't look at me I'm changing!"
+  },
+  {
+    "type": "general",
+    "setup": "What did the scarf say to the hat?",
+    "punchline": "You go on ahead, I am going to hang around a bit longer."
+  },
+  {
+    "type": "general",
+    "setup": "What did the shy pebble wish for?",
+    "punchline": "That she was a little boulder."
+  },
+  {
+    "type": "general",
+    "setup": "What did the traffic light say to the car as it passed?",
+    "punchline": "Don't look I'm changing!"
+  },
+  {
+    "type": "general",
+    "setup": "What did the Zen Buddist say to the hotdog vendor?",
+    "punchline": "Make me one with everything."
+  },
+  {
+    "type": "general",
+    "setup": "What do birds give out on Halloween?",
+    "punchline": "Tweets."
+  },
+  {
+    "type": "general",
+    "setup": "What do I look like?",
+    "punchline": "A JOKE MACHINE!?"
+  },
+  {
+    "type": "general",
+    "setup": "What do prisoners use to call each other?",
+    "punchline": "Cell phones."
+  },
+  {
+    "type": "general",
+    "setup": "What do vegetarian zombies eat?",
+    "punchline": "Grrrrrainnnnnssss."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a bear with no teeth?",
+    "punchline": "A gummy bear!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a bee that lives in America?",
+    "punchline": "A USB."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a boomerang that won't come back?",
+    "punchline": "A stick."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a careful wolf?",
+    "punchline": "Aware wolf."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a cow on a trampoline?",
+    "punchline": "A milk shake!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a cow with two legs?",
+    "punchline": "Lean beef."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a crowd of chess players bragging about their wins in a hotel lobby?",
+    "punchline": "Chess nuts boasting in an open foyer."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a dad that has fallen through the ice?",
+    "punchline": "A Popsicle."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a dictionary on drugs?",
+    "punchline": "High definition."
+  },
+  {
+    "type": "general",
+    "setup": "what do you call a dog that can do magic tricks?",
+    "punchline": "a labracadabrador"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a droid that takes the long way around?",
+    "punchline": "R2 detour."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a duck that gets all A's?",
+    "punchline": "A wise quacker."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a fake noodle?",
+    "punchline": "An impasta."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a fashionable lawn statue with an excellent sense of rhythmn?",
+    "punchline": "A metro-gnome"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a fat psychic?",
+    "punchline": "A four-chin teller."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a fly without wings?",
+    "punchline": "A walk."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a girl between two posts?",
+    "punchline": "Annette."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a group of disorganized cats?",
+    "punchline": "A cat-tastrophe."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a group of killer whales playing instruments?",
+    "punchline": "An Orca-stra."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a monkey in a mine field?",
+    "punchline": "A babooooom!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a nervous javelin thrower?",
+    "punchline": "Shakespeare."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a pig that knows karate?",
+    "punchline": "A pork chop!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a pig with three eyes?",
+    "punchline": "Piiig"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a pile of cats?",
+    "punchline": "A Meowtain."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a sheep with no legs?",
+    "punchline": "A cloud."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a troublesome Canadian high schooler?",
+    "punchline": "A poutine."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call an alligator in a vest?",
+    "punchline": "An in-vest-igator!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call an Argentinian with a rubber toe?",
+    "punchline": "Roberto"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call an eagle who can play the piano?",
+    "punchline": "Talonted!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call an elephant that doesn’t matter?",
+    "punchline": "An irrelephant."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call an old snowman?",
+    "punchline": "Water."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call cheese by itself?",
+    "punchline": "Provolone."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call corn that joins the army?",
+    "punchline": "Kernel."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call someone with no nose?",
+    "punchline": "Nobody knows."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call two barracuda fish?",
+    "punchline": "A Pairacuda!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you do on a remote island?",
+    "punchline": "Try and find the TV island it belongs to."
+  },
+  {
+    "type": "general",
+    "setup": "What do you do when you see a space man?",
+    "punchline": "Park your car, man."
+  },
+  {
+    "type": "general",
+    "setup": "What do you get hanging from Apple trees?",
+    "punchline": "Sore arms."
+  },
+  {
+    "type": "general",
+    "setup": "What do you get when you cross a bee and a sheep?",
+    "punchline": "A bah-humbug."
+  },
+  {
+    "type": "general",
+    "setup": "What do you get when you cross a chicken with a skunk?",
+    "punchline": "A fowl smell!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you get when you cross a rabbit with a water hose?",
+    "punchline": "Hare spray."
+  },
+  {
+    "type": "general",
+    "setup": "What do you get when you cross a snowman with a vampire?",
+    "punchline": "Frostbite."
+  },
+  {
+    "type": "general",
+    "setup": "What do you give a sick lemon?",
+    "punchline": "Lemonaid."
+  },
+  {
+    "type": "general",
+    "setup": "What does a clock do when it's hungry?",
+    "punchline": "It goes back four seconds!"
+  },
+  {
+    "type": "general",
+    "setup": "What does a pirate pay for his corn?",
+    "punchline": "A buccaneer!"
+  },
+  {
+    "type": "general",
+    "setup": "What does an angry pepper do?",
+    "punchline": "It gets jalapeño face."
+  },
+  {
+    "type": "general",
+    "setup": "What happens when you anger a brain surgeon?",
+    "punchline": "They will give you a piece of your mind."
+  },
+  {
+    "type": "general",
+    "setup": "What has ears but cannot hear?",
+    "punchline": "A field of corn."
+  },
+  {
+    "type": "general",
+    "setup": "What is a centipedes's favorite Beatle song?",
+    "punchline": "I want to hold your hand, hand, hand, hand..."
+  },
+  {
+    "type": "general",
+    "setup": "What is a tornado's favorite game to play?",
+    "punchline": "Twister!"
+  },
+  {
+    "type": "general",
+    "setup": "What is a vampire's favorite fruit?",
+    "punchline": "A blood orange."
+  },
+  {
+    "type": "general",
+    "setup": "What is a witch's favorite subject in school?",
+    "punchline": "Spelling!"
+  },
+  {
+    "type": "general",
+    "setup": "What is red and smells like blue paint?",
+    "punchline": "Red paint!"
+  },
+  {
+    "type": "general",
+    "setup": "What is the difference between ignorance and apathy?",
+    "punchline": "I don't know and I don't care."
+  },
+  {
+    "type": "general",
+    "setup": "What is the hardest part about sky diving?",
+    "punchline": "The ground."
+  },
+  {
+    "type": "general",
+    "setup": "What is the leading cause of dry skin?",
+    "punchline": "Towels"
+  },
+  {
+    "type": "general",
+    "setup": "What is the least spoken language in the world?",
+    "punchline": "Sign Language"
+  },
+  {
+    "type": "general",
+    "setup": "What is the tallest building in the world?",
+    "punchline": "The library, it’s got the most stories!"
+  },
+  {
+    "type": "general",
+    "setup": "What is this movie about?",
+    "punchline": "It is about 2 hours long."
+  },
+  {
+    "type": "general",
+    "setup": "What kind of award did the dentist receive?",
+    "punchline": "A little plaque."
+  },
+  {
+    "type": "general",
+    "setup": "What kind of bagel can fly?",
+    "punchline": "A plain bagel."
+  },
+  {
+    "type": "general",
+    "setup": "What kind of dinosaur loves to sleep?",
+    "punchline": "A stega-snore-us."
+  },
+  {
+    "type": "general",
+    "setup": "What kind of dog lives in a particle accelerator?",
+    "punchline": "A Fermilabrador Retriever."
+  },
+  {
+    "type": "general",
+    "setup": "What kind of magic do cows believe in?",
+    "punchline": "MOODOO."
+  },
+  {
+    "type": "general",
+    "setup": "What kind of music do planets listen to?",
+    "punchline": "Nep-tunes."
+  },
+  {
+    "type": "general",
+    "setup": "What kind of pants do ghosts wear?",
+    "punchline": "Boo jeans."
+  },
+  {
+    "type": "general",
+    "setup": "What kind of tree fits in your hand?",
+    "punchline": "A palm tree!"
+  },
+  {
+    "type": "general",
+    "setup": "What lies at the bottom of the ocean and twitches?",
+    "punchline": "A nervous wreck."
+  },
+  {
+    "type": "general",
+    "setup": "What musical instrument is found in the bathroom?",
+    "punchline": "A tuba toothpaste."
+  },
+  {
+    "type": "general",
+    "setup": "What time did the man go to the dentist?",
+    "punchline": "Tooth hurt-y."
+  },
+  {
+    "type": "general",
+    "setup": "What type of music do balloons hate?",
+    "punchline": "Pop music!"
+  },
+  {
+    "type": "general",
+    "setup": "What was a more important invention than the first telephone?",
+    "punchline": "The second one."
+  },
+  {
+    "type": "general",
+    "setup": "What was the pumpkin’s favorite sport?",
+    "punchline": "Squash."
+  },
+  {
+    "type": "general",
+    "setup": "What's black and white and read all over?",
+    "punchline": "The newspaper."
+  },
+  {
+    "type": "general",
+    "setup": "What's blue and not very heavy?",
+    "punchline": "Light blue."
+  },
+  {
+    "type": "general",
+    "setup": "What's brown and sticky?",
+    "punchline": "A stick."
+  },
+  {
+    "type": "general",
+    "setup": "What's orange and sounds like a parrot?",
+    "punchline": "A Carrot."
+  },
+  {
+    "type": "general",
+    "setup": "What's red and bad for your teeth?",
+    "punchline": "A Brick."
+  },
+  {
+    "type": "general",
+    "setup": "What's the best thing about elevator jokes?",
+    "punchline": "They work on so many levels."
+  },
+  {
+    "type": "general",
+    "setup": "What's the difference between a guitar and a fish?",
+    "punchline": "You can tune a guitar but you can't \"tuna\"fish!"
+  },
+  {
+    "type": "general",
+    "setup": "What's the difference between a hippo and a zippo?",
+    "punchline": "One is really heavy, the other is a little lighter."
+  },
+  {
+    "type": "general",
+    "setup": "What's the difference between a seal and a sea lion?",
+    "punchline": "An ion! "
+  },
+  {
+    "type": "general",
+    "setup": "What's the worst part about being a cross-eyed teacher?",
+    "punchline": "They can't control their pupils."
+  },
+  {
+    "type": "general",
+    "setup": "What's the worst thing about ancient history class?",
+    "punchline": "The teachers tend to Babylon."
+  },
+  {
+    "type": "general",
+    "setup": "What’s brown and sounds like a bell?",
+    "punchline": "Dung!"
+  },
+  {
+    "type": "general",
+    "setup": "What’s E.T. short for?",
+    "punchline": "He’s only got little legs."
+  },
+  {
+    "type": "general",
+    "setup": "What’s Forest Gump’s Facebook password?",
+    "punchline": "1forest1"
+  },
+  {
+    "type": "general",
+    "setup": "What’s the advantage of living in Switzerland?",
+    "punchline": "Well, the flag is a big plus."
+  },
+  {
+    "type": "general",
+    "setup": "What’s the difference between an African elephant and an Indian elephant?",
+    "punchline": "About 5000 miles."
+  },
+  {
+    "type": "general",
+    "setup": "When do doctors get angry?",
+    "punchline": "When they run out of patients."
+  },
+  {
+    "type": "general",
+    "setup": "When does a joke become a dad joke?",
+    "punchline": "When it becomes apparent."
+  },
+  {
+    "type": "general",
+    "setup": "When is a door not a door?",
+    "punchline": "When it's ajar."
+  },
+  {
+    "type": "general",
+    "setup": "Where did you learn to make ice cream?",
+    "punchline": "Sunday school."
+  },
+  {
+    "type": "general",
+    "setup": "Where do bees go to the bathroom?",
+    "punchline": "The BP station."
+  },
+  {
+    "type": "general",
+    "setup": "Where do hamburgers go to dance?",
+    "punchline": "The meat-ball."
+  },
+  {
+    "type": "general",
+    "setup": "Where do rabbits go after they get married?",
+    "punchline": "On a bunny-moon."
+  },
+  {
+    "type": "general",
+    "setup": "Where do sheep go to get their hair cut?",
+    "punchline": "The baa-baa shop."
+  },
+  {
+    "type": "general",
+    "setup": "Where do you learn to make banana splits?",
+    "punchline": "At sundae school."
+  },
+  {
+    "type": "general",
+    "setup": "Where do young cows eat lunch?",
+    "punchline": "In the calf-ateria."
+  },
+  {
+    "type": "general",
+    "setup": "Where does batman go to the bathroom?",
+    "punchline": "The batroom."
+  },
+  {
+    "type": "general",
+    "setup": "Where does Fonzie like to go for lunch?",
+    "punchline": "Chick-Fil-Eyyyyyyyy."
+  },
+  {
+    "type": "general",
+    "setup": "Where does Napoleon keep his armies?",
+    "punchline": "In his sleevies."
+  },
+  {
+    "type": "general",
+    "setup": "Where was the Declaration of Independence signed?",
+    "punchline": "At the bottom! "
+  },
+  {
+    "type": "general",
+    "setup": "Where’s the bin?",
+    "punchline": "I haven’t been anywhere!"
+  },
+  {
+    "type": "general",
+    "setup": "Which side of the chicken has more feathers?",
+    "punchline": "The outside."
+  },
+  {
+    "type": "general",
+    "setup": "Who did the wizard marry?",
+    "punchline": "His ghoul-friend"
+  },
+  {
+    "type": "general",
+    "setup": "Who is the coolest Doctor in the hospital?",
+    "punchline": "The hip Doctor!"
+  },
+  {
+    "type": "general",
+    "setup": "Why are fish easy to weigh?",
+    "punchline": "Because they have their own scales."
+  },
+  {
+    "type": "general",
+    "setup": "Why are fish so smart?",
+    "punchline": "Because they live in schools!"
+  },
+  {
+    "type": "general",
+    "setup": "Why are ghosts bad liars?",
+    "punchline": "Because you can see right through them!"
+  },
+  {
+    "type": "general",
+    "setup": "Why are graveyards so noisy?",
+    "punchline": "Because of all the coffin."
+  },
+  {
+    "type": "general",
+    "setup": "Why are mummys scared of vacation?",
+    "punchline": "They're afraid to unwind."
+  },
+  {
+    "type": "general",
+    "setup": "Why are oranges the smartest fruit?",
+    "punchline": "Because they are made to concentrate. "
+  },
+  {
+    "type": "general",
+    "setup": "Why are pirates called pirates?",
+    "punchline": "Because they arrr!"
+  },
+  {
+    "type": "general",
+    "setup": "Why are skeletons so calm?",
+    "punchline": "Because nothing gets under their skin."
+  },
+  {
+    "type": "general",
+    "setup": "Why can't a bicycle stand on its own?",
+    "punchline": "It's two-tired."
+  },
+  {
+    "type": "general",
+    "setup": "Why can't you use \"Beef stew\"as a password?",
+    "punchline": "Because it's not stroganoff."
+  },
+  {
+    "type": "general",
+    "setup": "Why can't your nose be 12 inches long?",
+    "punchline": "Because then it'd be a foot!"
+  },
+  {
+    "type": "general",
+    "setup": "Why can’t you hear a pterodactyl go to the bathroom?",
+    "punchline": "The p is silent."
+  },
+  {
+    "type": "general",
+    "setup": "Why couldn't the kid see the pirate movie?",
+    "punchline": "Because it was rated arrr!"
+  },
+  {
+    "type": "general",
+    "setup": "Why couldn't the lifeguard save the hippie?",
+    "punchline": "He was too far out, man."
+  },
+  {
+    "type": "general",
+    "setup": "Why did Dracula lie in the wrong coffin?",
+    "punchline": "He made a grave mistake."
+  },
+  {
+    "type": "general",
+    "setup": "Why did Sweden start painting barcodes on the sides of their battleships?",
+    "punchline": "So they could Scandinavian."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the A go to the bathroom and come out as an E?",
+    "punchline": "Because he had a vowel movement."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the barber win the race?",
+    "punchline": "He took a short cut."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the belt go to prison?",
+    "punchline": "He held up a pair of pants!"
+  },
+  {
+    "type": "general",
+    "setup": "Why did the burglar hang his mugshot on the wall?",
+    "punchline": "To prove that he was framed!"
+  },
+  {
+    "type": "general",
+    "setup": "Why did the chicken get a penalty?",
+    "punchline": "For fowl play."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the coffee file a police report?",
+    "punchline": "It got mugged."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the cookie cry?",
+    "punchline": "Because his mother was a wafer so long"
+  },
+  {
+    "type": "general",
+    "setup": "Why did the cookie cry?",
+    "punchline": "It was feeling crumby."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the cowboy have a weiner dog?",
+    "punchline": "Somebody told him to get a long little doggy."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the fireman wear red, white, and blue suspenders?",
+    "punchline": "To hold his pants up."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the girl smear peanut butter on the road?",
+    "punchline": "To go with the traffic jam."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the half blind man fall in the well?",
+    "punchline": "Because he couldn't see that well!"
+  },
+  {
+    "type": "general",
+    "setup": "Why did the house go to the doctor?",
+    "punchline": "It was having window panes."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the kid cross the playground?",
+    "punchline": "To get to the other slide."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the man put his money in the freezer?",
+    "punchline": "He wanted cold hard cash!"
+  },
+  {
+    "type": "general",
+    "setup": "Why did the man run around his bed?",
+    "punchline": "Because he was trying to catch up on his sleep!"
+  },
+  {
+    "type": "general",
+    "setup": "Why did the melons plan a big wedding?",
+    "punchline": "Because they cantaloupe!"
+  },
+  {
+    "type": "general",
+    "setup": "Why did the octopus beat the shark in a fight?",
+    "punchline": "Because it was well armed."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the opera singer go sailing?",
+    "punchline": "They wanted to hit the high Cs."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the scarecrow win an award?",
+    "punchline": "Because he was outstanding in his field."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the tomato blush?",
+    "punchline": "Because it saw the salad dressing."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the tree go to the dentist?",
+    "punchline": "It needed a root canal."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the worker get fired from the orange juice factory?",
+    "punchline": "Lack of concentration."
+  },
+  {
+    "type": "general",
+    "setup": "Why didn't the number 4 get into the nightclub?",
+    "punchline": "Because he is 2 square."
+  },
+  {
+    "type": "general",
+    "setup": "Why didn’t the orange win the race?",
+    "punchline": "It ran out of juice."
+  },
+  {
+    "type": "general",
+    "setup": "Why didn’t the skeleton cross the road?",
+    "punchline": "Because he had no guts."
+  },
+  {
+    "type": "general",
+    "setup": "Why do bananas have to put on sunscreen before they go to the beach?",
+    "punchline": "Because they might peel!"
+  },
+  {
+    "type": "general",
+    "setup": "Why do bears have hairy coats?",
+    "punchline": "Fur protection."
+  },
+  {
+    "type": "general",
+    "setup": "Why do bees have sticky hair?",
+    "punchline": "Because they use honey combs!"
+  },
+  {
+    "type": "general",
+    "setup": "Why do bees hum?",
+    "punchline": "Because they don't know the words."
+  },
+  {
+    "type": "general",
+    "setup": "Why do birds fly south for the winter?",
+    "punchline": "Because it's too far to walk."
+  },
+  {
+    "type": "general",
+    "setup": "Why do choirs keep buckets handy?",
+    "punchline": "So they can carry their tune"
+  },
+  {
+    "type": "general",
+    "setup": "Why do crabs never give to charity?",
+    "punchline": "Because they’re shellfish."
+  },
+  {
+    "type": "general",
+    "setup": "Why do ducks make great detectives?",
+    "punchline": "They always quack the case."
+  },
+  {
+    "type": "general",
+    "setup": "Why do mathematicians hate the U.S.?",
+    "punchline": "Because it's indivisible."
+  },
+  {
+    "type": "general",
+    "setup": "Why do pirates not know the alphabet?",
+    "punchline": "They always get stuck at \"C\"."
+  },
+  {
+    "type": "general",
+    "setup": "Why do pumpkins sit on people’s porches?",
+    "punchline": "They have no hands to knock on the door."
+  },
+  {
+    "type": "general",
+    "setup": "Why do scuba divers fall backwards into the water?",
+    "punchline": "Because if they fell forwards they’d still be in the boat."
+  },
+  {
+    "type": "general",
+    "setup": "Why do trees seem suspicious on sunny days?",
+    "punchline": "Dunno, they're just a bit shady."
+  },
+  {
+    "type": "general",
+    "setup": "Why do valley girls hang out in odd numbered groups?",
+    "punchline": "Because they can't even."
+  },
+  {
+    "type": "general",
+    "setup": "Why do wizards clean their teeth three times a day?",
+    "punchline": "To prevent bat breath!"
+  },
+  {
+    "type": "general",
+    "setup": "Why do you never see elephants hiding in trees?",
+    "punchline": "Because they're so good at it."
+  },
+  {
+    "type": "general",
+    "setup": "Why does a chicken coop only have two doors?",
+    "punchline": "Because if it had four doors it would be a chicken sedan."
+  },
+  {
+    "type": "general",
+    "setup": "Why does a Moon-rock taste better than an Earth-rock?",
+    "punchline": "Because it's a little meteor."
+  },
+  {
+    "type": "general",
+    "setup": "Why does it take longer to get from 1st to 2nd base, than it does to get from 2nd to 3rd base?",
+    "punchline": "Because there’s a Shortstop in between!"
+  },
+  {
+    "type": "general",
+    "setup": "Why does Norway have barcodes on their battleships?",
+    "punchline": "So when they get back to port, they can Scandinavian."
+  },
+  {
+    "type": "general",
+    "setup": "Why does Superman get invited to dinners?",
+    "punchline": "Because he is a Supperhero."
+  },
+  {
+    "type": "general",
+    "setup": "Why does Waldo only wear stripes?",
+    "punchline": "Because he doesn't want to be spotted."
+  },
+  {
+    "type": "programming",
+    "setup": "Knock-knock.",
+    "punchline": "A race condition. Who is there?"
+  },
+  {
+    "type": "programming",
+    "setup": "What's the best part about TCP jokes?",
+    "punchline": "I get to keep telling them until you get them."
+  },
+  {
+    "type": "programming",
+    "setup": "A programmer puts two glasses on his bedside table before going to sleep.",
+    "punchline": "A full one, in case he gets thirsty, and an empty one, in case he doesn’t."
+  },
+  {
+    "type": "general",
+    "setup": "Two guys walk into a bar . . .",
+    "punchline": "The first guy says \"Ouch!\" and the second says \"Yeah, I didn't see it either.\""
+  },
+  {
+    "type": "programming",
+    "setup": "What did the router say to the doctor?",
+    "punchline": "It hurts when IP."
+  },
+  {
+    "type": "programming",
+    "setup": "An IPv6 packet is walking out of the house.",
+    "punchline": "He goes nowhere."
+  },
+  {
+    "type": "programming",
+    "setup": "A DHCP packet walks into a bar and asks for a beer.",
+    "punchline": "Bartender says, \"here, but I’ll need that back in an hour!\""
+  },
+  {
+    "type": "programming",
+    "setup": "3 SQL statements walk into a NoSQL bar. Soon, they walk out",
+    "punchline": "They couldn't find a table."
+  },
+  {
+    "type": "general",
+    "setup": "I saw a nice stereo on Craigslist for $1. Seller says the volume is stuck on ‘high’",
+    "punchline": "I couldn’t turn it down."
+  },
+  {
+    "type": "programming",
+    "setup": "What’s the object-oriented way to become wealthy?",
+    "punchline": "Inheritance."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a bee that can't make up its mind?",
+    "punchline": "A maybe."
+  },
+  {
+    "type": "general",
+    "setup": "Why was Cinderalla thrown out of the football team?",
+    "punchline": "Because she ran away from the ball."
+  },
+  {
+    "type": "general",
+    "setup": "What kind of music do welders like?",
+    "punchline": "Heavy metal."
+  },
+  {
+    "type": "general",
+    "setup": "Why are “Dad Jokes” so good?",
+    "punchline": "Because the punchline is apparent."
+  },
+  {
+    "type": "programming",
+    "setup": "Why dot net developers don't wear glasses?",
+    "punchline": "Because they see sharp."
+  },
+  {
+    "type": "general",
+    "setup": "Why is seven bigger than nine?",
+    "punchline": "Because seven ate nine."
+  },
+  {
+    "type": "dad",
+    "setup": "Why do fathers take an extra pair of socks when they go golfing?",
+    "punchline": "In case they get a hole in one!"
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a suspicious looking laptop?",
+    "punchline": "Asus"
+  },
+  {
+    "type": "programming",
+    "setup": "What did the Java code say to the C code?",
+    "punchline": "You've got no class."
+  },
+  {
+    "type": "programming",
+    "setup": "What is the most used language in programming?",
+    "punchline": "Profanity."
+  },
+  {
+    "type": "programming",
+    "setup": "Why do programmers always get Christmas and Halloween mixed up?",
+    "punchline": "Because DEC 25 = OCT 31"
+  },
+  {
+    "type": "programming",
+    "setup": "What goes after USA?",
+    "punchline": "USB."
+  },
+  {
+    "type": "dad",
+    "setup": "Why don't eggs tell jokes?",
+    "punchline": "Because they would crack each other up."
+  },
+  {
+    "type": "general",
+    "setup": "How do you make the number one disappear?",
+    "punchline": "Add the letter G and it’s “gone”!"
+  },
+  {
+    "type": "general",
+    "setup": "My older brother always tore the last pages of my comic books, and never told me why.",
+    "punchline": "I had to draw my own conclusions."
+  },
+  {
+    "type": "general",
+    "setup": "The Sergeant-Major growled at the young soldier: I didn’t see you at camouflage training this morning.",
+    "punchline": "Thank you very much, sir."
+  },
+  {
+    "type": "general",
+    "setup": "Why does Waldo only wear stripes?",
+    "punchline": "Because he doesn't want to be spotted."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the kid throw the watch out the window?",
+    "punchline": "So time would fly."
+  },
+  {
+    "type": "programming",
+    "setup": "Where did the API go to eat?",
+    "punchline": "To the RESTaurant."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the rooster cross the road?",
+    "punchline": "He heard that the chickens at KFC were pretty hot."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the Viking who was reincarnated?",
+    "punchline": "He was Bjorn again"
+  },
+  {
+    "type": "general",
+    "setup": "What does the mermaid wear to math class?",
+    "punchline": "Algae-bra."
+  },
+  {
+    "type": "general",
+    "setup": "Did you hear about the crime in the parking garage?",
+    "punchline": "It was wrong on so many levels."
+  },
+  {
+    "type": "programming",
+    "setup": "Hey, wanna hear a joke?",
+    "punchline": "Parsing HTML with regex."
+  },
+  {
+    "type": "general",
+    "setup": "Why didn't the skeleton go for prom?",
+    "punchline": "Because it had nobody."
+  },
+  {
+    "type": "general",
+    "setup": "A grocery store cashier asked if I would like my milk in a bag.",
+    "punchline": "I told her 'No, thanks. The carton works fine.'"
+  },
+  {
+    "type": "general",
+    "setup": "99.9% of the people are dumb!",
+    "punchline": "Fortunately I belong to the remaining 1%"
+  },
+  {
+    "type": "programming",
+    "setup": "I just got fired from my job at the keyboard factory.",
+    "punchline": "They told me I wasn't putting in enough shifts."
+  },
+  {
+    "type": "general",
+    "setup": "You see, mountains aren't just funny.",
+    "punchline": "They are hill areas."
+  },
+  {
+    "type": "general",
+    "setup": "What do elves post on Social Media?",
+    "punchline": "Elf-ies."
+  },
+  {
+    "type": "general",
+    "setup": "While I was sleeping my friends decided to write math equations on me.",
+    "punchline": "You should have seen the expression on my face when I woke up."
+  },
+  {
+    "type": "general",
+    "setup": "Due to complaints, Hawaii passed a law where you're not allowed to laugh above a certain decibel.",
+    "punchline": "You can only use a low ha."
+  },
+  {
+    "type": "general",
+    "setup": "Why are football stadiums so cool?",
+    "punchline": "Because every seat has a fan in it."
+  },
+  {
+    "type": "programming",
+    "setup": "How do you generate a random string?",
+    "punchline": "Put a Windows user in front of Vim and tell them to exit."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the functions stop calling each other?",
+    "punchline": "Because they had constant arguments."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the private classes break up?",
+    "punchline": "Because they never saw each other."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the developer quit his job?",
+    "punchline": "Because he didn't get arrays."
+  },
+  {
+    "type": "programming",
+    "setup": "What's the best thing about a Boolean?",
+    "punchline": "Even if you're wrong, you're only off by a bit."
+  },
+  {
+    "type": "programming",
+    "setup": "How many React developers does it take to change a lightbulb?",
+    "punchline": "None, they prefer dark mode."
+  },
+  {
+    "type": "programming",
+    "setup": "Why don't React developers like nature?",
+    "punchline": "They prefer the virtual DOM."
+  },
+  {
+    "type": "programming",
+    "setup": "What do you get when you cross a React developer with a mathematician?",
+    "punchline": "A function component."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the developer go broke buying Bitcoin?",
+    "punchline": "He kept calling it bytecoin and didn't get any."
+  },
+  {
+      "type": "programming",
+      "setup": "Why did the programmer go to art school?",
+      "punchline": "He wanted to learn how to code outside the box."
+  },
+  {
+      "type": "programming",
+      "setup": "Why did the programmer's wife leave him?",
+      "punchline": "He didn't know how to commit."
+  },
+  {
+      "type": "programming",
+      "setup": "Why do programmers prefer dark chocolate?",
+      "punchline": "Because it's bitter like their code."
+  },
+  {
+      "type": "programming",
+      "setup": "Why did the programmer go broke?",
+      "punchline": "He used up all his cache"
+  },
+  {
+      "type": "programming",
+      "setup": "Why did the programmer always mix up Halloween and Christmas?",
+      "punchline": "Because Oct 31 equals Dec 25."
+  },
+  {
+      "type": "programming",
+      "setup": "Why don't programmers like nature?",
+      "punchline": "There's too many bugs."
+  },
+  {
+      "type": "programming",
+      "setup": "Why was the JavaScript developer sad?",
+      "punchline": "He didn't know how to null his feelings."
+  },
+  {
+    "type": "general",
+    "setup": "Why couldn't the bicycle stand up by itself?",
+    "punchline": "It was two-tired."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the math book look sad?",
+    "punchline": "Because it had too many problems."
+  },
+  {
+    "type": "general",
+    "setup": "What's a computer's favorite snack?",
+    "punchline": "Microchips."
+  },
+  {
+    "type": "general",
+    "setup": "What did the janitor say when he jumped out of the closet?",
+    "punchline": "Supplies!"
+  },
+  {
+    "type": "general",
+    "setup": "What did one ocean say to the other ocean?",
+    "punchline": "Nothing, they just waved."
+  },
+  {
+    "type": "general",
+    "setup": "What's the best thing about Switzerland?",
+    "punchline": "I don't know, but their flag is a big plus."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the golfer bring two pairs of pants?",
+    "punchline": "In case he got a hole in one."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the chicken cross the playground?",
+    "punchline": "To get to the other slide."
+  },
+  {
+    "type": "general",
+    "setup": "Why don't scientists trust atoms?",
+    "punchline": "Because they make up everything."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the scarecrow win an award?",
+    "punchline": "Because he was outstanding in his field."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the coffee file a police report?",
+    "punchline": "It got mugged."
+  },
+  {
+    "type": "general",
+    "setup": "Why don't oysters give to charity?",
+    "punchline": "Because they're shellfish."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the golfer wear two pairs of pants?",
+    "punchline": "In case he got a hole in one."
+  },
+  {
+    "type": "general",
+    "setup": "Why did the cookie go to the doctor?",
+    "punchline": " Because it was feeling crumbly."
+  },
+  {
+    "type": "programming",
+    "setup": "What do you call a computer mouse that swears a lot?",
+    "punchline": "A cursor!"
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the designer break up with their font?",
+    "punchline": "Because it wasn't their type."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the programmer quit their job?",
+    "punchline": "They didn't get arrays."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the developer go broke?",
+    "punchline": "They kept spending all their cache."
+  },
+  {
+    "type": "programming",
+    "setup": "How do you comfort a designer?",
+    "punchline": "You give them some space... between the elements."
+  },
+  {
+    "type": "programming",
+    "setup": "Why don't programmers like nature?",
+    "punchline": "Too many bugs."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the programmer bring a ladder to work?",
+    "punchline": "They heard the code needed to be debugged from a higher level."
+  },
+  {
+    "type": "general",
+    "setup": "Why was the developer always calm?",
+    "punchline": "Because they knew how to handle exceptions."
+  },
+  {
+    "type": "programming",
+    "setup": "Why was the font always tired?",
+    "punchline": "It was always bold."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the developer go to therapy?",
+    "punchline": "They had too many unresolved issues."
+  },
+  {
+    "type": "programming",
+    "setup": "Why was the designer always cold?",
+    "punchline": "Because they always used too much ice-olation."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the programmer bring a broom to work?",
+    "punchline": "To clean up all the bugs."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the developer break up with their keyboard?",
+    "punchline": "It just wasn't their type anymore."
+  },
+  {
+    "type": "programming",
+    "setup": "Why did the programmer always carry a pencil?",
+    "punchline": "They preferred to write in C#."
+  },
+  {
+    "type": "general",
+    "setup": "Why don't skeletons fight each other?",
+    "punchline": "They don't have the guts."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call fake spaghetti?",
+    "punchline": "An impasta."
+  },
+  {
+    "type": "general",
+    "setup": "What do you call a thieving alligator?",
+    "punchline": "A crookodile!"
+  }
+]

--- a/tools/build-jokes-from-icanhaz.js
+++ b/tools/build-jokes-from-icanhaz.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function clean(text) {
+  return text
+    .replace(/\r?\n+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/\s([?!.,;:])/g, '$1')
+    .trim();
+}
+
+function format(entries) {
+  const lines = ['window.jokes = ['];
+  entries.forEach((entry, index) => {
+    if (index === 0) {
+      lines.push('        {');
+    }
+    lines.push(`            "joke": ${JSON.stringify(entry.joke)},`);
+    lines.push(`            "punchline": ${JSON.stringify(entry.punchline)}`);
+    if (index === entries.length - 1) {
+      lines.push('        }');
+    } else {
+      lines.push('        }, {');
+    }
+  });
+  lines.push('    ];');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function build() {
+  const sourcePath = path.join(__dirname, '..', 'data', 'icanhazdadjokes-split.json');
+  const outputPath = path.join(__dirname, '..', 'apps', 'jokes', 'jokes.js');
+  const raw = fs.readFileSync(sourcePath, 'utf8');
+  const data = JSON.parse(raw);
+  const entries = data
+    .map((item) => ({
+      joke: clean(item.setup),
+      punchline: clean(item.punchline),
+    }))
+    .filter((item) => item.joke && item.punchline);
+
+  fs.writeFileSync(outputPath, format(entries));
+  console.log(`Wrote ${entries.length} jokes to ${path.relative(process.cwd(), outputPath)}`);
+}
+
+if (require.main === module) {
+  build();
+}

--- a/tools/build-quotes-from-data.js
+++ b/tools/build-quotes-from-data.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function clean(text) {
+  return text.replace(/\r?\n+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function format(entries) {
+  const lines = ['window.quotesData = ['];
+  entries.forEach((category, categoryIndex) => {
+    lines.push('  {');
+    lines.push(`    "id": ${JSON.stringify(category.id)},`);
+    lines.push(`    "label": ${JSON.stringify(category.label)},`);
+    lines.push('    "quotes": [');
+    category.quotes.forEach((quote, quoteIndex) => {
+      lines.push('      {');
+      lines.push(`        "text": ${JSON.stringify(clean(quote.text))},`);
+      lines.push(`        "author": ${JSON.stringify(clean(quote.author))}`);
+      if (quoteIndex === category.quotes.length - 1) {
+        lines.push('      }');
+      } else {
+        lines.push('      },');
+      }
+    });
+    lines.push('    ]');
+    if (categoryIndex === entries.length - 1) {
+      lines.push('  }');
+    } else {
+      lines.push('  },');
+    }
+  });
+  lines.push('];');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function build() {
+  const sourcePath = path.join(__dirname, '..', 'data', 'curated-quotes.json');
+  const outputPath = path.join(__dirname, '..', 'apps', 'quotes', 'quotes-data.js');
+  const raw = fs.readFileSync(sourcePath, 'utf8');
+  const data = JSON.parse(raw);
+  const prepared = data.map((category) => ({
+    id: category.id,
+    label: category.label,
+    quotes: category.quotes.map((quote) => ({
+      text: clean(quote.text),
+      author: clean(quote.author),
+    })),
+  }));
+  fs.writeFileSync(outputPath, format(prepared));
+  console.log(`Wrote ${prepared.reduce((total, category) => total + category.quotes.length, 0)} quotes across ${prepared.length} categories.`);
+}
+
+if (require.main === module) {
+  build();
+}

--- a/tools/dedupe-data.js
+++ b/tools/dedupe-data.js
@@ -1,0 +1,524 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function normalize(text) {
+  return (text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function canonicalJoke(entry) {
+  const setup = normalize(entry.joke || '');
+  const punchline = normalize(entry.punchline || '');
+  return `${setup}|${punchline}`.trim();
+}
+
+function canonicalQuote(entry) {
+  const text = normalize(entry.text || '');
+  const author = normalize(entry.author || '');
+  return `${text}|${author}`.trim();
+}
+
+function levenshtein(a, b, maxDistance = Number.POSITIVE_INFINITY) {
+  if (a === b) {
+    return 0;
+  }
+
+  const aLength = a.length;
+  const bLength = b.length;
+
+  if (!aLength) {
+    return bLength;
+  }
+  if (!bLength) {
+    return aLength;
+  }
+
+  if (Number.isFinite(maxDistance) && Math.abs(aLength - bLength) > maxDistance) {
+    return maxDistance + 1;
+  }
+
+  const previous = new Array(bLength + 1);
+  const current = new Array(bLength + 1);
+
+  for (let i = 0; i <= bLength; i += 1) {
+    previous[i] = i;
+  }
+
+  for (let i = 1; i <= aLength; i += 1) {
+    current[0] = i;
+    const charA = a.charCodeAt(i - 1);
+    let rowMin = current[0];
+
+    for (let j = 1; j <= bLength; j += 1) {
+      const charB = b.charCodeAt(j - 1);
+      const cost = charA === charB ? 0 : 1;
+      const deletion = previous[j] + 1;
+      const insertion = current[j - 1] + 1;
+      const substitution = previous[j - 1] + cost;
+      const value = Math.min(deletion, insertion, substitution);
+      current[j] = value;
+      if (value < rowMin) {
+        rowMin = value;
+      }
+    }
+
+    if (rowMin > maxDistance) {
+      return maxDistance + 1;
+    }
+
+    for (let j = 0; j <= bLength; j += 1) {
+      previous[j] = current[j];
+    }
+  }
+
+  return current[bLength];
+}
+
+function createTokenSet(baseText, fragments = [], options = {}) {
+  const { minWordLength = 4, maxTokens = 12 } = options;
+  const tokens = new Set();
+
+  const words = (baseText.match(/[a-z0-9']+/g) || []);
+  const uniqueWords = [];
+  words.forEach((word) => {
+    if (!uniqueWords.includes(word)) {
+      uniqueWords.push(word);
+    }
+  });
+
+  uniqueWords
+    .filter((word) => word.length >= minWordLength)
+    .sort((a, b) => b.length - a.length)
+    .slice(0, maxTokens)
+    .forEach((word) => tokens.add(word));
+
+  fragments.forEach((fragment) => {
+    if (!fragment) {
+      return;
+    }
+    const normalized = normalize(fragment).slice(0, 12);
+    if (normalized.length >= 4) {
+      tokens.add(normalized);
+    }
+  });
+
+  return tokens;
+}
+
+function hasTokenOverlap(tokensA, tokensB) {
+  if (!tokensA.size || !tokensB.size) {
+    return true;
+  }
+  const [smaller, larger] = tokensA.size <= tokensB.size ? [tokensA, tokensB] : [tokensB, tokensA];
+  for (const token of smaller) {
+    if (larger.has(token)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function createJokeMeta(entry, index) {
+  const canonical = canonicalJoke(entry);
+  if (!canonical) {
+    return null;
+  }
+
+  const setupNormalized = normalize(entry.joke || '');
+  const punchNormalized = normalize(entry.punchline || '');
+  const setupPreview = setupNormalized.slice(0, 96);
+  const punchPreview = punchNormalized.slice(0, 32);
+  const comparison = `${setupPreview}|${punchPreview}`.trim();
+  const tokenSource = `${setupNormalized} ${punchNormalized}`.trim();
+  const tokens = createTokenSet(tokenSource, [
+    punchPreview.slice(0, 24),
+    punchPreview.slice(-24),
+    setupPreview.slice(0, 24),
+    setupPreview.slice(-24),
+  ]);
+
+  return {
+    canonical,
+    comparison,
+    tokens,
+    punchPreview,
+    setupPreview,
+    originalIndex: index,
+  };
+}
+
+function shouldCompareJokes(a, b) {
+  if (hasTokenOverlap(a.tokens, b.tokens)) {
+    return true;
+  }
+
+  if (a.punchPreview && b.punchPreview) {
+    const previewLength = Math.min(8, a.punchPreview.length, b.punchPreview.length);
+    if (previewLength >= 4 && a.punchPreview.slice(0, previewLength) === b.punchPreview.slice(0, previewLength)) {
+      return true;
+    }
+  }
+
+  if (a.setupPreview && b.setupPreview) {
+    const previewLength = Math.min(10, a.setupPreview.length, b.setupPreview.length);
+    if (previewLength >= 6 && a.setupPreview.slice(0, previewLength) === b.setupPreview.slice(0, previewLength)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function createQuoteMeta(entry, index) {
+  const canonical = canonicalQuote(entry);
+  if (!canonical) {
+    return null;
+  }
+
+  const textNormalized = normalize(entry.text || '');
+  const authorNormalized = normalize(entry.author || '');
+  const textPreview = textNormalized.slice(0, 120);
+  const authorPreview = authorNormalized.slice(0, 40);
+  const comparison = `${textPreview}|${authorPreview}`.trim();
+  const tokenSource = `${textNormalized} ${authorNormalized}`.trim();
+  const tokens = createTokenSet(tokenSource, [
+    textPreview.slice(0, 36),
+    textPreview.slice(-36),
+    authorPreview,
+  ]);
+
+  return {
+    canonical,
+    comparison,
+    tokens,
+    authorPreview,
+    textPreview,
+    originalIndex: index,
+  };
+}
+
+function shouldCompareQuotes(a, b) {
+  if (hasTokenOverlap(a.tokens, b.tokens)) {
+    return true;
+  }
+
+  if (a.authorPreview && b.authorPreview && a.authorPreview === b.authorPreview) {
+    return true;
+  }
+
+  if (a.textPreview && b.textPreview) {
+    const previewLength = Math.min(12, a.textPreview.length, b.textPreview.length);
+    if (previewLength >= 6 && a.textPreview.slice(0, previewLength) === b.textPreview.slice(0, previewLength)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function distanceThreshold(metaA, metaB) {
+  if (!metaA.comparison || !metaB.comparison) {
+    return -1;
+  }
+
+  const minLength = Math.min(metaA.comparison.length, metaB.comparison.length);
+  const maxLength = Math.max(metaA.comparison.length, metaB.comparison.length);
+  const lengthDelta = Math.abs(metaA.comparison.length - metaB.comparison.length);
+
+  if (lengthDelta > Math.max(6, Math.floor(maxLength * 0.35))) {
+    return -1;
+  }
+
+  return Math.max(2, Math.floor(minLength * 0.08));
+}
+
+function logDuplicates(describe, duplicates, metas) {
+  if (!duplicates.length) {
+    console.log(`No duplicate ${describe} detected.`);
+    return;
+  }
+
+  let exactCount = 0;
+  duplicates.forEach((dup) => {
+    if (dup.reason === 'exact') {
+      exactCount += 1;
+    }
+  });
+  const similarCount = duplicates.length - exactCount;
+  const parts = [];
+  if (exactCount) {
+    parts.push(`${exactCount} exact`);
+  }
+  if (similarCount) {
+    parts.push(`${similarCount} similar`);
+  }
+  const breakdown = parts.length ? ` (${parts.join(', ')})` : '';
+
+  console.log(`Removed ${duplicates.length} duplicate ${describe}${breakdown}.`);
+
+  duplicates.slice(0, 5).forEach((dup) => {
+    const previewMeta = metas[dup.index];
+    const preview = previewMeta && previewMeta.comparison ? previewMeta.comparison.slice(0, 80) : '';
+    const distanceInfo = dup.reason === 'similar' ? ` (distance: ${dup.distance})` : '';
+    console.log(`  - entry ${dup.index} matched ${dup.reason} duplicate of entry ${dup.against}${distanceInfo}`);
+    if (preview) {
+      console.log(`      preview: ${preview}`);
+    }
+  });
+
+  if (duplicates.length > 5) {
+    console.log(`  … ${duplicates.length - 5} more duplicates`);
+  }
+}
+
+function dedupe(entries, options) {
+  const {
+    describe,
+    createMeta,
+    shouldCompare,
+    distanceThresholdFn,
+    fallbackWindow = 0,
+  } = options;
+
+  const metas = entries.map((entry, index) => createMeta(entry, index));
+  const tokenIndex = new Map();
+
+  metas.forEach((meta, index) => {
+    if (!meta) {
+      return;
+    }
+    meta.tokens.forEach((token) => {
+      if (!tokenIndex.has(token)) {
+        tokenIndex.set(token, []);
+      }
+      tokenIndex.get(token).push(index);
+    });
+  });
+
+  const canonicalMap = new Map();
+  const removed = new Set();
+  const duplicates = [];
+  const cleaned = [];
+
+  for (let i = 0; i < metas.length; i += 1) {
+    const meta = metas[i];
+    if (!meta) {
+      continue;
+    }
+    if (removed.has(i)) {
+      continue;
+    }
+
+    const existingIndex = canonicalMap.get(meta.canonical);
+    if (existingIndex !== undefined) {
+      const originalMeta = metas[existingIndex];
+      duplicates.push({
+        index: meta.originalIndex,
+        reason: 'exact',
+        against: originalMeta ? originalMeta.originalIndex : existingIndex,
+        distance: 0,
+      });
+      removed.add(i);
+      continue;
+    }
+
+    canonicalMap.set(meta.canonical, i);
+    cleaned.push(entries[i]);
+
+    const candidateIndices = new Set();
+    meta.tokens.forEach((token) => {
+      const indices = tokenIndex.get(token);
+      if (!indices) {
+        return;
+      }
+      indices.forEach((candidateIndex) => {
+        if (candidateIndex > i && !removed.has(candidateIndex)) {
+          candidateIndices.add(candidateIndex);
+        }
+      });
+    });
+
+    if (!candidateIndices.size && fallbackWindow > 0) {
+      const upperBound = Math.min(metas.length, i + 1 + fallbackWindow);
+      for (let j = i + 1; j < upperBound; j += 1) {
+        if (!removed.has(j) && metas[j]) {
+          candidateIndices.add(j);
+        }
+      }
+    }
+
+    candidateIndices.forEach((candidateIndex) => {
+      if (removed.has(candidateIndex)) {
+        return;
+      }
+      const candidate = metas[candidateIndex];
+      if (!candidate) {
+        return;
+      }
+
+      if (candidate.canonical === meta.canonical) {
+        duplicates.push({
+          index: candidate.originalIndex,
+          reason: 'exact',
+          against: meta.originalIndex,
+          distance: 0,
+        });
+        removed.add(candidateIndex);
+        return;
+      }
+
+      if (!shouldCompare(meta, candidate)) {
+        return;
+      }
+
+      const threshold = distanceThresholdFn(meta, candidate);
+      if (threshold < 0) {
+        return;
+      }
+
+      const distance = levenshtein(meta.comparison, candidate.comparison, threshold);
+      if (distance <= threshold) {
+        duplicates.push({
+          index: candidate.originalIndex,
+          reason: 'similar',
+          against: meta.originalIndex,
+          distance,
+        });
+        removed.add(candidateIndex);
+      }
+    });
+  }
+
+  logDuplicates(describe, duplicates, metas);
+  return cleaned;
+}
+
+function loadWindowData(filePath, property) {
+  const code = fs.readFileSync(filePath, 'utf8');
+  const context = { window: {} };
+  vm.createContext(context);
+  const script = new vm.Script(`${code}; window.${property};`);
+  const result = script.runInContext(context);
+  return Array.isArray(result) ? result : [];
+}
+
+function formatJokes(entries) {
+  const lines = ['window.jokes = ['];
+  entries.forEach((entry, index) => {
+    if (index === 0) {
+      lines.push('        {');
+    }
+    lines.push(`            "joke": ${JSON.stringify(entry.joke)},`);
+    lines.push(`            "punchline": ${JSON.stringify(entry.punchline || '')}`);
+    if (index === entries.length - 1) {
+      lines.push('        }');
+    } else {
+      lines.push('        }, {');
+    }
+  });
+  lines.push('    ];');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function formatQuotes(entries) {
+  const lines = ['window.quotesData = ['];
+  entries.forEach((category, categoryIndex) => {
+    lines.push('  {');
+    lines.push(`    "id": ${JSON.stringify(category.id)},`);
+    lines.push(`    "label": ${JSON.stringify(category.label)},`);
+    lines.push('    "quotes": [');
+    category.quotes.forEach((quote, quoteIndex) => {
+      lines.push('      {');
+      lines.push(`        "text": ${JSON.stringify(quote.text)},`);
+      lines.push(`        "author": ${JSON.stringify(quote.author)}`);
+      if (quoteIndex === category.quotes.length - 1) {
+        lines.push('      }');
+      } else {
+        lines.push('      },');
+      }
+    });
+    lines.push('    ]');
+    if (categoryIndex === entries.length - 1) {
+      lines.push('  }');
+    } else {
+      lines.push('  },');
+    }
+  });
+  lines.push('];');
+  return lines.join('\n');
+}
+
+function run() {
+  const args = process.argv.slice(2);
+  const write = args.includes('--write');
+
+  const jokesPath = path.join(__dirname, '..', 'apps', 'jokes', 'jokes.js');
+  const quotesPath = path.join(__dirname, '..', 'apps', 'quotes', 'quotes-data.js');
+
+  const jokes = loadWindowData(jokesPath, 'jokes');
+  const quotes = loadWindowData(quotesPath, 'quotesData');
+
+  const cleanedJokes = dedupe(jokes, {
+    describe: 'jokes',
+    createMeta: createJokeMeta,
+    shouldCompare: shouldCompareJokes,
+    distanceThresholdFn: distanceThreshold,
+    fallbackWindow: 12,
+  });
+
+  const flatQuotes = [];
+  quotes.forEach((category) => {
+    (category.quotes || []).forEach((quote) => {
+      flatQuotes.push({
+        categoryId: category.id,
+        text: quote.text,
+        author: quote.author,
+      });
+    });
+  });
+
+  const cleanedQuotes = dedupe(flatQuotes, {
+    describe: 'quotes',
+    createMeta: createQuoteMeta,
+    shouldCompare: shouldCompareQuotes,
+    distanceThresholdFn: distanceThreshold,
+    fallbackWindow: 8,
+  });
+
+  if (write) {
+    const jokesForWrite = cleanedJokes.map((entry) => ({
+      joke: entry.joke,
+      punchline: entry.punchline,
+    }));
+    fs.writeFileSync(jokesPath, formatJokes(jokesForWrite));
+
+    const categoryMap = new Map();
+    quotes.forEach((category) => {
+      categoryMap.set(category.id, { id: category.id, label: category.label, quotes: [] });
+    });
+
+    cleanedQuotes.forEach((entry) => {
+      const category = categoryMap.get(entry.categoryId);
+      if (category) {
+        category.quotes.push({ text: entry.text, author: entry.author });
+      }
+    });
+
+    const orderedCategories = quotes
+      .map((category) => categoryMap.get(category.id))
+      .filter(Boolean);
+
+    fs.writeFileSync(quotesPath, formatQuotes(orderedCategories));
+    console.log('Datasets updated without duplicates.');
+  }
+}
+
+if (require.main === module) {
+  run();
+}

--- a/tools/merge-jokes-sources.js
+++ b/tools/merge-jokes-sources.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function normalize(text) {
+  return (text || '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function canonical(setup, punchline) {
+  return `${normalize(setup)}|${normalize(punchline)}`;
+}
+
+function clean(text) {
+  return text
+    .replace(/\r?\n+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/\s([?!.,;:])/g, '$1')
+    .trim();
+}
+
+function readJson(filePath) {
+  const absolute = path.join(__dirname, '..', filePath);
+  return JSON.parse(fs.readFileSync(absolute, 'utf8'));
+}
+
+function writeJson(filePath, data) {
+  const absolute = path.join(__dirname, '..', filePath);
+  fs.writeFileSync(absolute, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function merge() {
+  const basePath = path.join('data', 'icanhazdadjokes-split.json');
+  const officialPath = path.join('data', 'official-jokes-index.json');
+  const base = readJson(basePath);
+  const official = readJson(officialPath);
+
+  const combined = [];
+  const seen = new Set();
+
+  base.forEach((entry) => {
+    const setup = clean(entry.setup || '');
+    const punchline = clean(entry.punchline || '');
+    const id = entry.id || '';
+    if (!setup || !punchline) {
+      return;
+    }
+    const key = canonical(setup, punchline);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    combined.push({ id, setup, punchline });
+  });
+
+  official.forEach((entry, index) => {
+    const setup = clean(entry.setup || '');
+    const punchline = clean(entry.punchline || '');
+    if (!setup || !punchline) {
+      return;
+    }
+    const key = canonical(setup, punchline);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    const id = `official-${entry.type || 'general'}-${String(index + 1).padStart(3, '0')}`;
+    combined.push({ id, setup, punchline });
+  });
+
+  writeJson(basePath, combined);
+  console.log(`Merged ${combined.length} jokes into ${basePath}`);
+}
+
+if (require.main === module) {
+  merge();
+}


### PR DESCRIPTION
## Summary
- merge the icanhazdadjoke and official_joke_api feeds and rebuild `apps/jokes/jokes.js` so the app ships with the expanded joke set
- rebuild `apps/quotes/quotes-data.js` from the curated quotes JSON to surface the new themed categories
- run the dedupe utility to tidy the regenerated data files

## Testing
- node tools/dedupe-data.js --write

------
https://chatgpt.com/codex/tasks/task_e_68ceb39133e083288983912d46c53740