### PR TITLE
Present quotes sequentially like jokes

### DIFF
--- a/apps/quotes/all-quotes.html
+++ b/apps/quotes/all-quotes.html
@@ -10,6 +10,7 @@
       font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
       --author-font: "Georgia", "Times New Roman", serif;
       --author-color: rgba(32, 32, 32, 0.65);
+      --meta-background: rgba(48, 86, 211, 0.08);
     }
 
     body {
@@ -27,13 +28,13 @@
 
       :root {
         --author-color: rgba(241, 245, 255, 0.7);
+        --meta-background: rgba(255, 255, 255, 0.08);
       }
 
       table {
         background: rgba(255, 255, 255, 0.04);
       }
 
-      th,
       td,
       table {
         border-color: rgba(255, 255, 255, 0.2);
@@ -67,7 +68,6 @@
       background: rgba(255, 255, 255, 0.9);
     }
 
-    th,
     td {
       padding: 12px 14px;
       border: 1px solid rgba(0, 0, 0, 0.15);
@@ -75,25 +75,37 @@
       text-align: left;
     }
 
-    th {
-      font-weight: 600;
-      background: rgba(0, 0, 0, 0.04);
+    .quote-cell {
+      white-space: pre-wrap;
+      line-height: 1.55;
     }
 
-    .text-cell {
-      white-space: pre-wrap;
+    .meta-row td {
+      font-family: var(--author-font);
+      color: var(--author-color);
+      text-align: right;
+      background: var(--meta-background);
+      font-size: 0.95rem;
+      letter-spacing: 0.01em;
+    }
+
+    .meta-author {
+      font-style: normal;
+      font-weight: 600;
+    }
+
+    .meta-category {
+      font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      font-size: 0.8rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      opacity: 0.75;
     }
 
     caption {
       text-align: left;
       font-weight: 600;
       margin-bottom: 0.75rem;
-    }
-
-    .author-cell {
-      font-family: var(--author-font);
-      color: var(--author-color);
-      text-align: right;
     }
   </style>
 </head>
@@ -103,17 +115,10 @@
     <p>Flip through every quote across the themed decks in one place.</p>
     <p class="count"><span data-count>0</span> quotes</p>
     <table>
-      <caption>Complete list of quotes</caption>
-      <thead>
-        <tr>
-          <th scope="col">Category</th>
-          <th scope="col">Quote</th>
-          <th scope="col">Author</th>
-        </tr>
-      </thead>
+      <caption>Quote followed by author and category</caption>
       <tbody>
         <tr>
-          <td colspan="3">Loading quotes…</td>
+          <td>Loading quotes…</td>
         </tr>
       </tbody>
     </table>

--- a/apps/quotes/render-all.js
+++ b/apps/quotes/render-all.js
@@ -9,7 +9,7 @@
   const categories = Array.isArray(window.quotesData)
     ? window.quotesData
         .map((entry) => ({
-          label: entry && typeof entry.label === 'string' ? entry.label : '',
+          label: entry && typeof entry.label === 'string' ? entry.label.trim() : '',
           quotes: Array.isArray(entry && entry.quotes)
             ? entry.quotes
                 .map((quote) => {
@@ -52,7 +52,6 @@
   if (!deck.length) {
     const emptyRow = document.createElement('tr');
     const emptyCell = document.createElement('td');
-    emptyCell.colSpan = 3;
     emptyCell.textContent = 'No quotes available.';
     emptyRow.appendChild(emptyCell);
     tbody.appendChild(emptyRow);
@@ -62,24 +61,39 @@
   const fragment = document.createDocumentFragment();
 
   deck.forEach((entry) => {
-    const row = document.createElement('tr');
+    const quoteRow = document.createElement('tr');
+    quoteRow.className = 'quote-row';
 
-    const categoryCell = document.createElement('td');
-    categoryCell.textContent = entry.category;
+    const quoteCell = document.createElement('td');
+    quoteCell.className = 'quote-cell';
+    quoteCell.textContent = entry.text;
+    quoteRow.appendChild(quoteCell);
 
-    const textCell = document.createElement('td');
-    textCell.className = 'text-cell';
-    textCell.textContent = entry.text;
+    const metaRow = document.createElement('tr');
+    metaRow.className = 'meta-row';
 
-    const authorCell = document.createElement('td');
-    authorCell.className = 'author-cell';
-    authorCell.textContent = entry.author;
+    const metaCell = document.createElement('td');
+    metaCell.className = 'meta-cell';
 
-    row.appendChild(categoryCell);
-    row.appendChild(textCell);
-    row.appendChild(authorCell);
+    metaCell.appendChild(document.createTextNode('— '));
 
-    fragment.appendChild(row);
+    const authorSpan = document.createElement('span');
+    authorSpan.className = 'meta-author';
+    authorSpan.textContent = entry.author;
+    metaCell.appendChild(authorSpan);
+
+    if (entry.category) {
+      metaCell.appendChild(document.createTextNode(' · '));
+      const categorySpan = document.createElement('span');
+      categorySpan.className = 'meta-category';
+      categorySpan.textContent = entry.category;
+      metaCell.appendChild(categorySpan);
+    }
+
+    metaRow.appendChild(metaCell);
+
+    fragment.appendChild(quoteRow);
+    fragment.appendChild(metaRow);
   });
 
   tbody.appendChild(fragment);


### PR DESCRIPTION
## Summary
- restyle the All Quotes page to show each entry as quote followed by its attribution instead of a three-column table
- update the renderer to create paired rows with the quote text and author/category metadata while trimming category labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee053bda08328aebbfa9c5c15cbf7