### PR TITLE
Add deterministic IDs and manifests for jokes and quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ npx serve .
 ```
 
 This starts a server on <http://localhost:3000> (or the next available port).
+
+## Data maintenance
+
+- Run `node tools/update-content-metadata.js` after refreshing the jokes or quotes datasets to assign deterministic IDs and
+  regenerate the manifest files under `data/`. The script rewrites `apps/jokes/jokes.js` and `apps/quotes/quotes-data.js` in the
+  house style and emits `data/jokes-manifest.json` / `data/quotes-manifest.json` with normalized hashes and embedding metadata
+  placeholders for downstream deduplication workflows.

--- a/apps/jokes/jokes.js
+++ b/apps/jokes/jokes.js
@@ -2,2598 +2,3463 @@
 
 window.jokes = [
         {
+            "id": "j-0001",
             "joke": "I'm tired of following my dreams.",
             "punchline": "I'm just going to ask them where they are going and meet up with them later."
         }, {
+            "id": "j-0002",
             "joke": "Did you hear about the guy whose whole left side was cut off?",
             "punchline": "He's all right now."
         }, {
+            "id": "j-0003",
             "joke": "Why didn’t the skeleton cross the road?",
             "punchline": "Because he had no guts."
         }, {
+            "id": "j-0004",
             "joke": "What did one nut say as he chased another nut?",
             "punchline": "I'm a cashew!"
         }, {
+            "id": "j-0005",
             "joke": "Where do fish keep their money?",
             "punchline": "In the riverbank"
         }, {
+            "id": "j-0006",
             "joke": "I accidentally took my cats meds last night.",
             "punchline": "Don’t ask meow."
         }, {
+            "id": "j-0007",
             "joke": "Chances are if you' ve seen one shopping center",
             "punchline": "you've seen a mall."
         }, {
+            "id": "j-0008",
             "joke": "Dermatologists are always in a hurry.",
             "punchline": "They spend all day making rash decisions."
         }, {
+            "id": "j-0009",
             "joke": "I knew I shouldn't steal a mixer from work",
             "punchline": "but it was a whisk I was willing to take."
         }, {
+            "id": "j-0010",
             "joke": "I won an argument with a weather forecaster once.",
             "punchline": "His logic was cloudy..."
         }, {
+            "id": "j-0011",
             "joke": "How come the stadium got hot after the game?",
             "punchline": "Because all of the fans left."
         }, {
+            "id": "j-0012",
             "joke": "\"Why do seagulls fly over the ocean?\" \"Because if they flew over the bay",
             "punchline": "we'd call them bagels.\""
         }, {
+            "id": "j-0013",
             "joke": "Why was it called the dark ages?",
             "punchline": "Because of all the knights."
         }, {
+            "id": "j-0014",
             "joke": "Why did the tomato blush?",
             "punchline": "Because it saw the salad dressing."
         }, {
+            "id": "j-0015",
             "joke": "Did you hear the joke about the wandering nun?",
             "punchline": "She was a roman catholic."
         }, {
+            "id": "j-0016",
             "joke": "What creature is smarter than a talking parrot?",
             "punchline": "A spelling bee."
         }, {
+            "id": "j-0017",
             "joke": "I'll tell you what often gets over looked...",
             "punchline": "garden fences."
         }, {
+            "id": "j-0018",
             "joke": "Why did the kid cross the playground?",
             "punchline": "To get to the other slide."
         }, {
+            "id": "j-0019",
             "joke": "Why do birds fly south for the winter?",
             "punchline": "Because it's too far to walk."
         }, {
+            "id": "j-0020",
             "joke": "What is a centipedes's favorite Beatle song?",
             "punchline": "I want to hold your hand, hand, hand, hand..."
         }, {
+            "id": "j-0021",
             "joke": "My first time using an elevator was an uplifting experience.",
             "punchline": "The second time let me down."
         }, {
+            "id": "j-0022",
             "joke": "To be Frank",
             "punchline": "I'd have to change my name."
         }, {
+            "id": "j-0023",
             "joke": "What do you call a female snake.",
             "punchline": "misssssssss"
         }, {
+            "id": "j-0024",
             "joke": "Why does a Moon-rock taste better than an Earth-rock?",
             "punchline": "Because it's a little meteor."
         }, {
+            "id": "j-0025",
             "joke": "I thought my wife was joking when she said she'd leave me if I didn't stop signing \"I'm A Believer\"...",
             "punchline": "Then I saw her face."
         }, {
+            "id": "j-0026",
             "joke": "I’m only familiar with 25 letters in the English language.",
             "punchline": "I don’t know why."
         }, {
+            "id": "j-0027",
             "joke": "What do you call two barracuda fish?",
             "punchline": "A Pairacuda!"
         }, {
+            "id": "j-0028",
             "joke": "What did the father tomato say to the baby tomato whilst on a family walk?",
             "punchline": "Ketchup."
         }, {
+            "id": "j-0029",
             "joke": "Why is Peter Pan always flying?",
             "punchline": "Because he Neverlands."
         }, {
+            "id": "j-0030",
             "joke": "What do you do on a remote island?",
             "punchline": "Try and find the TV island it belongs to."
         }, {
+            "id": "j-0031",
             "joke": "Did you know that protons have mass?",
             "punchline": "I didn't even know they were catholic."
         }, {
+            "id": "j-0032",
             "joke": "I was fired from the keyboard factory yesterday.",
             "punchline": "I wasn't putting in enough shifts."
         }, {
+            "id": "j-0033",
             "joke": "Wife: Honey I’m pregnant. Me: Well…. what do we do now? Wife: Well, I guess we should go to a baby doctor. Me: Hm..",
             "punchline": "I think I’d be a lot more comfortable going to an adult doctor."
         }, {
+            "id": "j-0034",
             "joke": "Have you heard the story about the magic tractor?",
             "punchline": "It drove down the road and turned into a field."
         }, {
+            "id": "j-0035",
             "joke": "When will the little snake arrive?",
             "punchline": "I don't know but he won't be long..."
         }, {
+            "id": "j-0036",
             "joke": "Why was Pavlov's beard so soft?",
             "punchline": "Because he conditioned it."
         }, {
+            "id": "j-0037",
             "joke": "Do I enjoy making courthouse puns?",
             "punchline": "Guilty"
         }, {
+            "id": "j-0038",
             "joke": "Why did the kid throw the clock out the window?",
             "punchline": "He wanted to see time fly!"
         }, {
+            "id": "j-0039",
             "joke": "Hear about the new restaurant called Karma?",
             "punchline": "There’s no menu: You get what you deserve."
         }, {
+            "id": "j-0040",
             "joke": "Why couldn't the kid see the pirate movie?",
             "punchline": "Because it was rated arrr!"
         }, {
+            "id": "j-0041",
             "joke": "It was so cold yesterday my computer froze.",
             "punchline": "My own fault though, I left too many windows open."
         }, {
+            "id": "j-0042",
             "joke": "Man, I really love my furniture...",
             "punchline": "me and my recliner go way back."
         }, {
+            "id": "j-0043",
             "joke": "What did the traffic light say to the car as it passed?",
             "punchline": "\"Don't look I'm changing!\""
         }, {
+            "id": "j-0044",
             "joke": "My son is studying to be a surgeon",
             "punchline": "I just hope he makes the cut."
         }, {
+            "id": "j-0045",
             "joke": "Why did the man run around his bed?",
             "punchline": "Because he was trying to catch up on his sleep!"
         }, {
+            "id": "j-0046",
             "joke": "What did one wall say to the other wall?",
             "punchline": "I'll meet you at the corner!"
         }, {
+            "id": "j-0047",
             "joke": "Sometimes I tuck my knees into my chest and lean forward.",
             "punchline": "That’s just how I roll."
         }, {
+            "id": "j-0048",
             "joke": "How many South Americans does it take to change a lightbulb?",
             "punchline": "A Brazilian"
         }, {
+            "id": "j-0049",
             "joke": "I don't trust stairs.",
             "punchline": "They're always up to something."
         }, {
+            "id": "j-0050",
             "joke": "What do you call two guys hanging out by your window?",
             "punchline": "Kurt & Rod."
         }, {
+            "id": "j-0051",
             "joke": "Why was the robot angry?",
             "punchline": "Because someone kept pressing his buttons!"
         }, {
+            "id": "j-0052",
             "joke": "Which is the fastest growing city in the world?",
             "punchline": "Dublin'"
         }, {
+            "id": "j-0053",
             "joke": "A police officer caught two kids playing with a firework and a car battery.",
             "punchline": "He charged one and let the other one off."
         }, {
+            "id": "j-0054",
             "joke": "What do you call a snake who builds houses?",
             "punchline": "A boa constructor!"
         }, {
+            "id": "j-0055",
             "joke": "What is the difference between ignorance and apathy?",
             "punchline": "I don't know and I don't care."
         }, {
+            "id": "j-0056",
             "joke": "I went to a Foo Fighters Concert once...",
             "punchline": "It was Everlong..."
         }, {
+            "id": "j-0057",
             "joke": "Why did the sentence fail the driving test?",
             "punchline": "It never came to a full stop."
         }, {
+            "id": "j-0058",
             "joke": "Some people eat light bulbs.",
             "punchline": "They say it's a nice light snack."
         }, {
+            "id": "j-0059",
             "joke": "What's the difference between a rooster and a crow?",
             "punchline": "A rooster can crow but a crow cannot rooster."
         }, {
+            "id": "j-0060",
             "joke": "I went to the store to pick up eight cans of sprite...",
             "punchline": "when I got home I realized I'd only picked seven up"
         }, {
+            "id": "j-0061",
             "joke": "I cut my finger chopping cheese",
             "punchline": "but I think that I may have grater problems."
         }, {
+            "id": "j-0062",
             "joke": "Yesterday, I accidentally swallowed some food coloring.",
             "punchline": "The doctor says I’m okay, but I feel like I’ve dyed a little inside."
         }, {
+            "id": "j-0063",
             "joke": "When people are sad, I sometimes let them colour in my tattoos.",
             "punchline": "Sometimes all they need is a shoulder to crayon."
         }, {
+            "id": "j-0064",
             "joke": "Last night me and my girlfriend watched three DVDs back to back.",
             "punchline": "Luckily I was the one facing the TV."
         }, {
+            "id": "j-0065",
             "joke": "I got a reversible jacket for Christmas",
             "punchline": "I can't wait to see how it turns out."
         }, {
+            "id": "j-0066",
             "joke": "What do you get when you cross a pig and a pineapple?",
             "punchline": "A porky pine"
         }, {
+            "id": "j-0067",
             "joke": "What did Romans use to cut pizza before the rolling cutter was invented?",
             "punchline": "Lil Caesars"
         }, {
+            "id": "j-0068",
             "joke": "Why did the banana go to the doctor?",
             "punchline": "He was not \"peeling\" well."
         }, {
+            "id": "j-0069",
             "joke": "My pet mouse 'Elvis' died last night.",
             "punchline": "He was caught in a trap.."
         }, {
+            "id": "j-0070",
             "joke": "Never take advice from electrons.",
             "punchline": "They are always negative."
         }, {
+            "id": "j-0071",
             "joke": "Why are oranges the smartest fruit?",
             "punchline": "Because they are made to concentrate."
         }, {
+            "id": "j-0072",
             "joke": "A girl once asked me what my heart desired, apparently blood",
             "punchline": "oxygen and neural messages were all wrong answers"
         }, {
+            "id": "j-0073",
             "joke": "Why is it always hot in the corner of a room?",
             "punchline": "Because a corner is 90 degrees."
         }, {
+            "id": "j-0074",
             "joke": "What did the beaver say to the tree?",
             "punchline": "It's been nice gnawing you."
         }, {
+            "id": "j-0075",
             "joke": "How do you fix a damaged jack-o-lantern?",
             "punchline": "You use a pumpkin patch."
         }, {
+            "id": "j-0076",
             "joke": "Why do cows not have toes?",
             "punchline": "They lactose!"
         }, {
+            "id": "j-0077",
             "joke": "What did the late tomato say to the early tomato?",
             "punchline": "I’ll ketch up"
         }, {
+            "id": "j-0078",
             "joke": "I have kleptomania, but when it gets bad",
             "punchline": "I take something for it."
         }, {
+            "id": "j-0079",
             "joke": "I used to be addicted to soap",
             "punchline": "but I'm clean now."
         }, {
+            "id": "j-0080",
             "joke": "When is a door not a door?",
             "punchline": "When it's ajar."
         }, {
+            "id": "j-0081",
             "joke": "I made a belt out of watches once...",
             "punchline": "It was a waist of time."
         }, {
+            "id": "j-0082",
             "joke": "Why did Mozart kill all his chickens?",
             "punchline": "Because when he asked them who the best composer was, they'd all say \"Bach bach bach!\""
         }, {
+            "id": "j-0083",
             "joke": "This furniture store keeps emailing me",
             "punchline": "all I wanted was one night stand!"
         }, {
+            "id": "j-0084",
             "joke": "How do you find Will Smith in the snow?",
             "punchline": "Look for fresh prints."
         }, {
+            "id": "j-0085",
             "joke": "My sister bet me $15 that I couldn't build a car out of spaghetti.",
             "punchline": "You should have seen the look on her face as I drove pasta."
         }, {
+            "id": "j-0086",
             "joke": "My boss told me to have a good day...",
             "punchline": "so I went home."
         }, {
+            "id": "j-0087",
             "joke": "I just read a book about Stockholm syndrome.",
             "punchline": "It was pretty bad at first, but by the end I liked it."
         }, {
+            "id": "j-0088",
             "joke": "Why do trees seem suspicious on sunny days?",
             "punchline": "Dunno, they're just a bit shady."
         }, {
+            "id": "j-0089",
             "joke": "If at first you don't succeed",
             "punchline": "sky diving is not for you!"
         }, {
+            "id": "j-0090",
             "joke": "I'd like to start a diet",
             "punchline": "but I've got too much on my plate right now."
         }, {
+            "id": "j-0091",
             "joke": "What did the drummer name her twin daughters?",
             "punchline": "Anna One, Anna Two..."
         }, {
+            "id": "j-0092",
             "joke": "What kind of music do mummy's like?",
             "punchline": "Rap"
         }, {
+            "id": "j-0093",
             "joke": "I remember when I was a kid, I opened my fridge and noticed one of my vegetables were crying.",
             "punchline": "I guess I have some emotional cabbage."
         }, {
+            "id": "j-0094",
             "joke": "What's large, grey, and doesn't matter?",
             "punchline": "An irrelephant."
         }, {
+            "id": "j-0095",
             "joke": "A book just fell on my head.",
             "punchline": "I only have my shelf to blame."
         }, {
+            "id": "j-0096",
             "joke": "What did the dog say to the two trees?",
             "punchline": "Bark bark."
         }, {
+            "id": "j-0097",
             "joke": "I've got a joke about vegetables for you...",
             "punchline": "but it's a bit corny."
         }, {
+            "id": "j-0098",
             "joke": "If a child refuses to sleep during nap time",
             "punchline": "are they guilty of resisting a rest?"
         }, {
+            "id": "j-0099",
             "joke": "Why can't your nose be 12 inches long?",
             "punchline": "Because then it'd be a foot!"
         }, {
+            "id": "j-0100",
             "joke": "Have you ever heard of a music group called Cellophane?",
             "punchline": "They mostly wrap."
         }, {
+            "id": "j-0101",
             "joke": "What do you call a boy who stopped digging holes?",
             "punchline": "Douglas."
         }, {
+            "id": "j-0102",
             "joke": "What did the mountain climber name his son?",
             "punchline": "Cliff."
         }, {
+            "id": "j-0103",
             "joke": "Why should you never trust a pig with a secret?",
             "punchline": "Because it's bound to squeal."
         }, {
+            "id": "j-0104",
             "joke": "Why are mummys scared of vacation?",
             "punchline": "They're afraid to unwind."
         }, {
+            "id": "j-0105",
             "joke": "Whiteboards...",
             "punchline": "are remarkable."
         }, {
+            "id": "j-0106",
             "joke": "What kind of dinosaur loves to sleep?",
             "punchline": "A stega-snore-us."
         }, {
+            "id": "j-0107",
             "joke": "What has three letters and starts with gas?",
             "punchline": "A Car."
         }, {
+            "id": "j-0108",
             "joke": "What’s Forest Gump’s Facebook password?",
             "punchline": "1forest1"
         }, {
+            "id": "j-0109",
             "joke": "What kind of tree fits in your hand?",
             "punchline": "A palm tree!"
         }, {
+            "id": "j-0110",
             "joke": "Whenever the cashier at the grocery store asks my dad if he would like the milk in a bag he replies, ‘No",
             "punchline": "just leave it in the carton!’"
         }, {
+            "id": "j-0111",
             "joke": "I used to be addicted to the hokey pokey",
             "punchline": "but I turned myself around."
         }, {
+            "id": "j-0112",
             "joke": "How many tickles does it take to tickle an octopus?",
             "punchline": "Ten-tickles!"
         }, {
+            "id": "j-0113",
             "joke": "Me: If humans lose the ability to hear high frequency volumes as they get older, can my 4 week old son hear a dog whistle? Doctor: No, humans can never hear that high of a frequency no matter what age they are. Me: Trick question...",
             "punchline": "dogs can't whistle."
         }, {
+            "id": "j-0114",
             "joke": "What musical instrument is found in the bathroom?",
             "punchline": "A tuba toothpaste."
         }, {
+            "id": "j-0115",
             "joke": "I can't take my dog to the pond anymore because the ducks keep attacking him.",
             "punchline": "That's what I get for buying a pure bread dog."
         }, {
+            "id": "j-0116",
             "joke": "My boss told me to attach two pieces of wood together...",
             "punchline": "I totally nailed it!"
         }, {
+            "id": "j-0117",
             "joke": "What was the pumpkin’s favorite sport?",
             "punchline": "Squash."
         }, {
+            "id": "j-0118",
             "joke": "What do you call corn that joins the army?",
             "punchline": "Kernel."
         }, {
+            "id": "j-0119",
             "joke": "I've been trying to come up with a dad joke about momentum...",
             "punchline": "but I just can't seem to get it going."
         }, {
+            "id": "j-0120",
             "joke": "Why don't skeletons ride roller coasters?",
             "punchline": "They don't have the stomach for it."
         }, {
+            "id": "j-0121",
             "joke": "Is there a hole in your shoe?",
             "punchline": "No… Then how’d you get your foot in it?"
         }, {
+            "id": "j-0122",
             "joke": "Every night at 11:11",
             "punchline": "I make a wish that someone will come fix my broken clock."
         }, {
+            "id": "j-0123",
             "joke": "Two muffins were sitting in an oven, and the first looks over to the second, and says, “man, it’s really hot in here”.",
             "punchline": "The second looks over at the first with a surprised look, and answers, “WHOA, a talking muffin!”"
         }, {
+            "id": "j-0124",
             "joke": "What's the difference between a guitar and a fish?",
             "punchline": "You can tune a guitar but you can't \"tuna\" fish!"
         }, {
+            "id": "j-0125",
             "joke": "Did you hear that the police have a warrant out on a midget psychic ripping people off?",
             "punchline": "It reads “Small medium at large.”"
         }, {
+            "id": "j-0126",
             "joke": "Why don't sharks eat clowns?",
             "punchline": "Because they taste funny."
         }, {
+            "id": "j-0127",
             "joke": "Just read a few facts about frogs.",
             "punchline": "They were ribbiting."
         }, {
+            "id": "j-0128",
             "joke": "Two satellites decided to get married.",
             "punchline": "The wedding wasn't much, but the reception was incredible."
         }, {
+            "id": "j-0129",
             "joke": "What do you call a fish with no eyes?",
             "punchline": "A fsh."
         }, {
+            "id": "j-0130",
             "joke": "What do you get if you put a duck in a cement mixer?",
             "punchline": "Quacks in the pavement."
         }, {
+            "id": "j-0131",
             "joke": "They tried to make a diamond shaped like a duck.",
             "punchline": "It quacked under the pressure."
         }, {
+            "id": "j-0132",
             "joke": "Where’s the bin?",
             "punchline": "Dad: I haven’t been anywhere!"
         }, {
+            "id": "j-0133",
             "joke": "My wife said I was immature.",
             "punchline": "So I told her to get out of my fort."
         }, {
+            "id": "j-0134",
             "joke": "Why did the knife dress up in a suit?",
             "punchline": "Because it wanted to look sharp"
         }, {
+            "id": "j-0135",
             "joke": "How do you make a water bed more bouncy.",
             "punchline": "You use Spring Water"
         }, {
+            "id": "j-0136",
             "joke": "I considered building the patio by myself.",
             "punchline": "But I didn't have the stones."
         }, {
+            "id": "j-0137",
             "joke": "In my career as a lumberjack I cut down exactly 52,487 trees.",
             "punchline": "I know because I kept a log."
         }, {
+            "id": "j-0138",
             "joke": "Why do bears have hairy coats?",
             "punchline": "Fur protection."
         }, {
+            "id": "j-0139",
             "joke": "What do you get when you cross a bee and a sheep?",
             "punchline": "A bah-humbug."
         }, {
+            "id": "j-0140",
             "joke": "What did one snowman say to the other snow man?",
             "punchline": "Do you smell carrot?"
         }, {
+            "id": "j-0141",
             "joke": "\"Dad, do you think it's going to snow this winter?\" \"I dont know",
             "punchline": "its all up in the air\""
         }, {
+            "id": "j-0142",
             "joke": "Why do bees hum?",
             "punchline": "Because they don't know the words."
         }, {
+            "id": "j-0143",
             "joke": "What do you call a troublesome Canadian high schooler?",
             "punchline": "A poutine."
         }, {
+            "id": "j-0144",
             "joke": "Don't trust atoms.",
             "punchline": "They make up everything."
         }, {
+            "id": "j-0145",
             "joke": "If you walk into a forest and cut down a tree, but the tree doesn't understand why you cut it down",
             "punchline": "do you think it's stumped?"
         }, {
+            "id": "j-0146",
             "joke": "Where do bees go to the bathroom?",
             "punchline": "The BP station."
         }, {
+            "id": "j-0147",
             "joke": "What is the best way to carve?",
             "punchline": "Whittle by whittle."
         }, {
+            "id": "j-0148",
             "joke": "What's a ninja's favorite type of shoes?",
             "punchline": "Sneakers!"
         }, {
+            "id": "j-0149",
             "joke": "Why did the tree go to the dentist?",
             "punchline": "It needed a root canal."
         }, {
+            "id": "j-0150",
             "joke": "It was raining cats and dogs the other day.",
             "punchline": "I almost stepped in a poodle."
         }, {
+            "id": "j-0151",
             "joke": "Why do bananas have to put on sunscreen before they go to the beach?",
             "punchline": "Because they might peel!"
         }, {
+            "id": "j-0152",
             "joke": "What do you call a bee that lives in America?",
             "punchline": "A USB."
         }, {
+            "id": "j-0153",
             "joke": "I was wondering why the frisbee was getting bigger",
             "punchline": "then it hit me."
         }, {
+            "id": "j-0154",
             "joke": "A farmer had 297 cows, when he rounded them up",
             "punchline": "he found he had 300"
         }, {
+            "id": "j-0155",
             "joke": "What's the difference between a hippo and a zippo?",
             "punchline": "One is really heavy, the other is a little lighter."
         }, {
+            "id": "j-0156",
             "joke": "I’ve got this disease where I can’t stop making airport puns.",
             "punchline": "The doctor says it terminal."
         }, {
+            "id": "j-0157",
             "joke": "What concert costs only 45 cents?",
             "punchline": "50 cent featuring Nickelback."
         }, {
+            "id": "j-0158",
             "joke": "I couldn't figure out how the seat belt worked.",
             "punchline": "Then it just clicked."
         }, {
+            "id": "j-0159",
             "joke": "What did the green grape say to the purple grape?",
             "punchline": "BREATH!!"
         }, {
+            "id": "j-0160",
             "joke": "What do you call a dad that has fallen through the ice?",
             "punchline": "A Popsicle."
         }, {
+            "id": "j-0161",
             "joke": "Two parrots are sitting on a perch.",
             "punchline": "One turns to the other and asks, \"do you smell fish?\""
         }, {
+            "id": "j-0162",
             "joke": "Bad at golf?",
             "punchline": "Join the club."
         }, {
+            "id": "j-0163",
             "joke": "I had a pair of racing snails.",
             "punchline": "I removed their shells to make them more aerodynamic, but they became sluggish."
         }, {
+            "id": "j-0164",
             "joke": "What do you call a pile of cats?",
             "punchline": "A Meowtain."
         }, {
+            "id": "j-0165",
             "joke": "How do hens stay fit?",
             "punchline": "They always egg-cercise!"
         }, {
+            "id": "j-0166",
             "joke": "Can a kangaroo jump higher than the Empire State Building?",
             "punchline": "Of course. The Empire State Building can't jump."
         }, {
+            "id": "j-0167",
             "joke": "What do you give a sick lemon?",
             "punchline": "Lemonaid."
         }, {
+            "id": "j-0168",
             "joke": "What do you call an old snowman?",
             "punchline": "Water."
         }, {
+            "id": "j-0169",
             "joke": "I tried to milk a cow today, but was unsuccessful.",
             "punchline": "Udder failure."
         }, {
+            "id": "j-0170",
             "joke": "I just got fired from a florist",
             "punchline": "apparently I took too many leaves."
         }, {
+            "id": "j-0171",
             "joke": "Why don’t skeletons ever go trick or treating?",
             "punchline": "Because they have nobody to go with."
         }, {
+            "id": "j-0172",
             "joke": "What does a female snake use for support?",
             "punchline": "A co-Bra!"
         }, {
+            "id": "j-0173",
             "joke": "\"Dad, I'm cold.\"",
             "punchline": "\"Go stand in the corner, I hear it's 90 degrees.\""
         }, {
+            "id": "j-0174",
             "joke": "Child: Dad, make me a sandwich. Dad: Poof!",
             "punchline": "You're a sandwich."
         }, {
+            "id": "j-0175",
             "joke": "which flower is most fierce?",
             "punchline": "Dandelion"
         }, {
+            "id": "j-0176",
             "joke": "Why are graveyards so noisy?",
             "punchline": "Because of all the coffin."
         }, {
+            "id": "j-0177",
             "joke": "What kind of bagel can fly?",
             "punchline": "A plain bagel."
         }, {
+            "id": "j-0178",
             "joke": "How many apples grow on a tree?",
             "punchline": "All of them!"
         }, {
+            "id": "j-0179",
             "joke": "What do you call a careful wolf?",
             "punchline": "Aware wolf."
         }, {
+            "id": "j-0180",
             "joke": "I was just looking at my ceiling.",
             "punchline": "Not sure if it’s the best ceiling in the world, but it’s definitely up there."
         }, {
+            "id": "j-0181",
             "joke": "Why do valley girls hang out in odd numbered groups?",
             "punchline": "Because they can't even."
         }, {
+            "id": "j-0182",
             "joke": "What do you call a cow with no legs?",
             "punchline": "Ground beef."
         }, {
+            "id": "j-0183",
             "joke": "Why are snake races so exciting?",
             "punchline": "They're always neck and neck."
         }, {
+            "id": "j-0184",
             "joke": "Why did the half blind man fall in the well?",
             "punchline": "Because he couldn't see that well!"
         }, {
+            "id": "j-0185",
             "joke": "As I suspected, someone has been adding soil to my garden.",
             "punchline": "The plot thickens."
         }, {
+            "id": "j-0186",
             "joke": "What do bees do after they are married?",
             "punchline": "They go on a honeymoon."
         }, {
+            "id": "j-0187",
             "joke": "If I could name myself after any Egyptian god",
             "punchline": "I'd be Set."
         }, {
+            "id": "j-0188",
             "joke": "Why doesn't the Chimney-Sweep call out sick from work?",
             "punchline": "Because he's used to working with a flue."
         }, {
+            "id": "j-0189",
             "joke": "It’s hard to explain puns to kleptomaniacs",
             "punchline": "because they take everything literally."
         }, {
+            "id": "j-0190",
             "joke": "It's difficult to say what my wife does",
             "punchline": "she sells sea shells by the sea shore."
         }, {
+            "id": "j-0191",
             "joke": "Why did Dracula lie in the wrong coffin?",
             "punchline": "He made a grave mistake."
         }, {
+            "id": "j-0192",
             "joke": "What did one plate say to the other plate?",
             "punchline": "Dinner is on me!"
         }, {
+            "id": "j-0193",
             "joke": "what do you call a dog that can do magic tricks?",
             "punchline": "a labracadabrador"
         }, {
+            "id": "j-0194",
             "joke": "Doctor: Do you want to hear the good news or the bad news? Patient: Good news please.",
             "punchline": "Doctor: we're naming a disease after you."
         }, {
+            "id": "j-0195",
             "joke": "I tried to write a chemistry joke",
             "punchline": "but could never get a reaction."
         }, {
+            "id": "j-0196",
             "joke": "I gave my friend 10 puns hoping that one of them would make him laugh.",
             "punchline": "Sadly, no pun in ten did."
         }, {
+            "id": "j-0197",
             "joke": "What do computers and air conditioners have in common?",
             "punchline": "They both become useless when you open windows."
         }, {
+            "id": "j-0198",
             "joke": "What do you call a monkey in a mine field?",
             "punchline": "A babooooom!"
         }, {
+            "id": "j-0199",
             "joke": "Scientists finally did a study on forks.",
             "punchline": "It's about tine!"
         }, {
+            "id": "j-0200",
             "joke": "I cut my finger cutting cheese.",
             "punchline": "I know it may be a cheesy story but I feel grate now."
         }, {
+            "id": "j-0201",
             "joke": "How do you steal a coat?",
             "punchline": "You jacket."
         }, {
+            "id": "j-0202",
             "joke": "Why don't you find hippopotamuses hiding in trees?",
             "punchline": "They're really good at it."
         }, {
+            "id": "j-0203",
             "joke": "what happens when you cross a sheep with a kangaroo?",
             "punchline": "A woolly jumper!"
         }, {
+            "id": "j-0204",
             "joke": "Want to hear a joke about construction?",
             "punchline": "Nah, I'm still working on it."
         }, {
+            "id": "j-0205",
             "joke": "My friend told me that pepper is the best seasoning for a roast",
             "punchline": "but I took it with a grain of salt."
         }, {
+            "id": "j-0206",
             "joke": "Why do choirs keep buckets handy?",
             "punchline": "So they can carry their tune"
         }, {
+            "id": "j-0207",
             "joke": "Did you hear about the kidnapping at school?",
             "punchline": "It's ok, he woke up."
         }, {
+            "id": "j-0208",
             "joke": "I asked my date to go to the gym the other day. They never showed up.",
             "punchline": "That's when I knew we wouldn't work out."
         }, {
+            "id": "j-0209",
             "joke": "You will never guess what Elsa did to the balloon.",
             "punchline": "She let it go."
         }, {
+            "id": "j-0210",
             "joke": "Did you hear about the two thieves who stole a calendar?",
             "punchline": "They each got six months."
         }, {
+            "id": "j-0211",
             "joke": "Why can't eggs have love?",
             "punchline": "They will break up too soon."
         }, {
+            "id": "j-0212",
             "joke": "You can't run through a camp site.",
             "punchline": "You can only ran, because it's past tents."
         }, {
+            "id": "j-0213",
             "joke": "They're making a movie about clocks.",
             "punchline": "It's about time"
         }, {
+            "id": "j-0214",
             "joke": "I’ve just been reading a book about anti-gravity",
             "punchline": "it’s impossible to put down!"
         }, {
+            "id": "j-0215",
             "joke": "Have you ever seen fruit preserves being made?",
             "punchline": "It's jarring."
         }, {
+            "id": "j-0216",
             "joke": "I was going to get a brain transplant",
             "punchline": "but I changed my mind"
         }, {
+            "id": "j-0217",
             "joke": "Have you heard about the owl sanctuary job opening?",
             "punchline": "It’s all night shifts but they’re all a hoot over there."
         }, {
+            "id": "j-0218",
             "joke": "Why can't you use \"Beef stew\" as a password?",
             "punchline": "Because it's not stroganoff."
         }, {
+            "id": "j-0219",
             "joke": "What did the piece of bread say to the knife?",
             "punchline": "Butter me up."
         }, {
+            "id": "j-0220",
             "joke": "Why couldn't the lifeguard save the hippie?",
             "punchline": "He was too far out, man."
         }, {
+            "id": "j-0221",
             "joke": "They say Dodger Stadium can hold up to fifty-six thousand people",
             "punchline": "but that is just a ballpark figure."
         }, {
+            "id": "j-0222",
             "joke": "Some people say that I never got over my obsession with Phil Collins.",
             "punchline": "But take a look at me now."
         }, {
+            "id": "j-0223",
             "joke": "Why did the girl smear peanut butter on the road?",
             "punchline": "To go with the traffic jam."
         }, {
+            "id": "j-0224",
             "joke": "How much does a hipster weigh?",
             "punchline": "An instagram."
         }, {
+            "id": "j-0225",
             "joke": "A woman is on trial for beating her husband to death with his guitar collection. Judge says, ‘First offender?’ She says, ‘No, first a Gibson!",
             "punchline": "Then a Fender!’"
         }, {
+            "id": "j-0226",
             "joke": "I saw an ad in a shop window, \"Television for sale, $1, volume stuck on full\", I thought",
             "punchline": "\"I can't turn that down\"."
         }, {
+            "id": "j-0227",
             "joke": "What kind of dog lives in a particle accelerator?",
             "punchline": "A Fermilabrador Retriever."
         }, {
+            "id": "j-0228",
             "joke": "I always wanted to look into why I procrastinate",
             "punchline": "but I keep putting it off."
         }, {
+            "id": "j-0229",
             "joke": "What's blue and not very heavy?",
             "punchline": "Light blue."
         }, {
+            "id": "j-0230",
             "joke": "Guy told me today he did not know what cloning is.",
             "punchline": "I told him, \"that makes 2 of us.\""
         }, {
+            "id": "j-0231",
             "joke": "I was so proud when I finished the puzzle in six months",
             "punchline": "when on the side it said three to four years."
         }, {
+            "id": "j-0232",
             "joke": "Where did you learn to make ice cream?",
             "punchline": "Sunday school."
         }, {
+            "id": "j-0233",
             "joke": "Coffee has a tough time at my house",
             "punchline": "every morning it gets mugged."
         }, {
+            "id": "j-0234",
             "joke": "A quick shoutout to all of the sidewalks out there...",
             "punchline": "Thanks for keeping me off the streets."
         }, {
+            "id": "j-0235",
             "joke": "Where does Napoleon keep his armies?",
             "punchline": "In his sleevies."
         }, {
+            "id": "j-0236",
             "joke": "What's the difference between roast beef and pea soup.",
             "punchline": "Anyone can roast beef, but nobody can pee soup."
         }, {
+            "id": "j-0237",
             "joke": "What do you get if you cross a turkey with a ghost?",
             "punchline": "A poultry-geist!"
         }, {
+            "id": "j-0238",
             "joke": "What is the tallest building in the world?",
             "punchline": "The library – it’s got the most stories!"
         }, {
+            "id": "j-0239",
             "joke": "What kind of magic do cows believe in?",
             "punchline": "MOODOO."
         }, {
+            "id": "j-0240",
             "joke": "What’s the longest word in the dictionary?",
             "punchline": "Smiles. Because there’s a mile between the two S’s."
         }, {
+            "id": "j-0241",
             "joke": "Why don't eggs tell jokes?",
             "punchline": "They'd crack each other up"
         }, {
+            "id": "j-0242",
             "joke": "I just broke my guitar.",
             "punchline": "It's okay, I won't fret"
         }, {
+            "id": "j-0243",
             "joke": "How many kids with ADD does it take to change a lightbulb?",
             "punchline": "Let's go ride bikes!"
         }, {
+            "id": "j-0244",
             "joke": "Where do hamburgers go to dance?",
             "punchline": "The meat-ball."
         }, {
+            "id": "j-0245",
             "joke": "I invented a new word!",
             "punchline": "Plagiarism!"
         }, {
+            "id": "j-0246",
             "joke": "What do you call a cow with two legs?",
             "punchline": "Lean beef."
         }, {
+            "id": "j-0247",
             "joke": "What did the big flower say to the littler flower?",
             "punchline": "Hi, bud!"
         }, {
+            "id": "j-0248",
             "joke": "I never wanted to believe that my Dad was stealing from his job as a road worker.",
             "punchline": "But when I got home, all the signs were there."
         }, {
+            "id": "j-0249",
             "joke": "Why do pumpkins sit on people’s porches?",
             "punchline": "They have no hands to knock on the door."
         }, {
+            "id": "j-0250",
             "joke": "Who is the coolest Doctor in the hospital?",
             "punchline": "The hip Doctor!"
         }, {
+            "id": "j-0251",
             "joke": "Why was ten scared of seven?",
             "punchline": "Because seven ate nine."
         }, {
+            "id": "j-0252",
             "joke": "What do you get when you cross a rabbit with a water hose?",
             "punchline": "Hare spray."
         }, {
+            "id": "j-0253",
             "joke": "I applied to be a doorman but didn't get the job due to lack of experience.",
             "punchline": "That surprised me, I thought it was an entry level position."
         }, {
+            "id": "j-0254",
             "joke": "I knew a guy who collected candy canes",
             "punchline": "they were all in mint condition"
         }, {
+            "id": "j-0255",
             "joke": "A boy dug three holes in the yard.",
             "punchline": "When his mother saw, she exclaimed: \"well, well, well\""
         }, {
+            "id": "j-0256",
             "joke": "Why do nurses carry around red crayons?",
             "punchline": "Sometimes they need to draw blood."
         }, {
+            "id": "j-0257",
             "joke": "Why was the shirt happy to hang around the tank top?",
             "punchline": "Because it was armless"
         }, {
+            "id": "j-0258",
             "joke": "Why does a chicken coop only have two doors?",
             "punchline": "Because if it had four doors it would be a chicken sedan."
         }, {
+            "id": "j-0259",
             "joke": "\"I'll call you later.\" Don't call me later",
             "punchline": "call me Dad."
         }, {
+            "id": "j-0260",
             "joke": "Why did the teddy bear say “no” to dessert?",
             "punchline": "Because she was stuffed."
         }, {
+            "id": "j-0261",
             "joke": "I don't trust sushi",
             "punchline": "there's something fishy about it."
         }, {
+            "id": "j-0262",
             "joke": "Did you hear the one about the giant pickle?",
             "punchline": "He was kind of a big dill."
         }, {
+            "id": "j-0263",
             "joke": "Breaking news!",
             "punchline": "Energizer Bunny arrested – charged with battery."
         }, {
+            "id": "j-0264",
             "joke": "How many bones are in the human hand?",
             "punchline": "A handful of them."
         }, {
+            "id": "j-0265",
             "joke": "A red and a blue ship have just collided in the Caribbean.",
             "punchline": "Apparently the survivors are marooned."
         }, {
+            "id": "j-0266",
             "joke": "I've just written a song about a tortilla.",
             "punchline": "Well, it is more of a rap really."
         }, {
+            "id": "j-0267",
             "joke": "Can February march?",
             "punchline": "No, but April may."
         }, {
+            "id": "j-0268",
             "joke": "Egyptians claimed to invent the guitar",
             "punchline": "but they were such lyres."
         }, {
+            "id": "j-0269",
             "joke": "What is a witch's favorite subject in school?",
             "punchline": "Spelling!"
         }, {
+            "id": "j-0270",
             "joke": "What do you call a crowd of chess players bragging about their wins in a hotel lobby?",
             "punchline": "Chess nuts boasting in an open foyer."
         }, {
+            "id": "j-0271",
             "joke": "Which side of the chicken has more feathers?",
             "punchline": "The outside."
         }, {
+            "id": "j-0272",
             "joke": "Remember",
             "punchline": "the best angle to approach a problem from is the \"try\" angle."
         }, {
+            "id": "j-0273",
             "joke": "Why are fish easy to weigh?",
             "punchline": "Because they have their own scales."
         }, {
+            "id": "j-0274",
             "joke": "What did the scarf say to the hat?",
             "punchline": "You go on ahead, I am going to hang around a bit longer."
         }, {
+            "id": "j-0275",
             "joke": "Did you hear about the scientist who was lab partners with a pot of boiling water?",
             "punchline": "He had a very esteemed colleague."
         }, {
+            "id": "j-0276",
             "joke": "This morning I was wondering where the sun was",
             "punchline": "but then it dawned on me."
         }, {
+            "id": "j-0277",
             "joke": "What did the sea say to the sand?",
             "punchline": "\"We have to stop meeting like this.\""
         }, {
+            "id": "j-0278",
             "joke": "Why is it so windy inside an arena?",
             "punchline": "All those fans."
         }, {
+            "id": "j-0279",
             "joke": "A panda walks into a bar and says to the bartender “I’ll have a Scotch and.............. Coke thank you”.",
             "punchline": "“Sure thing” the bartender replies and asks “but what’s with the big pause?” The panda holds up his hands and says “I was born with them”"
         }, {
+            "id": "j-0280",
             "joke": "I've started telling everyone about the benefits of eating dried grapes.",
             "punchline": "It's all about raisin awareness."
         }, {
+            "id": "j-0281",
             "joke": "“Doctor",
             "punchline": "I’ve broken my arm in several places” Doctor “Well don’t go to those places.”"
         }, {
+            "id": "j-0282",
             "joke": "Where was the Declaration of Independence signed?",
             "punchline": "At the bottom!"
         }, {
+            "id": "j-0283",
             "joke": "What’s the difference between an African elephant and an Indian elephant?",
             "punchline": "About 5000 miles."
         }, {
+            "id": "j-0284",
             "joke": "Two peanuts were walking down the street.",
             "punchline": "One was a salted"
         }, {
+            "id": "j-0285",
             "joke": "Don’t interrupt someone working intently on a puzzle.",
             "punchline": "Chances are, you’ll hear some crosswords."
         }, {
+            "id": "j-0286",
             "joke": "Today a man knocked on my door and asked for a small donation towards the local swimming pool.",
             "punchline": "I gave him a glass of water."
         }, {
+            "id": "j-0287",
             "joke": "What did the Zen Buddist say to the hotdog vendor?",
             "punchline": "Make me one with everything."
         }, {
+            "id": "j-0288",
             "joke": "Why did the clown have neck pain?",
             "punchline": "- Because he slept funny"
         }, {
+            "id": "j-0289",
             "joke": "What did the digital clock say to the grandfather clock?",
             "punchline": "Look, no hands!"
         }, {
+            "id": "j-0290",
             "joke": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before.",
             "punchline": "What can I get for you?\" \"Pop,\" goes the weasel."
         }, {
+            "id": "j-0291",
             "joke": "How was the snow globe feeling after the storm?",
             "punchline": "A little shaken."
         }, {
+            "id": "j-0292",
             "joke": "Did you hear the one about the guy with the broken hearing aid?",
             "punchline": "Neither did he."
         }, {
+            "id": "j-0293",
             "joke": "Did you hear about the campsite that got visited by Bigfoot?",
             "punchline": "It got in tents."
         }, {
+            "id": "j-0294",
             "joke": "I saw a documentary on TV last night about how they put ships together.",
             "punchline": "It was rivetting."
         }, {
+            "id": "j-0295",
             "joke": "What did the Red light say to the Green light?",
             "punchline": "Don't look at me I'm changing!"
         }, {
+            "id": "j-0296",
             "joke": "What did the ocean say to the beach?",
             "punchline": "Thanks for all the sediment."
         }, {
+            "id": "j-0297",
             "joke": "What did the left eye say to the right eye?",
             "punchline": "Between us, something smells!"
         }, {
+            "id": "j-0298",
             "joke": "What do you call a fly without wings?",
             "punchline": "A walk."
         }, {
+            "id": "j-0299",
             "joke": "Why did the melons plan a big wedding?",
             "punchline": "Because they cantaloupe!"
         }, {
+            "id": "j-0300",
             "joke": "Yesterday I confused the words \"jacuzzi\" and \"yakuza\".",
             "punchline": "Now I'm in hot water with the Japanese mafia."
         }, {
+            "id": "j-0301",
             "joke": "What is the least spoken language in the world?",
             "punchline": "Sign Language"
         }, {
+            "id": "j-0302",
             "joke": "What do birds give out on Halloween?",
             "punchline": "Tweets."
         }, {
+            "id": "j-0303",
             "joke": "I used to think I was indecisive",
             "punchline": "but now I'm not sure."
         }, {
+            "id": "j-0304",
             "joke": "Have you heard the rumor going around about butter?",
             "punchline": "Never mind, I shouldn't spread it."
         }, {
+            "id": "j-0305",
             "joke": "Every morning when I go out, I get hit by bicycle. Every morning!",
             "punchline": "It's a vicious cycle."
         }, {
+            "id": "j-0306",
             "joke": "What happens to a frog's car when it breaks down?",
             "punchline": "It gets toad."
         }, {
+            "id": "j-0307",
             "joke": "I fear for the calendar",
             "punchline": "its days are numbered."
         }, {
+            "id": "j-0308",
             "joke": "I'm glad I know sign language",
             "punchline": "it's pretty handy."
         }, {
+            "id": "j-0309",
             "joke": "The other day, my wife asked me to pass her lipstick but I accidentally passed her a glue stick.",
             "punchline": "She still isn't talking to me."
         }, {
+            "id": "j-0310",
             "joke": "What do you get when you cross a chicken with a skunk?",
             "punchline": "A fowl smell!"
         }, {
+            "id": "j-0311",
             "joke": "Where do you take someone who’s been injured in a peek-a-boo accident?",
             "punchline": "To the I.C.U."
         }, {
+            "id": "j-0312",
             "joke": "As I get older, I think of all the people I lost along the way.",
             "punchline": "Maybe a career as a tour guide wasn't such a good idea."
         }, {
+            "id": "j-0313",
             "joke": "How many hipsters does it take to change a lightbulb?",
             "punchline": "Oh, it's a really obscure number. You've probably never heard of it."
         }, {
+            "id": "j-0314",
             "joke": "Where do sheep go to get their hair cut?",
             "punchline": "The baa-baa shop."
         }, {
+            "id": "j-0315",
             "joke": "Our wedding was so beautiful",
             "punchline": "even the cake was in tiers."
         }, {
+            "id": "j-0316",
             "joke": "Why did the miner get fired from his job?",
             "punchline": "He took it for granite..."
         }, {
+            "id": "j-0317",
             "joke": "What did the hat say to the scarf? You can hang around.",
             "punchline": "I'll just go on ahead."
         }, {
+            "id": "j-0318",
             "joke": "Where do cats write notes?",
             "punchline": "Scratch Paper!"
         }, {
+            "id": "j-0319",
             "joke": "Why is the new Kindle screen textured to look like paper?",
             "punchline": "So you feel write at home."
         }, {
+            "id": "j-0320",
             "joke": "When my wife told me to stop impersonating a flamingo",
             "punchline": "I had to put my foot down."
         }, {
+            "id": "j-0321",
             "joke": "No matter how kind you are",
             "punchline": "German children are kinder."
         }, {
+            "id": "j-0322",
             "joke": "What’s the advantage of living in Switzerland?",
             "punchline": "Well, the flag is a big plus."
         }, {
+            "id": "j-0323",
             "joke": "When I left school, I passed every one of my exams with the exception of Greek Mythology.",
             "punchline": "It always was my achilles elbow"
         }, {
+            "id": "j-0324",
             "joke": "Why did the cookie cry?",
             "punchline": "It was feeling crumby."
         }, {
+            "id": "j-0325",
             "joke": "What did Yoda say when he saw himself in 4K?",
             "punchline": "\"HDMI\""
         }, {
+            "id": "j-0326",
             "joke": "How do you make a 'one' disappear?",
             "punchline": "You add a 'g' and it's 'gone'"
         }, {
+            "id": "j-0327",
             "joke": "Me and my mates are in a band called Duvet.",
             "punchline": "We're a cover band."
         }, {
+            "id": "j-0328",
             "joke": "Where do you learn to make banana splits?",
             "punchline": "At sundae school."
         }, {
+            "id": "j-0329",
             "joke": "Nurse: Doctor, there's a patient that says he's invisible.",
             "punchline": "Doctor: Well, tell him I can't see him right now!"
         }, {
+            "id": "j-0330",
             "joke": "What was a more important invention than the first telephone?",
             "punchline": "The second one."
         }, {
+            "id": "j-0331",
             "joke": "What do you get when you cross a snowman with a vampire?",
             "punchline": "Frostbite."
         }, {
+            "id": "j-0332",
             "joke": "What do you do when your bunny gets wet?",
             "punchline": "You get your hare dryer."
         }, {
+            "id": "j-0333",
             "joke": "Did you know crocodiles could grow up to 15 feet?",
             "punchline": "But most just have 4."
         }, {
+            "id": "j-0334",
             "joke": "There are two types of people in this world",
             "punchline": "those who can extrapolate from incomplete data..."
         }, {
+            "id": "j-0335",
             "joke": "Why did the fireman wear red, white, and blue suspenders?",
             "punchline": "To hold his pants up."
         }, {
+            "id": "j-0336",
             "joke": "In the news a courtroom artist was arrested today, I'm not surprised",
             "punchline": "he always seemed sketchy."
         }, {
+            "id": "j-0337",
             "joke": "What do you call someone with no nose?",
             "punchline": "Nobody knows."
         }, {
+            "id": "j-0338",
             "joke": "What do you call a girl between two posts?",
             "punchline": "Annette."
         }, {
+            "id": "j-0339",
             "joke": "What do you call a criminal going down the stairs?",
             "punchline": "Condescending"
         }, {
+            "id": "j-0340",
             "joke": "What do you call a fat psychic?",
             "punchline": "A four-chin teller."
         }, {
+            "id": "j-0341",
             "joke": "I used to be a banker",
             "punchline": "but I lost interest."
         }, {
+            "id": "j-0342",
             "joke": "Why can't a bicycle stand on its own?",
             "punchline": "It's two-tired."
         }, {
+            "id": "j-0343",
             "joke": "What does a pirate pay for his corn?",
             "punchline": "A buccaneer!"
         }, {
+            "id": "j-0344",
             "joke": "Astronomers got tired watching the moon go around the earth for 24 hours.",
             "punchline": "They decided to call it a day."
         }, {
+            "id": "j-0345",
             "joke": "My dog used to chase people on a bike a lot.",
             "punchline": "It got so bad I had to take his bike away."
         }, {
+            "id": "j-0346",
             "joke": "I ate a clock yesterday.",
             "punchline": "It was so time consuming."
         }, {
+            "id": "j-0347",
             "joke": "Is the pool safe for diving?",
             "punchline": "It deep ends."
         }, {
+            "id": "j-0348",
             "joke": "Why do scuba divers fall backwards into the water?",
             "punchline": "Because if they fell forwards they’d still be in the boat."
         }, {
+            "id": "j-0349",
             "joke": "My wife told me to rub the herbs on the meat for better flavor.",
             "punchline": "That's sage advice."
         }, {
+            "id": "j-0350",
             "joke": "A man was caught stealing in a supermarket today while balanced on the shoulders of a couple of vampires.",
             "punchline": "He was charged with shoplifting on two counts."
         }, {
+            "id": "j-0351",
             "joke": "Ben & Jerry's really need to improve their operation.",
             "punchline": "The only way to get there is down a rocky road."
         }, {
+            "id": "j-0352",
             "joke": "How are false teeth like stars?",
             "punchline": "They come out at night!"
         }, {
+            "id": "j-0353",
             "joke": "What time did the man go to the dentist?",
             "punchline": "Tooth hurt-y."
         }, {
+            "id": "j-0354",
             "joke": "I went to the zoo yesterday and saw a baguette in a cage.",
             "punchline": "It was bread in captivity."
         }, {
+            "id": "j-0355",
             "joke": "Did you hear about the cheese factory that exploded in France?",
             "punchline": "There was nothing left but de Brie."
         }, {
+            "id": "j-0356",
             "joke": "How does a penguin build it’s house?",
             "punchline": "Igloos it together."
         }, {
+            "id": "j-0357",
             "joke": "What is this movie about?",
             "punchline": "It is about 2 hours long."
         }, {
+            "id": "j-0358",
             "joke": "Why are pirates called pirates?",
             "punchline": "Because they arrr!"
         }, {
+            "id": "j-0359",
             "joke": "Where does Fonzie like to go for lunch?",
             "punchline": "Chick-Fil-Eyyyyyyyy."
         }, {
+            "id": "j-0360",
             "joke": "How does a dyslexic poet write?",
             "punchline": "Inverse."
         }, {
+            "id": "j-0361",
             "joke": "Don't tell secrets in corn fields.",
             "punchline": "Too many ears around."
         }, {
+            "id": "j-0362",
             "joke": "What did the pirate say on his 80th birthday?",
             "punchline": "Aye Matey!"
         }, {
+            "id": "j-0363",
             "joke": "Why did the A go to the bathroom and come out as an E?",
             "punchline": "Because he had a vowel movement."
         }, {
+            "id": "j-0364",
             "joke": "Yesterday a clown held a door open for me.",
             "punchline": "I thought it was a nice jester."
         }, {
+            "id": "j-0365",
             "joke": "Why did the opera singer go sailing?",
             "punchline": "They wanted to hit the high Cs."
         }, {
+            "id": "j-0366",
             "joke": "Bought a new jacket suit the other day and it burst into flames.",
             "punchline": "Well, it was a blazer"
         }, {
+            "id": "j-0367",
             "joke": "Whats a penguins favorite relative?",
             "punchline": "Aunt Arctica."
         }, {
+            "id": "j-0368",
             "joke": "Never Trust Someone With Graph Paper...",
             "punchline": "They're always plotting something."
         }, {
+            "id": "j-0369",
             "joke": "What do you call an elephant that doesn’t matter?",
             "punchline": "An irrelephant."
         }, {
+            "id": "j-0370",
             "joke": "What do you call a group of disorganized cats?",
             "punchline": "A cat-tastrophe."
         }, {
+            "id": "j-0371",
             "joke": "What is bread's favorite number?",
             "punchline": "Leaven."
         }, {
+            "id": "j-0372",
             "joke": "Why can’t you hear a pterodactyl go to the bathroom?",
             "punchline": "The p is silent."
         }, {
+            "id": "j-0373",
             "joke": "How do you know if there’s an elephant under your bed?",
             "punchline": "Your head hits the ceiling!"
         }, {
+            "id": "j-0374",
             "joke": "How do you teach a kid to climb stairs?",
             "punchline": "There is a step by step guide."
         }, {
+            "id": "j-0375",
             "joke": "Where do owls go to buy their baby clothes?",
             "punchline": "The owlet malls."
         }, {
+            "id": "j-0376",
             "joke": "Why does Norway have barcodes on their battleships?",
             "punchline": "So when they get back to port, they can Scandinavian."
         }, {
+            "id": "j-0377",
             "joke": "What's the worst part about being a cross-eyed teacher?",
             "punchline": "They can't control their pupils."
         }, {
+            "id": "j-0378",
             "joke": "What do you call a fashionable lawn statue with an excellent sense of rhythmn?",
             "punchline": "A metro-gnome"
         }, {
+            "id": "j-0379",
             "joke": "Someone broke into my house last night and stole my limbo trophy.",
             "punchline": "How low can you go?"
         }, {
+            "id": "j-0380",
             "joke": "Why did the coffee file a police report?",
             "punchline": "It got mugged."
         }, {
+            "id": "j-0381",
             "joke": "Mountains aren't just funny",
             "punchline": "they are hill areas"
         }, {
+            "id": "j-0382",
             "joke": "I was going to learn how to juggle",
             "punchline": "but I didn't have the balls."
         }, {
+            "id": "j-0383",
             "joke": "Why was the strawberry sad?",
             "punchline": "Its parents were in a jam."
         }, {
+            "id": "j-0384",
             "joke": "Why are ghosts bad liars?",
             "punchline": "Because you can see right through them!"
         }, {
+            "id": "j-0385",
             "joke": "Every machine in the coin factory broke down all of a sudden without explanation.",
             "punchline": "It just doesn’t make any cents."
         }, {
+            "id": "j-0386",
             "joke": "Why does it take longer to get from 1st to 2nd base, than it does to get from 2nd to 3rd base?",
             "punchline": "Because there’s a Shortstop in between!"
         }, {
+            "id": "j-0387",
             "joke": "What do you do when you see a space man?",
             "punchline": "Park your car, man."
         }, {
+            "id": "j-0388",
             "joke": "If you want a job in the moisturizer industry",
             "punchline": "the best advice I can give is to apply daily."
         }, {
+            "id": "j-0389",
             "joke": "When you have a bladder infection",
             "punchline": "urine trouble."
         }, {
+            "id": "j-0390",
             "joke": "How do you make Lady Gaga cry?",
             "punchline": "Poker face."
         }, {
+            "id": "j-0391",
             "joke": "What do you call a group of killer whales playing instruments?",
             "punchline": "An Orca-stra."
         }, {
+            "id": "j-0392",
             "joke": "I was in an 80's band called the prevention.",
             "punchline": "We were better than the cure."
         }, {
+            "id": "j-0393",
             "joke": "What did Michael Jackson name his denim store?",
             "punchline": "Billy Jeans!"
         }, {
+            "id": "j-0394",
             "joke": "People saying 'boo!",
             "punchline": "to their friends has risen by 85% in the last year.... That's a frightening statistic."
         }, {
+            "id": "j-0395",
             "joke": "Geology rocks",
             "punchline": "but Geography is where it's at!"
         }, {
+            "id": "j-0396",
             "joke": "Why does Han Solo like gum?",
             "punchline": "It's chewy!"
         }, {
+            "id": "j-0397",
             "joke": "I was at the library and asked if they have any books on \"paranoia\", the librarian replied, \"yes",
             "punchline": "they are right behind you\""
         }, {
+            "id": "j-0398",
             "joke": "Have you heard of the band 1023MB?",
             "punchline": "They haven't got a gig yet."
         }, {
+            "id": "j-0399",
             "joke": "What happens when you anger a brain surgeon?",
             "punchline": "They will give you a piece of your mind."
         }, {
+            "id": "j-0400",
             "joke": "I used to work at a stationery store. But, I didn't feel like I was going anywhere. So, I got a job at a travel agency.",
             "punchline": "Now, I know I'll be going places."
         }, {
+            "id": "j-0401",
             "joke": "I used to work in a shoe recycling shop.",
             "punchline": "It was sole destroying."
         }, {
+            "id": "j-0402",
             "joke": "I used to hate facial hair",
             "punchline": "but then it grew on me."
         }, {
+            "id": "j-0403",
             "joke": "R.I.P. boiled water.",
             "punchline": "You will be mist."
         }, {
+            "id": "j-0404",
             "joke": "Q: What did the spaghetti say to the other spaghetti?",
             "punchline": "A: Pasta la vista, baby!"
         }, {
+            "id": "j-0405",
             "joke": "The first time I got a universal remote control I thought to myself",
             "punchline": "\"This changes everything\""
         }, {
+            "id": "j-0406",
             "joke": "Why is the ocean always blue?",
             "punchline": "Because the shore never waves back."
         }, {
+            "id": "j-0407",
             "joke": "Why did the feline fail the lie detector test?",
             "punchline": "Because he be lion."
         }, {
+            "id": "j-0408",
             "joke": "Why did the man put his money in the freezer?",
             "punchline": "He wanted cold hard cash!"
         }, {
+            "id": "j-0409",
             "joke": "Why do ducks make great detectives?",
             "punchline": "They always quack the case."
         }, {
+            "id": "j-0410",
             "joke": "What does a clock do when it's hungry?",
             "punchline": "It goes back four seconds!"
         }, {
+            "id": "j-0411",
             "joke": "What do I look like?",
             "punchline": "A JOKE MACHINE!?"
         }, {
+            "id": "j-0412",
             "joke": "I bought shoes from a drug dealer once.",
             "punchline": "I don't know what he laced them with, but I was tripping all day."
         }, {
+            "id": "j-0413",
             "joke": "What is a tornado's favorite game to play?",
             "punchline": "Twister!"
         }, {
+            "id": "j-0414",
             "joke": "You know that cemetery up the road?",
             "punchline": "People are dying to get in there."
         }, {
+            "id": "j-0415",
             "joke": "Pie is $2.50 in Jamaica and $3.00 in The Bahamas.",
             "punchline": "These are the pie-rates of the Caribbean."
         }, {
+            "id": "j-0416",
             "joke": "What do you call a fish wearing a bowtie?",
             "punchline": "Sofishticated."
         }, {
+            "id": "j-0417",
             "joke": "Did you hear about the Mexican train killer?",
             "punchline": "He had loco motives"
         }, {
+            "id": "j-0418",
             "joke": "Can I watch the TV?",
             "punchline": "Dad: Yes, but don’t turn it on."
         }, {
+            "id": "j-0419",
             "joke": "What is worse then finding a worm in your Apple?",
             "punchline": "Finding half a worm in your Apple."
         }, {
+            "id": "j-0420",
             "joke": "What do vegetarian zombies eat?",
             "punchline": "Grrrrrainnnnnssss."
         }, {
+            "id": "j-0421",
             "joke": "\"I'm sorry.\" \"Hi sorry",
             "punchline": "I'm dad\""
         }, {
+            "id": "j-0422",
             "joke": "What is the hardest part about sky diving?",
             "punchline": "The ground."
         }, {
+            "id": "j-0423",
             "joke": "Why did the cowboy have a weiner dog?",
             "punchline": "Somebody told him to get a long little doggy."
         }, {
+            "id": "j-0424",
             "joke": "My friend keeps telling me \"Cheer up.",
             "punchline": "You aren't stuck in a deep hole in the ground, filled with water.\" I know he means well."
         }, {
+            "id": "j-0425",
             "joke": "Who did the wizard marry?",
             "punchline": "His ghoul-friend"
         }, {
+            "id": "j-0426",
             "joke": "How many seconds are in a year? 12. January 2nd, February 2nd, March 2nd, April 2nd....",
             "punchline": "etc"
         }, {
+            "id": "j-0427",
             "joke": "I ordered a chicken and an egg from Amazon.",
             "punchline": "I'll let you know."
         }, {
+            "id": "j-0428",
             "joke": "Ever wondered why bees hum?",
             "punchline": "It's because they don't know the words."
         }, {
+            "id": "j-0429",
             "joke": "How many optometrists does it take to change a light bulb? 1 or 2?",
             "punchline": "1... or 2?"
         }, {
+            "id": "j-0430",
             "joke": "There's not really any training for garbagemen.",
             "punchline": "They just pick things up as they go."
         }, {
+            "id": "j-0431",
             "joke": "Did you hear about the cow who jumped over the barbed wire fence?",
             "punchline": "It was udder destruction."
         }, {
+            "id": "j-0432",
             "joke": "I was shocked when I was diagnosed as colorblind...",
             "punchline": "It came out of the purple."
         }, {
+            "id": "j-0433",
             "joke": "Where does astronauts hangout after work?",
             "punchline": "At the spacebar."
         }, {
+            "id": "j-0434",
             "joke": "What do you call a bear with no teeth?",
             "punchline": "A gummy bear!"
         }, {
+            "id": "j-0435",
             "joke": "I’ve deleted the phone numbers of all the Germans I know from my mobile phone.",
             "punchline": "Now it’s Hans free."
         }, {
+            "id": "j-0436",
             "joke": "What do you call your friend who stands in a hole?",
             "punchline": "Phil."
         }, {
+            "id": "j-0437",
             "joke": "A doll was recently found dead in a rice paddy.",
             "punchline": "It's the only known instance of a nick nack paddy wack."
         }, {
+            "id": "j-0438",
             "joke": "How do you tell the difference between a crocodile and an alligator?",
             "punchline": "You will see one later and one in a while."
         }, {
+            "id": "j-0439",
             "joke": "What do you call a fake noodle?",
             "punchline": "An impasta."
         }, {
+            "id": "j-0440",
             "joke": "The word queue is ironic.",
             "punchline": "It's just q with a bunch of silent letters waiting in line."
         }, {
+            "id": "j-0441",
             "joke": "What do you call a droid that takes the long way around?",
             "punchline": "R2 detour."
         }, {
+            "id": "j-0442",
             "joke": "What's the best thing about elevator jokes?",
             "punchline": "They work on so many levels."
         }, {
+            "id": "j-0443",
             "joke": "Where do rabbits go after they get married?",
             "punchline": "On a bunny-moon."
         }, {
+            "id": "j-0444",
             "joke": "Why do cows wear bells?",
             "punchline": "Because their horns don't work."
         }, {
+            "id": "j-0445",
             "joke": "Two fish are in a tank, one turns to the other and says",
             "punchline": "\"how do you drive this thing?\""
         }, {
+            "id": "j-0446",
             "joke": "I finally bought the limited edition Thesaurus that I've always wanted.",
             "punchline": "When I opened it, all the pages were blank. I have no words to describe how angry I am."
         }, {
+            "id": "j-0447",
             "joke": "This is my step ladder.",
             "punchline": "I never knew my real ladder."
         }, {
+            "id": "j-0448",
             "joke": "A man walks into a bar and orders helicopter flavor chips.",
             "punchline": "The barman replies “sorry mate we only do plain”"
         }, {
+            "id": "j-0449",
             "joke": "It's been months since I bought the book \"how to scam people online\".",
             "punchline": "It still hasn't turned up."
         }, {
+            "id": "j-0450",
             "joke": "Why is it a bad idea to iron your four-leaf clover?",
             "punchline": "Cause you shouldn't press your luck."
         }, {
+            "id": "j-0451",
             "joke": "What did the fish say when it swam into a wall?",
             "punchline": "Damn!"
         }, {
+            "id": "j-0452",
             "joke": "I accidentally drank a bottle of invisible ink.",
             "punchline": "Now I’m in hospital, waiting to be seen."
         }, {
+            "id": "j-0453",
             "joke": "Why does Waldo only wear stripes?",
             "punchline": "Because he doesn't want to be spotted."
         }, {
+            "id": "j-0454",
             "joke": "Why did the scarecrow win an award?",
             "punchline": "Because he was outstanding in his field."
         }, {
+            "id": "j-0455",
             "joke": "Americans can't switch from pounds to kilograms overnight.",
             "punchline": "That would cause mass confusion."
         }, {
+            "id": "j-0456",
             "joke": "An apple a day keeps the bullies away.",
             "punchline": "If you throw it hard enough."
         }, {
+            "id": "j-0457",
             "joke": "Why does Superman get invited to dinners?",
             "punchline": "Because he is a Supperhero."
         }, {
+            "id": "j-0458",
             "joke": "Why is no one friends with Dracula?",
             "punchline": "Because he's a pain in the neck."
         }, {
+            "id": "j-0459",
             "joke": "A man got hit in the head with a can of Coke",
             "punchline": "but he was alright because it was a soft drink."
         }, {
+            "id": "j-0460",
             "joke": "What is the leading cause of dry skin?",
             "punchline": "Towels"
         }, {
+            "id": "j-0461",
             "joke": "A man walked in to a bar with some asphalt on his arm.",
             "punchline": "He said “Two beers please, one for me and one for the road.”"
         }, {
+            "id": "j-0462",
             "joke": "Did you know the first French fries weren't actually cooked in France?",
             "punchline": "They were cooked in Greece."
         }, {
+            "id": "j-0463",
             "joke": "I’ll tell you something about German sausages",
             "punchline": "they’re the wurst"
         }, {
+            "id": "j-0464",
             "joke": "Where did Captain Hook get his hook?",
             "punchline": "From a second hand store."
         }, {
+            "id": "j-0465",
             "joke": "I got fired from a florist",
             "punchline": "apparently I took too many leaves."
         }, {
+            "id": "j-0466",
             "joke": "Two silk worms had a race.",
             "punchline": "They ended up in a tie."
         }, {
+            "id": "j-0467",
             "joke": "I got fired from the transmission factor",
             "punchline": "turns out I didn't put on enough shifts..."
         }, {
+            "id": "j-0468",
             "joke": "Where do young cows eat lunch?",
             "punchline": "In the calf-ateria."
         }, {
+            "id": "j-0469",
             "joke": "How does a French skeleton say hello?",
             "punchline": "Bone-jour."
         }, {
+            "id": "j-0470",
             "joke": "Why was the big cat disqualified from the race?",
             "punchline": "Because it was a cheetah."
         }, {
+            "id": "j-0471",
             "joke": "What do prisoners use to call each other?",
             "punchline": "Cell phones."
         }, {
+            "id": "j-0472",
             "joke": "What’s E.T. short for?",
             "punchline": "He’s only got little legs."
         }, {
+            "id": "j-0473",
             "joke": "What kind of award did the dentist receive?",
             "punchline": "A little plaque."
         }, {
+            "id": "j-0474",
             "joke": "Got a new suit recently made entirely of living plants.",
             "punchline": "I wasn’t sure at first, but it’s grown on me"
         }, {
+            "id": "j-0475",
             "joke": "Do you know where you can get chicken broth in bulk?",
             "punchline": "The stock market."
         }, {
+            "id": "j-0476",
             "joke": "What's orange and sounds like a parrot?",
             "punchline": "A Carrot."
         }, {
+            "id": "j-0477",
             "joke": "A Sandwich walks into a bar, the bartender says “Sorry",
             "punchline": "we don’t serve food here”"
         }, {
+            "id": "j-0478",
             "joke": "What do you get hanging from Apple trees?",
             "punchline": "Sore arms."
         }, {
+            "id": "j-0479",
             "joke": "I thought about going on an all-almond diet.",
             "punchline": "But that's just nuts."
         }, {
+            "id": "j-0480",
             "joke": "I don’t play soccer because I enjoy the sport.",
             "punchline": "I’m just doing it for kicks."
         }, {
+            "id": "j-0481",
             "joke": "Today a girl said she recognized me from vegetarian club",
             "punchline": "but I’m sure I’ve never met herbivore."
         }, {
+            "id": "j-0482",
             "joke": "How do you organize a space party?",
             "punchline": "You planet."
         }, {
+            "id": "j-0483",
             "joke": "How do you make holy water?",
             "punchline": "You boil the hell out of it."
         }, {
+            "id": "j-0484",
             "joke": "A man is washing the car with his son. The son asks......",
             "punchline": "\"Dad, can’t you just use a sponge?\""
         }, {
+            "id": "j-0485",
             "joke": "What does an angry pepper do?",
             "punchline": "It gets jalapeño face."
         }, {
+            "id": "j-0486",
             "joke": "Don't buy flowers at a monastery.",
             "punchline": "Because only you can prevent florist friars."
         }, {
+            "id": "j-0487",
             "joke": "Hostess: Do you have a preference of where you sit?",
             "punchline": "Dad: Down."
         }, {
+            "id": "j-0488",
             "joke": "Did you hear about the submarine industry?",
             "punchline": "It really took a dive..."
         }, {
+            "id": "j-0489",
             "joke": "The biggest knight at King Arthur's round table was Sir Cumference.",
             "punchline": "He acquired his size from eating too much pi."
         }, {
+            "id": "j-0490",
             "joke": "How do you get a baby alien to sleep?",
             "punchline": "You rocket."
         }, {
+            "id": "j-0491",
             "joke": "Why do pirates not know the alphabet?",
             "punchline": "They always get stuck at \"C\"."
         }, {
+            "id": "j-0492",
             "joke": "I saw my husband trip and fall while carrying a laundry basket full of ironed clothes.",
             "punchline": "I watched it all unfold."
         }, {
+            "id": "j-0493",
             "joke": "Did you hear about the chameleon who couldn't change color?",
             "punchline": "They had a reptile dysfunction."
         }, {
+            "id": "j-0494",
             "joke": "Why did the house go to the doctor?",
             "punchline": "It was having window panes."
         }, {
+            "id": "j-0495",
             "joke": "I made a playlist for hiking. It has music from Peanuts, The Cranberries, and Eminem.",
             "punchline": "I call it my Trail Mix."
         }, {
+            "id": "j-0496",
             "joke": "What do you call a dictionary on drugs?",
             "punchline": "High definition."
         }, {
+            "id": "j-0497",
             "joke": "How do robots eat guacamole?",
             "punchline": "With computer chips."
         }, {
+            "id": "j-0498",
             "joke": "Today, my son asked \"Can I have a book mark?\" and I burst into tears.",
             "punchline": "11 years old and he still doesn't know my name is Brian."
         }, {
+            "id": "j-0499",
             "joke": "When does a joke become a dad joke?",
             "punchline": "When it becomes apparent."
         }, {
+            "id": "j-0500",
             "joke": "What’s brown and sounds like a bell?",
             "punchline": "Dung!"
         }, {
+            "id": "j-0501",
             "joke": "What has a bed that you can’t sleep in?",
             "punchline": "A river."
         }, {
+            "id": "j-0502",
             "joke": "Why do crabs never give to charity?",
             "punchline": "Because they’re shellfish."
         }, {
+            "id": "j-0503",
             "joke": "What do you call a pig with three eyes?",
             "punchline": "Piiig"
         }, {
+            "id": "j-0504",
             "joke": "How do you make a hankie dance?",
             "punchline": "Put a little boogie in it."
         }, {
+            "id": "j-0505",
             "joke": "Sgt.: Commissar! Commissar! The troops are revolting!",
             "punchline": "Commissar: Well, you’re pretty repulsive yourself."
         }, {
+            "id": "j-0506",
             "joke": "The other day I was listening to a song about superglue",
             "punchline": "it’s been stuck in my head ever since."
         }, {
+            "id": "j-0507",
             "joke": "What don't watermelons get married?",
             "punchline": "Because they cantaloupe."
         }, {
+            "id": "j-0508",
             "joke": "If you’re struggling to think of what to get someone for Christmas.",
             "punchline": "Get them a fridge and watch their face light up when they open it."
         }, {
+            "id": "j-0509",
             "joke": "Did you hear about the cheese who saved the world?",
             "punchline": "It was Legend-dairy!"
         }, {
+            "id": "j-0510",
             "joke": "What do you call cheese by itself?",
             "punchline": "Provolone."
         }, {
+            "id": "j-0511",
             "joke": "How do you fix a broken pizza?",
             "punchline": "With tomato paste."
         }, {
+            "id": "j-0512",
             "joke": "What's red and bad for your teeth?",
             "punchline": "A Brick."
         }, {
+            "id": "j-0513",
             "joke": "I heard there was a new store called Moderation.",
             "punchline": "They have everything there"
         }, {
+            "id": "j-0514",
             "joke": "A beekeeper was indicted after he confessed to years of stealing at work.",
             "punchline": "They charged him with emBEEzlement"
         }, {
+            "id": "j-0515",
             "joke": "I used to work for a soft drink can crusher.",
             "punchline": "It was soda pressing."
         }, {
+            "id": "j-0516",
             "joke": "Why did the chicken get a penalty?",
             "punchline": "For fowl play."
         }, {
+            "id": "j-0517",
             "joke": "My cat was just sick on the carpet",
             "punchline": "I don’t think it’s feline well."
         }, {
+            "id": "j-0518",
             "joke": "Why did the burglar hang his mugshot on the wall?",
             "punchline": "To prove that he was framed!"
         }, {
+            "id": "j-0519",
             "joke": "I dreamed about drowning in an ocean made out of orange soda last night.",
             "punchline": "It took me a while to work out it was just a Fanta sea."
         }, {
+            "id": "j-0520",
             "joke": "I had a dream that I was a muffler last night.",
             "punchline": "I woke up exhausted!"
         }, {
+            "id": "j-0521",
             "joke": "A dad washes his car with his son.",
             "punchline": "But after a while, the son says, \"why can't you just use a sponge?\""
         }, {
+            "id": "j-0522",
             "joke": "Doctor you've got you help me, I'm addicted to twitter.",
             "punchline": "Doctor: I don't follow you."
         }, {
+            "id": "j-0523",
             "joke": "I broke my finger at work today",
             "punchline": "on the other hand I'm completely fine."
         }, {
+            "id": "j-0524",
             "joke": "I went to a book store and asked the saleswoman where the Self Help section was",
             "punchline": "she said if she told me it would defeat the purpose."
         }, {
+            "id": "j-0525",
             "joke": "How does a scientist freshen their breath?",
             "punchline": "With experi-mints!"
         }, {
+            "id": "j-0526",
             "joke": "What has ears but cannot hear?",
             "punchline": "A field of corn."
         }, {
+            "id": "j-0527",
             "joke": "How did Darth Vader know what Luke was getting for Christmas?",
             "punchline": "He felt his presents."
         }, {
+            "id": "j-0528",
             "joke": "What's the difference between a seal and a sea lion?",
             "punchline": "An ion!"
         }, {
+            "id": "j-0529",
             "joke": "What did the Dorito farmer say to the other Dorito farmer?",
             "punchline": "Cool Ranch!"
         }, {
+            "id": "j-0530",
             "joke": "A ghost walks into a bar and asks for a glass of vodka but the bar tender says",
             "punchline": "“sorry we don’t serve spirits”"
         }, {
+            "id": "j-0531",
             "joke": "Why do wizards clean their teeth three times a day?",
             "punchline": "To prevent bat breath!"
         }, {
+            "id": "j-0532",
             "joke": "Someone asked me, what's the ninth letter of the alphabet?",
             "punchline": "It was a complete guess, but I was right."
         }, {
+            "id": "j-0533",
             "joke": "Feeling pretty proud of myself.",
             "punchline": "The Sesame Street puzzle I bought said 3-5 years, but I finished it in 18 months."
         }, {
+            "id": "j-0534",
             "joke": "Why are fish so smart?",
             "punchline": "Because they live in schools!"
         }, {
+            "id": "j-0535",
             "joke": "How does the moon cut his hair?",
             "punchline": "Eclipse it."
         }, {
+            "id": "j-0536",
             "joke": "Why did the worker get fired from the orange juice factory?",
             "punchline": "Lack of concentration."
         }, {
+            "id": "j-0537",
             "joke": "I couldn't get a reservation at the library.",
             "punchline": "They were completely booked."
         }, {
+            "id": "j-0538",
             "joke": "Dad, can you put my shoes on?",
             "punchline": "I don't think they'll fit me."
         }, {
+            "id": "j-0539",
             "joke": "How do you get two whales in a car?",
             "punchline": "Start in England and drive West."
         }, {
+            "id": "j-0540",
             "joke": "What do you call an Argentinian with a rubber toe?",
             "punchline": "Roberto"
         }, {
+            "id": "j-0541",
             "joke": "I tried taking some high resolution photos of local farmland",
             "punchline": "but they all turned out a bit grainy."
         }, {
+            "id": "j-0542",
             "joke": "What did the ocean say to the shore?",
             "punchline": "Nothing, it just waved."
         }, {
+            "id": "j-0543",
             "joke": "I went to the zoo the other day, there was only one dog in it.",
             "punchline": "It was a shitzu."
         }, {
+            "id": "j-0544",
             "joke": "Someone asked me to name two structures that hold water.",
             "punchline": "I said \"Well dam\""
         }, {
+            "id": "j-0545",
             "joke": "I gave all my dead batteries away today",
             "punchline": "free of charge."
         }, {
+            "id": "j-0546",
             "joke": "Did you hear the news?",
             "punchline": "FedEx and UPS are merging. They’re going to go by the name Fed-Up from now on."
         }, {
+            "id": "j-0547",
             "joke": "Why didn't the number 4 get into the nightclub?",
             "punchline": "Because he is 2 square."
         }, {
+            "id": "j-0548",
             "joke": "What do you call a sheep with no legs?",
             "punchline": "A cloud."
         }, {
+            "id": "j-0549",
             "joke": "Why did the m&m go to school?",
             "punchline": "Because it wanted to be a Smartie!"
         }, {
+            "id": "j-0550",
             "joke": "Did you hear that David lost his ID in prague?",
             "punchline": "Now we just have to call him Dav."
         }, {
+            "id": "j-0551",
             "joke": "My wife is on a tropical fruit diet, the house is full of stuff.",
             "punchline": "It is enough to make a mango crazy."
         }, {
+            "id": "j-0552",
             "joke": "Why are basketball players messy eaters?",
             "punchline": "Because they are always dribbling."
         }, {
+            "id": "j-0553",
             "joke": "Why do mathematicians hate the U.S.?",
             "punchline": "Because it's indivisible."
         }, {
+            "id": "j-0554",
             "joke": "I knew i shouldn’t have ate that seafood.",
             "punchline": "Because now i’m feeling a little… Eel"
         }, {
+            "id": "j-0555",
             "joke": "Past, present, and future walked into a bar....",
             "punchline": "It was tense."
         }, {
+            "id": "j-0556",
             "joke": "Did you hear about the bread factory burning down?",
             "punchline": "They say the business is toast."
         }, {
+            "id": "j-0557",
             "joke": "My boss told me that he was going to fire the person with the worst posture.",
             "punchline": "I have a hunch, it might be me."
         }, {
+            "id": "j-0558",
             "joke": "What's black and white and read all over?",
             "punchline": "The newspaper."
         }, {
+            "id": "j-0559",
             "joke": "Why are skeletons so calm?",
             "punchline": "Because nothing gets under their skin."
         }, {
+            "id": "j-0560",
             "joke": "“Hold on",
             "punchline": "I have something in my shoe” “I’m pretty sure it’s a foot”"
         }, {
+            "id": "j-0561",
             "joke": "Have you heard about the film \"Constipation\"",
             "punchline": "you probably haven't because it's not out yet."
         }, {
+            "id": "j-0562",
             "joke": "Did you know Albert Einstein was a real person?",
             "punchline": "All this time, I thought he was just a theoretical physicist!"
         }, {
+            "id": "j-0563",
             "joke": "I hate perforated lines",
             "punchline": "they're tearable."
         }, {
+            "id": "j-0564",
             "joke": "I asked the surgeon if I could administer my own anesthetic, they said: go ahead",
             "punchline": "knock yourself out."
         }, {
+            "id": "j-0565",
             "joke": "Why did the barber win the race?",
             "punchline": "He took a short cut."
         }, {
+            "id": "j-0566",
             "joke": "Why did the octopus beat the shark in a fight?",
             "punchline": "Because it was well armed."
         }, {
+            "id": "j-0567",
             "joke": "What did the doctor say to the gingerbread man who broke his leg?",
             "punchline": "Try icing it."
         }, {
+            "id": "j-0568",
             "joke": "What did the judge say to the dentist?",
             "punchline": "Do you swear to pull the tooth, the whole tooth and nothing but the tooth?"
         }, {
+            "id": "j-0569",
             "joke": "\"What time is it?\" I don't know...",
             "punchline": "it keeps changing."
         }, {
+            "id": "j-0570",
             "joke": "You can't trust a ladder.",
             "punchline": "It will always let you down"
         }, {
+            "id": "j-0571",
             "joke": "I wouldn't buy anything with velcro.",
             "punchline": "It's a total rip-off."
         }, {
+            "id": "j-0572",
             "joke": "What are the strongest days of the week?",
             "punchline": "Saturday and Sunday...the rest are weekdays."
         }, {
+            "id": "j-0573",
             "joke": "I had a rough day, and then somebody went and ripped the front and back pages from my dictionary.",
             "punchline": "It just goes from bad to worse."
         }, {
+            "id": "j-0574",
             "joke": "I adopted my dog from a blacksmith.",
             "punchline": "As soon as we got home he made a bolt for the door."
         }, {
+            "id": "j-0575",
             "joke": "Where does batman go to the bathroom?",
             "punchline": "The batroom."
         }, {
+            "id": "j-0576",
             "joke": "Some people say that comedians who tell one too many light bulb jokes soon burn out, but they don't know watt they are talking about.",
             "punchline": "They're not that bright."
         }, {
+            "id": "j-0577",
             "joke": "A bartender broke up with her boyfriend",
             "punchline": "but he kept asking her for another shot."
         }, {
+            "id": "j-0578",
             "joke": "What do you call a cow on a trampoline?",
             "punchline": "A milk shake!"
         }, {
+            "id": "j-0579",
             "joke": "What do you call a nervous javelin thrower?",
             "punchline": "Shakespeare."
         }, {
+            "id": "j-0580",
             "joke": "What do you call an eagle who can play the piano?",
             "punchline": "Talonted!"
         }, {
+            "id": "j-0581",
             "joke": "What do you call a boomerang that won't come back?",
             "punchline": "A stick."
         }, {
+            "id": "j-0582",
             "joke": "What do you call a duck that gets all A's?",
             "punchline": "A wise quacker."
         }, {
+            "id": "j-0583",
             "joke": "There’s a new type of broom out",
             "punchline": "it’s sweeping the nation."
         }, {
+            "id": "j-0584",
             "joke": "I just wrote a book on reverse psychology.",
             "punchline": "Do not read it!"
         }, {
+            "id": "j-0585",
             "joke": "Why don’t seagulls fly over the bay?",
             "punchline": "Because then they’d be bay-gulls!"
         }, {
+            "id": "j-0586",
             "joke": "Parallel lines have so much in common.",
             "punchline": "It’s a shame they’ll never meet."
         }, {
+            "id": "j-0587",
             "joke": "What do you call a magician who has lost their magic?",
             "punchline": "Ian."
         }, {
+            "id": "j-0588",
             "joke": "Why do fish live in salt water?",
             "punchline": "Because pepper makes them sneeze!"
         }, {
+            "id": "j-0589",
             "joke": "When do doctors get angry?",
             "punchline": "When they run out of patients."
         }, {
+            "id": "j-0590",
             "joke": "A man tried to sell me a coffin today.",
             "punchline": "I told him that's the last thing I need."
         }, {
+            "id": "j-0591",
             "joke": "It doesn't matter how much you push the envelope.",
             "punchline": "It will still be stationary."
         }, {
+            "id": "j-0592",
             "joke": "What did the shy pebble wish for?",
             "punchline": "That she was a little boulder."
         }, {
+            "id": "j-0593",
             "joke": "Why did the belt go to prison?",
             "punchline": "He held up a pair of pants!"
         }, {
+            "id": "j-0594",
             "joke": "Wife told me to take the spider out instead of killing it...",
             "punchline": "We had some drinks, cool guy, wants to be a web developer."
         }, {
+            "id": "j-0595",
             "joke": "What cheese can never be yours?",
             "punchline": "Nacho cheese."
         }, {
+            "id": "j-0596",
             "joke": "What is a vampire's favorite fruit?",
             "punchline": "A blood orange."
         }, {
+            "id": "j-0597",
             "joke": "Why did the cookie cry?",
             "punchline": "Because his mother was a wafer so long"
         }, {
+            "id": "j-0598",
             "joke": "Want to hear my pizza joke?",
             "punchline": "Never mind, it's too cheesy."
         }, {
+            "id": "j-0599",
             "joke": "What did the grape do when he got stepped on?",
             "punchline": "He let out a little wine."
         }, {
+            "id": "j-0600",
             "joke": "What did the 0 say to the 8?",
             "punchline": "Nice belt."
         }, {
+            "id": "j-0601",
             "joke": "Why was the picture sent to prison?",
             "punchline": "It was framed."
         }, {
+            "id": "j-0602",
             "joke": "I burned 2000 calories today",
             "punchline": "I left my food in the oven for too long."
         }, {
+            "id": "j-0603",
             "joke": "Cosmetic surgery used to be such a taboo subject.",
             "punchline": "Now you can talk about Botox and nobody raises an eyebrow."
         }, {
+            "id": "j-0604",
             "joke": "How can you tell a vampire has a cold?",
             "punchline": "They start coffin."
         }, {
+            "id": "j-0605",
             "joke": "At the boxing match, the dad got into the popcorn line and the line for hot dogs",
             "punchline": "but he wanted to stay out of the punchline."
         }, {
+            "id": "j-0606",
             "joke": "\"Hey, dad, did you get a haircut?\" \"No",
             "punchline": "I got them all cut.\""
         }, {
+            "id": "j-0607",
             "joke": "Why is there always a gate around cemeteries?",
             "punchline": "Because people are always dying to get in."
         }, {
+            "id": "j-0608",
             "joke": "I asked a frenchman if he played video games.",
             "punchline": "He said \"Wii\""
         }, {
+            "id": "j-0609",
             "joke": "My dentist is the best",
             "punchline": "he even has a little plaque!"
         }, {
+            "id": "j-0610",
             "joke": "So, I heard this pun about cows, but it’s kinda offensive so I won’t say it.",
             "punchline": "I don’t want there to be any beef between us."
         }, {
+            "id": "j-0611",
             "joke": "What do Alexander the Great and Winnie the Pooh have in common?",
             "punchline": "Same middle name."
         }, {
+            "id": "j-0612",
             "joke": "What kind of music do planets listen to?",
             "punchline": "Nep-tunes."
         }, {
+            "id": "j-0613",
             "joke": "Shout out to my grandma",
             "punchline": "that's the only way she can hear."
         }, {
+            "id": "j-0614",
             "joke": "Why was the broom late for the meeting?",
             "punchline": "He overswept."
         }, {
+            "id": "j-0615",
             "joke": "I went on a date last night with a girl from the zoo. It was great.",
             "punchline": "She’s a keeper."
         }, {
+            "id": "j-0616",
             "joke": "Why do you never see elephants hiding in trees?",
             "punchline": "Because they're so good at it."
         }, {
+            "id": "j-0617",
             "joke": "Mahatma Gandhi, as you know, walked barefoot most of the time, which produced an impressive set of calluses on his feet. He also ate very little, which made him rather frail and with his odd diet, he suffered from bad breath.",
             "punchline": "This made him a super calloused fragile mystic hexed by halitosis."
         }, {
+            "id": "j-0618",
             "joke": "What do you call an alligator in a vest?",
             "punchline": "An in-vest-igator!"
         }, {
+            "id": "j-0619",
             "joke": "What did celery say when he broke up with his girlfriend?",
             "punchline": "She wasn't right for me, so I really don't carrot all."
         }, {
+            "id": "j-0620",
             "joke": "Thanks for explaining the word \"many\" to me.",
             "punchline": "It means a lot."
         }, {
+            "id": "j-0621",
             "joke": "What's brown and sticky?",
             "punchline": "A stick."
         }, {
+            "id": "j-0622",
             "joke": "What biscuit does a short person like?",
             "punchline": "Shortbread."
         }, {
+            "id": "j-0623",
             "joke": "Why was Santa's little helper feeling depressed?",
             "punchline": "Because he has low elf esteem."
         }, {
+            "id": "j-0624",
             "joke": "Why did Sweden start painting barcodes on the sides of their battleships?",
             "punchline": "So they could Scandinavian."
         }, {
+            "id": "j-0625",
             "joke": "Want to hear a chimney joke?",
             "punchline": "Got stacks of em! First one's on the house"
         }, {
+            "id": "j-0626",
             "joke": "What do you call a pig that knows karate?",
             "punchline": "A pork chop!"
         }, {
+            "id": "j-0627",
             "joke": "If two vegans are having an argument",
             "punchline": "is it still considered beef?"
         }, {
+            "id": "j-0628",
             "joke": "For Valentine's day, I decided to get my wife some beads for an abacus.",
             "punchline": "It's the little things that count."
         }, {
+            "id": "j-0629",
             "joke": "What's the worst thing about ancient history class?",
             "punchline": "The teachers tend to Babylon."
         }, {
+            "id": "j-0630",
             "joke": "My new thesaurus is terrible.",
             "punchline": "In fact, it's so bad, I'd say it's terrible."
         }, {
+            "id": "j-0631",
             "joke": "What type of music do balloons hate?",
             "punchline": "Pop music!"
         }, {
+            "id": "j-0632",
             "joke": "Do you want a brief explanation of what an acorn is?",
             "punchline": "In a nutshell, it's an oak tree."
         }, {
+            "id": "j-0633",
             "joke": "How come a man driving a train got struck by lightning?",
             "punchline": "He was a good conductor."
         }, {
+            "id": "j-0634",
             "joke": "Dad died because he couldn't remember his blood type. I will never forget his last words.",
             "punchline": "Be positive."
         }, {
+            "id": "j-0635",
             "joke": "I’m on a whiskey diet.",
             "punchline": "I’ve lost three days already."
         }, {
+            "id": "j-0636",
             "joke": "How does Darth Vader like his toast?",
             "punchline": "On the dark side."
         }, {
+            "id": "j-0637",
             "joke": "Why didn’t the orange win the race?",
             "punchline": "It ran out of juice."
         }, {
+            "id": "j-0638",
             "joke": "Did you hear about the runner who was criticized?",
             "punchline": "He just took it in stride"
         }, {
+            "id": "j-0639",
             "joke": "What animal is always at a game of cricket?",
             "punchline": "A bat."
         }, {
+            "id": "j-0640",
             "joke": "Why did the Clydesdale give the pony a glass of water?",
             "punchline": "Because he was a little horse!"
         }, {
+            "id": "j-0641",
             "joke": "If you think swimming with dolphins is expensive",
             "punchline": "you should try swimming with sharks--it cost me an arm and a leg!"
         }, {
+            "id": "j-0642",
             "joke": "What did the Buffalo say to his little boy when he dropped him off at school?",
             "punchline": "Bison."
         }, {
+            "id": "j-0643",
             "joke": "I am terrified of elevators.",
             "punchline": "I’m going to start taking steps to avoid them."
         }, {
+            "id": "j-0644",
             "joke": "Why do bees have sticky hair?",
             "punchline": "Because they use honey combs!"
         }, {
+            "id": "j-0645",
             "joke": "Did you know you should always take an extra pair of pants golfing?",
             "punchline": "Just in case you get a hole in one."
         }, {
+            "id": "j-0646",
             "joke": "I wish I could clean mirrors for a living.",
             "punchline": "It's just something I can see myself doing."
         }, {
+            "id": "j-0647",
             "joke": "How do the trees get on the internet?",
             "punchline": "They log on."
         }, {
+            "id": "j-0648",
             "joke": "To the guy who invented zero...",
             "punchline": "thanks for nothing."
         }, {
+            "id": "j-0649",
             "joke": "What lies at the bottom of the ocean and twitches?",
             "punchline": "A nervous wreck."
         }, {
+            "id": "j-0650",
             "joke": "What is red and smells like blue paint?",
             "punchline": "Red paint!"
         }, {
+            "id": "j-0651",
             "joke": "*Reversing the car* \"Ah",
             "punchline": "this takes me back\""
         }, {
+            "id": "j-0652",
             "joke": "How do locomotives know where they're going?",
             "punchline": "Lots of training"
         }, {
+            "id": "j-0653",
             "joke": "How did the hipster burn the roof of his mouth?",
             "punchline": "He ate the pizza before it was cool."
         }, {
+            "id": "j-0654",
             "joke": "Did you hear about the new restaurant on the moon?",
             "punchline": "The food is great, but there’s just no atmosphere."
         }, {
+            "id": "j-0655",
             "joke": "What do you call a beehive without the b's?",
             "punchline": "An eehive."
         }, {
+            "id": "j-0656",
             "joke": "What kind of pants do ghosts wear?",
             "punchline": "Boo jeans."
         }, {
+            "id": "j-0657",
             "joke": "Two guys walked into a bar",
             "punchline": "the third one ducked."
         }, {
+            "id": "j-0658",
             "joke": "I really want to buy one of those supermarket checkout dividers",
             "punchline": "but the cashier keeps putting it back."
         }, {
+            "id": "j-0659",
             "joke": "A horse walks into a bar.",
             "punchline": "The bar tender says \"Hey.\" The horse says \"Sure.\""
         }, {
+            "id": "j-0660",
             "joke": "Did you hear about the guy who invented Lifesavers?",
             "punchline": "They say he made a mint."
         }, {
+            "id": "j-0661",
             "joke": "What's the difference between a poorly dressed man on a tricycle and a well dressed man on a bicycle?",
             "punchline": "Attire."
         }, {
+            "id": "j-0662",
             "joke": "Why are giraffes so slow to apologize?",
             "punchline": "Because it takes them a long time to swallow their pride."
         }, {
+            "id": "j-0663",
             "joke": "\"Dad, I'm hungry.\" Hello, Hungry.",
             "punchline": "I'm Dad."
         }, {
+            "id": "j-0664",
             "joke": "I have the heart of a lion...",
             "punchline": "and a lifetime ban from the San Diego Zoo."
         }, {
+            "id": "j-0665",
             "joke": "What do you call a guy lying on your doorstep?",
             "punchline": "Matt."
         }, {
+            "id": "j-0666",
             "joke": "I met this girl on a dating site and, I don't know",
             "punchline": "we just clicked."
         }, {
+            "id": "j-0667",
             "joke": "What did the calculator say to the student?",
             "punchline": "You can count on me."
         }, {
+            "id": "j-0668",
             "joke": "What do you call a gorilla wearing headphones?",
             "punchline": "Anything you'd like, it can't hear you."
         }, {
+            "id": "j-0669",
             "joke": "Have you heard about corduroy pillows?",
             "punchline": "They're making headlines!"
         }, {
+            "id": "j-0670",
             "joke": "What did the fish say when it hit the wall?",
             "punchline": "Dam."
         }, {
+            "id": "j-0671",
             "joke": "How do you make a tissue dance?",
             "punchline": "You put a little boogie on it."
         }, {
+            "id": "j-0672",
             "joke": "What's Forrest Gump's password?",
             "punchline": "1Forrest1"
         }, {
+            "id": "j-0673",
             "joke": "What do you call a belt made out of watches?",
             "punchline": "A waist of time."
         }, {
+            "id": "j-0674",
             "joke": "Why can't bicycles stand on their own?",
             "punchline": "They are two tired"
         }, {
+            "id": "j-0675",
             "joke": "How does a train eat?",
             "punchline": "It goes chew, chew"
         }, {
+            "id": "j-0676",
             "joke": "What do you call a singing Laptop?",
             "punchline": "A Dell"
         }, {
+            "id": "j-0677",
             "joke": "How many lips does a flower have?",
             "punchline": "Tulips"
         }, {
+            "id": "j-0678",
             "joke": "What kind of shoes does a thief wear?",
             "punchline": "Sneakers"
         }, {
+            "id": "j-0679",
             "joke": "What's the best time to go to the dentist?",
             "punchline": "Tooth hurty."
         }, {
+            "id": "j-0680",
             "joke": "Knock knock. Who's there? A broken pencil. A broken pencil who?",
             "punchline": "Never mind. It's pointless."
         }, {
+            "id": "j-0681",
             "joke": "Knock knock. Who's there? Cows go. Cows go who?",
             "punchline": "No, cows go moo."
         }, {
+            "id": "j-0682",
             "joke": "Knock knock. Who's there? Little old lady. Little old lady who?",
             "punchline": "I didn't know you could yodel!"
         }, {
+            "id": "j-0683",
             "joke": "Why would a guitarist become a good programmer?",
             "punchline": "He's adept at riffing in C#."
         }, {
+            "id": "j-0684",
             "joke": "What's the best thing about a Boolean?",
             "punchline": "Even if you're wrong, you're only off by a bit."
         }, {
+            "id": "j-0685",
             "joke": "What's the object-oriented way to become wealthy?",
             "punchline": "Inheritance"
         }, {
+            "id": "j-0686",
             "joke": "Where do programmers like to hangout?",
             "punchline": "The Foo Bar."
         }, {
+            "id": "j-0687",
             "joke": "Why did the programmer quit his job?",
             "punchline": "Because he didn't get arrays."
         }, {
+            "id": "j-0688",
             "joke": "Did you hear about the two silk worms in a race?",
             "punchline": "It ended in a tie."
         }, {
+            "id": "j-0689",
             "joke": "What do you call a laughing motorcycle?",
             "punchline": "A Yamahahahaha."
         }, {
+            "id": "j-0690",
             "joke": "A termite walks into a bar and says...",
             "punchline": "'Where is the bar tended?'"
         }, {
+            "id": "j-0691",
             "joke": "What does C.S. Lewis keep at the back of his wardrobe?",
             "punchline": "Narnia business!"
         }, {
+            "id": "j-0692",
             "joke": "A SQL query walks into a bar, walks up to two tables and asks...",
             "punchline": "'Can I join you?'"
         }, {
+            "id": "j-0693",
             "joke": "How many programmers does it take to change a lightbulb?",
             "punchline": "None that's a hardware problem"
         }, {
+            "id": "j-0694",
             "joke": "If you put a million monkeys at a million keyboards, one of them will eventually write a Java program",
             "punchline": "the rest of them will write Perl"
         }, {
+            "id": "j-0695",
             "joke": "['hip', 'hip']",
             "punchline": "(hip hip array)"
         }, {
+            "id": "j-0696",
             "joke": "To understand what recursion is...",
             "punchline": "You must first understand what recursion is"
         }, {
+            "id": "j-0697",
             "joke": "There are 10 types of people in this world...",
             "punchline": "Those who understand binary and those who don't"
         }, {
+            "id": "j-0698",
             "joke": "What did the duck say when he bought lipstick?",
             "punchline": "Put it on my bill"
         }, {
+            "id": "j-0699",
             "joke": "What happens to a frog's car when it breaks down?",
             "punchline": "It gets toad away"
         }, {
+            "id": "j-0700",
             "joke": "did you know the first French fries weren't cooked in France?",
             "punchline": "they were cooked in Greece"
         }, {
+            "id": "j-0701",
             "joke": "Which song would an exception sing?",
             "punchline": "Can't catch me - Avicii"
         }, {
+            "id": "j-0702",
             "joke": "Knock knock. Who's there? Opportunity.",
             "punchline": "That is impossible. Opportunity doesn’t come knocking twice!"
         }, {
+            "id": "j-0703",
             "joke": "Why do Java programmers wear glasses?",
             "punchline": "Because they don't C#."
         }, {
+            "id": "j-0704",
             "joke": "Why did the mushroom get invited to the party?",
             "punchline": "Because he was a fungi."
         }, {
+            "id": "j-0705",
             "joke": "Do you know what the word 'was' was initially?",
             "punchline": "Before was was was was was is."
         }, {
+            "id": "j-0706",
             "joke": "I'm reading a book about anti-gravity...",
             "punchline": "It's impossible to put down"
         }, {
+            "id": "j-0707",
             "joke": "If you're American when you go into the bathroom, and American when you come out, what are you when you're in there?",
             "punchline": "European"
         }, {
+            "id": "j-0708",
             "joke": "Want to hear a joke about a piece of paper?",
             "punchline": "Never mind...it's tearable"
         }, {
+            "id": "j-0709",
             "joke": "I just watched a documentary about beavers.",
             "punchline": "It was the best dam show I ever saw"
         }, {
+            "id": "j-0710",
             "joke": "If you see a robbery at an Apple Store...",
             "punchline": "Does that make you an iWitness?"
         }, {
+            "id": "j-0711",
             "joke": "A ham sandwhich walks into a bar and orders a beer. The bartender says...",
             "punchline": "I'm sorry, we don't serve food here"
         }, {
+            "id": "j-0712",
             "joke": "If you boil a clown...",
             "punchline": "Do you get a laughing stock?"
         }, {
+            "id": "j-0713",
             "joke": "Finally realized why my plant sits around doing nothing all day...",
             "punchline": "He loves his pot."
         }, {
+            "id": "j-0714",
             "joke": "Don't look at the eclipse through a colander.",
             "punchline": "You'll strain your eyes."
         }, {
+            "id": "j-0715",
             "joke": "I bought some shoes from a drug dealer.",
             "punchline": "I don't know what he laced them with, but I was tripping all day!"
         }, {
+            "id": "j-0716",
             "joke": "Why do chicken coops only have two doors?",
             "punchline": "Because if they had four, they would be chicken sedans"
         }, {
+            "id": "j-0717",
             "joke": "What do you call a factory that sells passable products?",
             "punchline": "A satisfactory"
         }, {
+            "id": "j-0718",
             "joke": "When a dad drives past a graveyard: Did you know that's a popular cemetery?",
             "punchline": "Yep, people are just dying to get in there"
         }, {
+            "id": "j-0719",
             "joke": "Why did the invisible man turn down the job offer?",
             "punchline": "He couldn't see himself doing it"
         }, {
+            "id": "j-0720",
             "joke": "How do you check if a webpage is HTML5?",
             "punchline": "Try it out on Internet Explorer"
         }, {
+            "id": "j-0721",
             "joke": "I dropped a pear in my car this morning.",
             "punchline": "You should drop another one, then you would have a pair."
         }, {
+            "id": "j-0722",
             "joke": "Lady: How do I spread love in this cruel world?",
             "punchline": "Random Dude: [...💘]"
         }, {
+            "id": "j-0723",
             "joke": "A user interface is like a joke.",
             "punchline": "If you have to explain it then it is not that good."
         }, {
+            "id": "j-0724",
             "joke": "Knock knock. Who's there? Hatch. Hatch who?",
             "punchline": "Bless you!"
         }, {
+            "id": "j-0725",
             "joke": "What do you call sad coffee?",
             "punchline": "Despresso."
         }, {
+            "id": "j-0726",
             "joke": "Why did the butcher work extra hours at the shop?",
             "punchline": "To make ends meat."
         }, {
+            "id": "j-0727",
             "joke": "Did you hear about the hungry clock?",
             "punchline": "It went back four seconds."
         }, {
+            "id": "j-0728",
             "joke": "Well...",
             "punchline": "That’s a deep subject."
         }, {
+            "id": "j-0729",
             "joke": "Did you hear the story about the cheese that saved the world?",
             "punchline": "It was legend dairy."
         }, {
+            "id": "j-0730",
             "joke": "Did you watch the new comic book movie?",
             "punchline": "It was very graphic!"
         }, {
+            "id": "j-0731",
             "joke": "I started a new business making yachts in my attic this year...",
             "punchline": "The sails are going through the roof."
         }, {
+            "id": "j-0732",
             "joke": "I got hit in the head by a soda can, but it didn't hurt that much...",
             "punchline": "It was a soft drink."
         }, {
+            "id": "j-0733",
             "joke": "I can't tell if i like this blender...",
             "punchline": "It keeps giving me mixed results."
         }, {
+            "id": "j-0734",
             "joke": "I couldn't get a reservation at the library...",
             "punchline": "They were fully booked."
         }, {
+            "id": "j-0735",
             "joke": "I was gonna tell you a joke about UDP...",
             "punchline": "...but you might not get it."
         }, {
+            "id": "j-0736",
             "joke": "The punchline often arrives before the set-up.",
             "punchline": "Do you know the problem with UDP jokes?"
         }, {
+            "id": "j-0737",
             "joke": "Why do C# and Java developers keep breaking their keyboards?",
             "punchline": "Because they use a strongly typed language."
         }, {
+            "id": "j-0738",
             "joke": "What do you give to a lemon in need?",
             "punchline": "Lemonaid."
         }, {
+            "id": "j-0739",
             "joke": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before. What can I get for you?\"",
             "punchline": "Pop,goes the weasel."
         }, {
+            "id": "j-0740",
             "joke": "Can I watch the TV?",
             "punchline": "Yes, but don’t turn it on."
         }, {
+            "id": "j-0741",
             "joke": "What do ghosts call their true love?",
             "punchline": "Their ghoul-friend"
         }, {
+            "id": "j-0742",
             "joke": "How good are you at Power Point?",
             "punchline": "I Excel at it."
         }, {
+            "id": "j-0743",
             "joke": "How many seconds are in a year?",
             "punchline": "12. January 2nd, February 2nd, March 2nd, April 2nd.... etc"
         }, {
+            "id": "j-0744",
             "joke": "What’s 50 Cent’s name in Zimbabwe?",
             "punchline": "200 Dollars."
         }, {
+            "id": "j-0745",
             "joke": "Where’s the bin?",
             "punchline": "I haven’t been anywhere!"
         }, {
+            "id": "j-0746",
             "joke": "Knock-knock.",
             "punchline": "A race condition. Who is there?"
         }, {
+            "id": "j-0747",
             "joke": "What's the best part about TCP jokes?",
             "punchline": "I get to keep telling them until you get them."
         }, {
+            "id": "j-0748",
             "joke": "A programmer puts two glasses on his bedside table before going to sleep.",
             "punchline": "A full one, in case he gets thirsty, and an empty one, in case he doesn’t."
         }, {
+            "id": "j-0749",
             "joke": "Two guys walk into a bar...",
             "punchline": "The first guy says \"Ouch!\" and the second says \"Yeah, I didn't see it either.\""
         }, {
+            "id": "j-0750",
             "joke": "What did the router say to the doctor?",
             "punchline": "It hurts when IP."
         }, {
+            "id": "j-0751",
             "joke": "An IPv6 packet is walking out of the house.",
             "punchline": "He goes nowhere."
         }, {
+            "id": "j-0752",
             "joke": "A DHCP packet walks into a bar and asks for a beer.",
             "punchline": "Bartender says, \"here, but I’ll need that back in an hour!\""
         }, {
+            "id": "j-0753",
             "joke": "3 SQL statements walk into a NoSQL bar. Soon, they walk out",
             "punchline": "They couldn't find a table."
         }, {
+            "id": "j-0754",
             "joke": "I saw a nice stereo on Craigslist for $1. Seller says the volume is stuck on ‘high’",
             "punchline": "I couldn’t turn it down."
         }, {
+            "id": "j-0755",
             "joke": "What do you call a bee that can't make up its mind?",
             "punchline": "A maybe."
         }, {
+            "id": "j-0756",
             "joke": "Why was Cinderalla thrown out of the football team?",
             "punchline": "Because she ran away from the ball."
         }, {
+            "id": "j-0757",
             "joke": "What kind of music do welders like?",
             "punchline": "Heavy metal."
         }, {
+            "id": "j-0758",
             "joke": "Why are “Dad Jokes” so good?",
             "punchline": "Because the punchline is apparent."
         }, {
+            "id": "j-0759",
             "joke": "Why dot net developers don't wear glasses?",
             "punchline": "Because they see sharp."
         }, {
+            "id": "j-0760",
             "joke": "Why is seven bigger than nine?",
             "punchline": "Because seven ate nine."
         }, {
+            "id": "j-0761",
             "joke": "Why do fathers take an extra pair of socks when they go golfing?",
             "punchline": "In case they get a hole in one!"
         }, {
+            "id": "j-0762",
             "joke": "What do you call a suspicious looking laptop?",
             "punchline": "Asus"
         }, {
+            "id": "j-0763",
             "joke": "What did the Java code say to the C code?",
             "punchline": "You've got no class."
         }, {
+            "id": "j-0764",
             "joke": "What is the most used language in programming?",
             "punchline": "Profanity."
         }, {
+            "id": "j-0765",
             "joke": "Why do programmers always get Christmas and Halloween mixed up?",
             "punchline": "Because DEC 25 = OCT 31"
         }, {
+            "id": "j-0766",
             "joke": "What goes after USA?",
             "punchline": "USB."
         }, {
+            "id": "j-0767",
             "joke": "Why don't eggs tell jokes?",
             "punchline": "Because they would crack each other up."
         }, {
+            "id": "j-0768",
             "joke": "How do you make the number one disappear?",
             "punchline": "Add the letter G and it’s “gone”!"
         }, {
+            "id": "j-0769",
             "joke": "My older brother always tore the last pages of my comic books, and never told me why.",
             "punchline": "I had to draw my own conclusions."
         }, {
+            "id": "j-0770",
             "joke": "The Sergeant-Major growled at the young soldier: I didn’t see you at camouflage training this morning.",
             "punchline": "Thank you very much, sir."
         }, {
+            "id": "j-0771",
             "joke": "Why did the kid throw the watch out the window?",
             "punchline": "So time would fly."
         }, {
+            "id": "j-0772",
             "joke": "Where did the API go to eat?",
             "punchline": "To the RESTaurant."
         }, {
+            "id": "j-0773",
             "joke": "Why did the rooster cross the road?",
             "punchline": "He heard that the chickens at KFC were pretty hot."
         }, {
+            "id": "j-0774",
             "joke": "Did you hear about the Viking who was reincarnated?",
             "punchline": "He was Bjorn again"
         }, {
+            "id": "j-0775",
             "joke": "What does the mermaid wear to math class?",
             "punchline": "Algae-bra."
         }, {
+            "id": "j-0776",
             "joke": "Did you hear about the crime in the parking garage?",
             "punchline": "It was wrong on so many levels."
         }, {
+            "id": "j-0777",
             "joke": "Hey, wanna hear a joke?",
             "punchline": "Parsing HTML with regex."
         }, {
+            "id": "j-0778",
             "joke": "Why didn't the skeleton go for prom?",
             "punchline": "Because it had nobody."
         }, {
+            "id": "j-0779",
             "joke": "A grocery store cashier asked if I would like my milk in a bag.",
             "punchline": "I told her 'No, thanks. The carton works fine.'"
         }, {
+            "id": "j-0780",
             "joke": "99.9% of the people are dumb!",
             "punchline": "Fortunately I belong to the remaining 1%"
         }, {
+            "id": "j-0781",
             "joke": "I just got fired from my job at the keyboard factory.",
             "punchline": "They told me I wasn't putting in enough shifts."
         }, {
+            "id": "j-0782",
             "joke": "You see, mountains aren't just funny.",
             "punchline": "They are hill areas."
         }, {
+            "id": "j-0783",
             "joke": "What do elves post on Social Media?",
             "punchline": "Elf-ies."
         }, {
+            "id": "j-0784",
             "joke": "While I was sleeping my friends decided to write math equations on me.",
             "punchline": "You should have seen the expression on my face when I woke up."
         }, {
+            "id": "j-0785",
             "joke": "Due to complaints, Hawaii passed a law where you're not allowed to laugh above a certain decibel.",
             "punchline": "You can only use a low ha."
         }, {
+            "id": "j-0786",
             "joke": "Why are football stadiums so cool?",
             "punchline": "Because every seat has a fan in it."
         }, {
+            "id": "j-0787",
             "joke": "How do you generate a random string?",
             "punchline": "Put a Windows user in front of Vim and tell them to exit."
         }, {
+            "id": "j-0788",
             "joke": "Why did the functions stop calling each other?",
             "punchline": "Because they had constant arguments."
         }, {
+            "id": "j-0789",
             "joke": "Why did the private classes break up?",
             "punchline": "Because they never saw each other."
         }, {
+            "id": "j-0790",
             "joke": "Why did the developer quit his job?",
             "punchline": "Because he didn't get arrays."
         }, {
+            "id": "j-0791",
             "joke": "How many React developers does it take to change a lightbulb?",
             "punchline": "None, they prefer dark mode."
         }, {
+            "id": "j-0792",
             "joke": "Why don't React developers like nature?",
             "punchline": "They prefer the virtual DOM."
         }, {
+            "id": "j-0793",
             "joke": "What do you get when you cross a React developer with a mathematician?",
             "punchline": "A function component."
         }, {
+            "id": "j-0794",
             "joke": "Why did the developer go broke buying Bitcoin?",
             "punchline": "He kept calling it bytecoin and didn't get any."
         }, {
+            "id": "j-0795",
             "joke": "Why did the programmer go to art school?",
             "punchline": "He wanted to learn how to code outside the box."
         }, {
+            "id": "j-0796",
             "joke": "Why did the programmer's wife leave him?",
             "punchline": "He didn't know how to commit."
         }, {
+            "id": "j-0797",
             "joke": "Why do programmers prefer dark chocolate?",
             "punchline": "Because it's bitter like their code."
         }, {
+            "id": "j-0798",
             "joke": "Why did the programmer go broke?",
             "punchline": "He used up all his cache"
         }, {
+            "id": "j-0799",
             "joke": "Why did the programmer always mix up Halloween and Christmas?",
             "punchline": "Because Oct 31 equals Dec 25."
         }, {
+            "id": "j-0800",
             "joke": "Why don't programmers like nature?",
             "punchline": "There's too many bugs."
         }, {
+            "id": "j-0801",
             "joke": "Why was the JavaScript developer sad?",
             "punchline": "He didn't know how to null his feelings."
         }, {
+            "id": "j-0802",
             "joke": "Why couldn't the bicycle stand up by itself?",
             "punchline": "It was two-tired."
         }, {
+            "id": "j-0803",
             "joke": "Why did the math book look sad?",
             "punchline": "Because it had too many problems."
         }, {
+            "id": "j-0804",
             "joke": "What's a computer's favorite snack?",
             "punchline": "Microchips."
         }, {
+            "id": "j-0805",
             "joke": "What did the janitor say when he jumped out of the closet?",
             "punchline": "Supplies!"
         }, {
+            "id": "j-0806",
             "joke": "What did one ocean say to the other ocean?",
             "punchline": "Nothing, they just waved."
         }, {
+            "id": "j-0807",
             "joke": "What's the best thing about Switzerland?",
             "punchline": "I don't know, but their flag is a big plus."
         }, {
+            "id": "j-0808",
             "joke": "Why did the golfer bring two pairs of pants?",
             "punchline": "In case he got a hole in one."
         }, {
+            "id": "j-0809",
             "joke": "Why did the chicken cross the playground?",
             "punchline": "To get to the other slide."
         }, {
+            "id": "j-0810",
             "joke": "Why don't scientists trust atoms?",
             "punchline": "Because they make up everything."
         }, {
+            "id": "j-0811",
             "joke": "Why don't oysters give to charity?",
             "punchline": "Because they're shellfish."
         }, {
+            "id": "j-0812",
             "joke": "Why did the cookie go to the doctor?",
             "punchline": "Because it was feeling crumbly."
         }, {
+            "id": "j-0813",
             "joke": "What do you call a computer mouse that swears a lot?",
             "punchline": "A cursor!"
         }, {
+            "id": "j-0814",
             "joke": "Why did the designer break up with their font?",
             "punchline": "Because it wasn't their type."
         }, {
+            "id": "j-0815",
             "joke": "Why did the programmer quit their job?",
             "punchline": "They didn't get arrays."
         }, {
+            "id": "j-0816",
             "joke": "Why did the developer go broke?",
             "punchline": "They kept spending all their cache."
         }, {
+            "id": "j-0817",
             "joke": "How do you comfort a designer?",
             "punchline": "You give them some space... between the elements."
         }, {
+            "id": "j-0818",
             "joke": "Why don't programmers like nature?",
             "punchline": "Too many bugs."
         }, {
+            "id": "j-0819",
             "joke": "Why did the programmer bring a ladder to work?",
             "punchline": "They heard the code needed to be debugged from a higher level."
         }, {
+            "id": "j-0820",
             "joke": "Why was the developer always calm?",
             "punchline": "Because they knew how to handle exceptions."
         }, {
+            "id": "j-0821",
             "joke": "Why was the font always tired?",
             "punchline": "It was always bold."
         }, {
+            "id": "j-0822",
             "joke": "Why did the developer go to therapy?",
             "punchline": "They had too many unresolved issues."
         }, {
+            "id": "j-0823",
             "joke": "Why was the designer always cold?",
             "punchline": "Because they always used too much ice-olation."
         }, {
+            "id": "j-0824",
             "joke": "Why did the programmer bring a broom to work?",
             "punchline": "To clean up all the bugs."
         }, {
+            "id": "j-0825",
             "joke": "Why did the developer break up with their keyboard?",
             "punchline": "It just wasn't their type anymore."
         }, {
+            "id": "j-0826",
             "joke": "Why did the programmer always carry a pencil?",
             "punchline": "They preferred to write in C#."
         }, {
+            "id": "j-0827",
             "joke": "Why don't skeletons fight each other?",
             "punchline": "They don't have the guts."
         }, {
+            "id": "j-0828",
             "joke": "What do you call fake spaghetti?",
             "punchline": "An impasta."
         }, {
+            "id": "j-0829",
             "joke": "What do you call a thieving alligator?",
             "punchline": "A crookodile!"
         }, {
+            "id": "j-0830",
             "joke": "Why would a guitarist become a good programmer?",
             "punchline": "He's adept at riffing in C#."
         }, {
+            "id": "j-0831",
             "joke": "Want to hear a joke about a piece of paper?",
             "punchline": "Never mind...it's tearable"
         }, {
+            "id": "j-0832",
             "joke": "Did you hear the story about the cheese that saved the world?",
             "punchline": "It was legend dairy."
         }, {
+            "id": "j-0833",
             "joke": "Did you watch the new comic book movie?",
             "punchline": "It was very graphic!"
         }, {
+            "id": "j-0834",
             "joke": "I started a new business making yachts in my attic this year...",
             "punchline": "The sails are going through the roof."
         }, {
+            "id": "j-0835",
             "joke": "I got hit in the head by a soda can, but it didn't hurt that much...",
             "punchline": "It was a soft drink."
         }, {
+            "id": "j-0836",
             "joke": "I can't tell if i like this blender...",
             "punchline": "It keeps giving me mixed results."
         }, {
+            "id": "j-0837",
             "joke": "How good are you at Power Point?",
             "punchline": "I Excel at it."
         }, {
+            "id": "j-0838",
             "joke": "Why can't you use \"Beef stew\"as a password?",
             "punchline": "Because it's not stroganoff."
         }, {
+            "id": "j-0839",
             "joke": "What's the best part about TCP jokes?",
             "punchline": "I get to keep telling them until you get them."
         }, {
+            "id": "j-0840",
             "joke": "A programmer puts two glasses on his bedside table before going to sleep.",
             "punchline": "A full one, in case he gets thirsty, and an empty one, in case he doesn’t."
         }, {
+            "id": "j-0841",
             "joke": "Two guys walk into a bar . . .",
             "punchline": "The first guy says \"Ouch!\" and the second says \"Yeah, I didn't see it either.\""
         }, {
+            "id": "j-0842",
             "joke": "What did the router say to the doctor?",
             "punchline": "It hurts when IP."
         }, {
+            "id": "j-0843",
             "joke": "An IPv6 packet is walking out of the house.",
             "punchline": "He goes nowhere."
         }, {
+            "id": "j-0844",
             "joke": "A DHCP packet walks into a bar and asks for a beer.",
             "punchline": "Bartender says, \"here, but I’ll need that back in an hour!\""
         }, {
+            "id": "j-0845",
             "joke": "3 SQL statements walk into a NoSQL bar. Soon, they walk out",
             "punchline": "They couldn't find a table."
         }, {
+            "id": "j-0846",
             "joke": "I saw a nice stereo on Craigslist for $1. Seller says the volume is stuck on ‘high’",
             "punchline": "I couldn’t turn it down."
         }, {
+            "id": "j-0847",
             "joke": "Why are “Dad Jokes” so good?",
             "punchline": "Because the punchline is apparent."
         }, {
+            "id": "j-0848",
             "joke": "What do you call a suspicious looking laptop?",
             "punchline": "Asus."
         }, {
+            "id": "j-0849",
             "joke": "What did the Java code say to the C code?",
             "punchline": "You've got no class."
         }, {
+            "id": "j-0850",
             "joke": "What is the most used language in programming?",
             "punchline": "Profanity."
         }, {
+            "id": "j-0851",
             "joke": "Why do fathers take an extra pair of socks when they go golfing?",
             "punchline": "In case they get a hole in one!"
         }, {
+            "id": "j-0852",
             "joke": "Where did the API go to eat?",
             "punchline": "To the RESTaurant."
         }, {
+            "id": "j-0853",
             "joke": "Hey, wanna hear a joke?",
             "punchline": "Parsing HTML with regex."
         }, {
+            "id": "j-0854",
             "joke": "How do you generate a random string?",
             "punchline": "Put a Windows user in front of Vim and tell them to exit."
         }, {
+            "id": "j-0855",
             "joke": "Why did the functions stop calling each other?",
             "punchline": "Because they had constant arguments."
         }, {
+            "id": "j-0856",
             "joke": "Why did the private classes break up?",
             "punchline": "Because they never saw each other."
         }, {
+            "id": "j-0857",
             "joke": "Why did the developer go broke buying Bitcoin?",
             "punchline": "He kept calling it bytecoin and didn't get any."
         }, {
+            "id": "j-0858",
             "joke": "Why did the programmer's wife leave him?",
             "punchline": "He didn't know how to commit."
         }, {
+            "id": "j-0859",
             "joke": "Why do programmers prefer dark chocolate?",
             "punchline": "Because it's bitter like their code."
         }, {
+            "id": "j-0860",
             "joke": "Why don't React developers like nature?",
             "punchline": "They prefer the virtual DOM."
         }, {
+            "id": "j-0861",
             "joke": "Why was the developer always calm?",
             "punchline": "Because they knew how to handle exceptions."
         }, {
+            "id": "j-0862",
             "joke": "Why did the programmer bring a ladder to work?",
             "punchline": "They heard the code needed to be debugged from a higher level."
         }, {
+            "id": "j-0863",
             "joke": "Why did the developer break up with their keyboard?",
             "punchline": "It just wasn't their type anymore."
         }, {
+            "id": "j-0864",
             "joke": "Why did the programmer always carry a pencil?",
             "punchline": "They preferred to write in C#."
         }, {
+            "id": "j-0865",
             "joke": "Why did the programmer go to art school?",
             "punchline": "He wanted to learn how to code outside the box."
         }

--- a/apps/quotes/quotes-data.js
+++ b/apps/quotes/quotes-data.js
@@ -4,194 +4,242 @@ window.quotesData = [
     "label": "Adventure",
     "quotes": [
       {
+        "id": "adventure-01",
         "text": "The danger of adventure is worth a thousand days of ease and comfort.",
         "author": "Paulo Coelho"
       },
       {
+        "id": "adventure-02",
         "text": "The world is a book and those who do not travel read only one page.",
         "author": "Saint Augustine"
       },
       {
+        "id": "adventure-03",
         "text": "If we were meant to stay in one place, we’d have roots instead of feet.",
         "author": "Rachel Wolchin"
       },
       {
+        "id": "adventure-04",
         "text": "If you are always trying to be normal, you will never know how amazing you can be.",
         "author": "Maya Angelou"
       },
       {
+        "id": "adventure-05",
         "text": "Do not go where the path may lead, go instead where there is no path and leave a trail.",
         "author": "Ralph Waldo Emerson"
       },
       {
+        "id": "adventure-06",
         "text": "Travel makes one modest. You see what a tiny place you occupy in the world.",
         "author": "Gustav Flaubert"
       },
       {
+        "id": "adventure-07",
         "text": "A ship in harbor is safe, but that is not what ships are built for.",
         "author": "John A. Shedd"
       },
       {
+        "id": "adventure-08",
         "text": "Until you step into the unknown, you don’t know what you’re made of.",
         "author": "Roy T. Bennett"
       },
       {
+        "id": "adventure-09",
         "text": "To live is the rarest thing in the world. Most people just exist.",
         "author": "Oscar Wilde"
       },
       {
+        "id": "adventure-10",
         "text": "Only those who risk going too far can possibly find out how far one can go.",
         "author": "T. S. Eliot"
       },
       {
+        "id": "adventure-11",
         "text": "Life isn’t about the number of breaths we take, but the moments that take our breath away.",
         "author": "Maya Angelou"
       },
       {
+        "id": "adventure-12",
         "text": "Don’t get so busy making a living that you forget to make a life.",
         "author": "Dolly Parton"
       },
       {
+        "id": "adventure-13",
         "text": "Man cannot discover new oceans unless he has the courage to lose sight of the shore.",
         "author": "Andre Gide"
       },
       {
+        "id": "adventure-14",
         "text": "Move out of your comfort zone. You can only grow if you are willing to feel awkward and uncomfortable when you try something new.",
         "author": "Brian Tracy"
       },
       {
+        "id": "adventure-15",
         "text": "Not all those who wander are lost.",
         "author": "J. R. R. Tolkien"
       },
       {
+        "id": "adventure-16",
         "text": "Every man dies. Not every man really lives.",
         "author": "William Wallace"
       },
       {
+        "id": "adventure-17",
         "text": "The worst thing you can do is nothing.",
         "author": "Terry Pratchett"
       },
       {
+        "id": "adventure-18",
         "text": "To travel is to evolve.",
         "author": "Pierre Bernardo"
       },
       {
+        "id": "adventure-19",
         "text": "It is not length of life, but depth of life.",
         "author": "Ralph Waldo Emerson"
       },
       {
+        "id": "adventure-20",
         "text": "Life begins at the end of your comfort zone.",
         "author": "Neale Donald Walsch"
       },
       {
+        "id": "adventure-21",
         "text": "Travel far enough, you meet yourself.",
         "author": "David Mitchell"
       },
       {
+        "id": "adventure-22",
         "text": "Don’t ask for security, ask for adventure.",
         "author": "Jim Rohn"
       },
       {
+        "id": "adventure-23",
         "text": "Live your life by a compass not a clock.",
         "author": "Stephen R. Covey"
       },
       {
+        "id": "adventure-24",
         "text": "Adventure is worthwhile in itself.",
         "author": "Amelia Earhart"
       },
       {
+        "id": "adventure-25",
         "text": "Travel is the only thing you buy that makes you richer.",
         "author": "Unknown"
       },
       {
+        "id": "adventure-26",
         "text": "Life is short and the world is wide.",
         "author": "Unknown"
       },
       {
+        "id": "adventure-27",
         "text": "Once a year, go somewhere you have never been before.",
         "author": "Dalai Lama"
       },
       {
+        "id": "adventure-28",
         "text": "The goal is to die with memories not dreams.",
         "author": "Anonymous"
       },
       {
+        "id": "adventure-29",
         "text": "Take only memories, leave only footprints.",
         "author": "Chief Seattle"
       },
       {
+        "id": "adventure-30",
         "text": "Life is an adventure. Live it.",
         "author": "Anonymous"
       },
       {
+        "id": "adventure-31",
         "text": "Investment in travel is an investment in yourself.",
         "author": "Matthew Karsten"
       },
       {
+        "id": "adventure-32",
         "text": "Don’t live the same year 75 times and call it a life.",
         "author": "Robin Sharma"
       },
       {
+        "id": "adventure-33",
         "text": "All life is an experiment. The more experiments you make the better.",
         "author": "Ralph Waldo Emerson"
       },
       {
+        "id": "adventure-34",
         "text": "The purpose of life is to live it, to taste experience to the utmost, to reach out eagerly and without fear for newer and richer experiences.",
         "author": "Eleanor Roosevelt"
       },
       {
+        "id": "adventure-35",
         "text": "Better to see something once than hear about it a thousand times.",
         "author": "Asian Proverb"
       },
       {
+        "id": "adventure-36",
         "text": "If you think adventure is dangerous, try routine, it is lethal.",
         "author": "Paulo Coelho"
       },
       {
+        "id": "adventure-37",
         "text": "Travel makes one modest, you see what a tiny place you occupy in the world.",
         "author": "Gustave Flaubert"
       },
       {
+        "id": "adventure-38",
         "text": "Travel. As much as you can. As far as you can. As long as you can. Life’s not meant to be lived in one place.",
         "author": "Unknown"
       },
       {
+        "id": "adventure-39",
         "text": "The real voyage of discovery consists not in seeking new landscapes, but in having new eyes.",
         "author": "Marcel Proust"
       },
       {
+        "id": "adventure-40",
         "text": "I would rather own a little and see the world than own the world and see a little of it.",
         "author": "Alexander Sattler"
       },
       {
+        "id": "adventure-41",
         "text": "Traveling – it leaves you speechless, then turns you into a storyteller.",
         "author": "Ibn Battuta"
       },
       {
+        "id": "adventure-42",
         "text": "The best way to experience the world is by going outside and exploring it.",
         "author": "Anonymous"
       },
       {
+        "id": "adventure-43",
         "text": "I travel because it makes me realize how much I haven’t seen, how much I’m not going to see, and how much I still need to see.",
         "author": "Carew Papritz"
       },
       {
+        "id": "adventure-44",
         "text": "For my part, I travel not to go anywhere, but to go. I travel for travel’s sake. The great affair is to move.",
         "author": "Robert Louis Stevenson"
       },
       {
+        "id": "adventure-45",
         "text": "A mind that is stretched by a new experience can never go back to its old dimensions.",
         "author": "Oliver Wendell Holmes, Jr"
       },
       {
+        "id": "adventure-46",
         "text": "A good traveler has no fixed plans and is not intent on arriving.",
         "author": "Lao Tzu"
       },
       {
+        "id": "adventure-47",
         "text": "The biggest adventure you can ever take is to live the life of your dreams.",
         "author": "Oprah Winfrey"
       },
       {
+        "id": "adventure-48",
         "text": "The beginning of knowledge is the discovery of something we do not understand.",
         "author": "Frank Herbert"
       }
@@ -202,202 +250,252 @@ window.quotesData = [
     "label": "Time",
     "quotes": [
       {
+        "id": "time-01",
         "text": "The two most powerful warriors are patience and time.",
         "author": "Leo Tolstoy, War and Peace"
       },
       {
+        "id": "time-02",
         "text": "Time is what we want most, but what we use worst.",
         "author": "William Penn, Fruits of Solitude"
       },
       {
+        "id": "time-03",
         "text": "All we have to decide is what to do with the time that is given us.",
         "author": "J. R. R. Tolkien, The Fellowship of the Ring"
       },
       {
+        "id": "time-04",
         "text": "The most precious resource we all have is time.",
         "author": "Steve Jobs"
       },
       {
+        "id": "time-05",
         "text": "Time has a wonderful way of showing us what really matters.",
         "author": "Margaret Peters"
       },
       {
+        "id": "time-06",
         "text": "Time is a created thing. To say ‘I don’t have time’ is to say ‘I don’t want to.’",
         "author": "Lao Tzu"
       },
       {
+        "id": "time-07",
         "text": "No man goes before his time. Unless the boss leaves early.",
         "author": "Groucho Marx"
       },
       {
+        "id": "time-08",
         "text": "Time is free, but it’s priceless. You can’t own it, but you can use it. You can’t keep it, but you can spend it. Once you’ve lost it, you can never get it back.",
         "author": "Harvey MacKay"
       },
       {
+        "id": "time-09",
         "text": "The future is something which everyone reaches at the rate of sixty minutes an hour, whatever he does, whoever he is.",
         "author": "C. S. Lewis"
       },
       {
+        "id": "time-10",
         "text": "The bad news is time flies. The good news is you’re the pilot.",
         "author": "Michael Altshuler"
       },
       {
+        "id": "time-11",
         "text": "There’s only one thing more precious than our time and that’s who we spend it on.",
         "author": "Leo Christopher"
       },
       {
+        "id": "time-12",
         "text": "An inch of time is an inch of gold, but you can’t buy that inch of time with an inch of gold.",
         "author": "Chinese Proverb"
       },
       {
+        "id": "time-13",
         "text": "There’s never enough time to do it right, but there’s always enough time to do it over.",
         "author": "Jack Bergman"
       },
       {
+        "id": "time-14",
         "text": "A man who dares to waste an hour of time has not discovered the value of life.",
         "author": "Charles Darwin"
       },
       {
+        "id": "time-15",
         "text": "Time isn’t the main thing. It’s the only thing.",
         "author": "Miles Davis"
       },
       {
+        "id": "time-16",
         "text": "I am not particularly interested in saving time; I prefer to enjoy it.",
         "author": "Eduardo Galeano"
       },
       {
+        "id": "time-17",
         "text": "Time flies over us, but leaves its shadow behind.",
         "author": "Nathaniel Hawthorne, The Marble Faun"
       },
       {
+        "id": "time-18",
         "text": "Time is what keeps everything from happening at once.",
         "author": "Ray Cummings, The Girl in the Golden Atom"
       },
       {
+        "id": "time-19",
         "text": "It’s not that we have little time, but more that we waste a good deal of it.",
         "author": "Seneca"
       },
       {
+        "id": "time-20",
         "text": "I wish I could turn back the clock and find you sooner so I can love you longer.",
         "author": "Unknown"
       },
       {
+        "id": "time-21",
         "text": "Time moves slowly, but passes quickly.",
         "author": "Alice Walker, The Color Purple"
       },
       {
+        "id": "time-22",
         "text": "You will never find time for anything. If you want time, you must make it.",
         "author": "Charles Buxton"
       },
       {
+        "id": "time-23",
         "text": "There’s never enough time to do all the nothing you want.",
         "author": "Calvin and Hobbes” by Bill Watterson"
       },
       {
+        "id": "time-24",
         "text": "They always say time changes things, but you actually have to change them yourself.",
         "author": "Andy Warhol, The Philosophy of Andy Warhol"
       },
       {
+        "id": "time-25",
         "text": "Time is a waste of money.",
         "author": "Oscar Wilde"
       },
       {
+        "id": "time-26",
         "text": "Time is a great healer, but a poor beautician.",
         "author": "Lucille S. Harper"
       },
       {
+        "id": "time-27",
         "text": "No measure of time with you will be long enough. But let’s start with forever.",
         "author": "Stephenie Meyer, Breaking Dawn"
       },
       {
+        "id": "time-28",
         "text": "You can’t turn back the clock. But you can wind it up again.",
         "author": "Bonnie Prudden"
       },
       {
+        "id": "time-29",
         "text": "Time and tide wait for no man, but time always stands still for a woman of 30.",
         "author": "Robert Frost"
       },
       {
+        "id": "time-30",
         "text": "Time has no meaning when you’re in love.",
         "author": "Unknown"
       },
       {
+        "id": "time-31",
         "text": "Better three hours too soon than one minute too late.",
         "author": "William Shakespeare, The Merry Wives of Windsor"
       },
       {
+        "id": "time-32",
         "text": "There is never a time or place for true love. It happens accidentally, in a heartbeat, in a single flashing, throbbing moment.",
         "author": "Sarah Dessen, The Truth About Forever"
       },
       {
+        "id": "time-33",
         "text": "There is a time for work and a time for love. That leaves no other time.",
         "author": "Coco Chanel"
       },
       {
+        "id": "time-34",
         "text": "Time is the longest distance between two places.",
         "author": "Tennessee Williams, The Glass Menagerie"
       },
       {
+        "id": "time-35",
         "text": "To live is so startling, it leaves little time for anything else.",
         "author": "Emily Dickinson"
       },
       {
+        "id": "time-36",
         "text": "Lost time is never found again.",
         "author": "Benjamin Franklin, Poor Richard’s Almanac"
       },
       {
+        "id": "time-37",
         "text": "The only reason for time is so that everything doesn’t happen at once.",
         "author": "Albert Einstein"
       },
       {
+        "id": "time-38",
         "text": "Time you enjoy wasted was not time wasted.",
         "author": "John Lennon"
       },
       {
+        "id": "time-39",
         "text": "Time is precious. Make sure you spend it with the right people.",
         "author": "Unknown"
       },
       {
+        "id": "time-40",
         "text": "Who controls the past, controls the future: who controls the present controls the past.",
         "author": "George Orwell, 1984"
       },
       {
+        "id": "time-41",
         "text": "Time, which changes people, does not alter the image we have of them.",
         "author": "Marcel Proust"
       },
       {
+        "id": "time-42",
         "text": "If you judge people, you have no time to love them.",
         "author": "Mother Teresa"
       },
       {
+        "id": "time-43",
         "text": "The few hours I spend with you are worth the thousand hours I spend without you.",
         "author": "Unknown"
       },
       {
+        "id": "time-44",
         "text": "If you spend too much time thinking about a thing, you’ll never get it done.",
         "author": "Bruce Lee"
       },
       {
+        "id": "time-45",
         "text": "Men talk of killing time, while time quietly kills them.",
         "author": "Dion Boucicault"
       },
       {
+        "id": "time-46",
         "text": "Don’t waste your time in anger, regrets, worries, and grudges. Life is too short to be unhappy.",
         "author": "Roy T. Bennett, The Light in the Heart"
       },
       {
+        "id": "time-47",
         "text": "It is the time you have wasted for your rose that makes your rose so important.” — Antoine de Saint",
         "author": "Exupéry, The Little Prince"
       },
       {
+        "id": "time-48",
         "text": "Own time, or time will own you.",
         "author": "Brian Norgard"
       },
       {
+        "id": "time-49",
         "text": "Punctuality is the thief of time.",
         "author": "Oscar Wilde, The Picture of Dorian Gray"
       },
       {
+        "id": "time-50",
         "text": "The wisest are the most annoyed at the loss of time.",
         "author": "Dante Alighieri"
       }
@@ -408,210 +506,262 @@ window.quotesData = [
     "label": "Motivation",
     "quotes": [
       {
+        "id": "motivation-01",
         "text": "What great thing would you attempt, if you knew you could not fail.",
         "author": "Robert H. Schuller"
       },
       {
+        "id": "motivation-02",
         "text": "It’s not about money or connections. It’s the willingness to outwork and outlearn everyone when it comes to your business.",
         "author": "Mark Cuban"
       },
       {
+        "id": "motivation-03",
         "text": "Success is not final; failure is not fatal; it is the courage to continue that counts.",
         "author": "Winston Churchill"
       },
       {
+        "id": "motivation-04",
         "text": "Don’t stop when you’re tired. Stop when you’re done.",
         "author": "Wesley Snipes"
       },
       {
+        "id": "motivation-05",
         "text": "Shoot for the moon. Even if you miss, you’ll land among the stars.",
         "author": "Norman Vincent Peale"
       },
       {
+        "id": "motivation-06",
         "text": "The journey of a thousand miles begins with one step.",
         "author": "Lao Tzu"
       },
       {
+        "id": "motivation-07",
         "text": "Act as if what you do makes a difference. It does.",
         "author": "William James"
       },
       {
+        "id": "motivation-08",
         "text": "Always take another step. If this is to no avail take another, and yet another. One step at a time is not too difficult.",
         "author": "Og Mandino"
       },
       {
+        "id": "motivation-09",
         "text": "If you can’t fly, then run, if you can’t run then walk, if you can’t walk then crawl, but whatever you do, you have to keep moving forward.",
         "author": "Martin Luther King, Jr."
       },
       {
+        "id": "motivation-10",
         "text": "Much effort, much prosperity.",
         "author": "Euripides"
       },
       {
+        "id": "motivation-11",
         "text": "Much good work is lost for the lack of a little more.",
         "author": "Edward H. Harriman"
       },
       {
+        "id": "motivation-12",
         "text": "Your biggest failure is the thing you dreamed of contributing but didn’t find the guts to do.",
         "author": "Seth Godin"
       },
       {
+        "id": "motivation-13",
         "text": "That some achieve great success, is proof to all that others can achieve it as well.",
         "author": "Abraham Lincoln"
       },
       {
+        "id": "motivation-14",
         "text": "Never let the fear of striking out get in your way.",
         "author": "Babe Ruth"
       },
       {
+        "id": "motivation-15",
         "text": "Hustle until you no longer need to introduce yourself.",
         "author": "Anonymous"
       },
       {
+        "id": "motivation-16",
         "text": "The heights by great men reached and kept, were not attained by sudden flight, but they, while their companions slept, were toiling upward in the night.",
         "author": "Henry Wadsworth Longfellow"
       },
       {
+        "id": "motivation-17",
         "text": "He who would accomplish little must sacrifice little; he who would achieve much must sacrifice much.",
         "author": "James Allen"
       },
       {
+        "id": "motivation-18",
         "text": "If you wish to be out front, then act as if you were behind.",
         "author": "Lao Tzu"
       },
       {
+        "id": "motivation-19",
         "text": "The key to success is failure.",
         "author": "Michael Jordan"
       },
       {
+        "id": "motivation-20",
         "text": "Formula for success: rise early, work hard, strike oil.",
         "author": "J. Paul Getty"
       },
       {
+        "id": "motivation-21",
         "text": "Plough deep while sluggards sleep.",
         "author": "Benjamin Franklin"
       },
       {
+        "id": "motivation-22",
         "text": "Work hard in silence and let success be your noise.",
         "author": "Anonymous"
       },
       {
+        "id": "motivation-23",
         "text": "Don’t stop until you’re proud.",
         "author": "Anonymous"
       },
       {
+        "id": "motivation-24",
         "text": "The path to success is to take massive, determined action.",
         "author": "Tony Robbins"
       },
       {
+        "id": "motivation-25",
         "text": "If it’s important, you’ll find a way. If it’s not, you’ll find an excuse.",
         "author": "Ryan Blair"
       },
       {
+        "id": "motivation-26",
         "text": "Men of action are favored by the goddess of good luck.",
         "author": "George S. Clason"
       },
       {
+        "id": "motivation-27",
         "text": "A somebody was once a nobody who wanted to and did.",
         "author": "John Burroughs"
       },
       {
+        "id": "motivation-28",
         "text": "Man cannot discover new oceans unless he has the courage to lose sight of the shore.",
         "author": "Andre Gide"
       },
       {
+        "id": "motivation-29",
         "text": "If you believe you can do a thing, you can do it.",
         "author": "Claude M. Bristol"
       },
       {
+        "id": "motivation-30",
         "text": "Action is the foundational key to all success.",
         "author": "Pablo Picasso"
       },
       {
+        "id": "motivation-31",
         "text": "Thought allied fearlessly to purpose becomes creative force.",
         "author": "James Allen"
       },
       {
+        "id": "motivation-32",
         "text": "Run your own race. Who cares what others are doing? The only question that matters is, am I progressing?",
         "author": "Robin Sharma"
       },
       {
+        "id": "motivation-33",
         "text": "There’s not a person on my team in 16 years that has consistently beat me to the ball every play. That ain’t got anything to do with talent, that’s just got everything to do with effort, and nothing else.",
         "author": "Ray Lewis"
       },
       {
+        "id": "motivation-34",
         "text": "Don’t watch the clock; do what it does. Keep going.",
         "author": "Sam Levonson"
       },
       {
+        "id": "motivation-35",
         "text": "Winners embrace hard work. They love the discipline of it, the trade-off they’re making to win. Losers, on the other hand, see it as a punishment.",
         "author": "Lou Holtz"
       },
       {
+        "id": "motivation-36",
         "text": "Push yourself, because no one else is going to do it for you.",
         "author": "Anonymous"
       },
       {
+        "id": "motivation-37",
         "text": "Life shrinks or expands in proportion to one’s courage.",
         "author": "Anais Nin"
       },
       {
+        "id": "motivation-38",
         "text": "Nothing in this world is worth having or worth doing unless it means effort, pain, difficulty.",
         "author": "Theodore Roosevelt"
       },
       {
+        "id": "motivation-39",
         "text": "In this world you only get what you grab for.",
         "author": "Giovanni Boccaccio"
       },
       {
+        "id": "motivation-40",
         "text": "Success means having the courage, the determination, and the will to become the person you believe you were meant to be.",
         "author": "George A. Sheehan"
       },
       {
+        "id": "motivation-41",
         "text": "The best way to predict the future is to create it.",
         "author": "Peter Drucker"
       },
       {
+        "id": "motivation-42",
         "text": "If you have everything seems under control, you’re just not going fast enough.",
         "author": "Mario Andretti"
       },
       {
+        "id": "motivation-43",
         "text": "Do the work. Everyone wants to be successful, but nobody wants to do the work.",
         "author": "Gary Vaynerchuk"
       },
       {
+        "id": "motivation-44",
         "text": "Be so good they can’t ignore you.",
         "author": "Steve Martin"
       },
       {
+        "id": "motivation-45",
         "text": "Be not afraid of going slowly; be afraid only of standing still.",
         "author": "Chinese Proverb"
       },
       {
+        "id": "motivation-46",
         "text": "When we strive to become better than we are, everything around us becomes better too.",
         "author": "Paulo Coelho"
       },
       {
+        "id": "motivation-47",
         "text": "With self-discipline, most anything is possible.",
         "author": "Theodore Roosevelt"
       },
       {
+        "id": "motivation-48",
         "text": "All the so-called ‘secrets of success’ will not work unless you do.",
         "author": "Anonymous"
       },
       {
+        "id": "motivation-49",
         "text": "Your dreams are on the other side of your grit.",
         "author": "Anonymous"
       },
       {
+        "id": "motivation-50",
         "text": "Nothing happens unless first we dream.",
         "author": "Carl Sandburg"
       },
       {
+        "id": "motivation-51",
         "text": "Never mistake activity for achievement.",
         "author": "John Wooden"
       },
       {
+        "id": "motivation-52",
         "text": "Goals are the fuel in the furnace of achievement.",
         "author": "Brian Tracy"
       }
@@ -622,202 +772,252 @@ window.quotesData = [
     "label": "Friendship",
     "quotes": [
       {
+        "id": "friendship-01",
         "text": "A real friend is one who walks in when the rest of the world walks out.",
         "author": "Walter Winchell"
       },
       {
+        "id": "friendship-02",
         "text": "To like and dislike the same things, that is what makes a solid friendship.",
         "author": "Sallust"
       },
       {
+        "id": "friendship-03",
         "text": "My friends and I are crazy. That’s the only thing that keeps us sane.",
         "author": "Matt Schucker"
       },
       {
+        "id": "friendship-04",
         "text": "I’ll stick to finding the funny in the ordinary because my life is pretty ordinary and so are the lives of my friends — and my friends are hilarious.",
         "author": "Issa Rae"
       },
       {
+        "id": "friendship-05",
         "text": "As much as a BFF can make you go WTF, there’s no denying we’d be a little less rich without them.",
         "author": "Gossip Girl"
       },
       {
+        "id": "friendship-06",
         "text": "A loyal friend laughs at your jokes when they’re not so good, and sympathizes with your problems when they’re not so bad.",
         "author": "Arnold H. Glasgow"
       },
       {
+        "id": "friendship-07",
         "text": "An old friend will help you move. A good friend will help you move a dead body.",
         "author": "Jim Hayes"
       },
       {
+        "id": "friendship-08",
         "text": "Whoever says friendship is easy has obviously never had a true friend!",
         "author": "Bronwyn Polson"
       },
       {
+        "id": "friendship-09",
         "text": "A day without a friend is like a pot without a single drop of honey left inside.",
         "author": "Winnie the Pooh"
       },
       {
+        "id": "friendship-10",
         "text": "How much good inside a day? Depends how good you live ‘em. How much love inside a friend? Depends how much you give ‘em.",
         "author": "Shel Silverstein"
       },
       {
+        "id": "friendship-11",
         "text": "A true friend is someone who thinks that you are a good egg even though he knows that you are slightly cracked.",
         "author": "Bernard Meltzer"
       },
       {
+        "id": "friendship-12",
         "text": "There is nothing better than a friend, unless it is a friend with chocolate.",
         "author": "Linda Grayson"
       },
       {
+        "id": "friendship-13",
         "text": "A true friend never gets in your way unless you happen to be going down.",
         "author": "Arnold H. Glasgow"
       },
       {
+        "id": "friendship-14",
         "text": "Friendship is a wildly underrated medication.",
         "author": "Anna Deavere Smith"
       },
       {
+        "id": "friendship-15",
         "text": "Friendship is a pretty full-time occupation if you really are friendly with somebody. You can’t have too many friends because then you’re just not really friends.",
         "author": "Truman Capote"
       },
       {
+        "id": "friendship-16",
         "text": "True friends are like diamonds — bright, beautiful, valuable, and always in style.",
         "author": "Nicole Richie"
       },
       {
+        "id": "friendship-17",
         "text": "Women’s friendships are like a renewable source of power.",
         "author": "Jane Fonda"
       },
       {
+        "id": "friendship-18",
         "text": "Friends are those rare people who ask how we are and then wait to hear the answer.",
         "author": "Ed Cunningham"
       },
       {
+        "id": "friendship-19",
         "text": "It is one of the blessings of old friends that you can afford to be stupid with them.",
         "author": "Ralph Waldo Emerson"
       },
       {
+        "id": "friendship-20",
         "text": "An integral part of any best friend’s job is to immediately clear your computer history if you die.",
         "author": "Darynda Jones"
       },
       {
+        "id": "friendship-21",
         "text": "Your friends will know you better in the first minute you meet than your acquaintances will know you in a thousand years.",
         "author": "Richard Bach"
       },
       {
+        "id": "friendship-22",
         "text": "When the world is so complicated, the simple gift of friendship is within all of our hands.",
         "author": "Maria Shriver"
       },
       {
+        "id": "friendship-23",
         "text": "What draws people to be friends is that they see the same truth. They share it.",
         "author": "C. S. Lewis"
       },
       {
+        "id": "friendship-24",
         "text": "Friendship isn’t a big thing — it’s a million little things.",
         "author": "Paulo Coelho"
       },
       {
+        "id": "friendship-25",
         "text": "A good friend is like a four-leaf clover; hard to find and lucky to have.",
         "author": "Irish Proverb"
       },
       {
+        "id": "friendship-26",
         "text": "Life is an awful, ugly place to not have a best friend.",
         "author": "Sarah Dessen, “Someone Like You"
       },
       {
+        "id": "friendship-27",
         "text": "If you have one true friend you have more than your share.",
         "author": "Thomas Fuller"
       },
       {
+        "id": "friendship-28",
         "text": "Friendship is the hardest thing in the world to explain. It’s not something you learn in school. But if you haven’t learned the meaning of friendship, you really haven’t learned anything.",
         "author": "Muhammad Ali"
       },
       {
+        "id": "friendship-29",
         "text": "A friend is one who knows you and loves you just the same.",
         "author": "Elbert Hubbard"
       },
       {
+        "id": "friendship-30",
         "text": "A friend knows the song in my heart and sings it to me when my memory fails.",
         "author": "Donna Roberts"
       },
       {
+        "id": "friendship-31",
         "text": "A friend is someone who makes it easy to believe in yourself.",
         "author": "Heidi Wills"
       },
       {
+        "id": "friendship-32",
         "text": "Friendship is always a sweet responsibility, never an opportunity.",
         "author": "Kahlil Gibran"
       },
       {
+        "id": "friendship-33",
         "text": "Friendships between women, as any woman will tell you, are built of a thousand small kindnesses. . . swapped back and forth and over again,",
         "author": "Michelle Obama, “Becoming"
       },
       {
+        "id": "friendship-34",
         "text": "No friendship is an accident.",
         "author": "O. Henry"
       },
       {
+        "id": "friendship-35",
         "text": "Friends are honest with each other. Even if the truth hurts.",
         "author": "Sarah Dessen, “Along for the Ride"
       },
       {
+        "id": "friendship-36",
         "text": "A single rose can be my garden; a single friend, my world.",
         "author": "Leo Buscaglia"
       },
       {
+        "id": "friendship-37",
         "text": "A friend may be waiting behind a stranger’s face.",
         "author": "Maya Angelou, “Letter to My Daughter"
       },
       {
+        "id": "friendship-38",
         "text": "Since there is nothing so well worth having as friends, never lose a chance to make them.",
         "author": "Francesco Guicciardini"
       },
       {
+        "id": "friendship-39",
         "text": "There’s nothing like a really loyal, dependable, good friend. Nothing.",
         "author": "Jennifer Aniston"
       },
       {
+        "id": "friendship-40",
         "text": "Friendship’s the wine of life.",
         "author": "Edward Young"
       },
       {
+        "id": "friendship-41",
         "text": "Some people arrive and make such a beautiful impact on your life, you can barely remember what life was like without them.",
         "author": "Anna Taylor"
       },
       {
+        "id": "friendship-42",
         "text": "True happiness consists not in the multitude of friends, but in the worth and choice.",
         "author": "Ben Jonson"
       },
       {
+        "id": "friendship-43",
         "text": "Fate chooses our relatives, we choose our friends.",
         "author": "Jacques Delille"
       },
       {
+        "id": "friendship-44",
         "text": "A friend is one of the nicest things you can have, and one of the best things you can be.",
         "author": "Douglas Pagels"
       },
       {
+        "id": "friendship-45",
         "text": "Wishing to be friends is quick work, but friendship is a slow-ripening fruit.",
         "author": "Aristotle"
       },
       {
+        "id": "friendship-46",
         "text": "Friendship is the only cement that will ever hold the world together.",
         "author": "Woodrow Wilson"
       },
       {
+        "id": "friendship-47",
         "text": "Nearly everything I know about love, I’ve learnt from my long-term friendships with women.",
         "author": "Dolly Alderton, “Everything I Know About Love"
       },
       {
+        "id": "friendship-48",
         "text": "Lots of people want to ride with you in the limo, but what you want is someone who will take the bus with you when the limo breaks down.",
         "author": "Oprah Winfrey"
       },
       {
+        "id": "friendship-49",
         "text": "That was what a best friend did: hold up a mirror and show you your heart.",
         "author": "Kristin Hannah"
       },
       {
+        "id": "friendship-50",
         "text": "Truly great friends are hard to find, difficult to leave and impossible to forget.",
         "author": "G. Randolf"
       }
@@ -828,202 +1028,252 @@ window.quotesData = [
     "label": "Music",
     "quotes": [
       {
+        "id": "music-01",
         "text": "Music is like a dream. One that I cannot hear.",
         "author": "Ludwig van Beethoven"
       },
       {
+        "id": "music-02",
         "text": "Without music, life would be a mistake",
         "author": "Friedrich Nietzsche"
       },
       {
+        "id": "music-03",
         "text": "I can chase you, and I can catch you, but there is nothing I can do to make you mine.",
         "author": "Morrissey"
       },
       {
+        "id": "music-04",
         "text": "Music gives a soul to the universe, wings to the mind, flight to the imagination and life to everything.",
         "author": "Plato"
       },
       {
+        "id": "music-05",
         "text": "How is it that music can, without words, evoke our laughter, our fears, our highest aspirations?",
         "author": "Jane Swan"
       },
       {
+        "id": "music-06",
         "text": "If I were not a physicist, I would probably be a musician. I often think in music. I live my daydreams in music. I see my life in terms of music.",
         "author": "Albert Einstein"
       },
       {
+        "id": "music-07",
         "text": "Music is a language that doesn’t speak in particular words. It speaks in emotions, and if it’s in the bones, it’s in the bones.",
         "author": "Keith Richards"
       },
       {
+        "id": "music-08",
         "text": "I think music in itself is healing. It’s an explosive expression of humanity. It’s something we are all touched by. No matter what culture we’re from, everyone loves music.",
         "author": "Billy Joel"
       },
       {
+        "id": "music-09",
         "text": "One good thing about music, when it hits you, you feel no pain.",
         "author": "Bob Marley"
       },
       {
+        "id": "music-10",
         "text": "The only truth is music.",
         "author": "Jack Kerouac"
       },
       {
+        "id": "music-11",
         "text": "There are two means of refuge from the miseries of life: music and cats.",
         "author": "Albert Schweitzer"
       },
       {
+        "id": "music-12",
         "text": "Music is the shorthand of emotion.",
         "author": "Leo Tolstoy"
       },
       {
+        "id": "music-13",
         "text": "Without music, life would be a blank to me.",
         "author": "Jane Austen"
       },
       {
+        "id": "music-14",
         "text": "If music be the food of love, play on, Give me excess of it; that surfeiting, The appetite may sicken, and so die.",
         "author": "William Shakespeare"
       },
       {
+        "id": "music-15",
         "text": "Music was my refuge. I could crawl into the space between the notes and curl my back to loneliness.",
         "author": "Maya Angelou"
       },
       {
+        "id": "music-16",
         "text": "After silence, that which comes nearest to expressing the inexpressible is music.",
         "author": "Aldous Huxley"
       },
       {
+        "id": "music-17",
         "text": "The most exciting rhythms seem unexpected and complex, the most beautiful melodies simple and inevitable.",
         "author": "W. H. Auden"
       },
       {
+        "id": "music-18",
         "text": "Where words fail, music speaks.",
         "author": "Hans Christian Andersen"
       },
       {
+        "id": "music-19",
         "text": "Music expresses that which cannot be said and on which it is impossible to be silent.",
         "author": "Victor Hugo"
       },
       {
+        "id": "music-20",
         "text": "We are the music makers, and we are the dreamers of dreams.",
         "author": "Arthur O’Shaughnessy"
       },
       {
+        "id": "music-21",
         "text": "If I had my life to live over again, I would have made a rule to read some poetry and listen to some music at least once every week.",
         "author": "Charles Darwin"
       },
       {
+        "id": "music-22",
         "text": "Music produces a kind of pleasure which human nature cannot do without.",
         "author": "Confucius"
       },
       {
+        "id": "music-23",
         "text": "Music is … A higher revelation than all Wisdom & Philosophy",
         "author": "Ludwig van Beethoven"
       },
       {
+        "id": "music-24",
         "text": "A man should hear a little music, read a little poetry, and see a fine picture every day of his life, in order that worldly cares may not obliterate the sense of the beautiful which God has implanted in the human soul.",
         "author": "Johann Wolfgang von Goethe"
       },
       {
+        "id": "music-25",
         "text": "Music is to the soul what words are to the mind.",
         "author": "Modest Mouse"
       },
       {
+        "id": "music-26",
         "text": "Music, once admitted to the soul, becomes a sort of spirit, and never dies.",
         "author": "Edward Bulwer-Lytton"
       },
       {
+        "id": "music-27",
         "text": "Music touches us emotionally, where words alone can’t.",
         "author": "Johnny Depp"
       },
       {
+        "id": "music-28",
         "text": "Virtually every writer I know would rather be a musician.",
         "author": "Kurt Vonnegut"
       },
       {
+        "id": "music-29",
         "text": "A painter paints pictures on canvas. But musicians paint their pictures on silence.",
         "author": "Leopold Stokowski"
       },
       {
+        "id": "music-30",
         "text": "Music . . . can name the unnameable and communicate the unknowable.",
         "author": "Leonard Bernstein"
       },
       {
+        "id": "music-31",
         "text": "I like beautiful melodies telling me terrible things.",
         "author": "Tom Waits"
       },
       {
+        "id": "music-32",
         "text": "When you make music or write or create, it’s really your job to have mind-blowing, irresponsible, condomless sex with whatever idea it is you’re writing about at the time.",
         "author": "Lady Gaga"
       },
       {
+        "id": "music-33",
         "text": "If being an egomaniac means I believe in what I do and in my art or music, then in that respect you can call me that… I believe in what I do, and I’ll say it.",
         "author": "John Lennon"
       },
       {
+        "id": "music-34",
         "text": "Live your truth. Express your love. Share your enthusiasm. Take action towards your dreams. Walk your talk. Dance and sing to your music. Embrace your blessings. Make today worth remembering.",
         "author": "Steve Maraboli"
       },
       {
+        "id": "music-35",
         "text": "Information is not knowledge. Knowledge is not wisdom. Wisdom is not truth. Truth is not beauty. Beauty is not love. Love is not music. Music is THE BEST.",
         "author": "Frank Zappa"
       },
       {
+        "id": "music-36",
         "text": "Music is the literature of the heart; it commences where speech ends.",
         "author": "Alphonse de Lamartine"
       },
       {
+        "id": "music-37",
         "text": "Beethoven tells you what it’s like to be Beethoven and Mozart tells you what it’s like to be human. Bach tells you what it’s like to be the universe.",
         "author": "Douglas Adams"
       },
       {
+        "id": "music-38",
         "text": "The music is not in the notes, but in the silence between.",
         "author": "Wolfgang Amadeus Mozart"
       },
       {
+        "id": "music-39",
         "text": "Music makes one feel so romantic – at least it always gets on one’s nerves – which is the same thing nowadays.",
         "author": "Oscar Wilde"
       },
       {
+        "id": "music-40",
         "text": "Without music to decorate it, time is just a bunch of boring production deadlines or dates by which bills must be paid.",
         "author": "Frank Zappa"
       },
       {
+        "id": "music-41",
         "text": "If you cannot teach me to fly, teach me to sing.",
         "author": "J. M. Barrie, Peter Pan"
       },
       {
+        "id": "music-42",
         "text": "Music is the strongest form of magic.",
         "author": "Marilyn Manson"
       },
       {
+        "id": "music-43",
         "text": "Music is the wine that fills the cup of silence.",
         "author": "Robert Fripp"
       },
       {
+        "id": "music-44",
         "text": "Music is the language of the spirit. It opens the secret of life bringing peace, abolishing strife.",
         "author": "Kahlil Gibran"
       },
       {
+        "id": "music-45",
         "text": "Music in the soul can be heard by the universe.",
         "author": "Lao Tzu"
       },
       {
+        "id": "music-46",
         "text": "Music acts like a magic key, to which the most tightly closed heart opens.",
         "author": "Maria Augusta von Trapp"
       },
       {
+        "id": "music-47",
         "text": "Music… will help dissolve your perplexities and purify your character and sensibilities, and in time of care and sorrow, will keep a fountain of joy alive in you.",
         "author": "Dietrich Bonhoeffer"
       },
       {
+        "id": "music-48",
         "text": "Music is an outburst of the soul.",
         "author": "Frederick Delius"
       },
       {
+        "id": "music-49",
         "text": "My personal hobbies are reading, listening to music, and silence.",
         "author": "Edith Sitwell"
       },
       {
+        "id": "music-50",
         "text": "Music is the great uniter. An incredible force. Something that people who differ on everything and anything else can have in common.",
         "author": "Sarah Dessen"
       }
@@ -1034,202 +1284,252 @@ window.quotesData = [
     "label": "Travel",
     "quotes": [
       {
+        "id": "travel-01",
         "text": "The world is a book, and those who do not travel read only a page.",
         "author": "Unknown"
       },
       {
+        "id": "travel-02",
         "text": "Take only memories, leave only footprints.",
         "author": "Unknown"
       },
       {
+        "id": "travel-03",
         "text": "Travel makes one modest. You see what a tiny place you occupy in the world.",
         "author": "Gustave Flaubert"
       },
       {
+        "id": "travel-04",
         "text": "Not all those who wander are lost.",
         "author": "J. R. R. Tolkien"
       },
       {
+        "id": "travel-05",
         "text": "Every man dies, but not every man really lives.",
         "author": "William Wallace"
       },
       {
+        "id": "travel-06",
         "text": "To live is the rarest thing in the world. Most people exist, that is all.",
         "author": "Oscar Wilde"
       },
       {
+        "id": "travel-07",
         "text": "Life is a journey. Make the most of it.",
         "author": "Unknown"
       },
       {
+        "id": "travel-08",
         "text": "I’ve traveled every road in this here land… I’ve been everywhere, man, I’ve been everywhere.",
         "author": "Johnny Cash"
       },
       {
+        "id": "travel-09",
         "text": "Paris is always a good idea.",
         "author": "Audrey Hepburn"
       },
       {
+        "id": "travel-10",
         "text": "Travel is the only thing you buy that makes you richer.",
         "author": "Unknown"
       },
       {
+        "id": "travel-11",
         "text": "Collect moments, not things.",
         "author": "Unknown"
       },
       {
+        "id": "travel-12",
         "text": "Today is your day, your mountain is waiting. So get on your way.",
         "author": "Dr Seuss"
       },
       {
+        "id": "travel-13",
         "text": "Twenty years from now you will be more disappointed by the things you didn’t do than by the things you did do. So throw off the bowlines. Catch the trade winds in your sails. Explore. Dream. Discover.",
         "author": "Unknown"
       },
       {
+        "id": "travel-14",
         "text": "I’m shaking the dust of this crummy little town off my feet and I’m gonna see the world.",
         "author": "George Bailey in It’s A Wonderful Life"
       },
       {
+        "id": "travel-15",
         "text": "It’s a dangerous business, Frodo, going out your door. You step onto the road, and if you don’t keep your feet, there’s no knowing where you might be swept off to.",
         "author": "J. R. R. Tolkien"
       },
       {
+        "id": "travel-16",
         "text": "Nature is not a place to visit. It is home.",
         "author": "Gary Snyder"
       },
       {
+        "id": "travel-17",
         "text": "Though we travel the world over to find the beautiful, we must carry it with us or we find it not.",
         "author": "Ralph Waldo Emerson"
       },
       {
+        "id": "travel-18",
         "text": "The journey of a thousand miles begins with a single step.",
         "author": "Lao Tzu"
       },
       {
+        "id": "travel-19",
         "text": "In every walk with nature one receives far more than he seeks.",
         "author": "John Muir"
       },
       {
+        "id": "travel-20",
         "text": "The mountains are calling and I must go.",
         "author": "John Muir"
       },
       {
+        "id": "travel-21",
         "text": "Climb the mountains and get their good tidings. Nature’s peace will flow into you as sunshine flows into trees. The winds will blow their own freshness into you, and the storms their energy, while cares will drop off like autumn leaves.",
         "author": "John Muir"
       },
       {
+        "id": "travel-22",
         "text": "Life is either a daring adventure or nothing at all",
         "author": "Helen Keller"
       },
       {
+        "id": "travel-23",
         "text": "I am not the same, having seen the moon shine on the other side of the world.",
         "author": "Mary Anne Radmacher"
       },
       {
+        "id": "travel-24",
         "text": "Don’t tell me how educated you are, tell me how much you have travelled.",
         "author": "Mohammed"
       },
       {
+        "id": "travel-25",
         "text": "Travel is fatal to prejudice, bigotry, and narrow-mindedness.",
         "author": "Mark Twain"
       },
       {
+        "id": "travel-26",
         "text": "Surely, of all the wonders of the world, the horizon is the greatest.",
         "author": "Freya Stark"
       },
       {
+        "id": "travel-27",
         "text": "Travel isn’t always pretty. It isn’t always comfortable. Sometimes it hurts, it even breaks your heart. But that’s okay. The journey changes you; it should change you. It leaves marks on your memory, on your consciousness, on your heart, and on your body. You take something with you. Hopefully, you leave something good behind.",
         "author": "Anthony Bourdain"
       },
       {
+        "id": "travel-28",
         "text": "A good traveler has no fixed plans, and is not intent on arriving.",
         "author": "Lao Tzu"
       },
       {
+        "id": "travel-29",
         "text": "There are no foreign lands. It is the traveler only who is foreign",
         "author": "Robert Louis Stevenson"
       },
       {
+        "id": "travel-30",
         "text": "The world is a book, and those who do not travel read only one page.",
         "author": "Saint Augustine"
       },
       {
+        "id": "travel-31",
         "text": "Life is meant for good friends and great adventures",
         "author": "Anonymous"
       },
       {
+        "id": "travel-32",
         "text": "I haven’t been everywhere, but it’s on my list.",
         "author": "Susan Sontag"
       },
       {
+        "id": "travel-33",
         "text": "Two roads diverged in a wood, and I – I took the one less traveled by",
         "author": "Robert Frost"
       },
       {
+        "id": "travel-34",
         "text": "Once a year, go somewhere you have never been before.",
         "author": "Dalai Lama"
       },
       {
+        "id": "travel-35",
         "text": "A journey is best measured in friends, rather than miles.",
         "author": "Tim Cahill"
       },
       {
+        "id": "travel-36",
         "text": "Wherever you go becomes a part of you somehow.",
         "author": "Anita Desai"
       },
       {
+        "id": "travel-37",
         "text": "Don’t listen to what they say. Go see.",
         "author": "Anonymous"
       },
       {
+        "id": "travel-38",
         "text": "Take only memories, leave only footprints.",
         "author": "Chief Seattle"
       },
       {
+        "id": "travel-39",
         "text": "Collect Moment, Not Things.",
         "author": "Anonymous"
       },
       {
+        "id": "travel-40",
         "text": "Blessed are the curious for they shall have adventures.",
         "author": "Lovelle Drachman"
       },
       {
+        "id": "travel-41",
         "text": "We wander for distraction, but we travel for fulfilment.",
         "author": "Hilaire Belloc"
       },
       {
+        "id": "travel-42",
         "text": "For my part, I travel not to go anywhere, but to go. I travel for travel’s sake. The great affair is to move.",
         "author": "Robert Louis Stevenson"
       },
       {
+        "id": "travel-43",
         "text": "I’m in love with cities I’ve never been to and people I’ve never met.",
         "author": "Melody Truong"
       },
       {
+        "id": "travel-44",
         "text": "This wasn’t a strange place; it was a new one.",
         "author": "Paulo Coelho"
       },
       {
+        "id": "travel-45",
         "text": "If we were meant to stay in one place, we’d have roots instead of feet",
         "author": "Rachel Wolchin"
       },
       {
+        "id": "travel-46",
         "text": "Once the travel bug bites there is no known antidote, and I know that I shall be happily infected until the end of my life.",
         "author": "Michael Palin"
       },
       {
+        "id": "travel-47",
         "text": "We travel for romance, we travel for architecture, and we travel to be lost.",
         "author": "Ray Bradbury"
       },
       {
+        "id": "travel-48",
         "text": "Twenty years from now you will be more disappointed by the things you didn’t do than by the ones you did.",
         "author": "Mark Twain"
       },
       {
+        "id": "travel-49",
         "text": "People don’t take trips, trips take people.",
         "author": "John Steinbeck"
       },
       {
+        "id": "travel-50",
         "text": "Travel is never a matter of money but of courage.",
         "author": "Paulo Coelho"
       }
@@ -1240,202 +1540,252 @@ window.quotesData = [
     "label": "Humor",
     "quotes": [
       {
+        "id": "humor-01",
         "text": "I’m sick of following my dreams, man. I’m just going to ask where they’re going and hook up with’em later.",
         "author": "Mitch Hedberg"
       },
       {
+        "id": "humor-02",
         "text": "A pessimist is a person who has had to listen to too many optimists.",
         "author": "Don Marquis"
       },
       {
+        "id": "humor-03",
         "text": "Whoever established the high road and how high it should be should be fired.",
         "author": "Sandra Bullock"
       },
       {
+        "id": "humor-04",
         "text": "Keep calm and carry a wand.",
         "author": "A. W. Jantha, “Hocus Pocus & The All New Sequel"
       },
       {
+        "id": "humor-05",
         "text": "Have you ever noticed that anybody driving slower than you is an idiot, and anyone going faster than you is a maniac?",
         "author": "George Carlin"
       },
       {
+        "id": "humor-06",
         "text": "If I’m not back in five minutes, just wait longer.",
         "author": "Ace Ventura, “Ace Ventura: Pet Detective"
       },
       {
+        "id": "humor-07",
         "text": "The suspense is terrible. I hope it’ll last.",
         "author": "Willy Wonka, “Willy Wonka & the Chocolate Factory"
       },
       {
+        "id": "humor-08",
         "text": "Why do they call it rush hour when nothing moves?",
         "author": "Robin Williams"
       },
       {
+        "id": "humor-09",
         "text": "Don’t be so humble — you are not that great.",
         "author": "Golda Meir"
       },
       {
+        "id": "humor-10",
         "text": "If you can’t be kind, at least be vague.",
         "author": "Judith Martin"
       },
       {
+        "id": "humor-11",
         "text": "There is only one thing in the world worse than being talked about, and that is not being talked about.",
         "author": "Oscar Wilde, “The Picture of Dorian Gray"
       },
       {
+        "id": "humor-12",
         "text": "Always forgive your enemies; nothing annoys them so much.",
         "author": "Oscar Wilde"
       },
       {
+        "id": "humor-13",
         "text": "In real life, I assure you, there is no such thing as algebra.",
         "author": "Fran Lebowitz"
       },
       {
+        "id": "humor-14",
         "text": "Instant gratification takes too long.",
         "author": "Carrie Fisher"
       },
       {
+        "id": "humor-15",
         "text": "Accept who you are. Unless you’re a serial killer.",
         "author": "Ellen DeGeneres"
       },
       {
+        "id": "humor-16",
         "text": "Whoever said that money can’t buy happiness, simply didn’t know where to go shopping.",
         "author": "Bo Derek"
       },
       {
+        "id": "humor-17",
         "text": "So be wise, because the world needs more wisdom, and if you cannot be wise, pretend to be someone who is wise, and then just behave like they would.",
         "author": "Neil Gaiman"
       },
       {
+        "id": "humor-18",
         "text": "I’m not good at the advice. Can I interest you in a sarcastic comment?",
         "author": "Chandler Bing, “Friends"
       },
       {
+        "id": "humor-19",
         "text": "I’m sick of following my dreams, man. I’m just going to ask where they’re going and hook up with’em later.",
         "author": "Mitch Hedberg"
       },
       {
+        "id": "humor-20",
         "text": "I’d love to stand here and talk with you. . . but I’m not going to.",
         "author": "Phil Connors, “Groundhog Day"
       },
       {
+        "id": "humor-21",
         "text": "All you need is love. But a little chocolate now and then doesn’t hurt.",
         "author": "Charles M. Schulz"
       },
       {
+        "id": "humor-22",
         "text": "People say that money is not the key to happiness, but I always figured if you have enough money, you can have a key made.",
         "author": "Joan Rivers"
       },
       {
+        "id": "humor-23",
         "text": "I’m not offended by blonde jokes because I know I’m not dumb…and I also know that I’m not blonde.",
         "author": "Dolly Parton"
       },
       {
+        "id": "humor-24",
         "text": "It is useless to try to hold a person to anything he says while he’s madly in love, drunk, or running for office.",
         "author": "Shirley MacLaine"
       },
       {
+        "id": "humor-25",
         "text": "I remember it like it was yesterday. Of course, I don’t really remember yesterday all that well.",
         "author": "Dory, “Finding Dory"
       },
       {
+        "id": "humor-26",
         "text": "The trouble with having an open mind, of course, is that people will insist on coming along and trying to put things in it.",
         "author": "Terry Pratchett, “Diggers"
       },
       {
+        "id": "humor-27",
         "text": "To call you stupid would be an insult to stupid people! I’ve known sheep that could outwit you. I’ve worn dresses with higher IQs.",
         "author": "Wanda, “A Fish Called Wanda"
       },
       {
+        "id": "humor-28",
         "text": "Those people who think they know everything are a great annoyance to those of us who do.",
         "author": "Isaac Asimov"
       },
       {
+        "id": "humor-29",
         "text": "The reason I talk to myself is because I’m the only one whose answers I accept.",
         "author": "George Carlin"
       },
       {
+        "id": "humor-30",
         "text": "I’m not superstitious…but I am a little stitious.",
         "author": "Michael Scott, “The Office"
       },
       {
+        "id": "humor-31",
         "text": "Here’s something to think about: How come you never see a headline like ‘Psychic Wins Lottery’?",
         "author": "Jay Leno"
       },
       {
+        "id": "humor-32",
         "text": "I’m sure wherever my Dad is, he’s looking down on us. He’s not dead, just very condescending.",
         "author": "Jack Whitehall"
       },
       {
+        "id": "humor-33",
         "text": "Before you marry a person, you should first make them use a computer with slow Internet to see who they really are.",
         "author": "Will Ferrell"
       },
       {
+        "id": "humor-34",
         "text": "I’d like to have a kid, but I’m not sure I’m ready to spend 10 years of my life constantly asking someone where his shoes are.",
         "author": "Damien Fahey"
       },
       {
+        "id": "humor-35",
         "text": "I want my children to have all the things I couldn’t afford. Then I want to move in with them.",
         "author": "Phyllis Diller"
       },
       {
+        "id": "humor-36",
         "text": "My husband and I fell in love at first sight. Maybe I should have taken a second look.",
         "author": "Halley Reed, “Crimes and Misdemeanors"
       },
       {
+        "id": "humor-37",
         "text": "When my kids become wild and unruly, I use a nice, safe playpen. When they’re finished, I climb out.",
         "author": "Erma Bombeck"
       },
       {
+        "id": "humor-38",
         "text": "When I was a kid my parents moved a lot, but I always found them.",
         "author": "Rodney Dangerfield"
       },
       {
+        "id": "humor-39",
         "text": "As I learned from growing up, you don’t mess with your grandmother.",
         "author": "Prince William"
       },
       {
+        "id": "humor-40",
         "text": "I’m not insane. My mother had me tested.",
         "author": "Sheldon Cooper, “The Big Bang Theory"
       },
       {
+        "id": "humor-41",
         "text": "I love being married. It’s so great to find that one special person you want to annoy for the rest of your life.",
         "author": "Rita Rudner"
       },
       {
+        "id": "humor-42",
         "text": "Good parenting means investing in your child’s future, which is why I am saving to buy mine a hoverboard someday.” — Lin",
         "author": "Manuel Miranda"
       },
       {
+        "id": "humor-43",
         "text": "Everybody knows how to raise children, except the people who have them.",
         "author": "P. J. O’Rourke"
       },
       {
+        "id": "humor-44",
         "text": "When your children are teenagers, it’s important to have a dog so that someone in the house is happy to see you.",
         "author": "Nora Ephron"
       },
       {
+        "id": "humor-45",
         "text": "You can kid the world, but not your sister.",
         "author": "Charlotte Gray"
       },
       {
+        "id": "humor-46",
         "text": "I generally avoid temptation unless I can’t resist it.",
         "author": "Mae West"
       },
       {
+        "id": "humor-47",
         "text": "There is no such thing as fun for the whole family.",
         "author": "Jerry Seinfeld"
       },
       {
+        "id": "humor-48",
         "text": "If you cannot get rid of the family skeleton, you may as well make it dance.",
         "author": "George Bernard Shaw, “Immaturity"
       },
       {
+        "id": "humor-49",
         "text": "Love is blind but marriage is a real eye-opener.",
         "author": "Pauline Thomason"
       },
       {
+        "id": "humor-50",
         "text": "Happiness is having a large, loving, caring, close-knit family in another city.",
         "author": "George Burns"
       }
@@ -1446,198 +1796,247 @@ window.quotesData = [
     "label": "Money",
     "quotes": [
       {
+        "id": "money-01",
         "text": "Money without financial intelligence is money soon gone.",
         "author": "Robert Kiyosaki"
       },
       {
+        "id": "money-02",
         "text": "Money is the harvest of our production.",
         "author": "Earl Nightingale"
       },
       {
+        "id": "money-03",
         "text": "Successful people make money. It’s not that people who make money become successful, but that successful people attract money. They bring success to what they do.",
         "author": "Wayne Dyer"
       },
       {
+        "id": "money-04",
         "text": "Too many people spend money they earned to buy things they don’t want, to impress people they don’t like.",
         "author": "Will Rogers"
       },
       {
+        "id": "money-05",
         "text": "Save money, and money will save you.",
         "author": "Anonymous"
       },
       {
+        "id": "money-06",
         "text": "Never spend your money before you have earned it.",
         "author": "Thomas Jefferson"
       },
       {
+        "id": "money-07",
         "text": "If you don’t find a way to make money while you sleep, you will work until the day you die.",
         "author": "Warren Buffett"
       },
       {
+        "id": "money-08",
         "text": "Having money isn’t everything, not having it, is.",
         "author": "Kanye West"
       },
       {
+        "id": "money-09",
         "text": "A penny saved is a penny earned",
         "author": "Benjamin Franlkin"
       },
       {
+        "id": "money-10",
         "text": "When money realizes that it is in good hands, it wants to stay and multiply in those hands.",
         "author": "Idowu Koyenikan"
       },
       {
+        "id": "money-11",
         "text": "Money is a tool. Used properly it makes something beautiful; used wrong, it makes a mess.",
         "author": "Bradley Vinson"
       },
       {
+        "id": "money-12",
         "text": "You can be young without money, but you can’t be old without it.",
         "author": "Tennessee Williams"
       },
       {
+        "id": "money-13",
         "text": "Money is a great servant but a bad master.",
         "author": "Francis Bacon"
       },
       {
+        "id": "money-14",
         "text": "The man who does more than he is paid for will soon be paid for more than he does.",
         "author": "Napoleon Hill"
       },
       {
+        "id": "money-15",
         "text": "It is a kind of spiritual snobbery that makes people think they can be happy without money.",
         "author": "Albert Camus"
       },
       {
+        "id": "money-16",
         "text": "There is no shortage of money in this world. Start hustling.",
         "author": "Grant Cardone"
       },
       {
+        "id": "money-17",
         "text": "Money isn’t everything…but it ranks right up there with oxygen.",
         "author": "Rita Davenport"
       },
       {
+        "id": "money-18",
         "text": "The man who damns money has obtained it dishonorably; the man who respects it has earned it.",
         "author": "Ayn Rand"
       },
       {
+        "id": "money-19",
         "text": "Work like you don’t need the money. Dance like no one is watching. And love like you’ve never been hurt.",
         "author": "Mark Twain"
       },
       {
+        "id": "money-20",
         "text": "The first rule is not to lose money. The second rule is not to forget the first rule.",
         "author": "Warren Buffett"
       },
       {
+        "id": "money-21",
         "text": "Money looks better in the bank than on your feet.",
         "author": "Sophia Amorus"
       },
       {
+        "id": "money-22",
         "text": "Not he who has much is rich, but he who gives much.",
         "author": "Erich Fromm"
       },
       {
+        "id": "money-23",
         "text": "That man is richest whose pleasures are cheapest.",
         "author": "Henry David Thoreau"
       },
       {
+        "id": "money-24",
         "text": "The money you have gives you freedom; the money you pursue enslaves you.",
         "author": "Jean-Jacques Rousseau"
       },
       {
+        "id": "money-25",
         "text": "Wealth is the ability to fully experience life.",
         "author": "Henry David Thoreau"
       },
       {
+        "id": "money-26",
         "text": "I will tell you how to become rich. Close the doors. Be fearful when others are greedy. Be greedy when others are fearful.",
         "author": "Warren Buffett"
       },
       {
+        "id": "money-27",
         "text": "The key to making money is to stay invested.",
         "author": "Suze Orman"
       },
       {
+        "id": "money-28",
         "text": "If you cannot control your emotions, you cannot control your money.",
         "author": "Warren Buffett"
       },
       {
+        "id": "money-29",
         "text": "Money is good for nothing unless you know the value of it by experience.",
         "author": "P. T Barnum"
       },
       {
+        "id": "money-30",
         "text": "Sloth and prosperity can never be companions.",
         "author": "James Allen"
       },
       {
+        "id": "money-31",
         "text": "If you would know the value of money, go and try to borrow some; for he that goes a borrowing, goes a sorrowing.",
         "author": "Benjamin Franklin"
       },
       {
+        "id": "money-32",
         "text": "Tell me how you use your spare time, and how you spend your money, and I will tell you where and what you will be in ten years from now.",
         "author": "Napoleon Hill"
       },
       {
+        "id": "money-33",
         "text": "Through positive, appreciative attitudes toward money, you can make money your servant, instead of becoming its slave. You should master money rather than be enslaved by it.",
         "author": "Catherine Ponder"
       },
       {
+        "id": "money-34",
         "text": "Rich people have their money work hard for them. Poor people work hard for their money.",
         "author": "T. Harv Eker"
       },
       {
+        "id": "money-35",
         "text": "The single biggest financial mistake I’ve made was not thinking big enough. I encourage you to go for more than a million. There is no shortage of money on this planet, only a shortage of people thinking big enough.",
         "author": "Grant Cardone"
       },
       {
+        "id": "money-36",
         "text": "Happiness is not in the mere possession of money; it lies in the joy of achievement, in the thrill of creative effort.",
         "author": "Franklin D. Roosevelt"
       },
       {
+        "id": "money-37",
         "text": "Money is not an end in itself. It is merely a tool to help us achieve some particular goal. If the way we handle our money conflicts with our personal values, we are not going to wind up living happy and fulfilled lives.",
         "author": "David Bach"
       },
       {
+        "id": "money-38",
         "text": "You don’t have time an money because you don’t invest time and money.",
         "author": "Grant Cardone"
       },
       {
+        "id": "money-39",
         "text": "Most people fail to realize that in life, it’s not how much money you make. It’s how much money you keep.",
         "author": "Robert Kiyosaki"
       },
       {
+        "id": "money-40",
         "text": "In the United States, where we have more land than people, it is not at all difficult for persons in good health to make money.",
         "author": "P. T. Barnum"
       },
       {
+        "id": "money-41",
         "text": "The philosophy of the rich and the poor is this: the rich invest their money and spend what is left. The poor spend their money and invest what is left.",
         "author": "Robert Kiyosaki"
       },
       {
+        "id": "money-42",
         "text": "Money is plentiful for those who understand the simple laws which govern it’s acquisitions.",
         "author": "George S. Clason"
       },
       {
+        "id": "money-43",
         "text": "While money can’t buy happiness, it certainly lets you choose your own form of misery.",
         "author": "Groucho Marx"
       },
       {
+        "id": "money-44",
         "text": "Money is really only important if you don’t have any.",
         "author": "Harrison Ford"
       },
       {
+        "id": "money-45",
         "text": "One penny may seem to you a very insignificant thing, but it is the small seed from which fortunes spring.",
         "author": "Orison Swett Marden"
       },
       {
+        "id": "money-46",
         "text": "The better you feel about money, the more money you magnetize to yourself.",
         "author": "Rhonda Byrne"
       },
       {
+        "id": "money-47",
         "text": "The fastest way to double your money is to fold them in half and put them in your pocket.",
         "author": "Andrew Carnegie"
       },
       {
+        "id": "money-48",
         "text": "Money is usually attracted, no pursued.",
         "author": "Jim Rohn"
       },
       {
+        "id": "money-49",
         "text": "Money may not buy happiness, but I’d rather cry in a Jaguar than on a bus.",
         "author": "Françoise Sagan"
       }
@@ -1648,202 +2047,252 @@ window.quotesData = [
     "label": "Family",
     "quotes": [
       {
+        "id": "family-01",
         "text": "It didn’t matter how big our house was; it mattered that there was love in it.",
         "author": "Peter Buffett"
       },
       {
+        "id": "family-02",
         "text": "Call it a clan, call it a network, call it a tribe, call it a family: Whatever you call it, whoever you are, you need one.",
         "author": "Jane Howard"
       },
       {
+        "id": "family-03",
         "text": "Family means nobody gets left behind or forgotten.",
         "author": "David Ogden Stiers"
       },
       {
+        "id": "family-04",
         "text": "We may have our differences, but nothing’s more important than family.",
         "author": "Coco"
       },
       {
+        "id": "family-05",
         "text": "The bond that links your true family is not one of blood, but of respect and joy in each other’s life.",
         "author": "Richard Bach"
       },
       {
+        "id": "family-06",
         "text": "A happy family is but an earlier heaven.",
         "author": "George Bernard Shaw"
       },
       {
+        "id": "family-07",
         "text": "Being a family means you are a part of something very wonderful. It means you will love and be loved for the rest of your life.",
         "author": "Lisa Weed"
       },
       {
+        "id": "family-08",
         "text": "Happiness is having a large, loving, caring, close-knit family in another city.",
         "author": "George Burns"
       },
       {
+        "id": "family-09",
         "text": "The strength of a family, like the strength of an army, lies in its loyalty to each other.",
         "author": "Mario Puzo"
       },
       {
+        "id": "family-10",
         "text": "The most important thing in the world is family and love.",
         "author": "John Wooden"
       },
       {
+        "id": "family-11",
         "text": "When everything goes to hell, the people who stand by you without flinching–they are your family.",
         "author": "Jim Butcher"
       },
       {
+        "id": "family-12",
         "text": "To us, family means putting your arms around each other and being there.",
         "author": "Barbara Bush"
       },
       {
+        "id": "family-13",
         "text": "In family life, love is the oil that eases friction, the cement that binds closer together, and the music that brings harmony.",
         "author": "Friedrich Nietzsche"
       },
       {
+        "id": "family-14",
         "text": "The other night I ate at a real nice family restaurant. Every table had an argument going.",
         "author": "George Carlin"
       },
       {
+        "id": "family-15",
         "text": "Family is not an important thing. It’s everything.",
         "author": "Michael J. Fox"
       },
       {
+        "id": "family-16",
         "text": "Family faces are magic mirrors. Looking at people who belong to us, we see the past, present, and future.",
         "author": "Gail Lumet Buckley"
       },
       {
+        "id": "family-17",
         "text": "The family is one of nature’s masterpieces.",
         "author": "George Santayana"
       },
       {
+        "id": "family-18",
         "text": "Families are the compass that guides us. They are the inspiration to reach great heights, and our comfort when we occasionally falter.",
         "author": "Brad Henry"
       },
       {
+        "id": "family-19",
         "text": "You are the bows from which your children as living arrows are sent forth.",
         "author": "Khalil Gibran"
       },
       {
+        "id": "family-20",
         "text": "So much of what is best in us is bound up in our love of family, that it remains the measure of our stability because it measures our sense of loyalty.",
         "author": "Haniel Long"
       },
       {
+        "id": "family-21",
         "text": "A man should never neglect his family for business.",
         "author": "Walt Disney"
       },
       {
+        "id": "family-22",
         "text": "The homemaker has the ultimate career. All other careers exist for one purpose only - and that is to support the ultimate career.",
         "author": "C. S. Lewis"
       },
       {
+        "id": "family-23",
         "text": "Sister is probably the most competitive relationship within the family, but once the sisters are grown, it becomes the strongest relationship.",
         "author": "Margaret Mead"
       },
       {
+        "id": "family-24",
         "text": "Everyone needs a house to live in, but a supportive family is what builds a home.",
         "author": "Anthony Liccione"
       },
       {
+        "id": "family-25",
         "text": "There is no such thing as fun for the whole family.",
         "author": "Jerry Seinfeld"
       },
       {
+        "id": "family-26",
         "text": "The informality of family life is a blessed condition that allows us all to become our best while looking our worst.",
         "author": "Marge Kennedy"
       },
       {
+        "id": "family-27",
         "text": "The greatest gift of family life is to be intimately acquainted with people you might never even introduce yourself to, had life not done it for you.",
         "author": "Kendall Hailey"
       },
       {
+        "id": "family-28",
         "text": "I know all those words, but that sentence makes no sense to me.",
         "author": "Matt Groening"
       },
       {
+        "id": "family-29",
         "text": "Having a place to go is a home. Having someone to love is a family. Having both is a blessing.",
         "author": "Donna Hedges"
       },
       {
+        "id": "family-30",
         "text": "Being part of a family means smiling for photos.",
         "author": "Harry Morgan"
       },
       {
+        "id": "family-31",
         "text": "There’s nothing that makes you more insane than family. Or more happy, or more exasperated, or more secure.",
         "author": "Jim Butcher"
       },
       {
+        "id": "family-32",
         "text": "Family is family.",
         "author": "Linda Linney"
       },
       {
+        "id": "family-33",
         "text": "In time of test, family is best.",
         "author": "Burmese Proverb"
       },
       {
+        "id": "family-34",
         "text": "If the family were a boat, it would be a canoe that makes no progress unless everyone paddles.",
         "author": "Letty Cottin Pogrebin"
       },
       {
+        "id": "family-35",
         "text": "One day you will do things for me that you hate. That is what it means to be family.",
         "author": "Jonathan Safran Foer"
       },
       {
+        "id": "family-36",
         "text": "I am blessed to have so many great things in my life – family, friends, and God. All will be in my thoughts daily.",
         "author": "Lil’ Kim"
       },
       {
+        "id": "family-37",
         "text": "I have learned that to be with those I like is enough.",
         "author": "Walt Whitman"
       },
       {
+        "id": "family-38",
         "text": "The family–that dear octopus from whose tentacles we never quite escape, nor, in our inmost hearts, ever quite wish to.",
         "author": "Dodie Smith"
       },
       {
+        "id": "family-39",
         "text": "The family is the first essential cell of human society.",
         "author": "Pope John XXIII"
       },
       {
+        "id": "family-40",
         "text": "Rejoice with your family in the beautiful land of life.",
         "author": "Albert Einstein"
       },
       {
+        "id": "family-41",
         "text": "Let love be genuine. Abhor what is evil; hold fast to what is good.",
         "author": "Romans 12: 9"
       },
       {
+        "id": "family-42",
         "text": "Sticking with your family is what makes it a family.",
         "author": "Mitch Albom"
       },
       {
+        "id": "family-43",
         "text": "It’s all about the quality of life and finding a happy balance between work and friends and family.",
         "author": "Philip Green"
       },
       {
+        "id": "family-44",
         "text": "If you cannot get rid of the family skeleton, you may as well make it dance.",
         "author": "George Bernard Shaw"
       },
       {
+        "id": "family-45",
         "text": "Show me a family of readers, and I will show you the people who move the world.",
         "author": "Napoleon Bonaparte"
       },
       {
+        "id": "family-46",
         "text": "Family and friendships are two of the greatest facilitators of happiness.",
         "author": "John C. Maxwell"
       },
       {
+        "id": "family-47",
         "text": "Parents were the only ones obligated to love you; from the rest of the world you had to earn it.",
         "author": "Ann Brashares"
       },
       {
+        "id": "family-48",
         "text": "Nothing is better than going home to family and eating good food and relaxing.",
         "author": "Irina Shayk"
       },
       {
+        "id": "family-49",
         "text": "Family and friends are hidden treasures, seek them and enjoy their riches.",
         "author": "Wanda Hope Carter"
       },
       {
+        "id": "family-50",
         "text": "Friends are the family you choose.",
         "author": "Jess C. Scott"
       }
@@ -1854,214 +2303,267 @@ window.quotesData = [
     "label": "Love",
     "quotes": [
       {
+        "id": "love-01",
         "text": "I saw that you were perfect, and so I loved you. Then I saw that you were not perfect and I loved you even more.",
         "author": "Angelita Lim"
       },
       {
+        "id": "love-02",
         "text": "You know you’re in love when you can’t fall asleep because reality is finally better than your dreams.",
         "author": "Dr. Seuss"
       },
       {
+        "id": "love-03",
         "text": "Love is that condition in which the happiness of another person is essential to your own.",
         "author": "Robert A. Heinlein"
       },
       {
+        "id": "love-04",
         "text": "The best thing to hold onto in life is each other.",
         "author": "Audrey Hepburn"
       },
       {
+        "id": "love-05",
         "text": "I need you like a heart needs a beat.",
         "author": "Unknown"
       },
       {
+        "id": "love-06",
         "text": "I am who I am because of you. You are every reason, every hope, and every dream I’ve ever had.",
         "author": "The Notebook"
       },
       {
+        "id": "love-07",
         "text": "If I had a flower for every time I thought of you. . . I could walk through my garden forever.",
         "author": "Alfred Tennyson"
       },
       {
+        "id": "love-08",
         "text": "Take my hand, take my whole life too. For I can’t help falling in love with you.",
         "author": "Elvis Presley"
       },
       {
+        "id": "love-09",
         "text": "If you live to be a hundred, I want to live to be a hundred minus one day so I never have to live without you.",
         "author": "A. A. Milne"
       },
       {
+        "id": "love-10",
         "text": "You’re the closest to heaven, that I’ll ever be.",
         "author": "Goo Goo Dolls"
       },
       {
+        "id": "love-11",
         "text": "You are the finest, loveliest, tenderest, and most beautiful person I have ever known and even that is an understatement.",
         "author": "F. Scott Fitzgerald"
       },
       {
+        "id": "love-12",
         "text": "I will never stop trying. Because when you find the one. . . you never give up.",
         "author": "Crazy, Stupid, Love"
       },
       {
+        "id": "love-13",
         "text": "It’s always better when we’re together.",
         "author": "Jack Johnson"
       },
       {
+        "id": "love-14",
         "text": "I love you for all that you are, all that you have been and all that you will be.",
         "author": "Unknown"
       },
       {
+        "id": "love-15",
         "text": "I wasn’t expecting you. I didn’t think that we would end up together. The single most extraordinary thing I’ve ever done with my life is fall in love with you. I’ve never been seen so completely, loved so passionately and protected so fiercely.",
         "author": "This Is Us"
       },
       {
+        "id": "love-16",
         "text": "To the world you may be one person, but to one person you are the world.",
         "author": "Unknown"
       },
       {
+        "id": "love-17",
         "text": "Two are better than one.",
         "author": "Ecclesiastes 4:9"
       },
       {
+        "id": "love-18",
         "text": "I’ve tried so many times to think of a new way to say it, and it’s still I love you.",
         "author": "Zelda Fitzgerald"
       },
       {
+        "id": "love-19",
         "text": "When you realize you want to spend the rest of your life with somebody, you want the rest of your life to start as soon as possible.",
         "author": "When Harry Met Sally"
       },
       {
+        "id": "love-20",
         "text": "I love you and that’s the beginning and end of everything.",
         "author": "F. Scott Fitzgerald"
       },
       {
+        "id": "love-21",
         "text": "If I know what love is, it is because of you.",
         "author": "Hermann Hesse"
       },
       {
+        "id": "love-22",
         "text": "My soul and your soul are forever tangled.",
         "author": "N. R. Hart"
       },
       {
+        "id": "love-23",
         "text": "I love you more than I have ever found a way to say to you.",
         "author": "Ben Folds"
       },
       {
+        "id": "love-24",
         "text": "I have found the one whom my soul loves.",
         "author": "Song of Solomon 3:4"
       },
       {
+        "id": "love-25",
         "text": "Sometimes all you need is a hug from the right person and all your stress will melt away.",
         "author": "Unknown"
       },
       {
+        "id": "love-26",
         "text": "In all the world, there is no heart for me like yours. In all the world, there is no love for you like mine.",
         "author": "Maya Angelou"
       },
       {
+        "id": "love-27",
         "text": "If you remember me, then I don’t care if everyone else forgets.",
         "author": "Haruki Murakami"
       },
       {
+        "id": "love-28",
         "text": "Love is when you sit beside someone doing nothing, yet you feel perfectly happy.",
         "author": "Unknown"
       },
       {
+        "id": "love-29",
         "text": "You are, and always have been, my dream.",
         "author": "Nicholas Sparks"
       },
       {
+        "id": "love-30",
         "text": "I love that you are the last person I want to talk to before I go to sleep at night.",
         "author": "When Harry Met Sally"
       },
       {
+        "id": "love-31",
         "text": "Love is composed of a single soul inhabiting two bodies.",
         "author": "Aristotle"
       },
       {
+        "id": "love-32",
         "text": "What is love? It is the morning and the evening star.",
         "author": "Sinclair Lewis"
       },
       {
+        "id": "love-33",
         "text": "If you find someone you love in your life, then hang on to that love.",
         "author": "Princess Diana"
       },
       {
+        "id": "love-34",
         "text": "Come near now, and kiss me.",
         "author": "Genesis 27:26"
       },
       {
+        "id": "love-35",
         "text": "I need you like a heart needs a beat.",
         "author": "One Republic"
       },
       {
+        "id": "love-36",
         "text": "Our love is like the wind. I can’t see it, but I can feel it.",
         "author": "A Walk to Remember"
       },
       {
+        "id": "love-37",
         "text": "Loving you never was an option. It was a necessity.",
         "author": "Truth Devour"
       },
       {
+        "id": "love-38",
         "text": "It’s always better when we’re together.",
         "author": "Jack Johnson"
       },
       {
+        "id": "love-39",
         "text": "I would rather spend one lifetime with you, than face all the ages of this world alone.",
         "author": "J. K. K. Tolken"
       },
       {
+        "id": "love-40",
         "text": "My love for you has no depth, its boundaries are ever-expanding.",
         "author": "Christina White"
       },
       {
+        "id": "love-41",
         "text": "When I see your face, there’s not a thing that I would change,’cause you’re amazing – just the way you are.",
         "author": "Bruno Mars"
       },
       {
+        "id": "love-42",
         "text": "Because of you, I can feel myself slowly, but surely, becoming the me I have always dreamed of being.",
         "author": "Tyler Knott Gregson"
       },
       {
+        "id": "love-43",
         "text": "We loved with a love that was more than love.",
         "author": "Edgar Allen Poe"
       },
       {
+        "id": "love-44",
         "text": "I saw that you were perfect, and so I loved you. Then I saw that you were not perfect and I loved you even more.",
         "author": "Angelita Lim"
       },
       {
+        "id": "love-45",
         "text": "I am my beloved’s and my beloved is mine.",
         "author": "Song of Solomon 6:3"
       },
       {
+        "id": "love-46",
         "text": "And in her smile I see something more beautiful than the stars.",
         "author": "Across the Universe"
       },
       {
+        "id": "love-47",
         "text": "It was love at first sight, at last sight, at ever and ever sight.",
         "author": "Vladimir Nabokov"
       },
       {
+        "id": "love-48",
         "text": "Love does not consist in gazing at each other, but in looking outward together in the same direction.",
         "author": "Antoine de Saint-Exupery"
       },
       {
+        "id": "love-49",
         "text": "You’re always the first and the last thing on this heart of mine. No matter where I go, or what I do, I’m thinking of you.",
         "author": "Dierks Bentley"
       },
       {
+        "id": "love-50",
         "text": "When I saw you I fell in love, and you smiled because you knew.",
         "author": "Arrigo Boito"
       },
       {
+        "id": "love-51",
         "text": "We can only learn to love by loving.",
         "author": "Iris Murdoch"
       },
       {
+        "id": "love-52",
         "text": "Love is the flower you've got to let grow.",
         "author": "John Lennon"
       },
       {
+        "id": "love-53",
         "text": "Only do what your heart tells you.",
         "author": "Princess Diana"
       }
@@ -2072,154 +2574,192 @@ window.quotesData = [
     "label": "Positive",
     "quotes": [
       {
+        "id": "positive-01",
         "text": "The only person you are destined to become is the person you decide to be.",
         "author": "Ralph Waldo Emerson"
       },
       {
+        "id": "positive-02",
         "text": "As we work to create light for others, we naturally light our own way.",
         "author": "Mary Anne Radmacher"
       },
       {
+        "id": "positive-03",
         "text": "To live is the rarest thing in the world. Most people exist, that is all.",
         "author": "Oscar Wilde"
       },
       {
+        "id": "positive-04",
         "text": "Keep your face to the sunshine and you cannot see a shadow.",
         "author": "Helen Keller"
       },
       {
+        "id": "positive-05",
         "text": "When the sun is shining I can do anything; no mountain is too high, no trouble too difficult to overcome.",
         "author": "Wilma Rudolph"
       },
       {
+        "id": "positive-06",
         "text": "Be fanatically positive and militantly optimistic. If something is not to your liking, change your liking.",
         "author": "Rick Steves"
       },
       {
+        "id": "positive-07",
         "text": "To be yourself in a world that is constantly trying to make you something else is the greatest accomplishment.",
         "author": "Ralph Waldo Emerson"
       },
       {
+        "id": "positive-08",
         "text": "We all have two lives. The second one starts when we realize we only have one.",
         "author": "Confucius"
       },
       {
+        "id": "positive-09",
         "text": "It is during our darkest moments that we must focus to see the light.",
         "author": "Aristotle"
       },
       {
+        "id": "positive-10",
         "text": "For every minute you are angry, you lose sixty seconds of happiness.",
         "author": "Ralph Waldo Emerson"
       },
       {
+        "id": "positive-11",
         "text": "All your dreams can come true if we have the courage to pursue them.",
         "author": "Walt Disney"
       },
       {
+        "id": "positive-12",
         "text": "Life is never fair, and perhaps it is a good thing for most of us that it is not.",
         "author": "Oscar Wilde"
       },
       {
+        "id": "positive-13",
         "text": "Be yourself; everyone else is already taken.",
         "author": "Oscar Wilde"
       },
       {
+        "id": "positive-14",
         "text": "You cannot change what you are, only what you do.",
         "author": "Philip Pullman"
       },
       {
+        "id": "positive-15",
         "text": "An unexamined life is not worth living.",
         "author": "Socrates"
       },
       {
+        "id": "positive-16",
         "text": "Every strike brings me closer to the next home run.",
         "author": "Babe Ruth"
       },
       {
+        "id": "positive-17",
         "text": "The happiness of your life depends on the quality of your thoughts.",
         "author": "Marcus Aurelius"
       },
       {
+        "id": "positive-18",
         "text": "Before anything else, preparation is the key to success.",
         "author": "Alexander Graham Bell"
       },
       {
+        "id": "positive-19",
         "text": "I dwell in possibility.",
         "author": "Emily Dickinson"
       },
       {
+        "id": "positive-20",
         "text": "Be happy for this moment. This moment is your life.",
         "author": "Omar Khayyam"
       },
       {
+        "id": "positive-21",
         "text": "The power of imagination makes us infinite.",
         "author": "John Muir"
       },
       {
+        "id": "positive-22",
         "text": "The next choice is the most important choice.",
         "author": "George Wells"
       },
       {
+        "id": "positive-23",
         "text": "Make your life matter and have fun doing it.",
         "author": "Aaron Hurst"
       },
       {
+        "id": "positive-24",
         "text": "Anything is possible with sunshine and a little pink.",
         "author": "Lilly Pulitzer"
       },
       {
+        "id": "positive-25",
         "text": "Do good and good will come to you.",
         "author": "Adam Lowy"
       },
       {
+        "id": "positive-26",
         "text": "You do not find the happy life. You make it.",
         "author": "Thomas S. Monson"
       },
       {
+        "id": "positive-27",
         "text": "The most wasted of days is one without laughter.",
         "author": "E. E. Cummings"
       },
       {
+        "id": "positive-28",
         "text": "You will face many defeats in life, but never let yourself be defeated.",
         "author": "Maya Angelou"
       },
       {
+        "id": "positive-29",
         "text": "Hope is the most exciting thing there is in life.",
         "author": "Mandy Moore"
       },
       {
+        "id": "positive-30",
         "text": "No act of kindness, no matter how small, is ever wasted.",
         "author": "Aesop"
       },
       {
+        "id": "positive-31",
         "text": "Lead from the heart, not the head.",
         "author": "Princess Diana"
       },
       {
+        "id": "positive-32",
         "text": "The only place where success comes before work is in the dictionary.",
         "author": "Vidal Sassoon"
       },
       {
+        "id": "positive-33",
         "text": "The most difficult thing is the decision to act, the rest is merely tenacity.",
         "author": "Amelia Earhart"
       },
       {
+        "id": "positive-34",
         "text": "The most important thing is to try and inspire people so that they can be great in whatever they want to do.",
         "author": "Kobe Bryant"
       },
       {
+        "id": "positive-35",
         "text": "If you spend your whole life waiting for the storm, you'll never enjoy the sunshine.",
         "author": "Morris West"
       },
       {
+        "id": "positive-36",
         "text": "Smile, breathe, and go slowly.",
         "author": "Thich Nhat Hanh"
       },
       {
+        "id": "positive-37",
         "text": "Before you put on a frown, make absolutely sure there are no smiles available.",
         "author": "Jim Beggs"
       },
       {
+        "id": "positive-38",
         "text": "Every time you smile at someone, it is an action of love, a gift to that person, a beautiful thing.",
         "author": "Mother Teresa"
       }
@@ -2230,57 +2770,71 @@ window.quotesData = [
     "label": "Happiness",
     "quotes": [
       {
+        "id": "happiness-01",
         "text": "Happiness depends upon ourselves.",
         "author": "Aristotle"
       },
       {
+        "id": "happiness-02",
         "text": "To be kind to all, to like many and love a few, to be needed and wanted by those we love, is certainly the nearest we can come to happiness.",
         "author": "Mary Stuart"
       },
       {
+        "id": "happiness-03",
         "text": "Happiness is not something ready - made. It comes from your own actions.",
         "author": "Dalai Lama"
       },
       {
+        "id": "happiness-04",
         "text": "If you want happiness for an hour— take a nap. If you want happiness for a day— go fishing. If you want happiness for a year— inherit a fortune. If you want happiness for a lifetime— help someone else.",
         "author": "Chinese Proverb"
       },
       {
+        "id": "happiness-05",
         "text": "It’s a helluva start, being able to recognize what makes you happy.",
         "author": "Lucille Ball"
       },
       {
+        "id": "happiness-06",
         "text": "Don’t underestimate the value of Doing Nothing, of just going along, listening to all the things you can’t hear, and not bothering.",
         "author": "Winnie the Pooh"
       },
       {
+        "id": "happiness-07",
         "text": "Some cause happiness wherever they go; others whenever they go.",
         "author": "Oscar Wilde"
       },
       {
+        "id": "happiness-08",
         "text": "Happiness is not in the mere possession of money; it lies in the joy of achievement, in the thrill of creative effort.",
         "author": "Franklin D. Roosevelt"
       },
       {
+        "id": "happiness-09",
         "text": "It’s been my experience that you can nearly always enjoy things if you make up your mind firmly that you will.",
         "author": "L. M. Montgomery"
       },
       {
+        "id": "happiness-10",
         "text": "Since you get more joy out of giving joy to others, you should put a good deal of thought into the happiness that you are able to give.",
         "author": "Eleanor Roosevelt"
       },
       {
+        "id": "happiness-11",
         "text": "Don't cry because it's over. Smile because it happened.",
         "author": "Dr. Seuss"
       },
       {
+        "id": "happiness-12",
         "text": "Great talent finds happiness in execution.",
         "author": "Johann Wolfgang von Goethe"
       },
       {
+        "id": "happiness-13",
         "text": "Some pursue happiness, others create it.",
         "author": "Unknown"
       }
     ]
   }
 ];
+

--- a/data/jokes-manifest.json
+++ b/data/jokes-manifest.json
@@ -1,0 +1,18179 @@
+{
+  "meta": {
+    "generatedAt": "2025-09-20T19:22:52.838Z",
+    "total": 865,
+    "hashAlgorithm": "sha256",
+    "tokenSignature": "unique-words-v1",
+    "fields": [
+      "joke",
+      "punchline"
+    ]
+  },
+  "records": {
+    "j-0001": {
+      "hashes": {
+        "setup": "c1d1156b58a3da705d8e06664d0e84c92d0cc1bb3103200cc612eb6b03f3c368",
+        "punchline": "50b79fcc3e8dfbae1eeb8c5d6bda7b9f43a516a6879e6b0279123b5c5da3fbf4",
+        "combined": "e97be435654b6cd7943764ddd5bf740a5f2ddff9afe6f79ed3a24734b914f715",
+        "tokenSignature": "and-are-ask-dreams-following-going-i-just-later-m-meet-my-of-them-they-tired-to-up-where-with"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 76
+      },
+      "source": {
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0002": {
+      "hashes": {
+        "setup": "e4e72f89e06daed0fe4b534b5efecc5d3cb4576df30f477732e49135666d6410",
+        "punchline": "c81e589c80aaa1912aea8c4b52847c8fa8c8accce8f088c9039314caef0daa92",
+        "combined": "f86c0ffec041f9de97084dc6e2dbc1a3422d1243562ed7de738a91c253aed5ba",
+        "tokenSignature": "about-all-cut-did-guy-he-hear-left-now-off-right-s-side-the-was-whole-whose-you"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0003": {
+      "hashes": {
+        "setup": "a5fb4569385ce7a84a51877b1771a5f6969d381919d8a6bc453dc948ac943429",
+        "punchline": "69aabb1c09eb24cb519049c5b3bd33515cc138eee86a2a5edd7cf08691a2d073",
+        "combined": "84318748ed562fa3ba78eb4564d8393dd6465fe6fd863754076bd16e7ee6d089",
+        "tokenSignature": "because-cross-didn-guts-had-he-no-road-skeleton-t-the-why"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0004": {
+      "hashes": {
+        "setup": "567074200073f977e91fe7d88d84f0805186688087e03fce8bb8d8c3ec4bdab3",
+        "punchline": "b03ae6bc746b6608a40d5940c75a240a10cc6a7129c6b66fdff4a8f75b131e3e",
+        "combined": "d5cfcca1f3f4dda8b53aac3c4dec6dbcfc2ab727a0c9266e94db8ac500bc4eb9",
+        "tokenSignature": "a-another-as-cashew-chased-did-he-i-m-nut-one-say-what"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0005": {
+      "hashes": {
+        "setup": "fb220d09b803f621af9ce4c010d7b88a8e936b3aa519de61a9657ee16a3cc7a8",
+        "punchline": "f3dcb576feb09884188dd6a614b0a82dbaf02636940b37b1ea108dcf5298bc79",
+        "combined": "66dda4f84db1b74b86959b712d3935cb28e2abb4ce8788d0057a196339b2775e",
+        "tokenSignature": "do-fish-in-keep-money-riverbank-the-their-where"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0006": {
+      "hashes": {
+        "setup": "ec1f6001c6da70a05b43ca363ae9c7762a7a0025711f75ffe6db71b846f4c6d5",
+        "punchline": "01caee5a19089d73dfdaa5755335ce8733c3e301ff5d8943a121075a56a269cb",
+        "combined": "8f0e989a7fdec37f334738ba0033d7ea9d22f335a9afd6fb660654544fa65325",
+        "tokenSignature": "accidentally-ask-cats-don-i-last-meds-meow-my-night-t-took"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0007": {
+      "hashes": {
+        "setup": "f49262789f24313f364e80b8d80d213bd126490e1442e51c7e92c0b6ee56b0be",
+        "punchline": "654a318a580d9c2bde896a019fac24d67bc18490c81065e8d08c27eb40d43c31",
+        "combined": "4792f7f5a7592e8a10a5f26dba53fcaacb4b8a35c37c5d9f3427839051ec7d40",
+        "tokenSignature": "a-are-center-chances-if-mall-one-seen-shopping-ve-you"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0008": {
+      "hashes": {
+        "setup": "45ca0e222b1f7e51a519d81da08891d5c61a19b6dcbcf67ff846efbfa0250136",
+        "punchline": "09ddd806049601183f578770e942abdf638b9db6effe56580d54f6af3cb3a5a2",
+        "combined": "c883f2efc3740e322bd66d9c98b93c100b875a5aa1303765dd6f68f155bcf7a5",
+        "tokenSignature": "a-all-always-are-day-decisions-dermatologists-hurry-in-making-rash-spend-they"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 41
+      },
+      "source": {
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0009": {
+      "hashes": {
+        "setup": "42ad319716043e7f71d429554e9e57bbaa1a7fbdf72f3664a9438ca56d95f717",
+        "punchline": "f6cccdee3a19a19e115654f1e8286e6efe21720a5228ba759e5cbc4c6715099a",
+        "combined": "c23ea2361a786ecb76b07bb0f472028dce645fe14f510ff4d316c9fcd2971c79",
+        "tokenSignature": "a-but-from-i-it-knew-mixer-shouldn-steal-t-take-to-was-whisk-willing-work"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 41
+      },
+      "source": {
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0010": {
+      "hashes": {
+        "setup": "699ec49b5b5965d31258f5a9a18a690271d3783da9b3df8538e7c923c1f6cb06",
+        "punchline": "a5bcf522374421e3fa227cda83cbbcc6f245d9619ca6ad07516c7a316a3e2b1c",
+        "combined": "01fdbc0539d62133705dca5c2ca86a4eb4b2fe7041f0c28759a6b926637764e1",
+        "tokenSignature": "a-an-argument-cloudy-forecaster-his-i-logic-once-was-weather-with-won"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0011": {
+      "hashes": {
+        "setup": "02b681684787b0cd6865dddd29f8b89a48c99600df5027de9b8b605ac2f10964",
+        "punchline": "41770fa7441f20b3e116e897a9ce95b4bc3a0a9756565a8c3b7f0a856a0351a4",
+        "combined": "5629bf6c546b7009080872b689c034e591a757364f5ac7e090dd819bc3c68daa",
+        "tokenSignature": "after-all-because-come-fans-game-got-hot-how-left-of-stadium-the"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0012": {
+      "hashes": {
+        "setup": "e4538e0217ded2a2dab66a045fb370332be165813f7b215547aea45b50c0c81d",
+        "punchline": "687c7520a29ba42a494d93cd5ead36f9900974a8da5a5bf35f7aeca7c7b860c1",
+        "combined": "27c288356361c429fdc7aa7d3ed75c37bf23c24f8d3aa789d9682e4b17f9fef3",
+        "tokenSignature": "bagels-bay-because-call-d-do-flew-fly-if-ocean-over-seagulls-the-them-they-we-why"
+      },
+      "lengths": {
+        "joke": 72,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0013": {
+      "hashes": {
+        "setup": "8f01c31d6119f4920801f0bc36387945e73cf101528653f2634dc5b0e303860a",
+        "punchline": "6da26afd3fcd2228eb55b896ee2ed84bc63738127cd7c04eb8b5c7adb9c1568c",
+        "combined": "09b1bf31a04c9887be5a8a6f0907a36da71cf2160f595b1a099fc911d2d08c1c",
+        "tokenSignature": "ages-all-because-called-dark-it-knights-of-the-was-why"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0014": {
+      "hashes": {
+        "setup": "776f7acf27a4e01284016726bbe68458463855ed3a632a582cd43d38449754cd",
+        "punchline": "dffe6b8ca1f5c1751df9eaf1d0c42082a202c96ec305421de87f36e4aa0ecd38",
+        "combined": "b13a945f97fc9be1c315712fe9caf284ec475979c5b8940a604261ea6028ca68",
+        "tokenSignature": "because-blush-did-dressing-it-salad-saw-the-tomato-why"
+      },
+      "lengths": {
+        "joke": 25,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0015": {
+      "hashes": {
+        "setup": "864ee2b043bb27b58ceb2fad428680ef39f22cb2fae02f79c425cfe9c18b48a2",
+        "punchline": "33112d2ab67c774fe862d5a7569a148ce7a362b5e9d4832696d06eaa78a4cfae",
+        "combined": "f96e83771d97e261cfa6b4e120642f145133081c89d97d058bf9cba1c6d75543",
+        "tokenSignature": "a-about-catholic-did-hear-joke-nun-roman-she-the-wandering-was-you"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0016": {
+      "hashes": {
+        "setup": "b1487bd8f4f8232bea1e04c47b3c644b5ec01e88cb88d5310c33988a99be9c3e",
+        "punchline": "c8417180c8e6f05511ee44b27e4471720a7ab60a655c88f0ce8df151d4c36fbd",
+        "combined": "42af9ca407f06f503ed49fdc800795dee021a9992c2f681807d0300eab2e8600",
+        "tokenSignature": "a-bee-creature-is-parrot-smarter-spelling-talking-than-what"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0017": {
+      "hashes": {
+        "setup": "f7bfc5cc47c30baa9525fc3dce6724677f70187c1351cffc901823ed0c236faa",
+        "punchline": "b8a64a3072c3898a141ea37b71b5ea50419f8f8c2ea8b8dfbe2507ea855c8c3d",
+        "combined": "dd3cc5ea3d12f51e60bc60ac1c323a2c5a67de38c925845a1f2c309ef15080bf",
+        "tokenSignature": "fences-garden-gets-i-ll-looked-often-over-tell-what-you"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0018": {
+      "hashes": {
+        "setup": "2cc6fed47bc737af079de0c6c8a91aea1fb70654dbc20ab9994332f1420ddc92",
+        "punchline": "e4d8a609f14d805cd3ab1794e306b10f6554b61fd6cd298feae4dbd78a23fc03",
+        "combined": "fa6fbe5ba5ea4b62f456bb70095fe960dd3d267e8e27262badef9742031c8789",
+        "tokenSignature": "cross-did-get-kid-other-playground-slide-the-to-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0019": {
+      "hashes": {
+        "setup": "23f766772d054b6ff2996e4dc11e4da6ce5316aa1066bd10ffdf21e9ce9388a9",
+        "punchline": "67c38415318ba827d5455d3b38e0cef1088d54f7524023164ef7f1d250a44455",
+        "combined": "8f8a780741bb174c61de756a9bb7e290e79fbe70a9a6a69eef2cd01a658aa492",
+        "tokenSignature": "because-birds-do-far-fly-for-it-s-south-the-to-too-walk-why-winter"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0020": {
+      "hashes": {
+        "setup": "4f0f000e42fb928178e864321e5d0d9a0dbab70696673183a2ae5eb82a38f9b2",
+        "punchline": "1f3b36ac2afbc10e55e0b0cc6a9f3a6bc6c455a8fb3e9efde92e827ec46cf63c",
+        "combined": "caf7e60af8f4a4e46cc24c1237e92dfe107036577c7da5a54c976f1beb904e2a",
+        "tokenSignature": "a-beatle-centipedes-favorite-hand-hold-i-is-s-song-to-want-what-your"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 45
+      },
+      "source": {
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0021": {
+      "hashes": {
+        "setup": "0127635df2a6383f178d971b214ee1e7380977166ecc31cfce61a495130babec",
+        "punchline": "3c8366ea2cc43e61455a1080855d2d8393cae56c6228c01e460b7cdc41a12495",
+        "combined": "4a8d9ebce6a84bff388c1ad4f595dc56b1dc981a02ca9e93a3e3c92e76d57902",
+        "tokenSignature": "an-down-elevator-experience-first-let-me-my-second-the-time-uplifting-using-was"
+      },
+      "lengths": {
+        "joke": 60,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0022": {
+      "hashes": {
+        "setup": "887fcd75c58132aa9f4ef7cef366c507000e1aaa051faee232b030a37f60487f",
+        "punchline": "a2ec5d9e3fc5b3e5ef2dacca2d8b187b78f08e5b778ddd8fc40bac9adeb5c55e",
+        "combined": "d822878349f6e640a153c7b88bbb81fa4aa7cb9aca42a5c7c07c09726a43c9af",
+        "tokenSignature": "be-change-d-frank-have-i-my-name-to"
+      },
+      "lengths": {
+        "joke": 11,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0023": {
+      "hashes": {
+        "setup": "5102b8e9cd236819a54563d0d892331f3682466f6ec5f497b19146f58f508fa2",
+        "punchline": "edd175556edf7b080fcee1e303c9673872f97f94904ab04990ad62febe14e820",
+        "combined": "99a486465c1353c2310a7561c9287929dbd429e50855c42faa3a8fe5d8418987",
+        "tokenSignature": "a-call-do-female-misssssssss-snake-what-you"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0024": {
+      "hashes": {
+        "setup": "4016ead32bf4abd925ca575e22bd5b8908d51ceb55cc1474e2adc099af5be92c",
+        "punchline": "b4c2e0b7f7b10c94e4661af9a06cb9c6a3a800be96c55fb82c3972d5abaeefa0",
+        "combined": "c2e8f992a3dbb4910c25f7be31bae3159cc0327e5b268b4a8133f9da3b6ad7e9",
+        "tokenSignature": "a-an-because-better-does-earth-it-little-meteor-moon-rock-s-taste-than-why"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0025": {
+      "hashes": {
+        "setup": "7ab14ab2acd48bb434ebd4b9d8fb7da378984cdc6a749eb2f478e05471547e32",
+        "punchline": "8728a8af9777cbb8f21fd243564161dedb7357dcffbdbb7b2dce065296b855cd",
+        "combined": "fae9bb93cc0ef3ebec1ca8bbc54c0b50e095374f95d67c0b1b2a2129bd28c090",
+        "tokenSignature": "a-believer-d-didn-face-her-i-if-joking-leave-m-me-my-said-saw-she-signing-stop-t-then-thought-was-when-wife"
+      },
+      "lengths": {
+        "joke": 102,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0026": {
+      "hashes": {
+        "setup": "a857df0f1429080871d409ff5a39633e5e7c7250329dc0bbba2548521f936254",
+        "punchline": "3f80b1dc8b2abf003477fb9e340e75f61c7e5a35c3637d2fae8a75927fc6ec45",
+        "combined": "bd8a3cca3dc8640c26eaf1f266d037af22606cf07ad152d22155babff62788a8",
+        "tokenSignature": "25-don-english-familiar-i-in-know-language-letters-m-only-t-the-why-with"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0027": {
+      "hashes": {
+        "setup": "67f27e8d1611e132647efb55cd92ceb3011e269179a6e2993f375cbfcf1ac52e",
+        "punchline": "058cd47ef58944590ca6f5efc46f40656f8f001dddf4cf5f8de1bd1b2594482f",
+        "combined": "3d83d22e0c1d5b6c288fba40343f7b85d6c8276a8033047268bdfb25b3ca12a8",
+        "tokenSignature": "a-barracuda-call-do-fish-pairacuda-two-what-you"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0028": {
+      "hashes": {
+        "setup": "a91958a844ff469766191346f7ce730f374541ba5c68026d67eb87c36d903692",
+        "punchline": "5323c57e45b41b999b44e239678b0b0f85672018f32aa971bd92e4df123b3ca4",
+        "combined": "34b00522962c4462f87b97c8673960dcbf14452e050cb9e827e0500fc1b4bffc",
+        "tokenSignature": "a-baby-did-family-father-ketchup-on-say-the-to-tomato-walk-what-whilst"
+      },
+      "lengths": {
+        "joke": 74,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0029": {
+      "hashes": {
+        "setup": "633b3786e29ddcc9b8ad9a62da554c1085394790e8c1e6840c9f9d876450f3b4",
+        "punchline": "e5714dcfd3339a70dd42ce6441c182e2b103b7d471753fe92453b97ccbf02e52",
+        "combined": "657befd41df8dee189702713fea381296f3f7a8e1fe499bbb2850c3274d9f410",
+        "tokenSignature": "always-because-flying-he-is-neverlands-pan-peter-why"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0030": {
+      "hashes": {
+        "setup": "e2bfdb494bade57f94928d218e7c0a043d75b958369c7a8e4cb4d48a39c7de11",
+        "punchline": "0bebe99173879f2cfd6e6f8f188cf3ec37f79a079ad15f6635b80159ac8a3243",
+        "combined": "31a3ea4b6ffafe5f5deb2510ba81f864ad12093b20b85591b323b2d6ffc2dae7",
+        "tokenSignature": "a-and-belongs-do-find-island-it-on-remote-the-to-try-tv-what-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 41
+      },
+      "source": {
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0031": {
+      "hashes": {
+        "setup": "234db9cc470a50f46f97558c0f3b675e7184675c69bccf31212e70e74993c419",
+        "punchline": "22db950dc4e5570228e7b9d696d77ed2897845eb588f2bf2dcc8f1ca185d1406",
+        "combined": "6b52f3131dd58ae4c681ef41836c1d14bc1aa2bb0e244bf85c6badbc80e69f92",
+        "tokenSignature": "catholic-did-didn-even-have-i-know-mass-protons-t-that-they-were-you"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0032": {
+      "hashes": {
+        "setup": "880d21a7e13226a3cf4da570ccfbc9a76413d88a12528801d6ca53a95a019802",
+        "punchline": "e04fcc58beda37340b37874f4100b2ec5776209e89766082fac837204f1bfa27",
+        "combined": "1dc07614f5ff0ef3eeda3faf412889c14ad353f593a9cd5d070e621317062862",
+        "tokenSignature": "enough-factory-fired-from-i-in-keyboard-putting-shifts-t-the-was-wasn-yesterday"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0033": {
+      "hashes": {
+        "setup": "79b14e26f17239cbb03f8b9ad7e58ee11313894df824416181b5294c234ce82e",
+        "punchline": "c8e21f637ef2359a998692ce3a95438fcef8af22272031d8916915402a95d98b",
+        "combined": "5afa83626d122b211cbec4f9db8f10e5309539dac98ae4b751bb2b539849dcb4",
+        "tokenSignature": "a-adult-an-baby-be-comfortable-d-do-doctor-go-going-guess-hm-honey-i-lot-m-me-more-now-pregnant-should-think-to-we-well-what-wife"
+      },
+      "lengths": {
+        "joke": 115,
+        "punchline": 63
+      },
+      "source": {
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0034": {
+      "hashes": {
+        "setup": "a1c46628773129982bca1c6838de7fd84bd2f5342791b0417de3562849f9d1a7",
+        "punchline": "dca84b048e16307256d55a763d9d934aa38099013f2e2c9da0d1598daad087b6",
+        "combined": "ca699d7d5dae727ac216068de5921e05af2b62f77ceb3ac1c44e2801447bf731",
+        "tokenSignature": "a-about-and-down-drove-field-have-heard-into-it-magic-road-story-the-tractor-turned-you"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0035": {
+      "hashes": {
+        "setup": "9464e1caa807d124e06e80af27a0b2ee7537266d8ddbc018a6bb94d4762325a5",
+        "punchline": "51d76a207194f1e4f534ea24cf1fe6c76dc5d4a1c228c9edbbc9b828ab96f2a9",
+        "combined": "c195bd2993dd1f7540eeac886270c30496b7b6b2776f327e1265624057d8a076",
+        "tokenSignature": "arrive-be-but-don-he-i-know-little-long-snake-t-the-when-will-won"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0036": {
+      "hashes": {
+        "setup": "f1999e0ee22f42ad479d6988dcde6a427d06d4809a45cb1b5f7f91a8f9f8ece6",
+        "punchline": "588dac21257fea5b703c12f9b099f2ea1dfe44339ce9e932c7c53c470b1a8aa6",
+        "combined": "c6cd3fab04935e21ba909586f6da5461ff3a3894d3449701d85fcdcb351db3a5",
+        "tokenSignature": "beard-because-conditioned-he-it-pavlov-s-so-soft-was-why"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0037": {
+      "hashes": {
+        "setup": "a415bafbac5fd6456c06f60900db9a59d2992418ed232f3c015bf707b6d4a872",
+        "punchline": "51997f8a8db2530ecb0d91e859f9e234e49aff15b0d96fb92a2ac98ded4424ac",
+        "combined": "381023325058ac0e988d6d59596ff44fc84a4f85581938b3ff990b7302d6f8ca",
+        "tokenSignature": "courthouse-do-enjoy-guilty-i-making-puns"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0038": {
+      "hashes": {
+        "setup": "6d31302ddc13f810ae7e0e0cbb9cc5fb2067a0480ce60e7985d84f1a8dc05133",
+        "punchline": "2223c6d871bbf67b7b98f0f3b3bb8237f079b1af0663a745befaa4e247129fdc",
+        "combined": "8e99d755d9faf6f94603fbe8480186de13b714cb76bf7c99481f691651c2534f",
+        "tokenSignature": "clock-did-fly-he-kid-out-see-the-throw-time-to-wanted-why-window"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0039": {
+      "hashes": {
+        "setup": "974b80fcf6652de2261eedc4335b1051a6f8c96cdc348f2ef777d064000721b9",
+        "punchline": "ffb6bae79ce1348efd12f76431ae27092b16056a64b7be5a784c139aac5da5ae",
+        "combined": "853f61206436540a2f768560a4f1492ade7510603ebfa53ea17ac14ba6ec9c8d",
+        "tokenSignature": "about-called-deserve-get-hear-karma-menu-new-no-restaurant-s-the-there-what-you"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0040": {
+      "hashes": {
+        "setup": "f3624b1736226dbfe28810be8cc3b90e18888bfd8c1f1e31e9ed09f65525c17f",
+        "punchline": "3c8c63089093d0db433fc3abcd1e9f71b441909fc38c0ae0bf0ff003f928637a",
+        "combined": "07c627cf6556e556dc9402164b068ad73e006e466602128334bd8a9fc5ef5253",
+        "tokenSignature": "arrr-because-couldn-it-kid-movie-pirate-rated-see-t-the-was-why"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0041": {
+      "hashes": {
+        "setup": "0b1ffac12f32b8bb2fa485adcca2a7d7225cf7a49ee8910845b11048015e2610",
+        "punchline": "175a8a2b65f347d1d027d471a6d9ea1f31c77773bf1be5dca5c8a4cac4b329b3",
+        "combined": "a0720ded57eb711acd42d0f18623e8119e9bd5727ca8d5d1fba27148231fe01d",
+        "tokenSignature": "cold-computer-fault-froze-i-it-left-many-my-open-own-so-though-too-was-windows-yesterday"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 50
+      },
+      "source": {
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0042": {
+      "hashes": {
+        "setup": "ea20aa9bb4ed30917eff351b45d3beef2245acdd4ba767bbe5c1520e5aebefdd",
+        "punchline": "152350ef9c6c229fd0b53b3c83a9bce9ad9f0104c61040242e5d1e0616df8ced",
+        "combined": "7449f2a3c028b838d35a1dcca40d0cfd92ba5a06846e24834a7abdd58c2122c9",
+        "tokenSignature": "and-back-furniture-go-i-love-man-me-my-really-recliner-way"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0043": {
+      "hashes": {
+        "setup": "a230264caf77fa6aacfd79784578dd4da49bcc8dec774c47d7bfa6bb6a0a84be",
+        "punchline": "34cc0e10f341731f83f72a0cf518959ae57771a6c1e702f1b1700955ab3c78b2",
+        "combined": "4183822094f1a2fb1e6d13290464e1086ed740079faa30f1daf1be9fbacc2234",
+        "tokenSignature": "as-car-changing-did-don-i-it-light-look-m-passed-say-t-the-to-traffic-what"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0044": {
+      "hashes": {
+        "setup": "9d69e578ce3db87ff5f9785250ad76348418370156b35fe4c78218b586adfb89",
+        "punchline": "0ea92964b7532ae964d2ada6689af64c836b19302a0bec2567093edb3e2655d1",
+        "combined": "8150e6b4465b0efe8d9fcef91933b716ac86764f4dadaa5dc326f87eb356ddaa",
+        "tokenSignature": "a-be-cut-he-hope-i-is-just-makes-my-son-studying-surgeon-the-to"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0045": {
+      "hashes": {
+        "setup": "0d2f8ae6e7978a9239e0f7aa0998dd765f968324e576cb40cfc23394e6b20b7c",
+        "punchline": "2970aee1b0114c02a11703d2652282218f8b13fcd0300d54fc1885cf07445868",
+        "combined": "82d28a04b07ade4a9cda077b98647660365cbffcbff002b8149f8f81a307a448",
+        "tokenSignature": "around-because-bed-catch-did-he-his-man-on-run-sleep-the-to-trying-up-was-why"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0046": {
+      "hashes": {
+        "setup": "1bfc5cce85eda9ef20fe2d4d1b6e63090b50b010662b4a973f28eb0a5c9d0256",
+        "punchline": "9180428c2383df296335d4ed477d0b8657d34ca8e3d254fe9ea33c911110cd5a",
+        "combined": "a27c1e8bc7f33bec396647badd327430158aa61017893b41706a836dba57a996",
+        "tokenSignature": "at-corner-did-i-ll-meet-one-other-say-the-to-wall-what-you"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0047": {
+      "hashes": {
+        "setup": "3b8d42f8c618d52c85331079c0a58fc9175d310912ae4280bea8dc45bd408013",
+        "punchline": "6cedbb410edfd2ee5e7c5c0e658704b902830be21250abd6fdc38df2f83e5e06",
+        "combined": "e6f41f73ce2d23048ea4a7d6b76364437ff9d44feff1368014dea16973a17434",
+        "tokenSignature": "and-chest-forward-how-i-into-just-knees-lean-my-roll-s-sometimes-that-tuck"
+      },
+      "lengths": {
+        "joke": 57,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0048": {
+      "hashes": {
+        "setup": "a4c94ae20d5500debffad11bdf193edacbceea623208893b654e8a46a7db899f",
+        "punchline": "d3cdcf047ccc9feaa69a3116a4e4cf4b689ce132c3ebad9e2e2a1b5d0acee277",
+        "combined": "619a14d9079d6bca14129f9da0a6ff68a648d0cf3e8bc7bc58c3721554d88f06",
+        "tokenSignature": "a-americans-brazilian-change-does-how-it-lightbulb-many-south-take-to"
+      },
+      "lengths": {
+        "joke": 60,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0049": {
+      "hashes": {
+        "setup": "c5681220259db4ff6596ca6f66cf6a144deb8ce20eeb4a25b292770c76068b89",
+        "punchline": "1fe11e1db9054b32801c92afef2936d8efc006084d426906d51e876eca249b7a",
+        "combined": "373ce4665c6d742778b121a5b43f33887cc55c1b1c144f158673af77103e3fa1",
+        "tokenSignature": "always-don-i-re-something-stairs-t-they-to-trust-up"
+      },
+      "lengths": {
+        "joke": 21,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0050": {
+      "hashes": {
+        "setup": "5da9e70634e9edce7ba80ea370d1f3b431a52e85309d2646887c469b90bef68a",
+        "punchline": "6db81213e9f7ae1eaad879c61f0369e4f5abb943fc04ba854358625cd13fa85b",
+        "combined": "ed9e08d90a6d2b5ef681b750992022b64f6416aea0bbe1c3f8e5fd98ee5b8379",
+        "tokenSignature": "by-call-do-guys-hanging-kurt-out-rod-two-what-window-you-your"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 50
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0051": {
+      "hashes": {
+        "setup": "4ab24b5b9b0085e88c0d82f96fdda866a273edd07f66502a63442b3d4e7da20b",
+        "punchline": "8f17052cb760098d3772b7733b7fcf25c6c24e877c83cfff98f68aac14da361b",
+        "combined": "321638c57fc4afdd9d1a04cb19cf99c40a23d0fadb726465d83e050472b1665d",
+        "tokenSignature": "angry-because-buttons-his-kept-pressing-robot-someone-the-was-why"
+      },
+      "lengths": {
+        "joke": 24,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 51
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0052": {
+      "hashes": {
+        "setup": "6ecc5f79a876fa48d2334530f215dde97acb19343694e742b3cb0122eb621306",
+        "punchline": "9a74d0b83157baac6ab30e6385811b2aae2ee342757af72148f06f2781499137",
+        "combined": "ed5bb0da2e52aef5a64d189ee93990be99ae63c0039e465780aed2d5c62a651c",
+        "tokenSignature": "city-dublin-fastest-growing-in-is-the-which-world"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 52
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0053": {
+      "hashes": {
+        "setup": "1ef13ebdb39783118e72f5ff4c2f822284518fdb678bef2e8227773071d22058",
+        "punchline": "98c8e54a7a9c2d29eba85b00b107b36d0a2666546f0ea7c313eaf251a51a4285",
+        "combined": "d3841637bc58f4cc65217f652f40eaf545e053ab50290fe02991b28c02caf79a",
+        "tokenSignature": "a-and-battery-car-caught-charged-firework-he-kids-let-off-officer-one-other-playing-police-the-two-with"
+      },
+      "lengths": {
+        "joke": 75,
+        "punchline": 41
+      },
+      "source": {
+        "sequence": 53
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0054": {
+      "hashes": {
+        "setup": "56eeb83af8e994bdea97b2a0ec82d4e3c7ac8fbc07c0b4bbcd85db299c10904f",
+        "punchline": "d0c214aeccf049b66769c1ca4e62e997385fb922c7a0808e11bb089ed83acdc6",
+        "combined": "3d2b415f7d4a4ecf6f761d29d68632e7cd57b7670d37f391f605b20c964553d7",
+        "tokenSignature": "a-boa-builds-call-constructor-do-houses-snake-what-who-you"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 54
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0055": {
+      "hashes": {
+        "setup": "7193601b7606ee0440930a82cb5f7e3f3fd7e0f085a727ab21c1ece6c359a6e2",
+        "punchline": "433220e13a0d5c486835f50dadc6f94021001dce17870b7fb81551cbcbb5362e",
+        "combined": "ab8a5a081fdc86ae4777e393af8b2670b541bbc2722102746a8440185d858561",
+        "tokenSignature": "and-apathy-between-care-difference-don-i-ignorance-is-know-t-the-what"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 55
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0056": {
+      "hashes": {
+        "setup": "29fc426770a6b2fec07fa60a1e0eb040c86b839ca5e0465e0c608e6ae3d9deea",
+        "punchline": "13e0c1dd0d54fbab33984d29e592ce47c2962ec735b821191eff99cc6cd0fb6d",
+        "combined": "c63bb3218be26318ad496b0e3232d154629b2a15f393eb78ca80e03af303c20f",
+        "tokenSignature": "a-concert-everlong-fighters-foo-i-it-once-to-was-went"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 56
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0057": {
+      "hashes": {
+        "setup": "2417ca2ec24b56b819d68e63c39870de924298e5ddf2249703af7b72502c4c39",
+        "punchline": "befd81dba79b2825c44a7df26f27f9b34106cabefe78b20ee998fc327e731b86",
+        "combined": "d05349b4c9d7e23a94995ecfff4387b6ccbb4ab8e6debfcc1fa0c55b3608cdbc",
+        "tokenSignature": "a-came-did-driving-fail-full-it-never-sentence-stop-test-the-to-why"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 57
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0058": {
+      "hashes": {
+        "setup": "4eba083712800b85bc2de5832478461dccb4690ac10d2d93966f9683bb5495af",
+        "punchline": "0617c6f5fd5d114c266e86663af7f03e874b41e69b88569d8f46c94374efca6c",
+        "combined": "f4effe32188536e445f9dababf4258a87f9f47d7bc40f979047db7126607690c",
+        "tokenSignature": "a-bulbs-eat-it-light-nice-people-s-say-snack-some-they"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 58
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0059": {
+      "hashes": {
+        "setup": "7edb963858fed16d9d0873f76065ccd6e5e26ded0816ba90cb776813ad1d3702",
+        "punchline": "e983006c30317e943d7a7718548253e1c89e7052c7c19b262268bb728e62fdf4",
+        "combined": "2abc5f5b52a35f2de19b09f55f537f17c1d72e8c136032b4bb22af8a51c7928e",
+        "tokenSignature": "a-and-between-but-can-cannot-crow-difference-rooster-s-the-what"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 45
+      },
+      "source": {
+        "sequence": 59
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0060": {
+      "hashes": {
+        "setup": "34160e5482f35338e6b95f456675d9525874139330cc4c8354d5dbd3e0660077",
+        "punchline": "7b3d696c57ac0ed49fe1f91d3356a8461bbdc77a88ae54d50cef0ddf8c5829ed",
+        "combined": "05424dab9beb74634611e10a677d5e7804edfba6f169224fee14d3b77b67e0af",
+        "tokenSignature": "cans-d-eight-got-home-i-of-only-pick-picked-realized-seven-sprite-store-the-to-up-went-when"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 51
+      },
+      "source": {
+        "sequence": 60
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0061": {
+      "hashes": {
+        "setup": "56db578d9eb76304845ef3d11e1544fc3b2ebcb57d720e174456b7b0ea2fbba4",
+        "punchline": "1c41928600eaacfbd2c71b35a8b22cf614178d227b0773f5bb746d41b5c97881",
+        "combined": "fa415ec5519fbfae4b1bef869f63257ab573487ce08730a23550fa58e8062ee6",
+        "tokenSignature": "but-cheese-chopping-cut-finger-grater-have-i-may-my-problems-that-think"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 44
+      },
+      "source": {
+        "sequence": 61
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0062": {
+      "hashes": {
+        "setup": "6d466f7552025ea2ccc5654c0ae9a9e0913ea39c9f63dc429f890b497809df41",
+        "punchline": "a64d2269fee99439c3f98351a086817642c557ded13fda66a14f57f5f8d64440",
+        "combined": "84acbbb78aca5baae1dd5e20891e07df2571cf6f7fc8f9b0fd38d84bdad850be",
+        "tokenSignature": "a-accidentally-but-coloring-doctor-dyed-feel-food-i-inside-like-little-m-okay-says-some-swallowed-the-ve-yesterday"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 68
+      },
+      "source": {
+        "sequence": 62
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0063": {
+      "hashes": {
+        "setup": "156feb7701ae392042bee653e00d51ede19b9c10dfe730a93233bb65c0a09440",
+        "punchline": "3d9bd81502defa4d7ec3c87db2901ef4c4a59c65c9e905af645f53f2bc433b86",
+        "combined": "9898dd2a09441815a8dc31b26ecb0cf3cc2c2b62b027a0c291a7f91c66de2c98",
+        "tokenSignature": "a-all-are-colour-crayon-i-in-is-let-my-need-people-sad-shoulder-sometimes-tattoos-them-they-to-when"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 48
+      },
+      "source": {
+        "sequence": 63
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0064": {
+      "hashes": {
+        "setup": "ece65412c885285b81ba5393ab0e086b5cd53d7dbaf765495987354b623b76d8",
+        "punchline": "21274ae3434f2efcd3e81e11d41fd084415fafbf4fad5c1b029a0e7f9d6b59a7",
+        "combined": "dd9aa8bfe6bfd6d59b03a9caa869d2bb2d47c1e91b8964500b230f3f353b1e3e",
+        "tokenSignature": "and-back-dvds-facing-girlfriend-i-last-luckily-me-my-night-one-the-three-to-tv-was-watched"
+      },
+      "lengths": {
+        "joke": 64,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 64
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0065": {
+      "hashes": {
+        "setup": "acd3052a193576dcfcd0e83d9717ae8ef347b74232c69b848ee74e65ea264d76",
+        "punchline": "70b20ae8c1ec4d0418f1a773e78cb17d19c6ab51949cd526bd10f3b55abadc44",
+        "combined": "df68e1b02891eea6196da1acda2665578e0d78c1b7e1a412debe2ffa648b097b",
+        "tokenSignature": "a-can-christmas-for-got-how-i-it-jacket-out-reversible-see-t-to-turns-wait"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 37
+      },
+      "source": {
+        "sequence": 65
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0066": {
+      "hashes": {
+        "setup": "18e3f17b0a1ce8a50f3c1fd56be4380eb8bd45d7c789a465cd4db1639d6e326c",
+        "punchline": "b217d89a872c080b7359a7d029af10600b9cbdc9a0fb0b690ac7d55607fa227f",
+        "combined": "96edda24203e5770c4f3ca254af84547632538384e895455ed3ec4192b7198bc",
+        "tokenSignature": "a-and-cross-do-get-pig-pine-pineapple-porky-what-when-you"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 66
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0067": {
+      "hashes": {
+        "setup": "22eef614ba919de969b9d1e034b28a0b74f3ed4a45e5e1d9e83a8436a58fd1d4",
+        "punchline": "803eed2bde914511cb42d7f0c6b6a751eedc3cfaf5bd0c5391af2f1f31f939b5",
+        "combined": "495678dcb6a12047dd6931f755cac30d3b5c46dbe23251a822b9e89b96784563",
+        "tokenSignature": "before-caesars-cut-cutter-did-invented-lil-pizza-rolling-romans-the-to-use-was-what"
+      },
+      "lengths": {
+        "joke": 72,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 67
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0068": {
+      "hashes": {
+        "setup": "0ae27194b09f15b84fa8b1ff9c6345d0e648e9d555d7abe8692b84bf48f8818e",
+        "punchline": "53eb865672f81d6aed7ea95622ca35352dbe009e31451f908ef9c3d53d408ebc",
+        "combined": "bed7b4ac9cc4a75c815c5fa033fc263d416d96fd5e6b7f7c9e2476b49bd8b2aa",
+        "tokenSignature": "banana-did-doctor-go-he-not-peeling-the-to-was-well-why"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 68
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0069": {
+      "hashes": {
+        "setup": "47bef10a0c2d8ba56caa327168b8bcd86b8ab1b734ed6391bf43f9acce0c7568",
+        "punchline": "c2db9c154c5fbca77e5c1bec785fe234ef3ba97c8fd743a8c995235238c29c0a",
+        "combined": "8ec2d0003881754ed7bfca4b44d1e10901f71427cb88a260bd3dec7c052dd354",
+        "tokenSignature": "a-caught-died-elvis-he-in-last-mouse-my-night-pet-trap-was"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 69
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0070": {
+      "hashes": {
+        "setup": "9bb2b65b716763dc0432d8e8b1e25029683e558334e786c84cc02b6fb9a471da",
+        "punchline": "9a965746ef6063415a20ff1ef885478762cdf57e319b7975068039594ad4dd46",
+        "combined": "520f7884449cc2e350bc247a29d1b2108cca3a6f24f4d2ed40cf7ad1b9d61fd7",
+        "tokenSignature": "advice-always-are-electrons-from-negative-never-take-they"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 70
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0071": {
+      "hashes": {
+        "setup": "e7cbf8abffb09d66ae7a22085543d43bddc6653c6569377dc5e11c95b8116329",
+        "punchline": "f00e1e92c49ba5248e59ee39819eaf1bf74a8632653af14e14e63d2a83009bd7",
+        "combined": "71c31be0b18539faa6bf0003794976daedc84342464bdff2891ed91aab4bb2f8",
+        "tokenSignature": "are-because-concentrate-fruit-made-oranges-smartest-the-they-to-why"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 37
+      },
+      "source": {
+        "sequence": 71
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0072": {
+      "hashes": {
+        "setup": "7f8ef2f32301e1d163d2d5e8f2dbbb811deb91be62219fca776ba2970f58ad3a",
+        "punchline": "84dc752e5bd3b42110bce20f0719097345b36f8812087b441206d42a4926fc1b",
+        "combined": "fede15cb4ca5b484016b33ada0cd86f9c4d5398114f9bf57f8a47b54785b0c3c",
+        "tokenSignature": "a-all-and-answers-apparently-asked-blood-desired-girl-heart-me-messages-my-neural-once-oxygen-were-what-wrong"
+      },
+      "lengths": {
+        "joke": 60,
+        "punchline": 49
+      },
+      "source": {
+        "sequence": 72
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0073": {
+      "hashes": {
+        "setup": "636825c34aceaceeb457145c50e002ad0cc3a7561763481209470d49d8f575fe",
+        "punchline": "0751e4afccd88eed55df57667a1a7681d04d1ffc6d2adaeca67c0da67f73e43e",
+        "combined": "ccbeefe96c3885737a24ecc618baf21cb45fe365bb1c8e37c093bb1862d7f28f",
+        "tokenSignature": "90-a-always-because-corner-degrees-hot-in-is-it-of-room-the-why"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 73
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0074": {
+      "hashes": {
+        "setup": "40204b90f43a3be42da74d5444e7546de8413008b13746996c1bf08a45d01e8c",
+        "punchline": "dab279534f09d8be0300d374b2b92e73c36c8aa8bd5ab442b7ed505958f449c8",
+        "combined": "792725be4ca00607964f499a29e28828e11a6054d3b05207ca4fba6a5ee1fce1",
+        "tokenSignature": "beaver-been-did-gnawing-it-nice-s-say-the-to-tree-what-you"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 74
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0075": {
+      "hashes": {
+        "setup": "cf0cf329c9206f30c37c92210bfdbf7617b266da2a555c6ef3a20a7276d61fa8",
+        "punchline": "13cea2e11ec1eb400f7ca968cd7db350fca67ddb52fdfc704b27dbb609b28b63",
+        "combined": "16db1a9b4b5ceae582f6dae6df47f9433dc2bb8b180e5d4e3578b3d6184eb21d",
+        "tokenSignature": "a-damaged-do-fix-how-jack-lantern-o-patch-pumpkin-use-you"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 75
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0076": {
+      "hashes": {
+        "setup": "08e8eedeca38ce8cd04af1fee3ba645509adbb783e10bdde8f4745fafca921a4",
+        "punchline": "05af2e4eee298b19be704f1227075b9101d61805a72520c5ed64d7bd4a88745c",
+        "combined": "f7eb369a9e14097fefc7522e66d74c5ffe14a26ce2686d2147ba10e5976b9b95",
+        "tokenSignature": "cows-do-have-lactose-not-they-toes-why"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 76
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0077": {
+      "hashes": {
+        "setup": "6acbda0f4b078ded72e6d290684a7433e8a10c003ce6698c0e40e17c8e8cfc64",
+        "punchline": "4a6b31fcab17cb925a73531f1594966c38d104699caca638545fd32744ea1c75",
+        "combined": "e21580f6ca750299d605e1a3493f983d3e88aca6d9cb050d66372202401fc056",
+        "tokenSignature": "did-early-i-ketch-late-ll-say-the-to-tomato-up-what"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 77
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0078": {
+      "hashes": {
+        "setup": "0bd82c2f50a4440d99ec9a60d08e37470e4f07863ceb694bf3cb5dc6aa9e8dd6",
+        "punchline": "9da8110f410ee0da10312bf88e2dc947e0ac9092f26998ecc538b53cc4406731",
+        "combined": "958dd3c406ce8ace82e47d72f2f5e5656c9a459c3c07f2ebea4af8fbc75c9a10",
+        "tokenSignature": "bad-but-for-gets-have-i-it-kleptomania-something-take-when"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 78
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0079": {
+      "hashes": {
+        "setup": "84eb4dc41f64a7a2fd4aca35471ef19bb97c5f237f03868cb53f17401b1bc413",
+        "punchline": "57c5199bb241b9e7a3ce545fbfa4ccbbdd0f3a7fa9f1cfb29404e9c7baf28c49",
+        "combined": "6d72efffc56fad2939ba28b846d19a0116973cc9824b7b284a8e76fcf567245e",
+        "tokenSignature": "addicted-be-but-clean-i-m-now-soap-to-used"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 79
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0080": {
+      "hashes": {
+        "setup": "ae11d707b08feaa8f901ec405e127e1ab73b5adba73710a94c6d67f776c93488",
+        "punchline": "20d613e17effb1eb184b45d3d3845c44ba68f35bc357234a401d1631aa274797",
+        "combined": "2f841801c6743037c53cfdaecc574e89a02b3b016e487ae5fd3a84926aadf37c",
+        "tokenSignature": "a-ajar-door-is-it-not-s-when"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 80
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0081": {
+      "hashes": {
+        "setup": "33fc0bf5a9fa0b3181462c16164d8bcd21cb5fe7957045b3ba07868bd244ee03",
+        "punchline": "f6a8322ed5f493db35a16104b5f9eed8ac83f957603b1ff73a34cc82a20fb558",
+        "combined": "1c4153de7e1bd03ec6cb797c8b602a58856f4b7727fe87c67498f84c50524077",
+        "tokenSignature": "a-belt-i-it-made-of-once-out-time-waist-was-watches"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 81
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0082": {
+      "hashes": {
+        "setup": "88baa458535a9c9dc305c6990282428e91b64dca52e92b2c73693079d9829add",
+        "punchline": "b3bb90ad631705ca9c808ae8796f4c5ed4897d5decd892ca842293b5656ca43a",
+        "combined": "55a80805f2d5aab3bd8b53dde555a35b8ed314c7dee82e8b01012d0f59e2ea67",
+        "tokenSignature": "all-asked-bach-because-best-chickens-composer-d-did-he-his-kill-mozart-say-the-them-they-was-when-who-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 86
+      },
+      "source": {
+        "sequence": 82
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0083": {
+      "hashes": {
+        "setup": "9af2c5ded6f0bef753bbaac7665e70e7c605560b6c76f9514a1f40b590d5aaba",
+        "punchline": "3ddf5501009901758dfc5479e88987b9f71267ff86c3d2a50bc589d58336d3d7",
+        "combined": "3f12de9f34251c8ad524609a96d9e1c05b8215a8e9a75dbf36e59d3e527a952f",
+        "tokenSignature": "all-emailing-furniture-i-keeps-me-night-one-stand-store-this-wanted-was"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 83
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0084": {
+      "hashes": {
+        "setup": "6840275989b140eef3de0a1ebad9d14f8214ecefbc0060d12d85407317db2998",
+        "punchline": "ea82188c78e753431f287f75989435868d4479bb1e8a5584657065c81267d3bf",
+        "combined": "a98b35517eb4ec45cb2b9c4870966670ec07821ad86cfce09e40b53c34141e6d",
+        "tokenSignature": "do-find-for-fresh-how-in-look-prints-smith-snow-the-will-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 84
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0085": {
+      "hashes": {
+        "setup": "67364e84dadd37ad471293887f18db24b7430ae9f2408dc11943e2a2f56ba4a1",
+        "punchline": "bb01e6e9501b6b369eb75a9572587d2755c149754ed59bc43045475ca6fffb5b",
+        "combined": "4fff3fa53afd4b8dc051271cdfea67b40f1dd7418316cda138ad307df1c48537",
+        "tokenSignature": "15-a-as-bet-build-car-couldn-drove-face-have-her-i-look-me-my-of-on-out-pasta-seen-should-sister-spaghetti-t-that-the-you"
+      },
+      "lengths": {
+        "joke": 66,
+        "punchline": 59
+      },
+      "source": {
+        "sequence": 85
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0086": {
+      "hashes": {
+        "setup": "970bd2477c23fcbc77407a5bda501c738a2e902e110021808f208d95c071da44",
+        "punchline": "31965c357ac3e59d9730621b7ca10d076d328d90d9bb12f9d78c03e94608c679",
+        "combined": "d49afada40776e26cbd00f4c00e001d1de346465d2989451af2ac8a224e8d48d",
+        "tokenSignature": "a-boss-day-good-have-home-i-me-my-so-to-told-went"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 86
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0087": {
+      "hashes": {
+        "setup": "c3fd518eb64b2d434f844f6f60456c73a1c51f0a724b1ec349fb748c1a8e98d7",
+        "punchline": "ad05d01a3f55d5d0aa7688d13203739af2e924358a4a358bd4f4a55cae053c52",
+        "combined": "1b626df396436b2e44099923172f71e339704cd61be31f0e9fa6b34948bbe274",
+        "tokenSignature": "a-about-at-bad-book-but-by-end-first-i-it-just-liked-pretty-read-stockholm-syndrome-the-was"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 54
+      },
+      "source": {
+        "sequence": 87
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0088": {
+      "hashes": {
+        "setup": "a6bb672eb9b5d8e7fc1056354418009a7f44057bcdf7d4096ed2059659a2ebfd",
+        "punchline": "5ccf88d383708b90f7754cacafef7c58536673410502e0f6479ed4b221ed0b06",
+        "combined": "ccc2f36e7e54e47bcc6bfca7917b47a760b130d9b8df650e1d5464a49f1ed5a3",
+        "tokenSignature": "a-bit-days-do-dunno-just-on-re-seem-shady-sunny-suspicious-they-trees-why"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 88
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0089": {
+      "hashes": {
+        "setup": "1f1f6040d18bda59d19260c5d75475e609f8f8839a0760a7df9b372e80078094",
+        "punchline": "25470ea77972480512524dfdc4b857a308c6424977843d0b50675ddfad1dbd33",
+        "combined": "c1cdd94e8334bf91aeaf3a5c90790c9f772e2f63cdcfd9fc1a394d7aa7d4006b",
+        "tokenSignature": "at-diving-don-first-for-if-is-not-sky-succeed-t-you"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 89
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0090": {
+      "hashes": {
+        "setup": "b70230126f66da38e7b92088f1d5cea87fab1c596c2e4266475426de179eed29",
+        "punchline": "1afedd744829e249124d78b26d33013214f3083e98933267ff64b50ae6759316",
+        "combined": "8e245c4e4dbf2cc3251b6be2c1fa829096e0198f2af2cd4b426b64fe5cc05a6b",
+        "tokenSignature": "a-but-d-diet-got-i-like-much-my-now-on-plate-right-start-to-too-ve"
+      },
+      "lengths": {
+        "joke": 24,
+        "punchline": 44
+      },
+      "source": {
+        "sequence": 90
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0091": {
+      "hashes": {
+        "setup": "06e874ebfbe10d1a6fa244e3da2826ea06f5614eb49f7f6d718110b295b4ed58",
+        "punchline": "408526fea85f693131a1ad29af44c19993d556ecb93c2110ec991b3564554b52",
+        "combined": "8133069879c4f8e95120053627881cfea5f6287306b977f5dfd2aa953feefcec",
+        "tokenSignature": "anna-daughters-did-drummer-her-name-one-the-twin-two-what"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 91
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0092": {
+      "hashes": {
+        "setup": "41ae3a45603a2c5223066c67de75c5391d3ac1520f78daaaea337595232209bd",
+        "punchline": "f7c465019a477431771ac66f011f386c3ea0b6528e76fa17f5f3ceab70511985",
+        "combined": "39c7af292e0961aee76f3b1918c355202308a66b2b8cee44bad3cd5e33b1f386",
+        "tokenSignature": "do-kind-like-mummy-music-of-rap-s-what"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 3
+      },
+      "source": {
+        "sequence": 92
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0093": {
+      "hashes": {
+        "setup": "9575e36175d6fd701b87201c1046695dd765ac336258e562811bf01cb91101f1",
+        "punchline": "ac45c3f6990de63600309baef6a91010cd15d49ca48713249b640e89d3ce75bc",
+        "combined": "cb1cd783f7e8c39bbbdf9bc87a8f30cb0a773ca47a18b1992e22a8f83055d274",
+        "tokenSignature": "a-and-cabbage-crying-emotional-fridge-guess-have-i-kid-my-noticed-of-one-opened-remember-some-vegetables-was-were-when"
+      },
+      "lengths": {
+        "joke": 93,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 93
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0094": {
+      "hashes": {
+        "setup": "d67ef473a219f57b69119577bce6822b06d2646a4b60230ae87c2c3b2177350a",
+        "punchline": "1b073bb0aa65d49cda087905c10c33a4904d74afc1822ef082881215c6007508",
+        "combined": "8fa44ff097ea4d31c52f18d3627916c00a35914243a46f8b9f2fa19938951648",
+        "tokenSignature": "an-and-doesn-grey-irrelephant-large-matter-s-t-what"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 94
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0095": {
+      "hashes": {
+        "setup": "ef966521aeb3ec0cc39bd609696feb720d565987e36ac5f06efd89322cf79797",
+        "punchline": "723411be5294aab9cb4261af322c5722ef49727d3959bdbabab5c2d92bfae3a1",
+        "combined": "ab41c9d2ff2a2e575cb58c6dc5992795618efacbf7fbfa06ad0dc9a36bdd38e0",
+        "tokenSignature": "a-blame-book-fell-have-head-i-just-my-on-only-shelf-to"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 95
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0096": {
+      "hashes": {
+        "setup": "4eeaf7a615705b5fde6d9c5267fdf903b286b03eaafc4b829941f7c3e45a461c",
+        "punchline": "7cb1cf3c3f30f21c2b325be24e385553aaa40678b103dc0d8aa1d12b127a7b1a",
+        "combined": "6ef912ae0d35a5c20e6007048d42bf6fcc1bbc35c3acec87424986d3f58e48f2",
+        "tokenSignature": "bark-did-dog-say-the-to-trees-two-what"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 96
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0097": {
+      "hashes": {
+        "setup": "649d77207d3dd77c025c2563b46e0daf80914d715c3aac8c18984a4fc08c389a",
+        "punchline": "d3975372b9863cd3f335792f627234ee0443d727971ba74e982ec6befe8b5b16",
+        "combined": "9f32fc7a30fc6a7f4969808dd3c50b1b55cd288111eaa37b980c352e83ee2336",
+        "tokenSignature": "a-about-bit-but-corny-for-got-i-it-joke-s-ve-vegetables-you"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 97
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0098": {
+      "hashes": {
+        "setup": "09d1b5866080f42078a79f6337c1399ba9e24221c22dc078256e569eff8867fa",
+        "punchline": "632549fdaeed9c9f2a96ea6a3fd6eda2f8fa0ac0b0316710848ff848793e9146",
+        "combined": "0d12b55db6d4b46f08a8cc083e626ad76caf5ce513748fcd3e46caeb40a9b924",
+        "tokenSignature": "a-are-child-during-guilty-if-nap-of-refuses-resisting-rest-sleep-they-time-to"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 98
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0099": {
+      "hashes": {
+        "setup": "1394d081d1961f3883e1d84d869deb214463d4a35c3558ea287f5e32e0aa52f1",
+        "punchline": "f3a2432a5973d4d0835ac6348f051fa666466098f63c40b8f7d70e9adf28c53b",
+        "combined": "4ddfa227474f0ac194ca5b1e942edba4db01b1c37f225c1284e960c86c88ed71",
+        "tokenSignature": "12-a-be-because-can-d-foot-inches-it-long-nose-t-then-why-your"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 99
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0100": {
+      "hashes": {
+        "setup": "198de79cc22ee269e76d560f71f6851b00bedc6b92f974ff71951765b7a400cb",
+        "punchline": "815576d7827aa842f1bd71ee5fb2e1d68f8ee1e104d49390d90a4ac16b74ce43",
+        "combined": "b1159a8d622654ad426c01fbbd7e4621c5a6f566501354f8453cb2c13f23794d",
+        "tokenSignature": "a-called-cellophane-ever-group-have-heard-mostly-music-of-they-wrap-you"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 100
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0101": {
+      "hashes": {
+        "setup": "ed751e759f664e0dcbfa9ac34e61a0fc012ff98fdd2eca4fcf9afcabe87d0a78",
+        "punchline": "ad0656c165b564c0e85e3962e2f77922945704a3cd3236067ef8ad9701f10ae8",
+        "combined": "0cdb248102ab63e405fe552cb48556a656a8bc4e5fce6409fba143fc48458ee3",
+        "tokenSignature": "a-boy-call-digging-do-douglas-holes-stopped-what-who-you"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 101
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0102": {
+      "hashes": {
+        "setup": "d771b30c4802286984eee0ceeb1b099261ff57070d5d8d654a1bce93d820656c",
+        "punchline": "e172131d9e033b50403d7158103ae43ef15caa4ebbe28b2a7c1b5e8644377d3b",
+        "combined": "00147750637a4b97417825c2e461a18e767b6076e9714381a9de7002054a7541",
+        "tokenSignature": "cliff-climber-did-his-mountain-name-son-the-what"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 102
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0103": {
+      "hashes": {
+        "setup": "1946f4a58ea38a18a6fd8f38251d92e9e436e7ae75140081330f52b8e5893e96",
+        "punchline": "86b1d2cbb5cc847571d4dd663ac3760b69176f3009edb11dca565df38420906a",
+        "combined": "ebc8941fa015abd9b373f9180f1e8e1660d98176474aba73cfdf19b2c7b16638",
+        "tokenSignature": "a-because-bound-it-never-pig-s-secret-should-squeal-to-trust-why-with-you"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 103
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0104": {
+      "hashes": {
+        "setup": "3b9bc5e5b0b609a40fe56caea2ca696ef451340fa5b3723ea6c018654cbf84c8",
+        "punchline": "e2f460a24e79f40c0bd1665f26fc5eca4cebb9f92af466cbb4c55a04992d447a",
+        "combined": "3002069cd237b28e005ad0d7847b3a4702723665627e320d48e5f1010e1e0086",
+        "tokenSignature": "afraid-are-mummys-of-re-scared-they-to-unwind-vacation-why"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 104
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0105": {
+      "hashes": {
+        "setup": "90b0e13050899dbaf91ff66f61f793245036f44a1e4a254091b4bb06de018840",
+        "punchline": "73d6507130014e4aa7aae70a2258a44a2f0eb5278fb97ce9edbf02705189128b",
+        "combined": "1f53554d3732ddd81a00b2630f7ae2d85c1c924792b7db055002cf30d4cb870a",
+        "tokenSignature": "are-remarkable-whiteboards"
+      },
+      "lengths": {
+        "joke": 14,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 105
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0106": {
+      "hashes": {
+        "setup": "49b77b7cd27b247ee6a1576350ab2beba72f54e1e8eb9c00ee675f640f371082",
+        "punchline": "7e183deaad28090c6a25881004952e868691eae0c31598fb3f00896fbb77b41a",
+        "combined": "e5d8f8ce0ea232f07593ab5397f29209a0a9d652696320897b2824b9fc08d631",
+        "tokenSignature": "a-dinosaur-kind-loves-of-sleep-snore-stega-to-us-what"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 106
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0107": {
+      "hashes": {
+        "setup": "a88682cd00bff620b5a7af084881d1284eb3a2a3be888ffbcac2b908a0f3667d",
+        "punchline": "59f21e7ec2098d6d5a0a93dd38b2138459e234b4b76097d9526e6dc232983f7c",
+        "combined": "f09aaacdc0afb10208af802e6bda9cb3cb8817ca1a2c79c0356818dd40ecb4f8",
+        "tokenSignature": "a-and-car-gas-has-letters-starts-three-what-with"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 107
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0108": {
+      "hashes": {
+        "setup": "790d34c50d0826428c54174e78504d0f4c3ec54600c5451db3bdb2dea7018256",
+        "punchline": "dbc5e7c90897e01dd41a38c09b69d8b68d8a4e109398b3b8ebe980cc364eb4ad",
+        "combined": "c4d6884ce00ec0771dcc0e6a1bf529351291115d8b3a7aaef1e1a9f21f476524",
+        "tokenSignature": "1forest1-facebook-forest-gump-password-s-what"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 108
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0109": {
+      "hashes": {
+        "setup": "ef7412eb708cb61bc3acf144e15327bf0e9c52608b168e8e9272295e41fa58e8",
+        "punchline": "6611be3d825f715e0c3fa6cd937a1f0c2ea36ee2ddaaa46387bdaec81c428e9b",
+        "combined": "897d64104160280da64f20c094f48500c96cec7d0fd30b2c42d310dd9bda6c99",
+        "tokenSignature": "a-fits-hand-in-kind-of-palm-tree-what-your"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 109
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0110": {
+      "hashes": {
+        "setup": "67de2534e8a1d5adbb5fbc69471bd524d49dde42dc03cddd298d2cabadc750d5",
+        "punchline": "8a01941b0b0aaabf8cf335db930dcd17a743fef2f34eeeb911b87f5f30dc525e",
+        "combined": "0afa64d60d26064163838a84919f0a788c95c3431bad386d4258481a536ba7e1",
+        "tokenSignature": "a-asks-at-bag-carton-cashier-dad-grocery-he-if-in-it-just-leave-like-milk-my-no-replies-store-the-whenever-would"
+      },
+      "lengths": {
+        "joke": 104,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 110
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0111": {
+      "hashes": {
+        "setup": "422e9a58559742605c84da183187052ee5669aad3cb21b68a340bef41d045748",
+        "punchline": "b88d14b8626ee56b282a589aecf6d6ac229d76703e36f74c488298552331626b",
+        "combined": "ed9fe00977697893fda8cefba093542df0ecef15a78ee4691f7ba3e66c12840d",
+        "tokenSignature": "addicted-around-be-but-hokey-i-myself-pokey-the-to-turned-used"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 111
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0112": {
+      "hashes": {
+        "setup": "74fd09741b3ecff5a271b0c20958dbcec1d58edc5c611b140e5016077a9e2487",
+        "punchline": "6147a68678170ec50140750b6de84eb6bf3fcdef74ccc2fddfeebf3870331488",
+        "combined": "10e20db385b1cef3205fa177d6c84467699686fe30f13555c7ef7ae661350b45",
+        "tokenSignature": "an-does-how-it-many-octopus-take-ten-tickle-tickles-to"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 112
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0113": {
+      "hashes": {
+        "setup": "c078fdb55323b78b56aa8d66a0cc1aa0b629332d950f8942b662602cdd685f12",
+        "punchline": "ec099f935324c8bedce9aa00b97e205eee27a68a248e1a24934a4370b98ca4b9",
+        "combined": "6a835322784141d9daea7b8df22ff590a1cdffccbbb40577a67eeb4a3a331660",
+        "tokenSignature": "4-a-ability-age-are-as-can-doctor-dog-dogs-frequency-get-hear-high-humans-if-lose-matter-me-my-never-no-of-old-older-question-son-t-that-the-they-to-trick-volumes-week-what-whistle"
+      },
+      "lengths": {
+        "joke": 232,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 113
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0114": {
+      "hashes": {
+        "setup": "3c936e637ec21cd824b1a5c36e5df5041dd8ce071c98e3357d326d4cc9bf8918",
+        "punchline": "94892b07cd3df275ad12f49af9c0cae676353dc21c35947bd416a143a54ec3a7",
+        "combined": "5a1e0a87c1df28631a40b21d5c5108d5fcde356a79441f2a97a0717bc9b46057",
+        "tokenSignature": "a-bathroom-found-in-instrument-is-musical-the-toothpaste-tuba-what"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 114
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0115": {
+      "hashes": {
+        "setup": "899b2495369266dbea4bc843498d0f8f4c8c8e20d66daa02d55ba6011f5803ff",
+        "punchline": "12992435f10b43640a2727272e42702db8595f302fc8b07c661c392da02ab855",
+        "combined": "aaddd1195ed4a68790bbdd959a8aced25b16dd722aeeb52a16137e6dd4eaab03",
+        "tokenSignature": "a-anymore-attacking-because-bread-buying-can-dog-ducks-for-get-him-i-keep-my-pond-pure-s-t-take-that-the-to-what"
+      },
+      "lengths": {
+        "joke": 77,
+        "punchline": 46
+      },
+      "source": {
+        "sequence": 115
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0116": {
+      "hashes": {
+        "setup": "79aebf0cb22d5acd32ede9cb483bde8912a821bc9c70bce3d3e8425c34e2ddbc",
+        "punchline": "e6c56127e086a9db124d05c4ebb665e16ab59dbb1c0610cd2b4cc04b5d7ce4cf",
+        "combined": "167c01cd746046e47242446b55cd44ac800cdbdf77e9ab4f2295b9a5e4e13f6d",
+        "tokenSignature": "attach-boss-i-it-me-my-nailed-of-pieces-to-together-told-totally-two-wood"
+      },
+      "lengths": {
+        "joke": 56,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 116
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0117": {
+      "hashes": {
+        "setup": "cab50fcb36b00dafc7b5703117773a75cd20948e64dd742702f892055a55877a",
+        "punchline": "595252d95088bf6c25e9647827d10b82f0059b53243004629dcc3b78c82b5d2e",
+        "combined": "dfd5cb6826020d8d813db0bde73456b5c2117eac812bc6d3e7735269f8d5317e",
+        "tokenSignature": "favorite-pumpkin-s-sport-squash-the-was-what"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 117
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0118": {
+      "hashes": {
+        "setup": "7b29224233d159438fb2a314de975e3ac40391fe21a9cda9145874e9833a7eb7",
+        "punchline": "6c0ddc642fdedfab1f8716693b2a0e0bcf1ec1c3ea41c9a0a53ebfcf99c2166d",
+        "combined": "685b207a942887d4582e86555fb710efca9599c18d2a99a4be146554ef57c0cd",
+        "tokenSignature": "army-call-corn-do-joins-kernel-that-the-what-you"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 118
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0119": {
+      "hashes": {
+        "setup": "cc4ffe326865b041071d836ce795b2a9955e848cdc70314ad7d5177a4b88243d",
+        "punchline": "2b9df3024d1bbcba969b23173f377dac8e614f3102c971a5eff34c9d62f43b1b",
+        "combined": "2b425fc8088c2ea9a5ba21d57b7dc2a7d960fae5117f7b2b2ba71da9ba25b0c9",
+        "tokenSignature": "a-about-been-but-can-come-dad-get-going-i-it-joke-just-momentum-seem-t-to-trying-up-ve-with"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 119
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0120": {
+      "hashes": {
+        "setup": "2a8b75f7bd929d246266366ba9bad25a40762878edf6d1de81c4bf69cd4a6b04",
+        "punchline": "00731ad4acac6551b6a661933c9a3b08b4a7969e3df03650f7a1f24f05e2e040",
+        "combined": "11c4a97695feeb80448535f2506a70e32838e9e31790958b443f3ff82058c7ec",
+        "tokenSignature": "coasters-don-for-have-it-ride-roller-skeletons-stomach-t-the-they-why"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 120
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0121": {
+      "hashes": {
+        "setup": "e24d91f2d322cc6c6c1aab78732d7a72176c840cbb2fce2a7b57b0e5b65077b9",
+        "punchline": "3466053c819a46ed81960649cc662d425783e83b02f58be197115c319292af23",
+        "combined": "078f4e084cbb2b2d68721794bd95e3625d536b80fc386a2a4a3fc609c9fcf299",
+        "tokenSignature": "a-d-foot-get-hole-how-in-is-it-no-shoe-then-there-you-your"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 39
+      },
+      "source": {
+        "sequence": 121
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0122": {
+      "hashes": {
+        "setup": "f56ccdb2e96d17440b5e86a5ec997fe1259816809da0a4f3029a179391a04ecf",
+        "punchline": "acfba342ae21a085af59fc5cb4f1df3a3e6231e14c400b21f2cf5e5ef357d6d4",
+        "combined": "fd7fdeb64fd465cd9a6e6e2694751d8e5e36c4cded2de03f9525f7e1996a30a9",
+        "tokenSignature": "11-a-at-broken-clock-come-every-fix-i-make-my-night-someone-that-will-wish"
+      },
+      "lengths": {
+        "joke": 20,
+        "punchline": 57
+      },
+      "source": {
+        "sequence": 122
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0123": {
+      "hashes": {
+        "setup": "fe9800d93154ae0f7efa22708fb718958e5ae181abfb5fe9bc49539b48ec37cc",
+        "punchline": "f0c8f4e9f06b2fda42febebb6846770cd27ad9cdd29ac32aaf366291f3dc83c4",
+        "combined": "6092f6e5c0cf66287bd34e3c1a693b2a94b2fc6fe6828af5bdbe4878d592bf44",
+        "tokenSignature": "a-an-and-answers-at-first-here-hot-in-it-look-looks-man-muffin-muffins-oven-over-really-s-says-second-sitting-surprised-talking-the-to-two-were-whoa-with"
+      },
+      "lengths": {
+        "joke": 118,
+        "punchline": 96
+      },
+      "source": {
+        "sequence": 123
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0124": {
+      "hashes": {
+        "setup": "fa93c05a36d4ee34dbdcd4bef63f140b03dd15ea20a4c9681f40072a45d08dd7",
+        "punchline": "b9705d164f15d7dd3e13b50dff03ab909f71d691c1a07c842325ff0ff0a8a852",
+        "combined": "cc936f1052a2024fa1534f76e6b662fee86df7f746650f82d33dc5109412cec3",
+        "tokenSignature": "a-and-between-but-can-difference-fish-guitar-s-t-the-tuna-tune-what-you"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 48
+      },
+      "source": {
+        "sequence": 124
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0125": {
+      "hashes": {
+        "setup": "84c87b0538f27d67699596346332e2a07375b12884ca248a8787ef33c55d4e2e",
+        "punchline": "5a7f4ab121e9207dbcc763c719082ebb044428e098aad6d2c042c4fb2ba849b6",
+        "combined": "df24ced1f710bb05978115bd2b445043dd67f96c9eb624bfd3f2ea557a2697d5",
+        "tokenSignature": "a-at-did-have-hear-it-large-medium-midget-off-on-out-people-police-psychic-reads-ripping-small-that-the-warrant-you"
+      },
+      "lengths": {
+        "joke": 87,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 125
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0126": {
+      "hashes": {
+        "setup": "55712bbb732617bea56bf6d0ac49a240d535c4a01fb720aa5dbea41b2ba1ff9b",
+        "punchline": "1c20336af813e00dc021aa6a817f009fbd196a122a71998c1afa54574ce3bf17",
+        "combined": "82e744e3ae658df414807cd2e3e7580a340d4aed45a7cc1245aedad1900c5484",
+        "tokenSignature": "because-clowns-don-eat-funny-sharks-t-taste-they-why"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 126
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0127": {
+      "hashes": {
+        "setup": "3bda0d655585054398d1256fa1fbfb39405789bd90f34b02bdddc677fbd4006b",
+        "punchline": "cba6ca2c1ecffe18515f71c212a09983b40b7237437357c283b488e3fbdbb1c8",
+        "combined": "6aaec4a1e8004df27f4770c7cb07919da88aea652607209e7a4a90258061201b",
+        "tokenSignature": "a-about-facts-few-frogs-just-read-ribbiting-they-were"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 127
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0128": {
+      "hashes": {
+        "setup": "afab5b6b31321b07db7f7d0826ea621383d674e5d7823d53644799c980297c06",
+        "punchline": "83c815791602808e19a84e2a1edd1ef839b6a3d3ad8c58ee278fabe4ecce70c9",
+        "combined": "801e1b93d052b40b615a18e281d7e38af8e6cd6df6ec067f92a5f8baff388e75",
+        "tokenSignature": "but-decided-get-incredible-married-much-reception-satellites-t-the-to-two-was-wasn-wedding"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 58
+      },
+      "source": {
+        "sequence": 128
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0129": {
+      "hashes": {
+        "setup": "c2310a4394d928477bad4904f79bee07017a7b5221f563831029beaa9e959279",
+        "punchline": "ca824d39b399536120caf821a914356c62822ea06e3697b80f0a72ca896acd8d",
+        "combined": "7d979a555efb4ae8ee5eea68a468bd591542fabb356c6dc943ddae74be584133",
+        "tokenSignature": "a-call-do-eyes-fish-fsh-no-what-with-you"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 129
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0130": {
+      "hashes": {
+        "setup": "3b1a2df3e94e79df4a2365732ba805d98ce1c829a6debd576015adaf638f7330",
+        "punchline": "a3a3172eb04505d0401f8ea6c6c0b01bdca6ade5547ca9a936ae9d444212ae1c",
+        "combined": "ae83f9a26c3a4e0299e49007a875a02a95db1377cdd640923d8ce89e07e2f5f1",
+        "tokenSignature": "a-cement-do-duck-get-if-in-mixer-pavement-put-quacks-the-what-you"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 130
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0131": {
+      "hashes": {
+        "setup": "14812d503a77903133bb461db9a0eea0b7e6c88460c0444f76b7f6184fd84191",
+        "punchline": "d866939f51ebbf65e61a8ef6cd0a626973fb7899e0e923e283db2935222ccf0c",
+        "combined": "b6d4d8f09da4049cfb7fbf438ce50b92d3f1c472a47553bff320d5d811963593",
+        "tokenSignature": "a-diamond-duck-it-like-make-pressure-quacked-shaped-the-they-to-tried-under"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 131
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0132": {
+      "hashes": {
+        "setup": "b22c1df822ae72976f690540f29d1014d7d9919b663be4470b09a9aaebb354bc",
+        "punchline": "c57d63eb04b3cb1448fed3a14c751c4698a20fd56b9af9d2c1635cd7e95ca497",
+        "combined": "a72b55b6008f1ef463961773a60b170e4f5fcf540438fc3cb8c53b07610c6d87",
+        "tokenSignature": "anywhere-been-bin-dad-haven-i-s-t-the-where"
+      },
+      "lengths": {
+        "joke": 16,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 132
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0133": {
+      "hashes": {
+        "setup": "d83bd7108d8ace0f09ffe528418f5b3d5c4770bfe96b6af3dc1ef90f32c9babf",
+        "punchline": "5c50f6f22924561c75ed15100b2de716bff8c632150e6f7a396f1909d2d1120d",
+        "combined": "cfd5a872dd3db11541a433aadd9ceba278499c9424c9c08b7066fd2785758283",
+        "tokenSignature": "fort-get-her-i-immature-my-of-out-said-so-to-told-was-wife"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 133
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0134": {
+      "hashes": {
+        "setup": "b7d29bfa56336b28168131dfe35850858d25b2f5bd7494677521c99fa323dc3f",
+        "punchline": "271a651d16e18004d624af3054b5794749e1dd86cc077bd0c412cf0692f42775",
+        "combined": "d81bc0e2e662560209b8095d5f69c70091069031818ce76eecb2ccdd2d066b7b",
+        "tokenSignature": "a-because-did-dress-in-it-knife-look-sharp-suit-the-to-up-wanted-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 134
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0135": {
+      "hashes": {
+        "setup": "4bf3a95ef5a3050a2d6ad541ae151c6f6a73bad061217a2b66b29ff37e101b56",
+        "punchline": "629d57ed02b56663804693a1a6a1fac03308623f30823368bb9b7a5ba90ffc56",
+        "combined": "1bd6387f8b6ab56d2e54ebbc1aa348d629f9e08025be861ca955210ba825ae10",
+        "tokenSignature": "a-bed-bouncy-do-how-make-more-spring-use-water-you"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 135
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0136": {
+      "hashes": {
+        "setup": "c4bf472f7eaab5c4372b1cc486ff854866c74332a0041b12c05ddc357df708a8",
+        "punchline": "2eed13cdca9ad996d6a702d9346b3a4aee7f02144fbc2a6bc41ffbbd313a2f7b",
+        "combined": "bbacf0ab00aeaf9794a4c5dd1d35cec4c6b6ec660ec5d8ddfb3a73f045344eb4",
+        "tokenSignature": "building-but-by-considered-didn-have-i-myself-patio-stones-t-the"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 136
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0137": {
+      "hashes": {
+        "setup": "e41153ae7c9a4c6cab8100d363f06e4b49df54ed9a744b346f257249f801b9d1",
+        "punchline": "f4c4a6ca29093e35c224c2589a91c97b6abd1085cb178082912c4c12b3ee738a",
+        "combined": "9f66d87235995059ef4f70d847f438f89d1b063b82f1060f5b4d60bcf17e8b83",
+        "tokenSignature": "487-52-a-as-because-career-cut-down-exactly-i-in-kept-know-log-lumberjack-my-trees"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 137
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0138": {
+      "hashes": {
+        "setup": "9ddacfa072b07b6a41d84d98e8c01e78a3f7cda8b88d125983b5df8f0f479e08",
+        "punchline": "a82fd2ffe679093166b03486d17c5c9f5b7ec3dd4add03e9b3fdedbb0d6bd486",
+        "combined": "0355f9dcdc2d5e6b80c38be1c3f5e69e2682fbad825a60e7bb37339d91c03189",
+        "tokenSignature": "bears-coats-do-fur-hairy-have-protection-why"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 138
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0139": {
+      "hashes": {
+        "setup": "e1c4dc424b12ea92040c3b57661b7604e88001098f6ca7763c672fffc88ad56a",
+        "punchline": "619608a44e8b40b647f8a77e8bf631f224dc28ab68f3fd6145f6730372744176",
+        "combined": "605a4cb47bbc5ce45fe4f3529db54abd53a4c73bac2e5a4170ebfde509755ff3",
+        "tokenSignature": "a-and-bah-bee-cross-do-get-humbug-sheep-what-when-you"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 139
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0140": {
+      "hashes": {
+        "setup": "04077d12b4dd22d5d383767559a096a3b2a339e2d90e10c1c12b0e5612e94fee",
+        "punchline": "ce469f2be709e844e583b3b8f9244f6fb6ed27d9db08460f49a60f4549a6217c",
+        "combined": "6f7b6893ac12aa2580ad716ef585cf3ed60bb00bbc0573166a02eb40e53d765c",
+        "tokenSignature": "carrot-did-do-man-one-other-say-smell-snow-snowman-the-to-what-you"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 140
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0141": {
+      "hashes": {
+        "setup": "4abb2498a7e2fcc32dfc081cf6940f7ad00cf6cd772828fc887ca875a9352a06",
+        "punchline": "619a8f7cbfd64be7716cc48a965762f13206bde580766599f06c1d6fe92eb1ee",
+        "combined": "ccdc5261561b72572cc370e84774b74948a00018b56e4ad8a54eeb2b86d6d69d",
+        "tokenSignature": "air-all-dad-do-dont-going-i-in-it-its-know-s-snow-the-think-this-to-up-winter-you"
+      },
+      "lengths": {
+        "joke": 64,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 141
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0142": {
+      "hashes": {
+        "setup": "1b947f9f81203342271f9c58160becdc851e22c1dec4ef483cc096c348cbd4cc",
+        "punchline": "0f676ef77f06834998d36263ad020b71f10604ec4e4f7dc28d1de76681cf8817",
+        "combined": "ed3e340c0e51532de99665c78c73bcef52d13cb5ea4c199033d738b62d6b4765",
+        "tokenSignature": "because-bees-do-don-hum-know-t-the-they-why-words"
+      },
+      "lengths": {
+        "joke": 16,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 142
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0143": {
+      "hashes": {
+        "setup": "5051aaf4dbba8e1f167fb0a14c5ac4160caf3c47ab8216bcecead18147f9567b",
+        "punchline": "d7e59300e91845fe596684b330277dff2f07c6c9b05b71d0c30b6eac29907bfb",
+        "combined": "73b99d935b4f4a0cec85318e75a2d8a09bf76fdfbb30676a38daf02309112c47",
+        "tokenSignature": "a-call-canadian-do-high-poutine-schooler-troublesome-what-you"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 143
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0144": {
+      "hashes": {
+        "setup": "0ab42c0e235547c871254b6fd2aff6dcaf14873309a9c98b3a5238a0f46aa2c0",
+        "punchline": "695947ea5481622102bd4d30ddd10913384af49496ceed6169f598f6f1574ce9",
+        "combined": "12ea29c1267ce8bf16dc0776bdac8e374547a7c2fcc61dfbddae431d9925ce03",
+        "tokenSignature": "atoms-don-everything-make-t-they-trust-up"
+      },
+      "lengths": {
+        "joke": 18,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 144
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0145": {
+      "hashes": {
+        "setup": "43fd43d1c106ac701cbdebd7e88dff1d9fdf5d72a93bd6c286f4d55fbc919fc1",
+        "punchline": "be2347475046d59102607886142f7b3913361f21a3e5785c658784f81b34f6fc",
+        "combined": "67d6cf023ab77052edcd1fb2593d19d44761ccd8bfdaa3323d9b06abf05b6430",
+        "tokenSignature": "a-and-but-cut-do-doesn-down-forest-if-into-it-s-stumped-t-the-think-tree-understand-walk-why-you"
+      },
+      "lengths": {
+        "joke": 98,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 145
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0146": {
+      "hashes": {
+        "setup": "8738f39d5c47ddd288a344aa60740732c5dc9e8abfe80f6af81fcec222bc596e",
+        "punchline": "81a348b4a8c28edf3226ee1f4f36877655f93daacf36410a65c86a487df62c7b",
+        "combined": "81712fc13341b43b1df56c8c6eb8af737628e0eb28bd4424f3a2e8466e7c1ee8",
+        "tokenSignature": "bathroom-bees-bp-do-go-station-the-to-where"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 146
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0147": {
+      "hashes": {
+        "setup": "a8a5ca3a877764f6ab00f8e606cf90f017a0a5eb60b71131ab8859ab553f71c5",
+        "punchline": "d722e78fe0a216767eee83b056b36f103f196cecdffbed5396f019e26ba800fe",
+        "combined": "2c5030b9bec6b4b470c81978aabdf4e82bcf600fb0397a2e1b7b72d9ffa9a490",
+        "tokenSignature": "best-by-carve-is-the-to-way-what-whittle"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 147
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0148": {
+      "hashes": {
+        "setup": "4afd40863e8142abf07c3fa962bbcd49d3b99990420100816e0925e842d20061",
+        "punchline": "70bddf70e6158b92593820ff5435e685c6f14a54ca5822cc11965d19520702eb",
+        "combined": "9d474bd090113698d8e5ec29ad1e7c7af8c70f7eed668e9d775e49fc87fdfec4",
+        "tokenSignature": "a-favorite-ninja-of-s-shoes-sneakers-type-what"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 148
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0149": {
+      "hashes": {
+        "setup": "c9b22ee6d371f86111534bb482584fb2b4067261093a03232c4b61e49a9fe380",
+        "punchline": "e0802b178b15d5fb06fb0dca7a63b51246cbc4f258c7f5d83ed292a237b5e6a8",
+        "combined": "a1d4e3f06597ff6d77752df9e91cbc580a349dc7cd9294249393f239fa2598c6",
+        "tokenSignature": "a-canal-dentist-did-go-it-needed-root-the-to-tree-why"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 149
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0150": {
+      "hashes": {
+        "setup": "8d4d180f56eea7b614dcca81bbbac29905e0232af1bf8fae5430fbd122daa3e1",
+        "punchline": "95616a94f90368050046d9e6038a3702d0d43d1ebb25447bc1d70202077791cf",
+        "combined": "01ad5662fa13f4145dd6c481f016b28315894f8c205f8c5c4d7c2ac622b9bd6b",
+        "tokenSignature": "a-almost-and-cats-day-dogs-i-in-it-other-poodle-raining-stepped-the-was"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 150
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0151": {
+      "hashes": {
+        "setup": "12dd5903041e4704a3440bdf5e79bc320acea3068ac144ef0f57e514419ad090",
+        "punchline": "7c3d5c34ca98b05d5a78c5daf32699969b75b336fa2ea4cc70240d596636f486",
+        "combined": "dff405e6cf3e9b7719e7f0413b09fbe2fcd61c5176f112cab424939ee6b4e538",
+        "tokenSignature": "bananas-beach-because-before-do-go-have-might-on-peel-put-sunscreen-the-they-to-why"
+      },
+      "lengths": {
+        "joke": 68,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 151
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0152": {
+      "hashes": {
+        "setup": "3c33f60631f6bd3be14c493fbd22287f85ca3fb6a7b54563f89302b3a2acd55f",
+        "punchline": "dcab0a2d5030176601e1d1c943f987e1df6d97726fb460e598605f6fabfdffd3",
+        "combined": "c9ac63928305dce8974c26fce1f0ba35dc773ac52607c712852f956f23157aab",
+        "tokenSignature": "a-america-bee-call-do-in-lives-that-usb-what-you"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 152
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0153": {
+      "hashes": {
+        "setup": "bcd36b840d9be8382df3354191396d11daf90b9ff19df1bb1cc6e87e0dd60b86",
+        "punchline": "81eaa0fd0d5a278ceae2041536e980507d6ee17b59478275ce057a511fca3ed8",
+        "combined": "6f90390a2a319ddad815daefad91ea4c8ff12b5a09fc1d958beb014f60f4b935",
+        "tokenSignature": "bigger-frisbee-getting-hit-i-it-me-the-then-was-why-wondering"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 153
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0154": {
+      "hashes": {
+        "setup": "5ea91cea9c92d46406b2c037d345dab4293a8884c3f09b68f13d61176d0a3a5f",
+        "punchline": "e1b48bdc09aafae63a4b8559b8f937f073c4a1e050ae3724e1a6771a1976ac76",
+        "combined": "be31957a9dbbc69154f8a73881b2cc117bbfbbb7a54aa9343955b3318ae21e82",
+        "tokenSignature": "297-300-a-cows-farmer-found-had-he-rounded-them-up-when"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 154
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0155": {
+      "hashes": {
+        "setup": "3b12ecdcf124c503dcf704853ff67cd2a577a4a745d473eab199fcd940ee5f93",
+        "punchline": "51dc2a53a30a9e1e614d817dfcc36a55dd69eb6d0d19978374e2447420213fb7",
+        "combined": "86ae6309ffb62f7ba45aa47f128d96d1a818b40dac341ca3f33cd09175b3e2b2",
+        "tokenSignature": "a-and-between-difference-heavy-hippo-is-lighter-little-one-other-really-s-the-what-zippo"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 51
+      },
+      "source": {
+        "sequence": 155
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0156": {
+      "hashes": {
+        "setup": "dc5c4c543bd171482e14d08f24a2f94f2bafb437047aa0e94312f3bf0f5d52be",
+        "punchline": "937f4b09cd66b00e8a2595b55a7e43d39a4169455e926d3ea5cdc179261aae5c",
+        "combined": "5f42d15d380f8bdb42ddeb0100764ed35da7ab7b24a8fd6c410a8d1f4d5f28cc",
+        "tokenSignature": "airport-can-disease-doctor-got-i-it-making-puns-says-stop-t-terminal-the-this-ve-where"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 156
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0157": {
+      "hashes": {
+        "setup": "540dba860c663a5ee8c25ca7022fd3746fb40ac3979f7d68fd0959cdb1dfac4c",
+        "punchline": "0398846fa41d9cc69d2709f07740ecfd540df94b300b0952ea7d94eb1988327b",
+        "combined": "b8708a533991a99872f61806ef133b885e64eeabb12f66ddb77324b71657fc36",
+        "tokenSignature": "45-50-cent-cents-concert-costs-featuring-nickelback-only-what"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 157
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0158": {
+      "hashes": {
+        "setup": "1c4169b240da95796a859e52ad41583a83532efb85e1262163bf62dcd41a6f4d",
+        "punchline": "571fcd2db96f9058cb856a35e39c2a475ffc389e4f4adb517cb703caeab101ee",
+        "combined": "7d12c7ef38e814a58330a31fa8af4349751fa853f27c17aa5ad96f6a75780534",
+        "tokenSignature": "belt-clicked-couldn-figure-how-i-it-just-out-seat-t-the-then-worked"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 158
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0159": {
+      "hashes": {
+        "setup": "f656ae45d5973242e3d0765c4c82997cb770990acb0c2e4b882a646bfdfc528d",
+        "punchline": "fd52999af2cd5e8cd05ca1932692878a8b805af8eb314e28c06ca41501ed751d",
+        "combined": "46b9b2187f364523f720a77f6cee8da3fadc867825e6d2c9a755ef2c05d4445b",
+        "tokenSignature": "breath-did-grape-green-purple-say-the-to-what"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 159
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0160": {
+      "hashes": {
+        "setup": "61659204eed8209e50cf7a78e829645de3da03cf1244bd0170b6884d8bc2cd11",
+        "punchline": "2a84b763518930ceefd90ee19c7282ef5da06b9317fb0c1f7a5495da7b829685",
+        "combined": "e711f560b94be50a18f3e0233528caf40fe523e45fa9283a56136de6cbc35800",
+        "tokenSignature": "a-call-dad-do-fallen-has-ice-popsicle-that-the-through-what-you"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 160
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0161": {
+      "hashes": {
+        "setup": "9b3592ddda5c735ec611c5a08e7b283c975d795cf1b41551aa6ee85147bbbecc",
+        "punchline": "4b7284036cda052c2c20a9750cdbab0c894544f787bccc4a56516b7b1da22052",
+        "combined": "f9b87580fcb7e9ad4e0de008d7547c0c32fc4f10e196227ddffc8119e015d316",
+        "tokenSignature": "a-and-are-asks-do-fish-on-one-other-parrots-perch-sitting-smell-the-to-turns-two-you"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 53
+      },
+      "source": {
+        "sequence": 161
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0162": {
+      "hashes": {
+        "setup": "b704ac9ef1280d01b0abc7191fe2f5502e59fe3f2adefe6ed062b026b6ad73d6",
+        "punchline": "1a96f07a3112226d23c6d3b130d2be5c38866ea1185ca1fbbd6b2c8ed84151e4",
+        "combined": "f00befa28c5e1363e733d4e9a7150e76f86451db159e64ba5f9131cb7d92cc24",
+        "tokenSignature": "at-bad-club-golf-join-the"
+      },
+      "lengths": {
+        "joke": 12,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 162
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0163": {
+      "hashes": {
+        "setup": "fe132ff3a2d5a632f17c2930afb6d7b3abfa111269c8e7dc480e1e0e9ee70322",
+        "punchline": "da9b9770cdc8a9cc21802674e987df95db5b1d0ed08be620600c194b4af9bd33",
+        "combined": "ab83adadab579c4d2d49e0c02beb08eb293fb0cdf0eb2c30071c46b9099168d0",
+        "tokenSignature": "a-aerodynamic-became-but-had-i-make-more-of-pair-racing-removed-shells-sluggish-snails-their-them-they-to"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 79
+      },
+      "source": {
+        "sequence": 163
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0164": {
+      "hashes": {
+        "setup": "8e3bcdd36f50e9e1b4a1b465594e8c825f54537a48c2cb069679a2c09aa31422",
+        "punchline": "3ddc36853869b2cdc669ad227f142e4f0a722a9b82afa37e6b4b5bde0518e4ba",
+        "combined": "16826c4a9ab669cd53b406eb0c54391d735b33ad400b42e75e3d8b778953c23a",
+        "tokenSignature": "a-call-cats-do-meowtain-of-pile-what-you"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 164
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0165": {
+      "hashes": {
+        "setup": "5eb32dd3f429fef84f49b84b355ef68e56d520c59d2d8aabb34928022413adfb",
+        "punchline": "be6c0034abc8afc88c878915ba340f5736ec0fd12c99bddfc01f12a1127be8be",
+        "combined": "a9bf45a7cf8414522a4d90d5669bf7111e4bd52a22855be37a36ebc2b375e557",
+        "tokenSignature": "always-cercise-do-egg-fit-hens-how-stay-they"
+      },
+      "lengths": {
+        "joke": 21,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 165
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0166": {
+      "hashes": {
+        "setup": "4365594e8681babfe81b8d98c426bd83d1e43d7b09816be45f0810e19333fe65",
+        "punchline": "b8159c4e3ec1b6f48003c66d7aefc74605708fa84708aecae9c496ad6df84cb7",
+        "combined": "e30df47f0ee8f5ff356398084dc2d1f3b1c825cc9c6040cab5d0085c8ab50d08",
+        "tokenSignature": "a-building-can-course-empire-higher-jump-kangaroo-of-state-t-than-the"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 48
+      },
+      "source": {
+        "sequence": 166
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0167": {
+      "hashes": {
+        "setup": "c539e5a846a57da07cfa83e86914cac1a320ecb81142a1df3a7073ff5dd06393",
+        "punchline": "bd99bc161256dc536445680e7fdd2787e36591eaf2699291e917a168ddf84d7e",
+        "combined": "642a2419c033fc64790df6ec123047e420adce531fc42b65bcf058aad83a2fd9",
+        "tokenSignature": "a-do-give-lemon-lemonaid-sick-what-you"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 167
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0168": {
+      "hashes": {
+        "setup": "25ff095f4a84414474a6bf1e4c62db97d7f289a3f82e89204b0fe3ac55ba3609",
+        "punchline": "a1e90e671dd1eed710e2e74a4388b06ce77b6c9c479643732b8494c28202ac8a",
+        "combined": "87b16eccdf9be6a49047e0c2331d556109457c320bd15230ef25c75332f8834c",
+        "tokenSignature": "an-call-do-old-snowman-water-what-you"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 168
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0169": {
+      "hashes": {
+        "setup": "8dec32641e9cd99a11ca8082b352f77a073fdb656f4b287c76f6440796064f5f",
+        "punchline": "0b17c0dfce6d19c7c81b9a645038abc08913dc83b538217d1f834de7121d9e53",
+        "combined": "62317e61ce45fae6eaee99f734000b6220698ed1184a213bdfbe6c2f7290a3ba",
+        "tokenSignature": "a-but-cow-failure-i-milk-to-today-tried-udder-unsuccessful-was"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 169
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0170": {
+      "hashes": {
+        "setup": "d4615bf9cac441329d0e8d31f9a846889bc24e15f33c758df4a800cbb175d7f4",
+        "punchline": "e044264e0b72ed7fcb001254832b6e83ce0ba6e8c55b203415758d4ca27fccf3",
+        "combined": "7d6c9da99eee51bfde2b8749851bb1a4d40343e1e214f523e5ff6543035250ec",
+        "tokenSignature": "a-apparently-fired-florist-from-got-i-just-leaves-many-too-took"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 170
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0171": {
+      "hashes": {
+        "setup": "08980067d1806347cac712481f4f712c0f9eaa48b54787cf549940caa8e35da6",
+        "punchline": "9a38405e5cf1f7049d39a3780142feb9bbcc37c75ef1f416e1a6bb267409a4ac",
+        "combined": "f520cb9cac972715e97a6ac4a6ccfd2a95c383c78264b2ba6db88ee49d8277b3",
+        "tokenSignature": "because-don-ever-go-have-nobody-or-skeletons-t-they-to-treating-trick-why-with"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 171
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0172": {
+      "hashes": {
+        "setup": "c531c0571781b43823d1bbdb469cb364635f5a88359ea8a7d928fc76f1fd5924",
+        "punchline": "5fbfe5a19dc8c0bd603f481c04fc96d23740861fa7861ff36dc4a2588c6d1758",
+        "combined": "9e4cdc1662e01d85a3f667f36d82c9089189d1cd99e0dc454b088d0baf5ddc21",
+        "tokenSignature": "a-bra-co-does-female-for-snake-support-use-what"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 172
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0173": {
+      "hashes": {
+        "setup": "9a81fb1378bae0c30c22a79cd25c577c6e23eeb267df63e66c55e3c81fc30967",
+        "punchline": "632df9c8163877c23915c49b5dc868fbb7870eccab3dc98e2b57eff93cae10c1",
+        "combined": "6a2485d60e915af8516aad1245a3622553c20eac2531c471a45bd11b55b42742",
+        "tokenSignature": "90-cold-corner-dad-degrees-go-hear-i-in-it-m-s-stand-the"
+      },
+      "lengths": {
+        "joke": 16,
+        "punchline": 49
+      },
+      "source": {
+        "sequence": 173
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0174": {
+      "hashes": {
+        "setup": "952531f6fadade69148eb1046c83e6b5269ce0035526085e66444d687d4f19a4",
+        "punchline": "73557f453208bbce2254a02a3bdc382d8bb8fa83e4e462d4ae1047f1f8ab17be",
+        "combined": "945d55288aa7a374551ed2d075c448d970531b2cfc00b3f065628ff2070098f7",
+        "tokenSignature": "a-child-dad-make-me-poof-re-sandwich-you"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 174
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0175": {
+      "hashes": {
+        "setup": "e4b312d41601a32cdde27f61d752c52f901d3024621caccbf7be4292889a16a9",
+        "punchline": "077ff8c245bf1f45eb194a3fbd4f8ca4b2c96271a540a7f8083cd31abe34894c",
+        "combined": "cee7ef112a1f3f9884043631a199a6103307855446ee979cd6e43d60fc0477af",
+        "tokenSignature": "dandelion-fierce-flower-is-most-which"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 175
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0176": {
+      "hashes": {
+        "setup": "4984fbfb2b2ece811b1c770e7edc767980a6d3aca378b7835cba877a40d5b6f3",
+        "punchline": "7b211ad8f73cb9404b79f3c7dec4596647a6d66dafa308e97db03bddc04fc5c1",
+        "combined": "f274c9766687e8e9f208a7caf74f975ac768dfd3d362f5575a5971179565f57f",
+        "tokenSignature": "all-are-because-coffin-graveyards-noisy-of-so-the-why"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 176
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0177": {
+      "hashes": {
+        "setup": "a37cceca37a4d3abcb9bc2adf4a7d3793c25957803cbbb17ddb573fdbd89c6d1",
+        "punchline": "5b0428d9d19c1f276672fb0df8ce9d5bdd25d1d391094e50f3a033b1d9c1fab6",
+        "combined": "5cbf1ab1b997acd2bbb970d1e4f636a45782de46a8ba967a651d5a88ae4525d4",
+        "tokenSignature": "a-bagel-can-fly-kind-of-plain-what"
+      },
+      "lengths": {
+        "joke": 27,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 177
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0178": {
+      "hashes": {
+        "setup": "e61f68fb24689556a608cae94557ba5ba8aaee6f1b3e319cddfce88ba8ca6951",
+        "punchline": "eaa408153fb669b71767886907b7ee560cc5251fe7e0f4b00f6630feb92c78c1",
+        "combined": "c86a7f86c24285381335d713e3eab19254a3cc892c862c710ad01a8d504258d3",
+        "tokenSignature": "a-all-apples-grow-how-many-of-on-them-tree"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 178
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0179": {
+      "hashes": {
+        "setup": "d79a1bba55abbd801f75f3d22274f642b7bb6c4ccbb6c965f6b8b12c751ebd8b",
+        "punchline": "0c9cfdcc8443b49823fcfef21d74be34f5f546dd7eef90447f3e8d6283a0db18",
+        "combined": "a7c96f47f2ccd369467f49fbde7c8adcf1bdd6b4957879f063afd94d52b4ec2f",
+        "tokenSignature": "a-aware-call-careful-do-what-wolf-you"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 179
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0180": {
+      "hashes": {
+        "setup": "0a81dd66a577eddf923dc38f89f162175e3de6773e63ba5b82e01f3ba4d62337",
+        "punchline": "2fd61d99799f13fa32ea1482f41163a796e84d8d91bfe553d1acfebf6ca364f3",
+        "combined": "3e5a8f7754c5e8ffcf04a66c9cffb5276eb96d5dd998fd9c9551fed29bc4691f",
+        "tokenSignature": "at-best-but-ceiling-definitely-i-if-in-it-just-looking-my-not-s-sure-the-there-up-was-world"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 77
+      },
+      "source": {
+        "sequence": 180
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0181": {
+      "hashes": {
+        "setup": "3a514a0c35fa82767c785193b9979c241aa045f43178cf7720acae37312bbab6",
+        "punchline": "70b6aeaf0e5e2b256ad4037e3026531e2662978955145afe3e259c59a0259240",
+        "combined": "d8b7c86be85c37125563d817ef3e3b85399cbb52bb32a7f59cd41675db286a95",
+        "tokenSignature": "because-can-do-even-girls-groups-hang-in-numbered-odd-out-t-they-valley-why"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 181
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0182": {
+      "hashes": {
+        "setup": "27314548997b065cf6f8d5e1d2a31273f3ba14b1cb100b1538dffe811de64b98",
+        "punchline": "bc1de2e56ab10b0beb2943a61dfbc0c25181e53b4300a981f19ce3031fa83b07",
+        "combined": "11288b8a3c4e151481e9df883b6d10119562da69b30d65da78c44d5ef82ef23a",
+        "tokenSignature": "a-beef-call-cow-do-ground-legs-no-what-with-you"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 182
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0183": {
+      "hashes": {
+        "setup": "165553f4212ea20672d4c1d106e54313ece0d1c67ce54874f705e28671d32859",
+        "punchline": "63f318c1b880b9cc51e5824ad09af83ef4f6e666e135d38063c2baa7576fbc5c",
+        "combined": "e6b1cbad4fdacca55e15a5a2d75a7343d60f92fcec7db20b950cb7b09bf63ebb",
+        "tokenSignature": "always-and-are-exciting-neck-races-re-snake-so-they-why"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 183
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0184": {
+      "hashes": {
+        "setup": "0552460f5b182c46e1551574fa25a8da62aaf6733b64cc5e1db35e99397f930e",
+        "punchline": "2495aaaf9d8b0221df440841e00eff08a7bc3f05dafa54a84d411a7cf0661786",
+        "combined": "4ab8decdc31644f07506c81ace953f0ef808e3b2f6f73928e2abcb7827ebfbbb",
+        "tokenSignature": "because-blind-couldn-did-fall-half-he-in-man-see-t-that-the-well-why"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 184
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0185": {
+      "hashes": {
+        "setup": "20e331fb87a19f4873c7a1a649491db173ddac8cddf5f405200dabe659ba9cea",
+        "punchline": "d709c334a300228ad7ab73e9d55a8a95f42e1c1f462e179fc46c287058e93e6e",
+        "combined": "682f900f82e0f603f523fcf988f83bb0f534ed74dd0743ba039ef937ca78ff6e",
+        "tokenSignature": "adding-as-been-garden-has-i-my-plot-soil-someone-suspected-the-thickens-to"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 185
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0186": {
+      "hashes": {
+        "setup": "9212e3301c3e32c07aadf78d6e3316612bd5751a916e4ce8f020afb6cc8e8027",
+        "punchline": "adc7d24242a5aea3f9ac616d17f29e7bb5dfa7b2e062a6d963898fd7c7baffcc",
+        "combined": "162c677753b87b54174ce76a609bbb00df2b36a9de4dd465f3a144d014a6760e",
+        "tokenSignature": "a-after-are-bees-do-go-honeymoon-married-on-they-what"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 186
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0187": {
+      "hashes": {
+        "setup": "c619274a699b2f48ee512dc93b864aae59adce670a3db6d4fb149e591a3d924d",
+        "punchline": "f9258b4d1a9feaba6ce77c1df4d277b2f07234f56a96bcc826fa61a5cb91d639",
+        "combined": "851a80b7e059cde329e8d5c058701ade32ae2359093ac2dadd3452fb8d0e6d95",
+        "tokenSignature": "after-any-be-could-d-egyptian-god-i-if-myself-name-set"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 187
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0188": {
+      "hashes": {
+        "setup": "6178dd1901160abcba2fe8368a236cbb448c3d4d3bd2a1c793baa8d3e830e33b",
+        "punchline": "464076f5e005510d0ff92f44c1846156a95a3c2d8186c65532401a613a2f7372",
+        "combined": "053dcb36d586250bd104d7b3172f8a00a09e0da848bce541d7cad174f1409a00",
+        "tokenSignature": "a-because-call-chimney-doesn-flue-from-he-out-s-sick-sweep-t-the-to-used-why-with-work-working"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 41
+      },
+      "source": {
+        "sequence": 188
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0189": {
+      "hashes": {
+        "setup": "10dc3f9b2dc359420a268da84ff376a4dde650b7e1f62b4df6572e3e22548c86",
+        "punchline": "cae863d75b3f0da9c8b1067dc838ded5d002b2f066152fd28bdaef4c250dcc8a",
+        "combined": "9a3314a34b2bfae7b2c9ee31ca7885a74d0de10e89c7cfb92d0a25f7874174c3",
+        "tokenSignature": "because-everything-explain-hard-it-kleptomaniacs-literally-puns-s-take-they-to"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 39
+      },
+      "source": {
+        "sequence": 189
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0190": {
+      "hashes": {
+        "setup": "9d1bdca5e68c6aa4c7437010a9c83d2bce541c56f2449542eceb0ceda3379294",
+        "punchline": "662ef3e583ac2971bfd8a638d66b24f32f48cb5e39eae2ea45a724aeec00da06",
+        "combined": "50d9ced8a8bde40854439c46b7f321d965b97210e038580857c4c91471fdd7ff",
+        "tokenSignature": "by-difficult-does-it-my-s-say-sea-sells-she-shells-shore-the-to-what-wife"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 190
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0191": {
+      "hashes": {
+        "setup": "758e0c7b0a78b0fdf9f617a10350fecb0ccc11c2c1d11c135e63e76584b885ca",
+        "punchline": "3fc41dd50e3b3722fae3e2545cc285754b08634108417962051436d0f13670ae",
+        "combined": "93581f001763d4f4b699e0974d77d592c4fa637a6618dd94f7af8fd50cc693a9",
+        "tokenSignature": "a-coffin-did-dracula-grave-he-in-lie-made-mistake-the-why-wrong"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 191
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0192": {
+      "hashes": {
+        "setup": "70f263974949bfb36796e1340cf370e75f11b5bb9a909b8a7535ac05c277b27f",
+        "punchline": "f74feb0ee2e54140166c7f252cfafc78c1c0136eefee3e29f9e338e616b10b95",
+        "combined": "85a4c71703f09f03fafd99b9a5046c71f9ba4e13847b07d1f6207ef778e23a08",
+        "tokenSignature": "did-dinner-is-me-on-one-other-plate-say-the-to-what"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 192
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0193": {
+      "hashes": {
+        "setup": "740260b87b461e1ff9a5afa24b20ebef2afb53ff69c744313920422457e0b2fc",
+        "punchline": "04909c04d5f7eed4425a337330aa5e6da942eef9853dc9b1afd0dbb80db9de01",
+        "combined": "a6aa917d3ae0d50f2c412229bf6b10aa7b4309ff5a325dc9b2e2a07200196d20",
+        "tokenSignature": "a-call-can-do-dog-labracadabrador-magic-that-tricks-what-you"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 193
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0194": {
+      "hashes": {
+        "setup": "751d77d9b30dfe3b5c575552962e44ab0dd6abe7fa9731911c159e859ca23312",
+        "punchline": "2a85c73eeffdde538a851a0a8ead99a277e6db481d47f6e922154e0736e2893b",
+        "combined": "3b86c26b4e2c745cafe828665aef55fb2dac3e759f2dd6de441e68560548432c",
+        "tokenSignature": "a-after-bad-disease-do-doctor-good-hear-naming-news-or-patient-please-re-the-to-want-we-you"
+      },
+      "lengths": {
+        "joke": 85,
+        "punchline": 41
+      },
+      "source": {
+        "sequence": 194
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0195": {
+      "hashes": {
+        "setup": "abd8062bf159c422606b186af1e966e94e0f2a62512a3581800c739bbd582238",
+        "punchline": "229efdb3684ae51c4a28c29f28393c57be9a1e5627b17b352021a1daa9ebd8de",
+        "combined": "ef182f37a26d21db9e87c0dd188931d1bc34762d5c53e8d54580fc2f38d6deeb",
+        "tokenSignature": "a-but-chemistry-could-get-i-joke-never-reaction-to-tried-write"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 195
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0196": {
+      "hashes": {
+        "setup": "12e1d8631e9df0ddab0aeadc45421c599848be531d4371f67a4efa59f6a49b2d",
+        "punchline": "23e90dfd57974f0751dce62a236e8abd19ae704bf29223f72177d45eb4dc4400",
+        "combined": "cdef035b3ba98a93083dc9f554a4bacc4c6e7d7a0c5d10fdb664eb16cb446609",
+        "tokenSignature": "10-did-friend-gave-him-hoping-i-in-laugh-make-my-no-of-one-pun-puns-sadly-ten-that-them-would"
+      },
+      "lengths": {
+        "joke": 70,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 196
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0197": {
+      "hashes": {
+        "setup": "c0402b967f735aedc169672f38a18781f5fb25e02071381fc49eb823fb307f73",
+        "punchline": "dd270b3934bf17d1398d6b912a4365bd0dcfbfb5e992065daa07826c195be2db",
+        "combined": "03d3c4a89f897b4585649f24234057b89f9cd14340c6222ef70fc9cc5ad93e9d",
+        "tokenSignature": "air-and-become-both-common-computers-conditioners-do-have-in-open-they-useless-what-when-windows-you"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 197
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0198": {
+      "hashes": {
+        "setup": "55978da830703a0c79a781d6f16fcf8c8e1421c3049df39c0a554c95634c2bb3",
+        "punchline": "b6029ae4a644dd841becf451ce7090e9555418f0480623544fdf27d27b10f2b4",
+        "combined": "d090440090de19b1ad3fb9a69c061c35669d2595e2b7d105deb9e2ee8ddcbaea",
+        "tokenSignature": "a-babooooom-call-do-field-in-mine-monkey-what-you"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 198
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0199": {
+      "hashes": {
+        "setup": "b6bcfc3fd1b22227ecb0938a75a69d9da330a611fa66d5707260fa8fb0de7375",
+        "punchline": "d90ac3210b38becb102083c5e0dee02aa4e84ceb41033ca0e4d92a5be87e8cf6",
+        "combined": "1f553070f51422214477b0625524c1095eda18349ff9d1b08d449fd7a23a2fff",
+        "tokenSignature": "a-about-did-finally-forks-it-on-s-scientists-study-tine"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 199
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0200": {
+      "hashes": {
+        "setup": "f7327e14df638047207bc23729030708fa588c14c8c3fe6aed3cfda5a671da3d",
+        "punchline": "6fce914a491194177e9c7b1a15eb5148e36b0fa2eb5df53a360027e16084cc54",
+        "combined": "a061a35578f115513742f960e80425a8fd3b64a1d4dad77c2955aea1b5903754",
+        "tokenSignature": "a-be-but-cheese-cheesy-cut-cutting-feel-finger-grate-i-it-know-may-my-now-story"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 53
+      },
+      "source": {
+        "sequence": 200
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0201": {
+      "hashes": {
+        "setup": "61d57614356d1c6a73a69892a5b62a9094b0d851d02e95b6a83a638d308eeb21",
+        "punchline": "082ffdd7765463f0db57bcb65a2deb3dc0849cc9d102d4d317faa135a23e073f",
+        "combined": "a21ac94a2a58d82d24454c57b73f9dea9be97df6745b3d418f80e37b556b82cd",
+        "tokenSignature": "a-coat-do-how-jacket-steal-you"
+      },
+      "lengths": {
+        "joke": 24,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 201
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0202": {
+      "hashes": {
+        "setup": "9fb15ccf4ce53c4a05475460c1208c8bbcee8ba7d78e37598e28ebc34ac10cc4",
+        "punchline": "af4f3b528df9e5a7dcb8f69d7b37d77300eca49a2ca29f285eab4963967ec27d",
+        "combined": "4a14286d01aba1ff4f59794d76f1c70c520b1805e349ee00c2a336e4545b14e8",
+        "tokenSignature": "at-don-find-good-hiding-hippopotamuses-in-it-re-really-t-they-trees-why-you"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 202
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0203": {
+      "hashes": {
+        "setup": "c9a1a745017a50bf9e23614ff666964f70cdb82f7833011969d06b09a1ce3830",
+        "punchline": "2db4ba7a05e7083f155337add328c34aa6b7f526a1cf004823a1e448f4ed6573",
+        "combined": "b2f1d27e71725a0e60813e560e641cab51aa2b1fa7589bf9d67a6f7dde5f51ff",
+        "tokenSignature": "a-cross-happens-jumper-kangaroo-sheep-what-when-with-woolly-you"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 203
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0204": {
+      "hashes": {
+        "setup": "beeae78a338b7d0cedec56ffbfac0547cf75e89c00155aed2302988d860389c8",
+        "punchline": "989e2bc36604220c103fedc2c7fd6842911cdcddb7069a6469382256c2d4dbba",
+        "combined": "452ba6478c6c2e331f39b7d7845a6d3083c2108b832a3b297a27639b341b7312",
+        "tokenSignature": "a-about-construction-hear-i-it-joke-m-nah-on-still-to-want-working"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 204
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0205": {
+      "hashes": {
+        "setup": "a159b3fe4a17cf72607b835fe1e03e11a1a9fdcb28fe78733b5b09bba2e0195f",
+        "punchline": "3d78791ddca07edfd5804581dbdb077eacf84902d69cfdaebbc8a9d443a8b3a7",
+        "combined": "d3edf5363727cdaa71b440c9cb97622c517a4e5e952b9a1dc81d59abb6754968",
+        "tokenSignature": "a-best-but-for-friend-grain-i-is-it-me-my-of-pepper-roast-salt-seasoning-that-the-told-took-with"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 205
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0206": {
+      "hashes": {
+        "setup": "8056503b2dbc0f5b4f496683f93cffdd59768d00df2d0d90f0dc48fa460dd26d",
+        "punchline": "ace04df48d0b134a6291dece48d8ee707a7e9b2f88ecbe3ff5eb23124638fd2c",
+        "combined": "d2c88b27f7f8f4e960c9369ec6c462e51292d675ef417e241e70bd4428f4a278",
+        "tokenSignature": "buckets-can-carry-choirs-do-handy-keep-so-their-they-tune-why"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 206
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0207": {
+      "hashes": {
+        "setup": "dbc4d6a944109533dbd78c66991ebc1fad5707223c8224f1f3ebf2de3de89517",
+        "punchline": "91143fb7a4fa7aaef49ece129453d70c57dcd9860592ca0f1636c47b54599931",
+        "combined": "c7d3318d246a393d0cb00c2af6a4540e19c7c4af20798312642f15fadc58e0ad",
+        "tokenSignature": "about-at-did-he-hear-it-kidnapping-ok-s-school-the-up-woke-you"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 207
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0208": {
+      "hashes": {
+        "setup": "0ade6c00958e24bd8b78dfb0d124763056faf75051fab57e3d2ee07ba3dbac51",
+        "punchline": "afedbfa678c27415f81a4ab5ab6c332f7e82fe7ca1f3d162599f18a516dc4d51",
+        "combined": "fee28e8c2bb9096ade3798543822f7d9b4d24cf224af5376a1666b89903f844e",
+        "tokenSignature": "asked-date-day-go-gym-i-knew-my-never-other-out-s-showed-t-that-the-they-to-up-we-when-work-wouldn"
+      },
+      "lengths": {
+        "joke": 69,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 208
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0209": {
+      "hashes": {
+        "setup": "c72d8aec1afd58a24db7c1bdd19712bdc31e19ee520443f9d78e7a666e07a0c1",
+        "punchline": "ac45d8186594af007c1c50e9e6cb23a145a26697b418b9b78002ed0dc2eb8eed",
+        "combined": "0d4c2aea36e55cad01b8715ef105815090f67ae3db2b73a0981252ce904d2b58",
+        "tokenSignature": "balloon-did-elsa-go-guess-it-let-never-she-the-to-what-will-you"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 209
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0210": {
+      "hashes": {
+        "setup": "b75827c8fffef0dba35417bdcfe5b149b759b7d39978b3b0b5f70bb20f7fdd9c",
+        "punchline": "ec5fca93dec926b89e15398b1bf206506ab6109d4c6c126a7f39c3b7702a4d88",
+        "combined": "51696a71a7b8da93697ab033fb79ad650274f5217e7d6406ad12e1088a6c5c7d",
+        "tokenSignature": "a-about-calendar-did-each-got-hear-months-six-stole-the-they-thieves-two-who-you"
+      },
+      "lengths": {
+        "joke": 56,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 210
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0211": {
+      "hashes": {
+        "setup": "c574edb40a3cfcd37621d4e0952c0cc8c0d8a2a5f70a0cfe37a52a66ef7fa09d",
+        "punchline": "4149f8417f02d6a2291e9d6fbf832287dbffb7c991648ac2ac0aa871aab605af",
+        "combined": "4a9aa1a913d09238ae924751f2a69b88fa54464a22972d164e3af6640b93436e",
+        "tokenSignature": "break-can-eggs-have-love-soon-t-they-too-up-why-will"
+      },
+      "lengths": {
+        "joke": 25,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 211
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0212": {
+      "hashes": {
+        "setup": "9b975216196095577137b4164cfa05b1d3776439b3b1d128b7fe8e3e60dfd5a0",
+        "punchline": "0ac392e60ad60821408cacc10a4dcfbbba98c375dac5a19d5539b95f0cc33df3",
+        "combined": "7a92bb7c46e64f8908494c5b260868eaecc1186cf3158cbc821c6279f5c6c0ba",
+        "tokenSignature": "a-because-camp-can-it-only-past-ran-run-s-site-t-tents-through-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 212
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0213": {
+      "hashes": {
+        "setup": "a7bfb3640afdf4a9454bf747ecdc78351d6c7c7e2aaa864f711f2f10724865cd",
+        "punchline": "a6bd5e0c3765b2740d44a109f90b6c122104d2de30a1936fc35b6b3d33614d04",
+        "combined": "d6a5f1332f2fc62eb223f10431b914f73f712f26802615039adc6cb1b09d6841",
+        "tokenSignature": "a-about-clocks-it-making-movie-re-s-they-time"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 213
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0214": {
+      "hashes": {
+        "setup": "f4da88c99815ed0870122aa8a110f1d2601e364351f5ae97034f5b0ebda8dd29",
+        "punchline": "7eafd31329d3b3d72aec4867fc220daa2e24f2f8798658da664a760102c6a8e5",
+        "combined": "9d13b646085a627d9f7bb3d595490410b6ca128b129ef9c1452f1553b1dd12ca",
+        "tokenSignature": "a-about-anti-been-book-down-gravity-i-impossible-it-just-put-reading-s-to-ve"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 214
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0215": {
+      "hashes": {
+        "setup": "e6ef84709663af0863b41f5d301e8fd1d6c7dd6c4b5652329787978f7b16d1e2",
+        "punchline": "3d72ce054df8d7d0dcc7111ae6dda552179e14894317ed6cdd9cfa8b78a843fd",
+        "combined": "41f5a62ab3ef1b76ed5f78ba6b26c2902306ef1189c159e24eeb4da2e9979306",
+        "tokenSignature": "being-ever-fruit-have-it-jarring-made-preserves-s-seen-you"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 215
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0216": {
+      "hashes": {
+        "setup": "8053a83c1f62b21bd02e1fabfacdb2c1a9bfa410e7aff6d01a1c4076e90f5f4e",
+        "punchline": "493d356a0f72293809360d0fb304f5092f44afa60fd0ad9acdc65ebea6839fd7",
+        "combined": "08127ff0807714616a0a2d5e12e5efb75bed3948332d2bf53c672308422bf4d7",
+        "tokenSignature": "a-brain-but-changed-get-going-i-mind-my-to-transplant-was"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 216
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0217": {
+      "hashes": {
+        "setup": "d0db34fab1dfcc6e6ecf94d82e4b9e6a63c1a68575ed7c9c45b1577f9c937c5b",
+        "punchline": "6c81a7cdee6decce17f1959198efa6c0d6c8d8582ad75a3ad394bb28490feb44",
+        "combined": "8cb98dbd26588398d5aafdeb8c5c2cf134e86fa1c6097e3f02f9136ff3f5d407",
+        "tokenSignature": "a-about-all-but-have-heard-hoot-it-job-night-opening-over-owl-re-s-sanctuary-shifts-the-there-they-you"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 56
+      },
+      "source": {
+        "sequence": 217
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0218": {
+      "hashes": {
+        "setup": "1375eb63e4a1f733b7b06201a155199513fb8a15ac33559a11725bcf947e6e29",
+        "punchline": "bff13324189fc94aceefdd09b13afd659fe1c59919fb56038d69c46e301ebf07",
+        "combined": "bfa8f532b92038bc03c898185cdc60774a930db5295fc1ec09bb6e7cafd8e62f",
+        "tokenSignature": "a-as-because-beef-can-it-not-password-s-stew-stroganoff-t-use-why-you"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 218
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0219": {
+      "hashes": {
+        "setup": "ec7e2accdbb4c111c94c4d9ffe239df39df5df006f85b8c9a9d006b0597c9b66",
+        "punchline": "563dde329310b292864ad8267bae9025ac9f92f216cb4d2c058cbb4317c58e10",
+        "combined": "c17e87823d7bbfabe26ecd7ed18d0dde552aec048035ef29736ce7acdf03f972",
+        "tokenSignature": "bread-butter-did-knife-me-of-piece-say-the-to-up-what"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 219
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0220": {
+      "hashes": {
+        "setup": "4710fff5df3ad476ff312de16f38a9b56606bec3f387a374a9463b26e024338d",
+        "punchline": "f350a4470705267f880a37d9ba1daa5b9e4bc245d3391b5f30adccb04fdd8f76",
+        "combined": "c818cbc93d569c30be0bcf6e55e50ebdf553eb735740779784175a42dbe4e91e",
+        "tokenSignature": "couldn-far-he-hippie-lifeguard-man-out-save-t-the-too-was-why"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 220
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0221": {
+      "hashes": {
+        "setup": "814e43e2dfdb087be3601166adc80940b36b1ab1b88ffbcfc09bb3bf08176cbd",
+        "punchline": "bd36f3c69fef1558c9e1ab4f7d6a8d93d99dce5a0f50b9e097a5499ab0d67c16",
+        "combined": "8e9dd7057e0b885d7fc5f935931192ff5cebbb091c053d525ee17dd31f9034b9",
+        "tokenSignature": "a-ballpark-but-can-dodger-fifty-figure-hold-is-just-people-say-six-stadium-that-they-thousand-to-up"
+      },
+      "lengths": {
+        "joke": 64,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 221
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0222": {
+      "hashes": {
+        "setup": "b27359a0cbeb79390613794a06d0fc2139c2f10c53ad9723e560f4347e7a359b",
+        "punchline": "77a448c807cba2d2d5808c16e4703e5f59502536419e9521e75bf25261f7dee5",
+        "combined": "05d827d8e3f132b0c1802d6e1c4eb0056bda66c91a1f6bb57d2976db4ce2a100",
+        "tokenSignature": "a-at-but-collins-got-i-look-me-my-never-now-obsession-over-people-phil-say-some-take-that-with"
+      },
+      "lengths": {
+        "joke": 69,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 222
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0223": {
+      "hashes": {
+        "setup": "ef0e46c3cd55352878de5a17314fd0f9569274bf68cf86f2c1dd2ad93c83fca8",
+        "punchline": "56047c80501de494ce0ba9cc0cc4f4cd564a9b4c686f1fa36107d121f552adb9",
+        "combined": "0980cc3e708aabce796176fe117ab6c5a24686d4a317e3692f6d974ea22c79d7",
+        "tokenSignature": "butter-did-girl-go-jam-on-peanut-road-smear-the-to-traffic-why-with"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 223
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0224": {
+      "hashes": {
+        "setup": "285190737ce03b7ebb34d006176b947902b7d0ecfedf7cfed845cd7377693d76",
+        "punchline": "89da819463d4ca59f23c855b230a31539113ba736d047f839b6ee2b80b363922",
+        "combined": "becdfaf6bc370335aaae9b187ce5a87764bbe66ad1647eee557f94c10f8d9d8f",
+        "tokenSignature": "a-an-does-hipster-how-instagram-much-weigh"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 224
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0225": {
+      "hashes": {
+        "setup": "c8fb4d485d31ab6e5da92f4a5222d7ac099044115699c0f2df3ede7cee10620f",
+        "punchline": "8a4530edecd176cd5e795258500a8c061bb3a0cd804474fcd11700adde83a992",
+        "combined": "acbb61e8ab4dd133696893993734c10a960dd1b2acbac01aa1a235fd7af16f85",
+        "tokenSignature": "a-beating-collection-death-fender-first-for-gibson-guitar-her-his-husband-is-judge-no-offender-on-says-she-then-to-trial-with-woman"
+      },
+      "lengths": {
+        "joke": 141,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 225
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0226": {
+      "hashes": {
+        "setup": "6a45d1eb6afefdb4dd5f1bda6704fcd0cfb309fa253f49d2d3cb41d7bacad904",
+        "punchline": "f9fffeaebd24fb085e0b4c67224c6faac2a6fd09d0c7d33970caefd852df8f97",
+        "combined": "5eae15c03a3e98ad3c182aab4edb08a44e3c8c44c6993be5552fc7a2bd594084",
+        "tokenSignature": "1-a-ad-an-can-down-for-full-i-in-on-sale-saw-shop-stuck-t-television-that-thought-turn-volume-window"
+      },
+      "lengths": {
+        "joke": 88,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 226
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0227": {
+      "hashes": {
+        "setup": "9bf5152a8fc6d0c72f1414e31e4ddc8f21a259b815234bf140b79140d64b90db",
+        "punchline": "726c3b47db1cd53e562effcefefa28fbb7b1b69b03e97d05c0e4bd18ae83eda3",
+        "combined": "e437b80dee9e2d8d415c8fea591c58c4af6e1d482d3c0e1ac5afc451df390e5b",
+        "tokenSignature": "a-accelerator-dog-fermilabrador-in-kind-lives-of-particle-retriever-what"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 227
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0228": {
+      "hashes": {
+        "setup": "faec291d2e3905fd0406fc572040a696fec90d53fc31ba145c4739333e7086e4",
+        "punchline": "fae5673b3c13ec76d62f58ac305cdbececa03c3ab7374100ef978f5f4a007af6",
+        "combined": "610aa4f00ccdb0bea9cb6c82b377fef870d14f42773c666cab5e2d81e76edb85",
+        "tokenSignature": "always-but-i-into-it-keep-look-off-procrastinate-putting-to-wanted-why"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 228
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0229": {
+      "hashes": {
+        "setup": "b39e72c901abcd3f3cd2eec839a595e5bf22b5ee9afe97384aa829632b8cad13",
+        "punchline": "c7cb2f004fc38c540e02f462270886d05c438b2be1fda95e4ac3615fc9fa8cf8",
+        "combined": "04d0f9c135f8d93f60f9124b063c5f516e748746bfdc09cb42cf922a03e1eef3",
+        "tokenSignature": "and-blue-heavy-light-not-s-very-what"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 229
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0230": {
+      "hashes": {
+        "setup": "8189d665e9fcb1de5c8075f719bc02b0d2fd24347df7ff605e4b433134599324",
+        "punchline": "2e12b0d3c375ca42820c858e6e8e8efea5180bce3e78c9181937ee0f4ed4daeb",
+        "combined": "50a33c78dac636a0a91d5fd43c3a1c1102999ec9815b0c6d802dd132b14124ec",
+        "tokenSignature": "2-cloning-did-guy-he-him-i-is-know-makes-me-not-of-that-today-told-us-what"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 230
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0231": {
+      "hashes": {
+        "setup": "1075f384c597e87e04c108e4d044bfef7864b2e06d45579708e1ebfed59545d2",
+        "punchline": "9cbbda31ede3e5a53a02c6183861fbb0067aa177e105045d4988b35615f1f9df",
+        "combined": "8712d43980876ab807af00959f9d17a7735c1660a49365bc31e64e32979b67cc",
+        "tokenSignature": "finished-four-i-in-it-months-on-proud-puzzle-said-side-six-so-the-three-to-was-when-years"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 45
+      },
+      "source": {
+        "sequence": 231
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0232": {
+      "hashes": {
+        "setup": "5f9e4e308b24cf53814434798f458b4f8a9f89da25aeac7434b9673d7ebbbb8e",
+        "punchline": "2cc111d5fa4be7f3852c109bdcbe4630716509b2b7b3318e49da1837a0f6a945",
+        "combined": "599698fb5c61ed1cb32a574cc94508b5e409d0be71b834b13b40efdc62b5a558",
+        "tokenSignature": "cream-did-ice-learn-make-school-sunday-to-where-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 232
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0233": {
+      "hashes": {
+        "setup": "fdd2f2ca560cfcd6989b1b6467aa2d68c91ca97ab8105877cbc35e930118a60f",
+        "punchline": "05a4da559ee09006e4983c85bdfd675a388da3fd29e526295c52486b87d55cce",
+        "combined": "76b96d34b5b08690c13c4f5052edf4d55d81d5e4a46f2239354193d04b02c215",
+        "tokenSignature": "a-at-coffee-every-gets-has-house-it-morning-mugged-my-time-tough"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 233
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0234": {
+      "hashes": {
+        "setup": "0da1ec6b744bc83e11b7a21d63d0310185a3a0b15e4b9c5b3bc17c4d931aae78",
+        "punchline": "cefe7e0505c1276ff1b0b43b9ec2ed2dcad2511fac1f0fff4fa63b557d810145",
+        "combined": "cc0220d27ac1d0df7d3a31a7eae9dc3eb26f1e656ca764cd02bfbdb8e3336a7a",
+        "tokenSignature": "a-all-for-keeping-me-of-off-out-quick-shoutout-sidewalks-streets-thanks-the-there-to"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 234
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0235": {
+      "hashes": {
+        "setup": "6fb65e0732846274e1814c0e1da5faff4c474f3f97eb94eb8867272c5b40be18",
+        "punchline": "18e3b0bfd78c4dba196b8f9f4c159e7de851847cafa4cfd8f7802fa93f1d16f5",
+        "combined": "8eab9af6c7b807d8829051830678d764ff8f2084f6434235cf59c46beebda636",
+        "tokenSignature": "armies-does-his-in-keep-napoleon-sleevies-where"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 235
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0236": {
+      "hashes": {
+        "setup": "40b6dcaf9684a2ce783d317c1bc2edf10efdb7ef29191c1725ba74e88c97dc12",
+        "punchline": "c4f3908330973299f0151b9f22dff53e0e6e6e7298735be79e5dad7d7ffaa92b",
+        "combined": "6b77e31d965b50827cd05998e95fd66359630993b1fbf9ff3511df680cf5782b",
+        "tokenSignature": "and-anyone-beef-between-but-can-difference-nobody-pea-pee-roast-s-soup-the-what"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 236
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0237": {
+      "hashes": {
+        "setup": "390c718dcd05d6989aaf6fe9ba8e335a24d470b256554dc8fc68a6a761ac734f",
+        "punchline": "6c93fdfe6ee5fc2c36c6fdae59c1602a4a9f033e148ee55854f002f619a5f9f0",
+        "combined": "89c4aa7e8a0346c6d1c1b75494bb4b72cef99672f072d8136551b14c11fda2b2",
+        "tokenSignature": "a-cross-do-geist-get-ghost-if-poultry-turkey-what-with-you"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 237
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0238": {
+      "hashes": {
+        "setup": "5ab391ba70449ea36037d2060def74c6b3969c35d014afd1f1b2c628d52a7014",
+        "punchline": "fe7f99855810113da395d5896f2be456416ba55e87e53b027f8679003325127a",
+        "combined": "327272789727375c81a1b3020c7d662685624a223ead6707bb2036d7e0d5327c",
+        "tokenSignature": "building-got-in-is-it-library-most-s-stories-tallest-the-what-world"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 238
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0239": {
+      "hashes": {
+        "setup": "3b9f159e35b5793450ac23db790a5ec2668bc3c2541266e40c82fefe39acb49d",
+        "punchline": "951598fd0e2f20978e92ff621af464dba8985443bfc3431f3e3016a90d050ade",
+        "combined": "61d73f8b8c016c73d02ddcd7cb4c4cc58bca2b997f14ea8f7a0c3823d14fe174",
+        "tokenSignature": "believe-cows-do-in-kind-magic-moodoo-of-what"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 239
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0240": {
+      "hashes": {
+        "setup": "23c1ee10f9b4a25fdb821e2ac6574700f18ac428023c9dc612c1315fe0f43465",
+        "punchline": "6642432de0301b571aee9fd105bbf1ad912ea0fe1f9b2e33570cc3d825120bc9",
+        "combined": "06c8e4d0b9240d295bc968d737bb91f457de92bd383cd18e00eb8715a4515994",
+        "tokenSignature": "a-because-between-dictionary-in-longest-mile-s-smiles-the-there-two-what-word"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 51
+      },
+      "source": {
+        "sequence": 240
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0241": {
+      "hashes": {
+        "setup": "6d0620adbd0c48d39ec19a253ca9a2c033d7e3902430fb55b9ac374f921e549d",
+        "punchline": "cc50207c5c71be1b51f61df2729a77745ca8b4f1bb4d110b2f574701cd3641e5",
+        "combined": "96d7bfa8fefc7714fb5904ab6b92ee505b9bf37c1aed8a990bb4d1079a676b29",
+        "tokenSignature": "crack-d-don-each-eggs-jokes-other-t-tell-they-up-why"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 241
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0242": {
+      "hashes": {
+        "setup": "17b9e67f09479dc81b02927d5115f066586e9b84ca0390768a0b1bce1e01d259",
+        "punchline": "1f97accf86944e89840969596fcde8da9587d4bd7e3341cfde72f54c08e13f64",
+        "combined": "bfac292d2acc29e10f46d701b079744b8c95a9d80ca65058f3186153b8528360",
+        "tokenSignature": "broke-fret-guitar-i-it-just-my-okay-s-t-won"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 242
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0243": {
+      "hashes": {
+        "setup": "7a88df4e12498d88a865fbdd811cc3dd0f5e198b8fa6b78bad9903de62e02342",
+        "punchline": "9ecd6331fccffc97e20f9e536e76cdd0a2c583f0c5bcf98afde0379502355b8d",
+        "combined": "9e0bfbb868ee88ad9b0628d7d6555200845b035dc4da650964bc3431d1803604",
+        "tokenSignature": "a-add-bikes-change-does-go-how-it-kids-let-lightbulb-many-ride-s-take-to-with"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 243
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0244": {
+      "hashes": {
+        "setup": "eb677dcaa24ab4a9ab5f64a2d0920bb0b77d2ad9cb0ab1873007fce0ac2ce844",
+        "punchline": "72a9db9e25a64acd66c8c3b5019d7bdaca9c25ceac1a5d4dc4d2f3a9d01ce968",
+        "combined": "f9a0a50c46149812c679055fc8e89abd78839ff0ed9b0e5a16654a23eb5f0848",
+        "tokenSignature": "ball-dance-do-go-hamburgers-meat-the-to-where"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 244
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0245": {
+      "hashes": {
+        "setup": "12afb592656a58794fcc01ed1bb789acef38896a1effefa5be69e74c1dd73469",
+        "punchline": "ab495f199bf047371ded031e973771cd1414a18e9cff6ff44458483b56c34d90",
+        "combined": "5523918545bd23d28a5d417455f1281f09afbb94ff3f90e8e3b5c6e2228099a1",
+        "tokenSignature": "a-i-invented-new-plagiarism-word"
+      },
+      "lengths": {
+        "joke": 22,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 245
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0246": {
+      "hashes": {
+        "setup": "6df0ed7ff14b3cf54bb5cd43ba911843f0aa1447aa9b79b60357ad5476a939e3",
+        "punchline": "a483becd55ade094e4f397b492a71483f8a0241d931afdac92a0f38b1e04cb57",
+        "combined": "179eecea1ab466e9a769ed22ed8651c2d0d2d8594d864843f95b57d7d0a11b6e",
+        "tokenSignature": "a-beef-call-cow-do-lean-legs-two-what-with-you"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 246
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0247": {
+      "hashes": {
+        "setup": "648e0e4b13bf4f7215977facccecce88af8412e5f8020f9a08cc40bd94bd0a2c",
+        "punchline": "c80e9e0738d822b2c500921c438c6c866bb46ccf10f46ed1f19c2a3ae4f1b93c",
+        "combined": "b2f4e5c6550fedb0113a8880bae77dd8693a8c6d20932ff5cb2f62d8caa50db1",
+        "tokenSignature": "big-bud-did-flower-hi-littler-say-the-to-what"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 247
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0248": {
+      "hashes": {
+        "setup": "6d7aae948ad1c84193cbecadecbddca4c3f5905f34d313044bc22d432d93676e",
+        "punchline": "cfa9187ce1041285f8f84b01c98117a863a636215d5b588ce986e514fdf5ada9",
+        "combined": "a3953526216a9675388f179ca5ddbeed0ab34a01f55b9057abc90872cb794a4d",
+        "tokenSignature": "a-all-as-believe-but-dad-from-got-his-home-i-job-my-never-road-signs-stealing-that-the-there-to-wanted-was-were-when-worker"
+      },
+      "lengths": {
+        "joke": 81,
+        "punchline": 46
+      },
+      "source": {
+        "sequence": 248
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0249": {
+      "hashes": {
+        "setup": "6444dd4aaced728a52a37a66415557eedd4c10363751de483c4a333c2b08f669",
+        "punchline": "c1139c896f24cadb1920a5dfcf1d477042c8f555f9579be05e3194721d34cb13",
+        "combined": "38c85025b6cee78046593db2aef572e1dbc631eb7e0bf53a9f8564dd7d43cc2e",
+        "tokenSignature": "do-door-hands-have-knock-no-on-people-porches-pumpkins-s-sit-the-they-to-why"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 249
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0250": {
+      "hashes": {
+        "setup": "a3451804dd68483f89cb4e6bcef8cb5f107318297de42a9e3d9575478ab59082",
+        "punchline": "b7512a5423af3505dbacca5141df1ca3f65e44fc164743aa71af4eaca23f32ba",
+        "combined": "9401400bb0411b5da4f86eee8cf2b3244d6a54f315998392c62f6a57566139c5",
+        "tokenSignature": "coolest-doctor-hip-hospital-in-is-the-who"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 250
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0251": {
+      "hashes": {
+        "setup": "dbb48106c2db319f16ddf9b0bd5d00f376d8c88cbed62fb1398bcee51ebf71db",
+        "punchline": "c895da0443a01b2a3af45796ad9cb392a1a7603eb1a86ca606109117b471d073",
+        "combined": "24a414c9a0d86ad6ded8618441feb72e0de023b091b64f9f976ce56f6f0f0c0d",
+        "tokenSignature": "ate-because-nine-of-scared-seven-ten-was-why"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 251
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0252": {
+      "hashes": {
+        "setup": "575d52f09687d58aa2e1347520cddfc34d2e4e5857eeec6c0e3d26e905b28c94",
+        "punchline": "062000245a5894bb7c5fb4f8a8792fd2f4155e1703927f1c6b00a6ac939a079d",
+        "combined": "991bddf58257520bec1633017a2d1853a3e408cafadc42693bc3fb6373dc8634",
+        "tokenSignature": "a-cross-do-get-hare-hose-rabbit-spray-water-what-when-with-you"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 252
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0253": {
+      "hashes": {
+        "setup": "2817cba7ec7474b90966ca1a7fa830050cdcd906edab44c1c2ca6b2632575387",
+        "punchline": "842a4b3ad611c0a9c91e239c1e9e84874ff8eab0e25006e2ac43d75f2395b14e",
+        "combined": "6cad1d4f5a7d14b995d3087892a241faaf0650baca354456fef2b9dc1e3c8cdf",
+        "tokenSignature": "a-an-applied-be-but-didn-doorman-due-entry-experience-get-i-it-job-lack-level-me-of-position-surprised-t-that-the-thought-to-was"
+      },
+      "lengths": {
+        "joke": 75,
+        "punchline": 60
+      },
+      "source": {
+        "sequence": 253
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0254": {
+      "hashes": {
+        "setup": "74154b7d8b273fa627e93ff300ab34eacdf902d139fd75523affd3d454cabebf",
+        "punchline": "babe606f64441e1c2aab5a3ceceb35c382856a30486091ae3be1e01f2dcb0f7e",
+        "combined": "3a75c8781e9672553c4b0e92c7067053a73fc9e0c5690da12d3e49e6cfbf65e7",
+        "tokenSignature": "a-all-candy-canes-collected-condition-guy-i-in-knew-mint-they-were-who"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 254
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0255": {
+      "hashes": {
+        "setup": "b7c2d8da1c251acc5d85e978f46e6b14c81fe6514510ea8b036ac55f401ec691",
+        "punchline": "55b5a84eade11bb63c11e58e098a48a796c22148e1d4ca82aa90cd1121cc242d",
+        "combined": "f55ee699eb15af84a6c7722798689cc22608e7e353545cfaaa0872050e76c212",
+        "tokenSignature": "a-boy-dug-exclaimed-his-holes-in-mother-saw-she-the-three-well-when-yard"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 54
+      },
+      "source": {
+        "sequence": 255
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0256": {
+      "hashes": {
+        "setup": "a6a2b73309cb987ef3ca9f3ee7d8e6f6c7ebe488b9ae5d457e067a852b048a64",
+        "punchline": "53029562086337fc7ac43c463020ce0cc496f37933bf839041058724c560eac5",
+        "combined": "f7cad8796e661c938af627f9e0fa4cd2a9acc4cb4cd2ac27dac42fe52956e2c3",
+        "tokenSignature": "around-blood-carry-crayons-do-draw-need-nurses-red-sometimes-they-to-why"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 256
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0257": {
+      "hashes": {
+        "setup": "d009bcd9b7c5476d731a31fd381ce15795c2bb7c509d4a06bd65a632a8cb2951",
+        "punchline": "3dcfb0077da9abb22a82afbb5a04fac5464df61012f322337326489e4682cca6",
+        "combined": "34a852467fe9aa9226e1586f4b6f8a51a23d9c5cec83659e703ae529d0c1c600",
+        "tokenSignature": "armless-around-because-hang-happy-it-shirt-tank-the-to-top-was-why"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 257
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0258": {
+      "hashes": {
+        "setup": "c958c963cf962e0b9fdefaa3ea76154491679510057ceac2273405c787554d99",
+        "punchline": "a405c4581e4690fe713f76ea54bb6878fbaad018dfb2466e2e9a7012871bf8d3",
+        "combined": "f2ed7975f3ba457fd3463e194ea9b4a0054e92dadeb1374c59e4d50daf237ecb",
+        "tokenSignature": "a-be-because-chicken-coop-does-doors-four-had-have-if-it-only-sedan-two-why-would"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 57
+      },
+      "source": {
+        "sequence": 258
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0259": {
+      "hashes": {
+        "setup": "11b56967f113a854f1bd071351b4d2d5903525217b23ca64991c85ff469f149f",
+        "punchline": "f0890fa223052bf02282a5106f6cd45f04e15ba96c70137645ec1585fd2ad3eb",
+        "combined": "c0858fc50b7a1f99d6b097010483a74d335bc714ba334fea0d8eafdac7cf61f6",
+        "tokenSignature": "call-dad-don-i-later-ll-me-t-you"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 259
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0260": {
+      "hashes": {
+        "setup": "77f2b2689212f0d8d9ee6df13625ea9a0ee2fee41b5d59426ba2242e504d1b66",
+        "punchline": "4d85c4a8e90c4baac1acc742bdd1f9644526a7426035682bfba6e75c87361f2a",
+        "combined": "8f6a7932450c18503a8cbd77bc1290a0344e753d6e8c48cee1595f98fecb19a3",
+        "tokenSignature": "bear-because-dessert-did-no-say-she-stuffed-teddy-the-to-was-why"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 260
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0261": {
+      "hashes": {
+        "setup": "c6683e092179a623961a9c1b736b0dc879663c559c71bb85415bcbbb285bb3c4",
+        "punchline": "5e27842550d9939f98585d6770b126e22a6e19fb92fecb364126d0321d294b5c",
+        "combined": "90c8c52ea0e0913967319bcf7eea27ac519ba7406fbe930fca3b57f1136515e9",
+        "tokenSignature": "about-don-fishy-i-it-s-something-sushi-t-there-trust"
+      },
+      "lengths": {
+        "joke": 19,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 261
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0262": {
+      "hashes": {
+        "setup": "7db3865b770ee3acfa5eac51a201742b89a17c2c1e91fe3e32d51f2e35693cb1",
+        "punchline": "8c62fbbe4ba259351fa8b3d1244659e48ed4bec3c8ac63deb025d96e76d1bffa",
+        "combined": "9cc4c1b444ddf1dedb95dd916b5f38a76e28d5f76d394eeb199b691580f6da5f",
+        "tokenSignature": "a-about-big-did-dill-giant-he-hear-kind-of-one-pickle-the-was-you"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 262
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0263": {
+      "hashes": {
+        "setup": "0c239a77697ea131b25b133ce758f4871e697f72f9e749c1204849bb98f57d71",
+        "punchline": "f81d2f74083b9444ae230db446f6e41d2edba1c6243e1f0dab5362810fab82bb",
+        "combined": "4cafdeba6b94253181728fe49735178fce5ea61d3231a334e85820c29f1dce2c",
+        "tokenSignature": "arrested-battery-breaking-bunny-charged-energizer-news-with"
+      },
+      "lengths": {
+        "joke": 14,
+        "punchline": 48
+      },
+      "source": {
+        "sequence": 263
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0264": {
+      "hashes": {
+        "setup": "358932238fecccc430c215594a7c0d0ebdf606ac4ec0a202ae70a52bb73aa02d",
+        "punchline": "c8fd18dcec981599db88c4efac3cb469a131387d15d07d34ced6c8df1cee44f6",
+        "combined": "0e4a83343a468d9f9d8b29665204764e9c8ec0574fd22e126a1b2d71d0fbd10e",
+        "tokenSignature": "a-are-bones-hand-handful-how-human-in-many-of-the-them"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 264
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0265": {
+      "hashes": {
+        "setup": "dfeb9e5d002d7432a8792130a636323e138cf3617d6555161fe0899d4b93c723",
+        "punchline": "c2f7dd70e4d00b10c451319b5b745b81ed81beb746cf452fbf5af87014255184",
+        "combined": "fa28a6cba30f466357648a8c1c073f86425f644af603d24c9ba28095f4448e67",
+        "tokenSignature": "a-and-apparently-are-blue-caribbean-collided-have-in-just-marooned-red-ship-survivors-the"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 265
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0266": {
+      "hashes": {
+        "setup": "a196bf51f12146daecddf614381c835a7557ab9c30c314ac38b48a254ee7f27c",
+        "punchline": "4dfdc7c505c49f52ded4915b58eb094487cd507d8286168c1c3fed2c4d7edb9b",
+        "combined": "b7be126275306f26189f7fb415ec569e690b8853fdeda2abb2b1203ea89e1dd6",
+        "tokenSignature": "a-about-i-is-it-just-more-of-rap-really-song-tortilla-ve-well-written"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 266
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0267": {
+      "hashes": {
+        "setup": "fbb36577bf7b5a5532aa47c04ab67a208b144c1bf23f977c234dde539b0799a1",
+        "punchline": "f8aebf2fa716a9518a3d9975350ec59020e2e7311a7ba8ca553eaa05cc6e011c",
+        "combined": "de4eb1d1fb1f87a56654be988aecea654bb8c9144852c629b86d5f5b63531700",
+        "tokenSignature": "april-but-can-february-march-may-no"
+      },
+      "lengths": {
+        "joke": 19,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 267
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0268": {
+      "hashes": {
+        "setup": "d3812ebd9255e923689930e5e82b217e34f967dee2001c70a583d3c3bf9f9520",
+        "punchline": "7f61ede5b2c25b74bf9b9d65c779124a437c551fe24f7064f543609abcd21be8",
+        "combined": "73aaa2954b8b4e9552e1589ac1db0b1d94f4f6703906d993ca666f9f60b9a997",
+        "tokenSignature": "but-claimed-egyptians-guitar-invent-lyres-such-the-they-to-were"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 268
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0269": {
+      "hashes": {
+        "setup": "5886c5e84bf59c2e29d216b051853e19014f5cd374cc8d3b9f9882bfd2ea1277",
+        "punchline": "a33e9a1b16d10f6526b87d0487ad456dd2828bbe1006f216f912f6fdff06f517",
+        "combined": "caae42e6fe79eed27499c9c0dfaac3d6831330655e47d938414b0f3c3d82ad4c",
+        "tokenSignature": "a-favorite-in-is-s-school-spelling-subject-what-witch"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 269
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0270": {
+      "hashes": {
+        "setup": "5677df328070e1b9ac84cf03cb089a6ec48cb17d001ba7c5d9b25317c10e9424",
+        "punchline": "70605960749b0f3e436cfab6fb3dd3512919ef745fe8c1806e1d89b6e1e0f728",
+        "combined": "f4e2eaa8a39cfe26797617293e81ceb642e260f386ec890ff8bf4464c0a55add",
+        "tokenSignature": "a-about-an-boasting-bragging-call-chess-crowd-do-foyer-hotel-in-lobby-nuts-of-open-players-their-what-wins-you"
+      },
+      "lengths": {
+        "joke": 85,
+        "punchline": 37
+      },
+      "source": {
+        "sequence": 270
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0271": {
+      "hashes": {
+        "setup": "aca4181c6b79aa6433169946732d59f3dc4f89881d4af02c13cf5006fdf9d30b",
+        "punchline": "59def8ea245db7bca22081e6a3476cb44621897d5ca5ba465ae955deacbfb540",
+        "combined": "600ff466d7256b0f7434f2617be44fd2fd137a43d315d349ba2367127987df3e",
+        "tokenSignature": "chicken-feathers-has-more-of-outside-side-the-which"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 271
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0272": {
+      "hashes": {
+        "setup": "35379d9c009e290d702b72abf3f5f9bdbaa7e00a63fc37b5174fc3825c8095e3",
+        "punchline": "8f24d0859190e36c3cc86a9e3ac36e45ca153a40f8a748914c5ac6786a58d424",
+        "combined": "23262a95042c4329141d1cd4959404c5bc2369d2b686f2ac0b48cfbaf2afb67d",
+        "tokenSignature": "a-angle-approach-best-from-is-problem-remember-the-to-try"
+      },
+      "lengths": {
+        "joke": 8,
+        "punchline": 61
+      },
+      "source": {
+        "sequence": 272
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0273": {
+      "hashes": {
+        "setup": "b65c867e742110238a86d8ea565e99e1891857e3e093fb687030fc08e9f8931c",
+        "punchline": "61c4d94d220514838512615def1e7af77e33ecb362e9cbdd1bb319b81d558976",
+        "combined": "401d54cfd61be2291661c0a2d8fa1f251e77caebe7d76d58585634022067f7df",
+        "tokenSignature": "are-because-easy-fish-have-own-scales-their-they-to-weigh-why"
+      },
+      "lengths": {
+        "joke": 27,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 273
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0274": {
+      "hashes": {
+        "setup": "538be3e1d1d1c479d208c0690504e86ef722f46b819de06cfaf3a894a98e1000",
+        "punchline": "6a22b6bba8b5f3c40ac43530353b3a07d0c724133479f314880446907c805833",
+        "combined": "6c739c4aba52ca43121538be6445b957240880a9b7de34db8ed5d87ddbab7caf",
+        "tokenSignature": "a-ahead-am-around-bit-did-go-going-hang-hat-i-longer-on-say-scarf-the-to-what-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 56
+      },
+      "source": {
+        "sequence": 274
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0275": {
+      "hashes": {
+        "setup": "8abf38bdc3b8ec5b4c5e1327ae0b9e517313265b49e72a8b552ce8a7eaa61903",
+        "punchline": "3399b087d5a2ba5315db1c8c51788fdc8559e6759e8b51c3b513d84b69b07a54",
+        "combined": "163af3d6c1d7c32a7b009f182778dd008b51dcd4dfed37633ec2b4e88ae19f6c",
+        "tokenSignature": "a-about-boiling-colleague-did-esteemed-had-he-hear-lab-of-partners-pot-scientist-the-very-was-water-who-with-you"
+      },
+      "lengths": {
+        "joke": 82,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 275
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0276": {
+      "hashes": {
+        "setup": "3f1ec4cf4d51db2bc4daeaf5dc83a001cc2098acd31bdf051566ad662e9ee9dd",
+        "punchline": "0f0046f3c939a01d6c799e01a28d88472a8266937db1fbae7dfaf6da17cac772",
+        "combined": "1da575a5a2ff7f6e72bd36a1f0b67cb772cd1786fadcd08761698b5039fc45f5",
+        "tokenSignature": "but-dawned-i-it-me-morning-on-sun-the-then-this-was-where-wondering"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 276
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0277": {
+      "hashes": {
+        "setup": "a209c7d319929f4d1c2eb98ac5a13fe9241d4547f03492b0c7e352fb22ca45f3",
+        "punchline": "3b1568973518b2ab0dc07fef87aa216e0f40e49f46efea6017c425a4c9cbc4e1",
+        "combined": "f7949d7e460bceae5777df54ba77181853382da61ec985e2f6633fce310cd623",
+        "tokenSignature": "did-have-like-meeting-sand-say-sea-stop-the-this-to-we-what"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 277
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0278": {
+      "hashes": {
+        "setup": "e131a86c40a53febf67e090c02451672b003f7374588baf66864e6ab3a31c8ce",
+        "punchline": "5ecfc55a5a6d2d3bd2fc00e0bc33f6ebf9d12ad3a5b57536636864bfef065cf0",
+        "combined": "f6d67db56bad20f0b26029874c6bb82c9b40aef9c4a310d21787116729909cfb",
+        "tokenSignature": "all-an-arena-fans-inside-is-it-so-those-why-windy"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 278
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0279": {
+      "hashes": {
+        "setup": "5c2346cfaf85d419c4ff86b93a4ca6473c455847609c45ee0d0bc92c14121839",
+        "punchline": "664dbdcbbe11bae1754668dbd786a1359127846084bca6c1495eb562cc0ce2ef",
+        "combined": "b662f193e4bbd3db29e9d60bd2d05476cfcea8aeac18383ff6a7f4a73f06160d",
+        "tokenSignature": "a-and-asks-bar-bartender-big-born-but-coke-hands-have-his-holds-i-into-ll-panda-pause-replies-s-says-scotch-sure-thank-the-them-thing-to-up-walks-was-what-with-you"
+      },
+      "lengths": {
+        "joke": 105,
+        "punchline": 137
+      },
+      "source": {
+        "sequence": 279
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0280": {
+      "hashes": {
+        "setup": "efbe5648e1b14183b16eb2ba45f4cbf1c19ac52ed84a7c7bd31555fabd225b48",
+        "punchline": "e63746379b8aa7e452660243929830dd85bbff4f888d9ef070038a849b78e999",
+        "combined": "1598259ca28f81ab7984287c01aa380ae066a76801cb5013d359e0b42bc8c77a",
+        "tokenSignature": "about-all-awareness-benefits-dried-eating-everyone-grapes-i-it-of-raisin-s-started-telling-the-ve"
+      },
+      "lengths": {
+        "joke": 72,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 280
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0281": {
+      "hashes": {
+        "setup": "70072af7b0ef8bec945eda9d907d37266c37b4677048049dcf9ac28f38274184",
+        "punchline": "262722913b851e71eb382c04eb00e34d4ce0a43b2bcb10bc57958948349fbd09",
+        "combined": "6a8e1c602b5361f1bb24937c68c0fc1fdf7eb6bae10646a82e1db417b41cdb09",
+        "tokenSignature": "arm-broken-doctor-don-go-i-in-my-places-several-t-those-to-ve-well"
+      },
+      "lengths": {
+        "joke": 7,
+        "punchline": 77
+      },
+      "source": {
+        "sequence": 281
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0282": {
+      "hashes": {
+        "setup": "5e8f162763bb223050822ec4ed8e0f0c3121cde1d116e222727474bbc523796f",
+        "punchline": "c7a0433bdd91b6b09a30eff35c22196b8d7d600a266c68c5c38c18d8528cb13c",
+        "combined": "370a73a44f8515bcf03a88719c00453f9eb6221570dd7e8f11150d43a1873596",
+        "tokenSignature": "at-bottom-declaration-independence-of-signed-the-was-where"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 282
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0283": {
+      "hashes": {
+        "setup": "62480a5bb16c37d40105be6452cb03aae536ba190663e183162d4b14d897813c",
+        "punchline": "17ecb3f5cef990b23edbfa4eba9434221748caad8e7c01e41530e7c614a15ddc",
+        "combined": "4f7cdb05974c0f1845cc640279bc6fa0a41607eb884c5b940e1a9552caec42d8",
+        "tokenSignature": "5000-about-african-an-and-between-difference-elephant-indian-miles-s-the-what"
+      },
+      "lengths": {
+        "joke": 73,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 283
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0284": {
+      "hashes": {
+        "setup": "1888d13363743f53ab41fb0ddd9eac02440edd2d5cdec03a576ddd1aa127a7ed",
+        "punchline": "68cc01f8f1eeec85258f3e94908a8bdfee4187adfc16fa03e617f4917d623268",
+        "combined": "56a35826307049b2e76907175a8cec51ed7020d2fb508af84a269a15209ddb29",
+        "tokenSignature": "a-down-one-peanuts-salted-street-the-two-walking-was-were"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 284
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0285": {
+      "hashes": {
+        "setup": "6d1decd551f971cd2b88d286c04f41af93289ab987ac09ccbc7a597d3efd051c",
+        "punchline": "2d30100f919d373151a762722c3d7f9c98ab71f6e2e5e7acf3f7230f038f88b0",
+        "combined": "a7df9dad949fcdbf311fdb0a9c6bc1d5d0b74cd85c37c3aecbc324b4d80654cc",
+        "tokenSignature": "a-are-chances-crosswords-don-hear-intently-interrupt-ll-on-puzzle-some-someone-t-working-you"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 41
+      },
+      "source": {
+        "sequence": 285
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0286": {
+      "hashes": {
+        "setup": "5488026ef17c6d400ebe22c47a4819f3a0e016cdb3a8f32e7c77a4620e25267c",
+        "punchline": "d16acdb9b395ef8d0744bebcb53b70cad84e827bf7b2decfa38dd312060c00c4",
+        "combined": "8b5faf1e6e16044e2aee64471105b2f77063497b99dbc9537e7acbe09ec8a3ee",
+        "tokenSignature": "a-and-asked-donation-door-for-gave-glass-him-i-knocked-local-man-my-of-on-pool-small-swimming-the-today-towards-water"
+      },
+      "lengths": {
+        "joke": 94,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 286
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0287": {
+      "hashes": {
+        "setup": "01cfce0cb30b6879af4d1da082bcac2f15be57fb46d618bbac1a8ec0080d9469",
+        "punchline": "1e98a0a824b75d5ba8abfcdd5dc5fcf9cf210c24e82bdf8330153b4802d57f69",
+        "combined": "4ed2f8b463aae64da72d7c81e296d845a37ecf4134fc382eabe216908a0701eb",
+        "tokenSignature": "buddist-did-everything-hotdog-make-me-one-say-the-to-vendor-what-with-zen"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 287
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0288": {
+      "hashes": {
+        "setup": "0326eadf5fedb23db4231b1b5242ba985cd8bebfb0da57e3c2a667a5ee95f0da",
+        "punchline": "546107b4abd22dd38e2741793b67797031903564449103c534a5d119c5f778b0",
+        "combined": "22c78b7b339953eee74d7529709260e40bf448723f60b0878ab04f5cde563759",
+        "tokenSignature": "because-clown-did-funny-have-he-neck-pain-slept-the-why"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 288
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0289": {
+      "hashes": {
+        "setup": "5559bca091417d414ec02f7b6c5459e1285e95ce718dbca071c2f1ecab55fff3",
+        "punchline": "b2552dcf235a09b6d937624fe10eea07ca37df16626b1a0dac2d7abdb93edfd1",
+        "combined": "72e8a437c4e1118eff8461603cb782225fbbb54a2753d53fab392557296c8885",
+        "tokenSignature": "clock-did-digital-grandfather-hands-look-no-say-the-to-what"
+      },
+      "lengths": {
+        "joke": 56,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 289
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0290": {
+      "hashes": {
+        "setup": "866218ae99c1c67ba9c2205e05a2bfba51c339b7bf1aca21cf8bff029ac9e46b",
+        "punchline": "879b6c2b579945ffe84eb3dec9d674391062c4c979e01c5dbd061cdccd4ccd98",
+        "combined": "1dd5c5d54b727e4dba4a0413e5d3f0822a90535cdd741e6769521896b128e134",
+        "tokenSignature": "a-bar-bartender-before-can-for-get-goes-i-into-never-pop-says-served-the-ve-walks-weasel-what-wow-you"
+      },
+      "lengths": {
+        "joke": 87,
+        "punchline": 48
+      },
+      "source": {
+        "sequence": 290
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0291": {
+      "hashes": {
+        "setup": "9e56786d55757498690840034a80c1961f0f6181017590ab51a80c7034796b87",
+        "punchline": "605d4eab99373319e4e1d6d8163148e76d7bb3b9644f5659ccde5a0eb3855c43",
+        "combined": "640162305e2040abeeec90f20d7a0765d7342c9953ee3628a16004cd14e43876",
+        "tokenSignature": "a-after-feeling-globe-how-little-shaken-snow-storm-the-was"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 291
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0292": {
+      "hashes": {
+        "setup": "2a70e27ad1534e8b18b457aeccc21f245bd63eb407224f94f00947755d78aa0f",
+        "punchline": "21438e134050ee55cf6b1c1071e561bbaf887c07b697641074b47a81dda384fe",
+        "combined": "4d853fbde11b11c3b489a9131a4a262a569bbb51d072f9b494cc33cfc8189302",
+        "tokenSignature": "about-aid-broken-did-guy-he-hear-hearing-neither-one-the-with-you"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 292
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0293": {
+      "hashes": {
+        "setup": "877789ea52bbc6ca7dd28f3ef122600f359dc8e59718d4b53a4dc6ef85e5c276",
+        "punchline": "69e014ee9461ae8de8e6aee9cb5bcc982a2c9e56be0c10fd6481fd804db25807",
+        "combined": "134216f7ac0497cfa0bb16262a91d2c06d26f7f7a6e4a34e301693fc0f05e319",
+        "tokenSignature": "about-bigfoot-by-campsite-did-got-hear-in-it-tents-that-the-visited-you"
+      },
+      "lengths": {
+        "joke": 60,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 293
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0294": {
+      "hashes": {
+        "setup": "3fd951f250749fe72375286da4588696dd473d260b7c673cb09cdf2fb312b8f9",
+        "punchline": "a9573c4020dfa0acbbe120844a2e548be6a2492e1befb42428798db85bd424ce",
+        "combined": "076d358e4ed9c0b0eb4f20cf17cfe86e3f60d259a79fe97ce6e06ccdb2459534",
+        "tokenSignature": "a-about-documentary-how-i-it-last-night-on-put-rivetting-saw-ships-they-together-tv-was"
+      },
+      "lengths": {
+        "joke": 71,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 294
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0295": {
+      "hashes": {
+        "setup": "e45396ddb30772ed543f3e7285098b5cb34c74c32f4c87f2a356dbf21479d7a6",
+        "punchline": "fc94925f568068bbf9605e652cb105b6884c5368c343d3901ebfdf4b364dab85",
+        "combined": "5f5d32cf789689a36fbf3e39e7875d85b566d80da86d3cd04c8038a9945f6918",
+        "tokenSignature": "at-changing-did-don-green-i-light-look-m-me-red-say-t-the-to-what"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 295
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0296": {
+      "hashes": {
+        "setup": "066cfc3d02b1819439cd574ebe08e0909b66d888e0251a7c84d13da2b6ca3869",
+        "punchline": "c5556cc60d7899179720c355bfb0da6d781a04aa7f1a72a77b96d05ec8615545",
+        "combined": "805010f0c4a98b9282e1d390d33c25fa0d4981b3a6018875651e1f96d4c9ca79",
+        "tokenSignature": "all-beach-did-for-ocean-say-sediment-thanks-the-to-what"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 296
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0297": {
+      "hashes": {
+        "setup": "8bece0fd88bfb60ed27bfc6b2f909147be9f57dfc4ffa9548b3face3be385aaf",
+        "punchline": "3fe20a54ce5568ae4cc92daaf0d9f0ad92c8d04557c70b4d29acb53332d2db97",
+        "combined": "055a0bb6106b1dba6ef84d3a2a445f9ee0b5115b48693ac00b2534f0eb0880fd",
+        "tokenSignature": "between-did-eye-left-right-say-smells-something-the-to-us-what"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 297
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0298": {
+      "hashes": {
+        "setup": "cfb6da57920ce420d83067e319a89641b1b1453de130781692d9b8bf1c0d4ed6",
+        "punchline": "fc8bdaca8e740cf942c4cdc89062dabfabdb2a5ef4a5b27dfc267636d3b279e3",
+        "combined": "f48ebf6da18a6e9e517126adf1486b69267dfa63a5c253ca3ea28111ba0fec1e",
+        "tokenSignature": "a-call-do-fly-walk-what-wings-without-you"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 298
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0299": {
+      "hashes": {
+        "setup": "3d34e7c988b2179849c34ee1d33cd8542075b6653c6d9908e90d9ac0100c1759",
+        "punchline": "296958295909b8fb60458d28cea442166ad45007c9dc75b56ada2fc7967bad6c",
+        "combined": "cedd5fe3b5c6cfc0fd43dd350f6bb0af154f5d9485c699361bd85c805c3439d0",
+        "tokenSignature": "a-because-big-cantaloupe-did-melons-plan-the-they-wedding-why"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 299
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0300": {
+      "hashes": {
+        "setup": "f69c2b9e9dc278118925ab90fd2ffc36d92acdc7244feec80b480c8862d52ea1",
+        "punchline": "40123893469ed1b5bfc2776385655ae7e4e31f097f800b52f11a6523c6c54962",
+        "combined": "9d52d8d1fe47a469514fe8a99018971e6a6c6031cc80ed94da10a6ddba6d874a",
+        "tokenSignature": "and-confused-hot-i-in-jacuzzi-japanese-m-mafia-now-the-water-with-words-yakuza-yesterday"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 45
+      },
+      "source": {
+        "sequence": 300
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0301": {
+      "hashes": {
+        "setup": "c3fa55587177fca6e2805d4669ab0c3b8fb314e171b1460acbdb59f018a92594",
+        "punchline": "56b8ada0e77dff8c39ff3965a56190f65fe0a4ae918836f513dfb9f4449519f2",
+        "combined": "d614d4c10a2ae6b0066d2d33b251e56d1cf4b238efc4b31ead7b737acc84c294",
+        "tokenSignature": "in-is-language-least-sign-spoken-the-what-world"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 301
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0302": {
+      "hashes": {
+        "setup": "276d1ca8d6da20eda622101c0d65fed61d98f0ba364164d7d400b51b7c9343d0",
+        "punchline": "8185dd05fd0cf930acd0e9de83d4b10cae216e892dc9cbb5612d72f33e45dead",
+        "combined": "21831450166aa7fefb2f415c0ad9c76395319e519091a40535292a1f5088f8d4",
+        "tokenSignature": "birds-do-give-halloween-on-out-tweets-what"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 302
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0303": {
+      "hashes": {
+        "setup": "ed949fb4cc195471982d1558cc3ae50ba2aa20f99a691836c726ec02f729abda",
+        "punchline": "93b0549ab1938f7b2aadb1382b5f02e2652eb5fabff7dd1f4d483cd8587a08fb",
+        "combined": "b2ab0601c75481a46ed0f1154cc609d8eb6a463344f0b8db49167ff9a138dbc5",
+        "tokenSignature": "but-i-indecisive-m-not-now-sure-think-to-used-was"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 303
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0304": {
+      "hashes": {
+        "setup": "1b5b1853319cac0e96f0ba515d4ef270b0bce886176d641f62eee5f409e145a1",
+        "punchline": "cc0c77b9dc6033bfb7ee13d2e09249a40d8513d3a0dd0c58abf6be681a4a608c",
+        "combined": "87e62322a1643c92044a7c2d2e42d823f27d8ddc89db5be7b3b2ed8fe3a41040",
+        "tokenSignature": "about-around-butter-going-have-heard-i-it-mind-never-rumor-shouldn-spread-t-the-you"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 304
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0305": {
+      "hashes": {
+        "setup": "8089f29a25e7e7e46bcfa6f7acb62a1dcff89a75c38f5ca81cabcb54c6531b0c",
+        "punchline": "15fa48ca4f33469b6c865ef075916bc4880b04ed9a22819b7c23f356bfd99c84",
+        "combined": "aa4ab95ee289e3cbddfc942758b5907915ec05226abeca102d1fe0a28de34582",
+        "tokenSignature": "a-bicycle-by-cycle-every-get-go-hit-i-it-morning-out-s-vicious-when"
+      },
+      "lengths": {
+        "joke": 65,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 305
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0306": {
+      "hashes": {
+        "setup": "53c66a41c47250b36d8df590e96f75b0335a84b7782eea83909452d7808a7c22",
+        "punchline": "3dfbd3d72964db346714f92066392f8610ee5fd6975c56cdfec9cc1979ad2801",
+        "combined": "c8774ccf068961fe337d609ccfa4e08ad4f1a20234975e2238cfe0a7a8e54724",
+        "tokenSignature": "a-breaks-car-down-frog-gets-happens-it-s-to-toad-what-when"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 306
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0307": {
+      "hashes": {
+        "setup": "a5a740a014c1e3eb7cf81741930f9c49b5ec970c46aba1db59cff2e58aa1e955",
+        "punchline": "f6b1b4ec4249ef359af50f9d4119b551b0326d4445f9797e2daa59f6dee0afda",
+        "combined": "78d433d4f952c2e378f386c86c4e3160342ede18284fcdc15a7577d9be5abdef",
+        "tokenSignature": "are-calendar-days-fear-for-i-its-numbered-the"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 307
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0308": {
+      "hashes": {
+        "setup": "6d01db88a92d0ef2b537d2e36dcebc7a61bbe3cebd4fbf264aab615f5a6384eb",
+        "punchline": "bb0c1f9659069913da3f8e6994fcf90ac4f5d5e2350f58eff2469a00f963dd92",
+        "combined": "5668213b5e4ba3dcea45dd1b3be6d1eb5a2829db45dd9a48f0a17ad73940e4dd",
+        "tokenSignature": "glad-handy-i-it-know-language-m-pretty-s-sign"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 308
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0309": {
+      "hashes": {
+        "setup": "576db4c376613b04635e446cc4c43fb6cd34ce72ac4f8d0b4ba79e9e608bd228",
+        "punchline": "8ce09bc377f7451804d973d2afc48d5f7fb83b9dbafb59dcfcd2ca7c333f062d",
+        "combined": "d80c4c06023de99430748890456d8ec8d3dc7df78459a4cea5d241ada423dfee",
+        "tokenSignature": "a-accidentally-asked-but-day-glue-her-i-isn-lipstick-me-my-other-pass-passed-she-stick-still-t-talking-the-to-wife"
+      },
+      "lengths": {
+        "joke": 96,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 309
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0310": {
+      "hashes": {
+        "setup": "2dbb730fb2e1741801197f9ab2654836425d3106cfc7b69e2ee80e199d1e1970",
+        "punchline": "d115acd2c29d9413178cd7cc089e55aff8bef50f2afd3e5542d4d9bd5f32929e",
+        "combined": "a197b4de0a5286795dd21cad0d5ad3a515fbafbaa04080973b0880d4b72de204",
+        "tokenSignature": "a-chicken-cross-do-fowl-get-skunk-smell-what-when-with-you"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 310
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0311": {
+      "hashes": {
+        "setup": "3ea2f171e7943f34b2fbb5870851d049400231faee6e802e939b72b56434abf0",
+        "punchline": "d8d5ea98108c32aeaa966682c8d2347b77131bddb3fff25aaf2c51167647f63a",
+        "combined": "6a5457b4c8f37370fee5c16ae48d0537d01c0484e7db7348ff5aa35ff151540c",
+        "tokenSignature": "a-accident-been-boo-c-do-i-in-injured-peek-s-someone-take-the-to-u-where-who-you"
+      },
+      "lengths": {
+        "joke": 70,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 311
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0312": {
+      "hashes": {
+        "setup": "9cbefb3ffe65f27402cbef89ef7adaba81f4b7a783a1864bbb1ac63fc824f7e7",
+        "punchline": "f452622713dfacbf5b22c60814979cb51474917c1255dbcf672aa973a90c1362",
+        "combined": "143c7949d62cc94ca0dc6e36dd72ad8e0ac5d759bd030da32aec127dad24b8c5",
+        "tokenSignature": "a-all-along-as-career-get-good-guide-i-idea-lost-maybe-of-older-people-such-t-the-think-tour-wasn-way"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 55
+      },
+      "source": {
+        "sequence": 312
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0313": {
+      "hashes": {
+        "setup": "21548d22cb523a50e20f705f531e335748635c63c86487e6fe27a702ba3bbc3d",
+        "punchline": "a8d0260ca9b513c6205f85d111b23e54ae99dd11365779e18bc87a283cda73ac",
+        "combined": "739474d7ec177dc032a0e348d34b59ea3ca80e13320c127e36a651cfecc1325d",
+        "tokenSignature": "a-change-does-heard-hipsters-how-it-lightbulb-many-never-number-obscure-of-oh-probably-really-s-take-to-ve-you"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 68
+      },
+      "source": {
+        "sequence": 313
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0314": {
+      "hashes": {
+        "setup": "61e6001a309c2cf2a3bbca606854daabb00d82f5bd758692c88704cb490f7df5",
+        "punchline": "a2b9b7d7b11064a37cf59938367b15343d725c91e030be320c97bfa22fdf5d86",
+        "combined": "58c0fb5356e1983cb614174f22eb92c3182aed481eb2bba732f6b8bec80be244",
+        "tokenSignature": "baa-cut-do-get-go-hair-sheep-shop-the-their-to-where"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 314
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0315": {
+      "hashes": {
+        "setup": "206c9f1e4de74706cb4d145237b1c9273d57b94bd98982cd47da12b1c8893d8e",
+        "punchline": "da5560b3b0b326c8acfad2fc36ea62d2cff0bdb5232eeb4a2bd94b2371d39460",
+        "combined": "cdf8666eced41a86f50ee19c21d9432dd6606fef75fddf9dff3f63c7237632ca",
+        "tokenSignature": "beautiful-cake-even-in-our-so-the-tiers-was-wedding"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 315
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0316": {
+      "hashes": {
+        "setup": "4044a9e679fae78b3220f7c7c7252156e95b108fba27698e3326510c2ab544c1",
+        "punchline": "c616c5b4bf78cf167efeb9fb30790b2ab623f7c72844fecf8e7bc4a35863607e",
+        "combined": "b7f23d20958702a191b9758bdac8798618aa6a0930951a7bacb96c7c7c499261",
+        "tokenSignature": "did-fired-for-from-get-granite-he-his-it-job-miner-the-took-why"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 316
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0317": {
+      "hashes": {
+        "setup": "3fe4218b2d6cfbebd91f6373a58f82e0e539f375fee5d1f3ace0401e1364fb8e",
+        "punchline": "57a10103d560459e6e07f89c75d2ccb05b340d4b3d0a419514d84cda8db810ae",
+        "combined": "a7c44a2a8c92584a170ce195f356b56deaceaf2ad2f852c9d8ed60a5efcf40e7",
+        "tokenSignature": "ahead-around-can-did-go-hang-hat-i-just-ll-on-say-scarf-the-to-what-you"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 317
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0318": {
+      "hashes": {
+        "setup": "599c73cbbbcee631cb1eb0a06f9be7faa4806ec615613d74d4cc6111dee27020",
+        "punchline": "7e7dc3b1df7a70abe3af1864636460e77815c3d1e060b6def6ac1ed22ff5c3fc",
+        "combined": "6c8cd402911258a5018e3d342ef4b5afc8f8791011612ee8a08643c74048ddf6",
+        "tokenSignature": "cats-do-notes-paper-scratch-where-write"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 318
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0319": {
+      "hashes": {
+        "setup": "8c7813c599b1eb8aeae6ca7b3aa9fc08934ee9a65342a7973da8f3136bd497ae",
+        "punchline": "7015006317a1e3e9e4596da7c2804e20574d201b051e74c388c5a0096a9184de",
+        "combined": "d722898906f461dd5a4b4d9e10e499b586fc79676597137fbecdd893228931b6",
+        "tokenSignature": "at-feel-home-is-kindle-like-look-new-paper-screen-so-textured-the-to-why-write-you"
+      },
+      "lengths": {
+        "joke": 57,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 319
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0320": {
+      "hashes": {
+        "setup": "d4913731bd7b2451d3f9d1e00476fbd6e9b5c1556403c251c0dff8f81b009d4a",
+        "punchline": "09067892b3624dcf90a8cc581a6ba948dae2ced51ef5799a37f2763591af948e",
+        "combined": "e941a3943a82b9ed38565c7ea9eb533aaad19a2c3c8b55cad5cff4cbb11d80db",
+        "tokenSignature": "a-down-flamingo-foot-had-i-impersonating-me-my-put-stop-to-told-when-wife"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 320
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0321": {
+      "hashes": {
+        "setup": "ecfae8d79e3eb8ef685c57e314b12b0edfef3761060fdb4a0f1ce0e52057613e",
+        "punchline": "f80f905f94d11e5ae69f1f94f6a86fa7f0582e6859e4ec8118b6b151b045f47e",
+        "combined": "1fcc92095ab7ad8f7840238dca0e8044f2abc13fbda7d81e407272a71078bd03",
+        "tokenSignature": "are-children-german-how-kind-kinder-matter-no-you"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 321
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0322": {
+      "hashes": {
+        "setup": "17bfb7341ba0682788fe0a02f73204ffee314a2cdb9650fe3477060b8e476ff5",
+        "punchline": "001d32eb1cf8d3490994dbb8d361db3403634d7a7d95b2beafb7aac8796bc5ce",
+        "combined": "3ad3ac04bb14a6ee4d34638d4bb605dc1cd43b0ede5fa4c581c9a68aefeb33a8",
+        "tokenSignature": "a-advantage-big-flag-in-is-living-of-plus-s-switzerland-the-well-what"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 322
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0323": {
+      "hashes": {
+        "setup": "63ee88d4518a1ee596dc902d764f67f6eaad4a86db6986ebadab8a7679323597",
+        "punchline": "c0746b41e2f05519b705bed19a669bc652bcf91d3c014bb829cc94796344035c",
+        "combined": "3a3fafb3da4d4bd80e19f1d26870d8dc0b9aa52b980ed28695e75362335164c8",
+        "tokenSignature": "achilles-always-elbow-every-exams-exception-greek-i-it-left-my-mythology-of-one-passed-school-the-was-when-with"
+      },
+      "lengths": {
+        "joke": 89,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 323
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0324": {
+      "hashes": {
+        "setup": "a28604f34a3df8331c103a977d17b1958756056330479499c0e88e57acd322cb",
+        "punchline": "742145be7f63eed8ca98d6b4e5888cd40a9dda1b298727f3f2663e52613b5576",
+        "combined": "bdff40910a4c57476f5dbac53fd8df3565d9e8bca4ed65a283bd56f4d3109748",
+        "tokenSignature": "cookie-crumby-cry-did-feeling-it-the-was-why"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 324
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0325": {
+      "hashes": {
+        "setup": "fa3cb78e5dbd465aa47a743f6cbec2f35509600cedaccaf3b9988ca5bf29b9b1",
+        "punchline": "a31f39a8ee9f1443cbdfa5c6302f4a76c72e6caa79e6b559645c4a2675c718bb",
+        "combined": "b4716bf327a5bc49483748d54c03d8c96050255361ec51c37418a07cdb125db8",
+        "tokenSignature": "4k-did-hdmi-he-himself-in-saw-say-what-when-yoda"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 325
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0326": {
+      "hashes": {
+        "setup": "cebf90d9a94d5e73792157709919828e398a1fe965cd4d2d9fa7017cebe087c6",
+        "punchline": "19c36fe9a01b5932bdcd7945d0cf3f8eaae07e94c6edeb9edc1d156e759b0146",
+        "combined": "3b91673f34e50f764248c89705fc30a02d02358d22a4267384bf3f1f631de0bd",
+        "tokenSignature": "a-add-and-disappear-do-g-gone-how-it-make-one-s-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 326
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0327": {
+      "hashes": {
+        "setup": "b9ed49db1f69191fcd3cdcced06d2ed3ac3918b67f26307a1cbbc3c681482f42",
+        "punchline": "2a753d8dd7959301ff660655f752a07a904b1d5353075b31e2eea94c7e6a26c2",
+        "combined": "a2c416bfb7482e38454cafa32ba7daea3e1d3f8e5de7f18960c912246a4c2253",
+        "tokenSignature": "a-and-are-band-called-cover-duvet-in-mates-me-my-re-we"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 327
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0328": {
+      "hashes": {
+        "setup": "ae8951178367b965c8c52725c12966815660518766571789f826c4f3fc856560",
+        "punchline": "ce3054c826969e92499140eab2838142dcf550f6e3b3c4a893dba3538e9d5d8b",
+        "combined": "159b51dc1a3f9ab10376c36f810c40e5b81d7cf7cf0d3dde9298bef58dd989e8",
+        "tokenSignature": "at-banana-do-learn-make-school-splits-sundae-to-where-you"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 328
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0329": {
+      "hashes": {
+        "setup": "50bb50e956beb47b245feb4c7e3e0af99cf1d0b97e83c87ac8bd344fabe05659",
+        "punchline": "ec9ecc93ef02a4051a7bede33eb58eb26c72e9b2f33524bbdb994230eeabd4f5",
+        "combined": "dc96c560590f12203b2f6ee1135907af40e356ab95029ee2c02fc21911e12515",
+        "tokenSignature": "a-can-doctor-he-him-i-invisible-now-nurse-patient-right-s-says-see-t-tell-that-there-well"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 49
+      },
+      "source": {
+        "sequence": 329
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0330": {
+      "hashes": {
+        "setup": "0dcbe4fcfa6bbf7ddb2e04bb45827aa013e703229d6bafe404d4909f7799a207",
+        "punchline": "30e4f8cf8aa437863362a4417cc67efc0b6b3173a4ba30c6aba045fdd6348a92",
+        "combined": "b27fa1c6359e61bdc76cf3386c7e5f92b0514ff7675b16c1685eaa6986e329c7",
+        "tokenSignature": "a-first-important-invention-more-one-second-telephone-than-the-was-what"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 330
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0331": {
+      "hashes": {
+        "setup": "20299da65261f1a1ac3fb10dc7973bf90b57a364c6d6d3814f4ae0063c0a2fd6",
+        "punchline": "4b5a6e3095f2b064771d2114be1869ce3a06440509abf2fba1b98bd7e85b5214",
+        "combined": "e46e5a13690193bd1ff3166f81a97e94ff37edf825da600ee9d020f03e0e5b6a",
+        "tokenSignature": "a-cross-do-frostbite-get-snowman-vampire-what-when-with-you"
+      },
+      "lengths": {
+        "joke": 56,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 331
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0332": {
+      "hashes": {
+        "setup": "50d98d228b4f697142b984316441a857d8fd9cbfabeb126f0caa8e6967ec089a",
+        "punchline": "f398447824942ab638eaa8fd6adc122f5da54b85f43016304915f66235b96401",
+        "combined": "d956bef50fe30b38628f064ca50cbd070441322ffac5dac2a9b160925f137b52",
+        "tokenSignature": "bunny-do-dryer-get-gets-hare-wet-what-when-you-your"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 332
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0333": {
+      "hashes": {
+        "setup": "44266829a86d04520311df8f831c1e7d305f0a1a2e1221cbf18f09d29e3df0cb",
+        "punchline": "4864ce78c969e742ff051f6813717106c4cfdaec302bdde141ee38975ab25630",
+        "combined": "5ee4323c32054981a1751364162f3140e872bd51b1a1d61a75a4e85f16d5a52b",
+        "tokenSignature": "15-4-but-could-crocodiles-did-feet-grow-have-just-know-most-to-up-you"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 333
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0334": {
+      "hashes": {
+        "setup": "849f8ba55c0fa9e36345a9afaa2f3d464ed223c4ed7e29c32287849864a22522",
+        "punchline": "8d0029b4c1e75ba32f2727ebdca4d32d3d6e03f618aa60004d4a979038221c35",
+        "combined": "7a5cc7a34daf37daf3843a2f06722ebec50df15cc8c436f744eb9a3b7aaadbf4",
+        "tokenSignature": "are-can-data-extrapolate-from-in-incomplete-of-people-there-this-those-two-types-who-world"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 49
+      },
+      "source": {
+        "sequence": 334
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0335": {
+      "hashes": {
+        "setup": "55e9e393bde3af8036c480cd9627ceec768e636cfbe5f0997a753cc1c40fb645",
+        "punchline": "39d89249072951cd43d24920ff8e7c3484a2d5927e36218a4c7676fdf410d38c",
+        "combined": "d5f84743835695a3baa1befa79d377200094c1920c061471b3f54566ffb26c75",
+        "tokenSignature": "and-blue-did-fireman-his-hold-pants-red-suspenders-the-to-up-wear-white-why"
+      },
+      "lengths": {
+        "joke": 57,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 335
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0336": {
+      "hashes": {
+        "setup": "fedfeee298b25242e7c95ab7b35a3d658ca229df9fcdaa3ed7f02e486aa9488b",
+        "punchline": "12058d1f20ee7b6fa88e7fa1aa850053d0818d852e808bace0fc39a0ed20d792",
+        "combined": "c55cfdea0cc69db152e4576af6548bb44bb4cdcfb796e47d055a8b4af9d57c65",
+        "tokenSignature": "a-always-arrested-artist-courtroom-he-i-in-m-news-not-seemed-sketchy-surprised-the-today-was"
+      },
+      "lengths": {
+        "joke": 68,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 336
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0337": {
+      "hashes": {
+        "setup": "47a2baf5a340ad1dbed08640dca46fcbd2482ba98920a065e4e091c134f02a5c",
+        "punchline": "21a6734435e22c2b8c8b8ad821a17f5ce8b04719036c0bd689f99da6b03777a8",
+        "combined": "40da911369a2bc27d863e092b4e674c9ec0acaa9d0098161ebc90e8b0206d15b",
+        "tokenSignature": "call-do-knows-no-nobody-nose-someone-what-with-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 337
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0338": {
+      "hashes": {
+        "setup": "e409c7c2bb5024f88f9db6e6c4942cbe54bc2999fd5b382f6d0935a6a492549b",
+        "punchline": "7e15e37645a78cfd92710ecf7460b1acb95e8eb3131091a6ac0f8dbc32b6555e",
+        "combined": "eda39268c24eb1af8a65a2b51eaf94a910b83f7e6c244aa836375a70dc6483e7",
+        "tokenSignature": "a-annette-between-call-do-girl-posts-two-what-you"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 338
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0339": {
+      "hashes": {
+        "setup": "38560d036c5829fc84854183d3f32993eca82fb1a9813954a6de780084396123",
+        "punchline": "e1bbe6bb65be0074b120de881f31885eaf32698599701d735fb33d4af7a2c437",
+        "combined": "e04edbddae7d0e4bc1495a057acf5e2887367cf03c00a4f7a94b3d60b720ffeb",
+        "tokenSignature": "a-call-condescending-criminal-do-down-going-stairs-the-what-you"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 339
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0340": {
+      "hashes": {
+        "setup": "5d46504fd84b4730b8ab6f194875bb77cb1b48a80f99177f7c6f7f7fcbeff7fc",
+        "punchline": "eea93d8d0ae6704c2d95df0d1b92fe6411b6e85bd02a43dd41944b950e4d39fa",
+        "combined": "1aadf5caf04416768451d64caa4f37bcdf6b3bcb94822e48b564470f791fb91c",
+        "tokenSignature": "a-call-chin-do-fat-four-psychic-teller-what-you"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 340
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0341": {
+      "hashes": {
+        "setup": "b0569382114c36ae9fcd34d8ed4a00e7e7e833c45c781e285b18e4cf92c1b68c",
+        "punchline": "bac71b09cccafb8b86cbb4c4cb3575b44c53e4637b829f0c0315f019c6ae2bee",
+        "combined": "47e2ebbe4ab76e89fd7a020e4e37bb794e46cd81bf6daf4b26359aa58507879c",
+        "tokenSignature": "a-banker-be-but-i-interest-lost-to-used"
+      },
+      "lengths": {
+        "joke": 21,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 341
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0342": {
+      "hashes": {
+        "setup": "2bb36bcbb0cb93e762c0ddb6c5529c038376b5c6cd21f2800024441980ba694a",
+        "punchline": "b8196051faefdd2a4c4d67c6c1137c65abf9beda443a7cfdb7b74a120c6a8e0c",
+        "combined": "a5d2595832b85908c4ced67c851511860ee0fe2e2bc7d9c8a8258da4966561c1",
+        "tokenSignature": "a-bicycle-can-it-its-on-own-s-stand-t-tired-two-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 342
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0343": {
+      "hashes": {
+        "setup": "f297e3044631bc5e61c6afe114ff99e61f55b6b8fb44d7c2834c7a047abd7814",
+        "punchline": "96de845eb90770ce9df1c651ddf729a0abc21d5740fa1c9ef4d55db235605577",
+        "combined": "23ce11d74cec67e8d0edb0dd652832d223f0c9f77e71f627c597f28f49d7d059",
+        "tokenSignature": "a-buccaneer-corn-does-for-his-pay-pirate-what"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 343
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0344": {
+      "hashes": {
+        "setup": "d46ef5cfd7b6a3793703659dcf660ae0bddcbdf3fb571ec84cf4d516d0843897",
+        "punchline": "d5ce595034fa2af4df6c7dcce5c2d94f0cc33e762633a7a8d208fc3ef47372ab",
+        "combined": "2636bd11aba1a93a9c98bb3cc4c25229333b09f46dbfbe76487eaecb7f64718c",
+        "tokenSignature": "24-a-around-astronomers-call-day-decided-earth-for-go-got-hours-it-moon-the-they-tired-to-watching"
+      },
+      "lengths": {
+        "joke": 73,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 344
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0345": {
+      "hashes": {
+        "setup": "145fa6f10e54053434bb0209c5dc5090b940bcc313d3a3851766583ce5baeb70",
+        "punchline": "c0791f9c103d94d6e76e006101e5ff8dcaf6bd42b00398dee328a03f84d72a23",
+        "combined": "b2589d874e521fd60c07e887024b66da28fb3b973ada2d367e8ab8870198f730",
+        "tokenSignature": "a-away-bad-bike-chase-dog-got-had-his-i-it-lot-my-on-people-so-take-to-used"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 345
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0346": {
+      "hashes": {
+        "setup": "37b5c26cd9260891bef08b2e6b6c79a8fb813129a9377b303b6fd90342e480c1",
+        "punchline": "146a4e812d8c3d2882b077b4c47af0c25c39ea9421ba64fd824360e16390497a",
+        "combined": "dbd65ac2de39972f51eff07b81591f4618f0834f47cac7a3bdf2317dcccdb8b7",
+        "tokenSignature": "a-ate-clock-consuming-i-it-so-time-was-yesterday"
+      },
+      "lengths": {
+        "joke": 24,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 346
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0347": {
+      "hashes": {
+        "setup": "91a9a34936665987229e51721394430502d9fd3be11db6231127ab1854e7e0c0",
+        "punchline": "f50eb518288c8fd06086b5ce53666a365057b1f94333023626d8e74def80b2b9",
+        "combined": "ebe9f012355d1304206e0453d98f2828b8cf047a0bcff403a8ed3727854cecf8",
+        "tokenSignature": "deep-diving-ends-for-is-it-pool-safe-the"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 347
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0348": {
+      "hashes": {
+        "setup": "4762bfaa315dcc74dd5b5eec1d042092ff117a10096691c79635ed3e6aadb745",
+        "punchline": "3846b1761c0274737a89e67f8636e1e6826abb84289550c4f0b384ed4b2874e0",
+        "combined": "76b25a6b590875a25a0d93306452626e05763c04bc6d4ef7ae9bb10b7e89be57",
+        "tokenSignature": "backwards-be-because-boat-d-divers-do-fall-fell-forwards-if-in-into-scuba-still-the-they-water-why"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 58
+      },
+      "source": {
+        "sequence": 348
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0349": {
+      "hashes": {
+        "setup": "7853db9f6b7c929f2994cfa7807f68026f3ea6aea5abae9218416759ed8abb6d",
+        "punchline": "2b2337086b78c5054ed8bda456090c6ac8b59c8a7ae17bd2cf40fce89374d403",
+        "combined": "a87a592c75fd03134323885e5e0c0fc3a08654b21208e6ff333e62200cdb29f0",
+        "tokenSignature": "advice-better-flavor-for-herbs-me-meat-my-on-rub-s-sage-that-the-to-told-wife"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 349
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0350": {
+      "hashes": {
+        "setup": "c5a7e9bf51f0cab2498dce77c5bc2f9941693a7f693f68c7f55042664c4478a2",
+        "punchline": "57aaad0d107417bdda0a3abaa352069c9bb86d048f8bb8ef89c9746357feeddf",
+        "combined": "06f4ada7a5d5693cde0219182f325b990dbea70a6e76e2db8eba345ce7a24444",
+        "tokenSignature": "a-balanced-caught-charged-counts-couple-he-in-man-of-on-shoplifting-shoulders-stealing-supermarket-the-today-two-vampires-was-while-with"
+      },
+      "lengths": {
+        "joke": 105,
+        "punchline": 46
+      },
+      "source": {
+        "sequence": 350
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0351": {
+      "hashes": {
+        "setup": "2912e14e37f36dd4ecf03a832f47a1cbeff65c3bf557d6e6cd79a38fe9568b3f",
+        "punchline": "b46322e6aa8ab25c9c80767ea2d19c6d34213ba58d4dde8e9542b5ae330a0d02",
+        "combined": "7d077da3a180e744d83c983e05b746c141a3e2777242cb42b0d6b8ab618da234",
+        "tokenSignature": "a-ben-down-get-improve-is-jerry-need-only-operation-really-road-rocky-s-the-their-there-to-way"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 351
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0352": {
+      "hashes": {
+        "setup": "bcf4146ea5aa1444f912e0e51ec7a61e1d3c6d5a9d59984675d4614ed86459c9",
+        "punchline": "f1a12341057453eb5881d5072693cc44cc88474b8eeb701efcfd048a0e7754f4",
+        "combined": "f52c13a3056b3182dc1d1679af80430c7acce5b27964b1e91fbdbff628150b28",
+        "tokenSignature": "are-at-come-false-how-like-night-out-stars-teeth-they"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 352
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0353": {
+      "hashes": {
+        "setup": "c8623450f0400580801826b1f33c94d733b49cfb61c23ce320e9abc0d19a6017",
+        "punchline": "146d6f667010b9b1152d424d0512b27c6c901018936c744dbf1b9770d948ded5",
+        "combined": "8bf6d59263a65fbe4ca899581cd89f30b397a04fbf744f2491abd36aa4f9e3c9",
+        "tokenSignature": "dentist-did-go-hurt-man-the-time-to-tooth-what-y"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 353
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0354": {
+      "hashes": {
+        "setup": "ad838756bf000c663a4d6e15bba12310244600b7af3e28c73f29318194ff24e1",
+        "punchline": "31c7d1deb26b4e38f251b3b2b57f670ee3703ca980f0b59471ac5ba1f977eb62",
+        "combined": "2bf7232f205176fc97c03bfafdf4280dfdad2d4d10bfabcba5b3dabf232e5c53",
+        "tokenSignature": "a-and-baguette-bread-cage-captivity-i-in-it-saw-the-to-was-went-yesterday-zoo"
+      },
+      "lengths": {
+        "joke": 57,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 354
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0355": {
+      "hashes": {
+        "setup": "6b607e6a7f3b9edf4a9ee7c8fd9128a70c85673547da243040dea0f9bc517db7",
+        "punchline": "e5e556073a8b423ae280069cf7adfbab46d0f67732a7c94ef73d14790cca54d4",
+        "combined": "aa40ed6a5aec3f7bfdbec2d66daa76f33eb336dd7f4ca841bd42fe534305c559",
+        "tokenSignature": "about-brie-but-cheese-de-did-exploded-factory-france-hear-in-left-nothing-that-the-there-was-you"
+      },
+      "lengths": {
+        "joke": 62,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 355
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0356": {
+      "hashes": {
+        "setup": "9a43f091aa12d55578ec21a822cdca94068deef603165d1ed1f6de4e287e5a05",
+        "punchline": "3410cc104adb11b4d2bca808863e6f3284fe5ffb65b293a0bfb17581c2e83f2d",
+        "combined": "2c66df83503a45c3ed3973c57cface9cdb223032f40b216f6bb9dff053a8eb75",
+        "tokenSignature": "a-build-does-house-how-igloos-it-penguin-s-together"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 356
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0357": {
+      "hashes": {
+        "setup": "43a0e27f4b741443c23e28607cbcd08275759e6abceb04dc451271b74833091a",
+        "punchline": "3718b1ef5fa616eb70028ddfee2c591d9477e0d84d1dfcb848f5ba1a034a7d5f",
+        "combined": "b8e5993dbdf180737493f4060c88e99a66bd4766a656a1383ae933e258c328a6",
+        "tokenSignature": "2-about-hours-is-it-long-movie-this-what"
+      },
+      "lengths": {
+        "joke": 25,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 357
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0358": {
+      "hashes": {
+        "setup": "2c06015e8a9029afde27ee6a6d0601849d23fca4546f95bf89c3842476c95455",
+        "punchline": "907f7e88a45378db531a8dc3c65d29d61ebca195e12a5236ee00b817dd618b64",
+        "combined": "1f987e72c61b2cd9a4cd0024d409f9d5d5ddc5a511455a8ee0c51f56d885cd95",
+        "tokenSignature": "are-arrr-because-called-pirates-they-why"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 358
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0359": {
+      "hashes": {
+        "setup": "578fedabe37233bf54ded9e85a3098519ca1d97367ccbd24e17077722af3785b",
+        "punchline": "7216f9edb05791bf6bb44972374dc754d9d57d5429ec80cd5c354e002a90e2ec",
+        "combined": "153b59627d30b3dac7cd1a6c0bd06806dee9e03cadffed1ecabf81e014575e69",
+        "tokenSignature": "chick-does-eyyyyyyyy-fil-fonzie-for-go-like-lunch-to-where"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 359
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0360": {
+      "hashes": {
+        "setup": "2bc9d0a66c79b7cfac9530691217d4caf56c3e57b88ceb260e5a5193fa158f66",
+        "punchline": "adcdb91f93eec90a271b4147c3317f063649596fe123b00731197d9471d397ad",
+        "combined": "0aa9d382d4e6d9f38230cec0e2c176f5534f37e90c05ddddd758f5b3cb075bdd",
+        "tokenSignature": "a-does-dyslexic-how-inverse-poet-write"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 360
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0361": {
+      "hashes": {
+        "setup": "79b7f55cc3ed8cae0cab75b1f51e8d94bf0dc5352165c0f09512579bcfae4d5d",
+        "punchline": "860486a98a7c4ddde7775716827b214a1b427866335e650cb4e2067b5258270f",
+        "combined": "f1e9b012f74414e6d6775980f7fc61f30e5dca456007b469f351b9b48b354d9a",
+        "tokenSignature": "around-corn-don-ears-fields-in-many-secrets-t-tell-too"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 361
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0362": {
+      "hashes": {
+        "setup": "9bd65c286f02613fb18dd59f14d27a2078f82bd7884d0fb3b60e99391dd8f618",
+        "punchline": "6c674ea959ae1d2c4e4f450995a0288f3fe4cba3de23d7642e7eb56372938759",
+        "combined": "dc5292099fcca39cbe4b0a089780187de25cd84449f1a78c03f003b39102474f",
+        "tokenSignature": "80th-aye-birthday-did-his-matey-on-pirate-say-the-what"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 362
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0363": {
+      "hashes": {
+        "setup": "e5ae5e3f27363e473f13db09d58c17040409f9966dc8c3ef88cf37c1f9a216d2",
+        "punchline": "284e3eaa5883832285ec5a68599d36d54960561ed8e99c9d109a9c60ff2c1c4e",
+        "combined": "9c30ea6162971a83c070d1930cdc3f170dd498dd395c8acf324b031e8dd62033",
+        "tokenSignature": "a-an-and-as-bathroom-because-come-did-e-go-had-he-movement-out-the-to-vowel-why"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 363
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0364": {
+      "hashes": {
+        "setup": "3512045817ef24dddf78b6f076dc916068260fbcd256eb8f515111c2f6ff8d84",
+        "punchline": "cbd4545ada013de1be800e1de3ba96af446840f71a742618f0a462c4056b36c9",
+        "combined": "4b4d4cb11ea1190b3411fd499b9f6f25876e23a594db676ddcfc83f56da909b8",
+        "tokenSignature": "a-clown-door-for-held-i-it-jester-me-nice-open-thought-was-yesterday"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 364
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0365": {
+      "hashes": {
+        "setup": "dfbfd34b31eb1bfcc1a2dab9ed26f2914b3a33f8f9ab5a18ae24709e2d89481f",
+        "punchline": "34b5210c271d746d506d091aa13db4665f73eee76153dec7ca7adc1f003308b3",
+        "combined": "8c0d3d0f0e665bae6d416e7ffa55e01157e43a9a435f9d3e3eef51ca18301ff0",
+        "tokenSignature": "cs-did-go-high-hit-opera-sailing-singer-the-they-to-wanted-why"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 365
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0366": {
+      "hashes": {
+        "setup": "4ddacbe7c19b0386a32e4cc6f76ef6ea817811143517f20dc9fa39081da0c0d0",
+        "punchline": "4ad0847744e6418eb9c72da8b651d6956e7e6f9cae7aaa8ae8449c267b393cff",
+        "combined": "8a98e3c3b4e507316762aa27d313404b9f39d0548dd95768ec07a52460e464ee",
+        "tokenSignature": "a-and-blazer-bought-burst-day-flames-into-it-jacket-new-other-suit-the-was-well"
+      },
+      "lengths": {
+        "joke": 64,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 366
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0367": {
+      "hashes": {
+        "setup": "28ef0c5be6ba1ff204791e7c9759be0331ef586bf9f2c5619b88e6ff7dac546f",
+        "punchline": "20c7735ba4d7e3e6a1f4ae8b33b834b63e73a0a6a32f4f8ba63ca14fc25f2525",
+        "combined": "393d4a11f68cdc2c9b1acc62e526a8b0d32c21f42033bd0e03392758bcbf706e",
+        "tokenSignature": "a-arctica-aunt-favorite-penguins-relative-whats"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 367
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0368": {
+      "hashes": {
+        "setup": "0a0c8acc36a5e94525d790086978c360590ee19178b4a861a5f365e656d5f694",
+        "punchline": "9ee1912a63a3d20c6dc0c1317bcaacf4bb2d1a421169dc744a4e5390bf9fe23e",
+        "combined": "4c3299c85c4e14566efafd9ad7848c6b121eef34688a79cfea21a264ca42fe75",
+        "tokenSignature": "always-graph-never-paper-plotting-re-someone-something-they-trust-with"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 368
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0369": {
+      "hashes": {
+        "setup": "d15e0afd9838417096b2aca6bdd5f26309dc6cab8b8071c68ccfb7e3e0687e96",
+        "punchline": "1b073bb0aa65d49cda087905c10c33a4904d74afc1822ef082881215c6007508",
+        "combined": "6c3f9ebe266167955ce59a81377f1d0b52282fcea646d925c1430010c5a5faff",
+        "tokenSignature": "an-call-do-doesn-elephant-irrelephant-matter-t-that-what-you"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 369
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0370": {
+      "hashes": {
+        "setup": "3ae6a272b8a59c494de3334082eea1699bdbc755a2e8b530e92735a4e1571210",
+        "punchline": "4d9c34d8289d81438596e7cab09c9e9ac7d824149b577339f6048e3da0046582",
+        "combined": "6b058a6f40cba4c34c1df7e834aa0da45a210891d62d7ed93419067f44fed1cf",
+        "tokenSignature": "a-call-cat-cats-disorganized-do-group-of-tastrophe-what-you"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 370
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0371": {
+      "hashes": {
+        "setup": "3756bf69ca56182f034024bddc840be8a4c0cc8aeec915417e1cf71e08ee4a84",
+        "punchline": "b1f25f7896ac06a104d96d099c3061b2c420bfcaf2fb3e55649ed72ec1293be6",
+        "combined": "fe0fd76b79b364d3574ce645dc8a199c7bb9eb8405aecd88920677048e665f3f",
+        "tokenSignature": "bread-favorite-is-leaven-number-s-what"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 371
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0372": {
+      "hashes": {
+        "setup": "20fbcdf04e457b3caa1465e0ca5403ba5bd3f73d0e025cfa0bed4ead54522063",
+        "punchline": "6abf83e2fb84ad9acd5fa27f91a01dcc6fd16be76c25dbc435854c6956e0f15e",
+        "combined": "e8c3d44efa406ef0476cd1fea78734736fc6b00d94441b2b551c4899546806f3",
+        "tokenSignature": "a-bathroom-can-go-hear-is-p-pterodactyl-silent-t-the-to-why-you"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 372
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0373": {
+      "hashes": {
+        "setup": "d367f2c3d2cd915160092852e5a56518faf2b4f5953985276b07d5674e5d0fc7",
+        "punchline": "3daa5b10c1f4f4feb874b8841f82ee6d9e6e768be6976080b44001cc88afdd75",
+        "combined": "d1993f984b7ed7d6b7b1d30e1493f47e6fd5bb9fcf479337b4b447a91d318ef5",
+        "tokenSignature": "an-bed-ceiling-do-elephant-head-hits-how-if-know-s-the-there-under-you-your"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 373
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0374": {
+      "hashes": {
+        "setup": "75a53de32ac9b533003c8428a6c0cdc064091780e340dcd4e174b39242f13652",
+        "punchline": "70d1d8b8d9ee763e7d3a4cbfc5fee52260c554c09f4d4d30adfdc834e28fb863",
+        "combined": "f57e0d9f2a49fb9488d95d17e76dc1ea0de8c81392d3cf46e1adf4618bbda460",
+        "tokenSignature": "a-by-climb-do-guide-how-is-kid-stairs-step-teach-there-to-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 374
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0375": {
+      "hashes": {
+        "setup": "0161f5372afaaf67e902ac18666b1eb45f70effa6418036dc263e475f1d7baaa",
+        "punchline": "d865b73b0a6cf0c53ef318c4c73a001609ba79a3865c995663415bcb9a8381eb",
+        "combined": "a8a11d587dbc5d0668fff0727ecb0e83a81280b8f07cf352613604b4a6e3b5d9",
+        "tokenSignature": "baby-buy-clothes-do-go-malls-owlet-owls-the-their-to-where"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 375
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0376": {
+      "hashes": {
+        "setup": "3bddf5ff29e2f4fdc8587a67a54444291ab28aa37e53774eadc723f74e940f2d",
+        "punchline": "7c179c6d2a0e3f05fe14557d8406c3593229245f85092efb2d4e722b1dc93099",
+        "combined": "0c47bb6dfb1882dd56ce97f784b1a88283dc46df7e9f8d6d68f28637cf752ac5",
+        "tokenSignature": "back-barcodes-battleships-can-does-get-have-norway-on-port-scandinavian-so-their-they-to-when-why"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 53
+      },
+      "source": {
+        "sequence": 376
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0377": {
+      "hashes": {
+        "setup": "66c770559959fb065beb6c210a4812f0e104597ebfd0af29737dc929c397e8c7",
+        "punchline": "ce9c46047747884837fe8bf138c66e0556d09be8ec7b36276406d083217be169",
+        "combined": "ec5a2904f2567f22c8f518f41c8ea1b1d4193111f444aad200e66c2cd11d82a0",
+        "tokenSignature": "a-about-being-can-control-cross-eyed-part-pupils-s-t-teacher-the-their-they-what-worst"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 377
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0378": {
+      "hashes": {
+        "setup": "5f8f03e16ea028a38b9c60a2c98592abc210fa31555f84073d9e49688f920bc4",
+        "punchline": "6c491a6e2eff27eb2193e1773cc65e95896efb6c899d4152dad82986961f5850",
+        "combined": "1bdb76d34851bad04ff14ae8b1d5c307b47705d7434251edcad95933bf4204e1",
+        "tokenSignature": "a-an-call-do-excellent-fashionable-gnome-lawn-metro-of-rhythmn-sense-statue-what-with-you"
+      },
+      "lengths": {
+        "joke": 78,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 378
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0379": {
+      "hashes": {
+        "setup": "fe5fa503e9385b0498a73aef45a52a3d7195fef29c785ce67971b128866663bc",
+        "punchline": "9946c7ffb132efa192bed6b193c4acb2a78bc0536fad40a4cd2c9d6f808465a3",
+        "combined": "f8393a1003edf1d5378ca30ac3006b9e0459b1dcfc01279c45a1c82732f881c4",
+        "tokenSignature": "and-broke-can-go-house-how-into-last-limbo-low-my-night-someone-stole-trophy-you"
+      },
+      "lengths": {
+        "joke": 65,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 379
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0380": {
+      "hashes": {
+        "setup": "5e2a1b9bfabd568ddd7165af52f9e62cb35f07dfb3b14400b755fd50ec6e381e",
+        "punchline": "78b17c60f45acc38a9b1e47baae86b8132eb93321dfa4ce7fb53542761ab54ec",
+        "combined": "f00013dffeef9082369782ddb55f5306b2cb136a0e15475b21aefe72532c4347",
+        "tokenSignature": "a-coffee-did-file-got-it-mugged-police-report-the-why"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 380
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0381": {
+      "hashes": {
+        "setup": "2e4dcd91e545a258fe6ff3753b9fff483796aff1224ba503c8b709a6469ba2b4",
+        "punchline": "0097ad3a35492f8f5d70f69413736d009de2c430c4f1af6d821cdfa729afee36",
+        "combined": "06e122dc48a4bb3b64a9ffb75d3b4e349aedc924107789732b32b4a23794e6e3",
+        "tokenSignature": "are-areas-aren-funny-hill-just-mountains-t-they"
+      },
+      "lengths": {
+        "joke": 27,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 381
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0382": {
+      "hashes": {
+        "setup": "d7a1d5bc4302d0c923b007635d8cdcd0f78d8e5508e02628e34c2fc6333ce3bb",
+        "punchline": "917192b8cc0d9b71dd5af6bf0fa2193f5841059ebaf223940c7b39ed3f7ae669",
+        "combined": "735343d576ac27132814ae1fe21660c91761c57b1efd767896ac1c5b95a0aec6",
+        "tokenSignature": "balls-but-didn-going-have-how-i-juggle-learn-t-the-to-was"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 382
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0383": {
+      "hashes": {
+        "setup": "9f17b3406ea43642d11e0266bc27eddcc19bb0714a55ae252c63bd27a8ef5154",
+        "punchline": "498c16aa439bf8fd997b01cbd212e40aafc4bb0f269b049803009ad069004cf3",
+        "combined": "0cda3e5292bfea49a09610eb2a80d7ec7182097a144d550ee0f200b85c603731",
+        "tokenSignature": "a-in-its-jam-parents-sad-strawberry-the-was-were-why"
+      },
+      "lengths": {
+        "joke": 27,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 383
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0384": {
+      "hashes": {
+        "setup": "18b0a49f3a90130e6b2a2f5e277781472698a49c98cb36e41ea329854520e659",
+        "punchline": "5d129d63818eb757e67f3430b7f44b1ab0dcdbe3e81d034e7276b33e25ee0656",
+        "combined": "427a9d22f9d6820c3497b29c1b8945a5753f0081a14d91e63e57459e147d3cce",
+        "tokenSignature": "are-bad-because-can-ghosts-liars-right-see-them-through-why-you"
+      },
+      "lengths": {
+        "joke": 25,
+        "punchline": 39
+      },
+      "source": {
+        "sequence": 384
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0385": {
+      "hashes": {
+        "setup": "50ca9018692dbf1cd8d862dad2358a99728e71632fbfb37b2f032c57e19dc8b7",
+        "punchline": "426bfe90654fd8a9f1d92140bdfcc667416932db8c475a829c37d1a3de6de56e",
+        "combined": "d3a7a6b095bc9b598ef787c3d919964d550449db30ce1e4884db0f7e6f8f23b3",
+        "tokenSignature": "a-all-any-broke-cents-coin-doesn-down-every-explanation-factory-in-it-just-machine-make-of-sudden-t-the-without"
+      },
+      "lengths": {
+        "joke": 81,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 385
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0386": {
+      "hashes": {
+        "setup": "bdbaba28d7679e291fd2aa1ebf216ccbf52d80109dcb681db70456b983144209",
+        "punchline": "6d46c24577cbb7eabf7224151e3cf1eb9761febcf124d788ecf5430df7666884",
+        "combined": "c4787280f36e0e33fe766685fe517acfd7fee174c8b84b11577461c501f52ea3",
+        "tokenSignature": "1st-2nd-3rd-a-base-because-between-does-from-get-in-it-longer-s-shortstop-take-than-there-to-why"
+      },
+      "lengths": {
+        "joke": 94,
+        "punchline": 39
+      },
+      "source": {
+        "sequence": 386
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0387": {
+      "hashes": {
+        "setup": "1ce9571d762e4ace840472343962ddeae6192f4a5513a0fe553462e0e68b8021",
+        "punchline": "491752ff27c753d31cb9e794494004acae32e5aa3a410cc883537648dab89705",
+        "combined": "e126851b1991aaae6e4a107f1c227d4aace4e273fd119e1338fe1569717e336d",
+        "tokenSignature": "a-car-do-man-park-see-space-what-when-you-your"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 387
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0388": {
+      "hashes": {
+        "setup": "92296e401712fab623d94c6bd8b0147a899493f98b38291c90e319016a7eb0fe",
+        "punchline": "b1acf257807a67ba9a7f8dc2657bb73c711707eefbd984cab54eda3e1b42961b",
+        "combined": "97c3926bbe4f12e3fa2c7d420fd0a919b21efb242a042df8774e5d70531a00d1",
+        "tokenSignature": "a-advice-apply-best-can-daily-give-i-if-in-industry-is-job-moisturizer-the-to-want-you"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 45
+      },
+      "source": {
+        "sequence": 388
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0389": {
+      "hashes": {
+        "setup": "e7b616c19fb4c193906cc147a6f97eec9595cb85da263ace53e397ca56ce02f3",
+        "punchline": "7802bfc2cb1d73967160e3aea029715a79550ab40a8670bdb8d55077d33174f8",
+        "combined": "b8ad6ca8324e389bd62f525debf24106c3f8ca07afe335939a7271d628c51152",
+        "tokenSignature": "a-bladder-have-infection-trouble-urine-when-you"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 389
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0390": {
+      "hashes": {
+        "setup": "c27ea8423d603b7ac7b3d2800c596fc59b70bebd45236779118d59f00ce40741",
+        "punchline": "4a09dcab05b5b1993fbf9a31900c27877dd64f73bf3eb07bb9d93b12409ac37e",
+        "combined": "29a6cab9ed1cd774f0402d1e0ee0e439f7e7e926e4f40e45e8431ed9c8f4ceb8",
+        "tokenSignature": "cry-do-face-gaga-how-lady-make-poker-you"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 390
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0391": {
+      "hashes": {
+        "setup": "cf937d082d8ded41b654512953ca4277a8c31909683b1fedd3df0073f7b53073",
+        "punchline": "27994721d9c1d732d0c0630cf96598e01bc477eeb7e4abe90dacd087ba3a2885",
+        "combined": "dbdab50126e1b029676e24a4b6c5437b7a4c3b274fda536f1d23385794dd4b76",
+        "tokenSignature": "a-an-call-do-group-instruments-killer-of-orca-playing-stra-whales-what-you"
+      },
+      "lengths": {
+        "joke": 62,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 391
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0392": {
+      "hashes": {
+        "setup": "11bdd84a80d3877a039dffc870c20befb2cfbc25b4c4b41c2e5a8c7f9e0d1fe6",
+        "punchline": "96e82415dc3524d94cc40a6bedb5e854772dc5556dd76377dd6189474e1520dc",
+        "combined": "9dc2b877cf292f2b062a1fa3f9e09c5dd00bb66265a2655f11237ebd116d955d",
+        "tokenSignature": "80-an-band-better-called-cure-i-in-prevention-s-than-the-was-we-were"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 392
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0393": {
+      "hashes": {
+        "setup": "b7cd9aa43a5c863898d51d8b52508ad06275046efcf3a6c673e33ebb154163fb",
+        "punchline": "2fde91d6d8b3947962a13cd32b6813ec9fb7c110aec065e07e529d71daf42da1",
+        "combined": "99b015b71e7f152e1731a843ed7e867d85ba6d5f10a37c84d5438d48ca3ec084",
+        "tokenSignature": "billy-denim-did-his-jackson-jeans-michael-name-store-what"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 393
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0394": {
+      "hashes": {
+        "setup": "76301217ab4f64add06d5671f1b61bad8c50d0f94d637a0e110cf06b5b933a20",
+        "punchline": "891c429e52a1852c70d66ac50ea437582c626ecc470f744fcceb96ccbbee85b8",
+        "combined": "e223821acd936648ef032a2a06f79ad972f67aacbb687c7a88eba370a467247b",
+        "tokenSignature": "85-a-boo-by-friends-frightening-has-in-last-people-risen-s-saying-statistic-that-the-their-to-year"
+      },
+      "lengths": {
+        "joke": 19,
+        "punchline": 86
+      },
+      "source": {
+        "sequence": 394
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0395": {
+      "hashes": {
+        "setup": "73b00239a2fed2a9814e8c9e6d36fa57fc59f84cb143de4998664882af17c390",
+        "punchline": "2a875fae1c801273bdc7d10d5bc6dfea4c8526dd6795d3f295dca4784281fdf7",
+        "combined": "e12552a6a1c4aa976f3a918c93060ff9f248ac4b0cedbc8a583c4f4c7db3ef31",
+        "tokenSignature": "at-but-geography-geology-is-it-rocks-s-where"
+      },
+      "lengths": {
+        "joke": 13,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 395
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0396": {
+      "hashes": {
+        "setup": "5724659fffbc7cd5644b41850a2b41090c15e8ad694689a3e591a09caa8a70f8",
+        "punchline": "319d6cae975b2a3768fddfdf5642e8b4e77e2acb5108384fcf83bf727bb45fd2",
+        "combined": "a8a05990f61509f0317060be456175f0a0f34973adf67d21b5b2378888c75f23",
+        "tokenSignature": "chewy-does-gum-han-it-like-s-solo-why"
+      },
+      "lengths": {
+        "joke": 27,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 396
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0397": {
+      "hashes": {
+        "setup": "b069ae82d54113ae1e5496a47de45a7256c6038934e9f08b750230e5e9a3904d",
+        "punchline": "3538b5a235a62a10a24eb95197b9b2fa5e86aa93d5c815302b9eef95347b61f6",
+        "combined": "54a1ae440f9e2d202b7fc1cbd2ebc1ccfff5a3f3d17a12a3b98b94d3b7e3e2ee",
+        "tokenSignature": "and-any-are-asked-at-behind-books-have-i-if-librarian-library-on-paranoia-replied-right-the-they-was-yes-you"
+      },
+      "lengths": {
+        "joke": 96,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 397
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0398": {
+      "hashes": {
+        "setup": "182e37981b26452425b42c670ef4a58a6b5966e3cb18d6afb5504fbd3e4764d0",
+        "punchline": "a3fd12399fc59f7d7299362c1932b413027dbc950f4ba16e23e16bea57fbaf9f",
+        "combined": "10b9e9f02cf883e3abed0cd35756a1d804cad070bb23caa640716d6af8492053",
+        "tokenSignature": "1023mb-a-band-gig-got-have-haven-heard-of-t-the-they-yet-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 398
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0399": {
+      "hashes": {
+        "setup": "561470fd6338d187b38efec816563686d02961af23191609be718258665b1eed",
+        "punchline": "cd4c32f90773b17ff10b3c49afba9415b59f1fc5ba6ecd42e980d973a24284d5",
+        "combined": "2d5674ab690eeb955b328c997dbfc437d58c189bc978face17f68f8a7475f1d4",
+        "tokenSignature": "a-anger-brain-give-happens-mind-of-piece-surgeon-they-what-when-will-you-your"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 399
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0400": {
+      "hashes": {
+        "setup": "620e2c5259c44e8f505af996ff1b5a01b6dd032cdb2384463ed73d430c2262d1",
+        "punchline": "6611751bfda0b4f00d019b4d0431e905809a4de4668c778eaeacf864f4f1c155",
+        "combined": "19ede057c653214e5b795920b22ff3d3a9774e28957f8a07428487fc0ac977b7",
+        "tokenSignature": "a-agency-anywhere-at-be-but-didn-feel-going-got-i-job-know-like-ll-now-places-so-stationery-store-t-to-travel-used-was-work"
+      },
+      "lengths": {
+        "joke": 119,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 400
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0401": {
+      "hashes": {
+        "setup": "d88e4959920dcc2ff31fdabe3849f6062ccb3117b73f57eb6757b32293140f68",
+        "punchline": "2a140df47f2348f407297b3fa79d13d58178f00162f29e529f375a77961acd4e",
+        "combined": "af5f7c7ae45cc4419b563f20a44763b34106ec3ad7a10dc4382f1d176b0dfb18",
+        "tokenSignature": "a-destroying-i-in-it-recycling-shoe-shop-sole-to-used-was-work"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 401
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0402": {
+      "hashes": {
+        "setup": "e1e4e198c69bb08d583d517f3801431f5a735f068d51d47ca3d66d36f0a642b6",
+        "punchline": "64aa964b105866bc0b76e3ca769e8c04740981155742b386b13a966f41ccac6c",
+        "combined": "c58f5c012f1c725da705ed36a5188b0703dad6284d2b187cc484e48c868fc2b2",
+        "tokenSignature": "but-facial-grew-hair-hate-i-it-me-on-then-to-used"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 402
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0403": {
+      "hashes": {
+        "setup": "785b62b87dd9d17aa558275876ee36981656ff85c407120c9104d4182dc8f14a",
+        "punchline": "653228470b9d1d25ae03a7e6a57acc61fc8c905e70c75cefe7141bd5a4f58a0d",
+        "combined": "a8873eb2211bd76b7e8b7068608e48895f118a072b285fe30025a4fc48fe5faf",
+        "tokenSignature": "be-boiled-i-mist-p-r-water-will-you"
+      },
+      "lengths": {
+        "joke": 20,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 403
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0404": {
+      "hashes": {
+        "setup": "6050c13fb6c72ac2319b91ea9db5a5f523a3019d28fe0a01277072eaeb5501d0",
+        "punchline": "1285a52eec2f85a662bd99ee0c516ad70941dd40358acd4be5c41897f3def41f",
+        "combined": "fa7d00c8332aa7a8eb8420f50e6dd841d0141855e2a4138f1dbfd5a31959e8c5",
+        "tokenSignature": "a-baby-did-la-other-pasta-q-say-spaghetti-the-to-vista-what"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 404
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0405": {
+      "hashes": {
+        "setup": "bb9a5645d206c22d169059a56056e89400697410f2beb38c08d16f22c1e2fbbf",
+        "punchline": "d25eaf515366b302a404fb215595edbfa9a6f93715fe4ad8340dc2c3fd9be104",
+        "combined": "4d1b294b3d71adfa7044ac2cdb1af0c2c61d7d53c14a26381bdbd518c82c865e",
+        "tokenSignature": "a-changes-control-everything-first-got-i-myself-remote-the-this-thought-time-to-universal"
+      },
+      "lengths": {
+        "joke": 67,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 405
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0406": {
+      "hashes": {
+        "setup": "0d095bf82f188b95bf249da7714488ca25f35418a0cbe3bf3a5647774d5a13c0",
+        "punchline": "799be36ed01efa8c0b3707b30b3aa8da5e221d7dcb0bddd99fe3dbeeaa6ecf4e",
+        "combined": "6e7c51bff840b7a79436808abdb726953c8bedfef2f5a4b3e4bc25768581a83d",
+        "tokenSignature": "always-back-because-blue-is-never-ocean-shore-the-waves-why"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 406
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0407": {
+      "hashes": {
+        "setup": "ac2ea14fd7d28e0d0c87df1ae1284e4917054b44d3948deb7fe5dce923797803",
+        "punchline": "2aee5eab36ffb1bbbdcc704670a32b17e5665ae9cfaea54465b7988407490a74",
+        "combined": "39f4e9f67dfdddbaf12747e204040c2b78429466edba0494ec3ec8e49a3b32e6",
+        "tokenSignature": "be-because-detector-did-fail-feline-he-lie-lion-test-the-why"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 407
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0408": {
+      "hashes": {
+        "setup": "170d73a4c7465140acd8f61b8548185cf383eae5a12b736a2cefcc29d70955c6",
+        "punchline": "01f302346f3dc594cc4d2f499f55f1a6a63e182efa878a29decbb8d5894c67a4",
+        "combined": "5ababaf8db0bbed07f44561d0aed5e35f63a3e4de951153d9956fd28e1baf012",
+        "tokenSignature": "cash-cold-did-freezer-hard-he-his-in-man-money-put-the-wanted-why"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 408
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0409": {
+      "hashes": {
+        "setup": "96029c53a09abf8b75d099a9c99d0417b1568160d15425b5e742d34e459bcde2",
+        "punchline": "fe902d99b6d422f27e4685416e0bbe30e698df3fd648ccc7f2143c24b5c2d312",
+        "combined": "ad16ff92a0f62fc88009a79839480a0c36352ec125a0066ebafc1495646b9d35",
+        "tokenSignature": "always-case-detectives-do-ducks-great-make-quack-the-they-why"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 409
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0410": {
+      "hashes": {
+        "setup": "845860241c528507c0f211ef177fd224086154549e923ae8eef9831897148368",
+        "punchline": "8823c2d80c96d2253468debe570287327d0caafe3d9ec756d7176f56b2a1485f",
+        "combined": "eb1d16c7128ebccf7d033dc4dc1e7f2369bfb46bd20a46c526ebcf89cf7a5bb9",
+        "tokenSignature": "a-back-clock-do-does-four-goes-hungry-it-s-seconds-what-when"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 410
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0411": {
+      "hashes": {
+        "setup": "a9187ae705a0b1074c7d0edb1af30a5728da8c9e95c2c5ae69188096df485247",
+        "punchline": "6248a4b27cd1f8baa0a4082486085f54c54857070e267a8bf65b640ef80986f5",
+        "combined": "9ccdcf5b582a20803a853d00d04c521d9e16515c6222ac6005f9c28e22451075",
+        "tokenSignature": "a-do-i-joke-like-look-machine-what"
+      },
+      "lengths": {
+        "joke": 20,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 411
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0412": {
+      "hashes": {
+        "setup": "e834b85edf615d77308769afb04d9921a07e10001f59878589f969c3cf3a18c3",
+        "punchline": "79d2f3bf40b9f197098d4bc8cc8fa7fcafe2b2ad63681005f09c038f164bca9d",
+        "combined": "24609b5c09c170fea0b9face259f6b77975938c47a2986e631110428479c5891",
+        "tokenSignature": "a-all-bought-but-day-dealer-don-drug-from-he-i-know-laced-once-shoes-t-them-tripping-was-what-with"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 65
+      },
+      "source": {
+        "sequence": 412
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0413": {
+      "hashes": {
+        "setup": "aa6aa4dc32bd9ceb9bd2257434260e5607239c12afd4273787d3ceed9a87d0b7",
+        "punchline": "f47d91b3260de3407ef8ae4e7132f47f33583eb43f649d829ada57b25809bc77",
+        "combined": "473b3b5a9ad7f4fe1469ef96652d73c2ca71da3f23e1917c6543fd5ec688f1a4",
+        "tokenSignature": "a-favorite-game-is-play-s-to-tornado-twister-what"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 413
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0414": {
+      "hashes": {
+        "setup": "489e17fa9a6072f796aefc0c8dd485130d4c2bb7025cdfa2bbc9cb534fd00de1",
+        "punchline": "156f3ddc74e2ea7d7bd7ecd5e4acdb88909f6be65a3d057359c7025be4fca270",
+        "combined": "6fb36d903eea0fce38a888b59782651b87743808b246332df92d48a89e96ea1e",
+        "tokenSignature": "are-cemetery-dying-get-in-know-people-road-that-the-there-to-up-you"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 414
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0415": {
+      "hashes": {
+        "setup": "3eb3d606bbebebd21ed4b3a52eba298d541deb85dc9b2cdf635e50791edb9d9c",
+        "punchline": "82895700b31779327c586889b5dccf8b69ebf6d4d545903de3494f454c1c6fb7",
+        "combined": "f12d465a61e5e577006f1f4cdef5cf00388de6a2cbf265cb4d6b31d605836fee",
+        "tokenSignature": "00-2-3-50-and-are-bahamas-caribbean-in-is-jamaica-of-pie-rates-the-these"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 41
+      },
+      "source": {
+        "sequence": 415
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0416": {
+      "hashes": {
+        "setup": "b5362fe6b09c1930f6febc9a51ff3eb2964cebb3099e442e41555a58a88abd9a",
+        "punchline": "007802bca8d490f65c93f227bb6b38d4907f5c05e75a02344191b579fb2c43b2",
+        "combined": "f7ad504ecde9962ca6483eccfcb7e6180a0d95a07e71e66820dc8781e4fd7e05",
+        "tokenSignature": "a-bowtie-call-do-fish-sofishticated-wearing-what-you"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 416
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0417": {
+      "hashes": {
+        "setup": "9f0388a54d3644743f64632ba0a9d310c873bc81a73b983786a64387797d6c3f",
+        "punchline": "d8c0b05e0b835195fc219f707f7ec184b6cfe518b055cab6d0c968b956428b72",
+        "combined": "4c2dc89d0ac80d3e14f950e1cc9a7b43941aeb79d21baf74644bd2873baea854",
+        "tokenSignature": "about-did-had-he-hear-killer-loco-mexican-motives-the-train-you"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 417
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0418": {
+      "hashes": {
+        "setup": "f90546c74b6637bca789cedd33bf3c53f8dd689d62cce2bfefabe965e4202e52",
+        "punchline": "28e0c2a68c6c6a1f8c561a4726db0df2b9493022d3b129fb64ee1fcd92f88a07",
+        "combined": "a63ebd76253b30b4e5c6bff9c09e32e41632ae002d0d3697078bf544650038ba",
+        "tokenSignature": "but-can-dad-don-i-it-on-t-the-turn-tv-watch-yes"
+      },
+      "lengths": {
+        "joke": 19,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 418
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0419": {
+      "hashes": {
+        "setup": "f1b4638b7ea21700237a063bdba424e9d76e61d200477ceaeebe801005880d30",
+        "punchline": "32ca62b76e00ebc1c7ff8628c79ca4eab8e58c884160498527b600d228c5e691",
+        "combined": "8c2998d6b4545a683db31d2f8b6a3cd531fed119829c5740526d089171342349",
+        "tokenSignature": "a-apple-finding-half-in-is-then-what-worm-worse-your"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 419
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0420": {
+      "hashes": {
+        "setup": "d9dd01b3212af1f4e587d92a36b8074393e556fa5843ad27551d34e6ca477013",
+        "punchline": "309892b85a4be8eee2ae6b997991bafb35cc446353028d810a8b99dee56c095d",
+        "combined": "407e7551e004b69823a9d80310a847457a2eefd25c7d6e780510eeae7c9899f1",
+        "tokenSignature": "do-eat-grrrrrainnnnnssss-vegetarian-what-zombies"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 420
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0421": {
+      "hashes": {
+        "setup": "0944baafa2e28c8bf82b1b0b62c44c05a6b06d9d1df8d461958042b89cfba871",
+        "punchline": "b028736dae2206f9bbf39beedbe238c2fc5ca751343780daf38064cc8c3cf664",
+        "combined": "5e482f5921a1bc706996c5d7f1b0246f14c5455c8ae861981280a1dfc9f57685",
+        "tokenSignature": "dad-hi-i-m-sorry"
+      },
+      "lengths": {
+        "joke": 22,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 421
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0422": {
+      "hashes": {
+        "setup": "1a57ebfb02a3664927190631099e7c5359f7a02eeb79e11db31bdd5c732ef0b0",
+        "punchline": "12294077fcc4d729d64f95eb5a11d6d720a098df47e68deb20537b7e7751c700",
+        "combined": "5b2dface3a1f1616213f41a181f5a6e556b0d4e3fc244afd2e7bbb11c6093854",
+        "tokenSignature": "about-diving-ground-hardest-is-part-sky-the-what"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 422
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0423": {
+      "hashes": {
+        "setup": "b85a7d50893c4b2f2f8843a43dfe070cc9f384ab40fc86591a3116793eb5a440",
+        "punchline": "36c29e3f66d086386fc0fa45bea7813e521f86da95a936dbb126b6b7a391eb9d",
+        "combined": "25f7b43029b73568dba5f3add696ae3a3954b89746371145c8f4a461700a649e",
+        "tokenSignature": "a-cowboy-did-dog-doggy-get-have-him-little-long-somebody-the-to-told-weiner-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 45
+      },
+      "source": {
+        "sequence": 423
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0424": {
+      "hashes": {
+        "setup": "03e069d655039ca7ca59d17e82c73537be12afaa867efa52c3ac79fd60428105",
+        "punchline": "483ccc83540b59e7a09b966ad3bbd0ec3d9a80e8c8b0c8ece20d1e0844547c0e",
+        "combined": "02d6824e61ed8e012d5d155991e3689738349d9cee3bc21127ce6c8f3167f78f",
+        "tokenSignature": "a-aren-cheer-deep-filled-friend-ground-he-hole-i-in-keeps-know-me-means-my-stuck-t-telling-the-up-water-well-with-you"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 88
+      },
+      "source": {
+        "sequence": 424
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0425": {
+      "hashes": {
+        "setup": "184800c3db66c23b27b84c4005ad5dba59982799e904399f98843f20966eab0c",
+        "punchline": "b46522fb22ec184567b7c2b233778d445c5c3a8d827da0dcb0189d33c453c0ca",
+        "combined": "dfe3c89d33859a4f6ce5540d6f22bb8ebde084712e78f13c0c06601622eac94d",
+        "tokenSignature": "did-friend-ghoul-his-marry-the-who-wizard"
+      },
+      "lengths": {
+        "joke": 25,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 425
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0426": {
+      "hashes": {
+        "setup": "119832802e1a582bbaeb7291bd8fbdc750e893c6e5cffca2baefa2cdba6697f0",
+        "punchline": "812de6e718f869feb16b45c6bbcfdb1269fe6f6fffdc2420166482e3cd0aa647",
+        "combined": "6555f45cce2aafbc069e222105254bbbe8ec9c8b6f9a7e0eb5acb6959c626584",
+        "tokenSignature": "12-2nd-a-april-are-etc-february-how-in-january-many-march-seconds-year"
+      },
+      "lengths": {
+        "joke": 87,
+        "punchline": 3
+      },
+      "source": {
+        "sequence": 426
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0427": {
+      "hashes": {
+        "setup": "1054e55b1f87ffbc9bda81865b2dea40d32be3656b86dec11b1c2a313757473e",
+        "punchline": "0d3d9b217e5cd511925e9b1a2627d61519762586d1b9bfdfa70a09a9779015a3",
+        "combined": "02c3eae5764b1abde98bec9a9c376ab429a2338c2d293cbaa0e1757b8b246ae6",
+        "tokenSignature": "a-amazon-an-and-chicken-egg-from-i-know-let-ll-ordered-you"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 427
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0428": {
+      "hashes": {
+        "setup": "ba28988d88511a1a6ca7beebc89c13a8e048ae864a382b93a06b72cc00863db0",
+        "punchline": "ff8d9f73f6feee7079610926ca1ea8b6454b2efa59ba6ba582c6c8616f1bf365",
+        "combined": "1d09940788d83b70518b2864aca81e97b8f076896861d94ac85b64d021d7b329",
+        "tokenSignature": "because-bees-don-ever-hum-it-know-s-t-the-they-why-wondered-words"
+      },
+      "lengths": {
+        "joke": 27,
+        "punchline": 39
+      },
+      "source": {
+        "sequence": 428
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0429": {
+      "hashes": {
+        "setup": "289806e5ae02b7c9a8effcbf86dd59a82c784db1eb33eefe333b8fc817ff7614",
+        "punchline": "af07a32cc8d452ed428d6a91722783ff39329b2f7d718298d9b78228efd6deb4",
+        "combined": "23d3ced270dd95e36ab7a185c271bf923f37fd4f5ead944c55d6437dc95103ad",
+        "tokenSignature": "1-2-a-bulb-change-does-how-it-light-many-optometrists-or-take-to"
+      },
+      "lengths": {
+        "joke": 66,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 429
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0430": {
+      "hashes": {
+        "setup": "19800c87016f78fb9c07c7b6a65743afc42483effe3f96841b352b1c71bb10e4",
+        "punchline": "7c20757c2a345e94d4aec0820ed71dda117b359134bdf17e83d247e99fea320d",
+        "combined": "2bb9af5bb8ea2e6b0080f87cd58e94e4b2f986d5d5a18bbec92914fef80a3029",
+        "tokenSignature": "any-as-for-garbagemen-go-just-not-pick-really-s-there-they-things-training-up"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 430
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0431": {
+      "hashes": {
+        "setup": "36221eac7ad5078beee01e2da8b679bb9b2b1f4707e68dfeac016e3c268b6605",
+        "punchline": "be12dcca014f6e6ed0755b2133e953e9f47d40d01bab392cae0b53da8035daf6",
+        "combined": "889a17e5481e57ae535b96e9f70e386ff8491d0ab048d8b80f46c09d827bc564",
+        "tokenSignature": "about-barbed-cow-destruction-did-fence-hear-it-jumped-over-the-udder-was-who-wire-you"
+      },
+      "lengths": {
+        "joke": 65,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 431
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0432": {
+      "hashes": {
+        "setup": "0e5169c0106450973e8bdf49871df4fd10ccead3bd4bc545a85bcf278238c0a9",
+        "punchline": "0f545c8799de48a26387ea3a22038428d33bc8a8a0a136ee411f580557cad287",
+        "combined": "b05ebea1bc248fe29949704901fc2765c935f09986be1c0add467a0a9f27eba8",
+        "tokenSignature": "as-came-colorblind-diagnosed-i-it-of-out-purple-shocked-the-was-when"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 432
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0433": {
+      "hashes": {
+        "setup": "cd3c32ada43566d719da071cea210ecc80349a4a3e663cae16a7ce289f48bbf3",
+        "punchline": "9c4aaa763f971bf84d452196d6a20d533a2a3482e262e6c49841f7d2040fbbd2",
+        "combined": "87c0dfbd319df66592703923cff39b057c422ff96c9e3ba59f6fd61a5b781c69",
+        "tokenSignature": "after-astronauts-at-does-hangout-spacebar-the-where-work"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 433
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0434": {
+      "hashes": {
+        "setup": "b855b976a31d4bb0feadf378c592219115ab8d860f9c0686d189b4d17b25200d",
+        "punchline": "ac06c78a7c3d7f80293ee69515f3626bbc401c42f011b00dc34ecdcbf9e89bb6",
+        "combined": "e337b6348fa27406b6ed420d97e05a6ccede68a5d5ce70f71b2560544787b335",
+        "tokenSignature": "a-bear-call-do-gummy-no-teeth-what-with-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 434
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0435": {
+      "hashes": {
+        "setup": "3efe71aec8609ee6d4d56726e84dba0a0883fa48fab697bb5947dc9fc0855940",
+        "punchline": "736fa04c4d913102dbd67ac28a6e3182dfa22717a1081376d99fbbcf1455703c",
+        "combined": "d076975e4fec6b35a27cf19e12c38fb7c215af1dc0288c01005a05492699c573",
+        "tokenSignature": "all-deleted-free-from-germans-hans-i-it-know-mobile-my-now-numbers-of-phone-s-the-ve"
+      },
+      "lengths": {
+        "joke": 78,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 435
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0436": {
+      "hashes": {
+        "setup": "2adc2a16a50a26b664dd6c463a0d48a4b6d7593ae02ca1c5ac6bd384edf9fe10",
+        "punchline": "14704a1b40eae89fa221669fb6bed6b17809a67634bd72ce79489c31b446de0f",
+        "combined": "308840d0c6e22f39e52964da501ebe89bdc9da8510c6c148cd8a961f77468b54",
+        "tokenSignature": "a-call-do-friend-hole-in-phil-stands-what-who-you-your"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 5
+      },
+      "source": {
+        "sequence": 436
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0437": {
+      "hashes": {
+        "setup": "acd0a0d42ea707b1e688f74978aa192d09b043fda599367f937282220f93da6e",
+        "punchline": "81d603d1071c62772f6a5e7ae2a54ed3f03d4ed2d9480e709674a4d9596bf56c",
+        "combined": "8da516ba7d170213d491a4c28a41e08119c3de58599a95aa811235a3f8d526fe",
+        "tokenSignature": "a-dead-doll-found-in-instance-it-known-nack-nick-of-only-paddy-recently-rice-s-the-wack-was"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 55
+      },
+      "source": {
+        "sequence": 437
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0438": {
+      "hashes": {
+        "setup": "ef63b3f42dc6fa3f3edb4cf4f2e5d72aa7cc2e0b905e499e419bbff1dc16e371",
+        "punchline": "4cb4a01bbd68621f78d8893499ed894106c8ce8a934a52a23f0fd98c2bc37ef0",
+        "combined": "e8dfda69523e1146cf07a8d82d3e4b373e2e9afd57719ddec4db5903f08f403f",
+        "tokenSignature": "a-alligator-an-and-between-crocodile-difference-do-how-in-later-one-see-tell-the-while-will-you"
+      },
+      "lengths": {
+        "joke": 68,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 438
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0439": {
+      "hashes": {
+        "setup": "8f35de355bbe5fc03dfda33f9277e3f634e82a83eaed94e7ad0bd9b017514415",
+        "punchline": "e847e79d655bbd2a4361c5e21772362537724ab100f7710389517831ff3f4ed3",
+        "combined": "24f2d3fedc0653c56e131861afebc7ed1004946b09243a42844f64467bf2ac46",
+        "tokenSignature": "a-an-call-do-fake-impasta-noodle-what-you"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 439
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0440": {
+      "hashes": {
+        "setup": "95032c3536404624384734f674788bb734875c1f37119bfc93980a786dba9856",
+        "punchline": "a4ff76c328c9485382b50a72f0ac65668b14ef48515fcec510f59db64e728537",
+        "combined": "c562087f44019fe1c068efae23e56065e197ae5d958b248fb7b8595cb1ec6056",
+        "tokenSignature": "a-bunch-in-ironic-is-it-just-letters-line-of-q-queue-s-silent-the-waiting-with-word"
+      },
+      "lengths": {
+        "joke": 25,
+        "punchline": 59
+      },
+      "source": {
+        "sequence": 440
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0441": {
+      "hashes": {
+        "setup": "81c5d9979845a6459a61fa30351877d98cf6237911e9c4bf5f04bf9d150e7457",
+        "punchline": "3416623c1d0d8ec2332f159cc2a6223e4411b0e03fd9ec57e51108576bc19984",
+        "combined": "35edc26ed77d5a44266e6e4b3f0f4a2897cba5b1bee4782f121c6f5f52ce0964",
+        "tokenSignature": "a-around-call-detour-do-droid-long-r2-takes-that-the-way-what-you"
+      },
+      "lengths": {
+        "joke": 56,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 441
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0442": {
+      "hashes": {
+        "setup": "1eef96fb8f720e5a785ea7f48d394a0480012d1988ca2461a8974f8fb7a9434c",
+        "punchline": "0520ef9afef2c407b958894ee8af52994059e4676d36b431b03b88630093f526",
+        "combined": "e6a186f6bb0a46d81cae620c6e28ed8575065b658f7ffc547593ef40ef299893",
+        "tokenSignature": "about-best-elevator-jokes-levels-many-on-s-so-the-they-thing-what-work"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 442
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0443": {
+      "hashes": {
+        "setup": "957799ec1e3befd7f8c2e802debf01739a968e56f9f9ac484ca759c8cfb42c85",
+        "punchline": "191a02e2c7da034a0bdbe2afcd036c90b2446405e99f924814beaa9d35c00f1b",
+        "combined": "ac287978e5834874977b7f245525ca68f6dae8848f8ef8a77ea2ecb5f9ab2219",
+        "tokenSignature": "a-after-bunny-do-get-go-married-moon-on-rabbits-they-where"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 443
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0444": {
+      "hashes": {
+        "setup": "afef18212620d4b541ec0e3c4b914941e9e64d6479fb99fd16e297451b9b9583",
+        "punchline": "280bdb99e0c3f4c1d0a2ebc8bc249860146cb55d0c2831c60b5bd5a05fbc4fd1",
+        "combined": "c49143169a892e7c7eac53137c56da02eb096fe58d7361bc429596d237f39525",
+        "tokenSignature": "because-bells-cows-do-don-horns-t-their-wear-why-work"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 444
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0445": {
+      "hashes": {
+        "setup": "ae642da422ba07d682dd78945ac42e0312516e7ce53b09ffd48ef60407bc2c11",
+        "punchline": "4c758ca3de85734e3a87105c21a2c6bf257a5fa249cf88dd742314db2e29737a",
+        "combined": "7f2cbca3088dc96d18dd27f5a6048f8db5fd6bd2060d8f58bcc9291e2bd83fde",
+        "tokenSignature": "a-and-are-do-drive-fish-how-in-one-other-says-tank-the-thing-this-to-turns-two-you"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 445
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0446": {
+      "hashes": {
+        "setup": "b3d98aa6d6bd25ac449cfd8372a5e52b53a83e6e82df37f9bed2f1b6396b4b41",
+        "punchline": "856ea618d8ed15c11506ccd18cd4bc6189814c9e7ea43b8f800f460f1be84812",
+        "combined": "181c55865b8143c6939fbdec9d8cb16dc37b449e16ad15325c35bdb822ac656a",
+        "tokenSignature": "all-always-am-angry-blank-bought-describe-edition-finally-have-how-i-it-limited-no-opened-pages-that-the-thesaurus-to-ve-wanted-were-when-words"
+      },
+      "lengths": {
+        "joke": 71,
+        "punchline": 87
+      },
+      "source": {
+        "sequence": 446
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0447": {
+      "hashes": {
+        "setup": "96ea2a9e1f90371df4a90dce11ad26b4868b69db2734e5a5b6451ed3639db0e3",
+        "punchline": "0c71f76d01d86d551764f0dd917662ec6c56e8e9dfc9c8db564465d456643ac2",
+        "combined": "5cbcfe66a7f964e164729b781ca6666a11a730a516422899bfa7fd164cebb92c",
+        "tokenSignature": "i-is-knew-ladder-my-never-real-step-this"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 447
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0448": {
+      "hashes": {
+        "setup": "466f758465ec8b05fcebd6fedbc3f392c8dc244c1afe50bde73d52c7dcd59d4a",
+        "punchline": "b47d037ebc44ff463655a691145fae9cfb67097e05eb1833d2d3fa62766fe937",
+        "combined": "24020cc8b392e17fc1f71cee8c966418abe5af540ae46dfb2f17858ee4243537",
+        "tokenSignature": "a-and-bar-barman-chips-do-flavor-helicopter-into-man-mate-only-orders-plain-replies-sorry-the-walks-we"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 48
+      },
+      "source": {
+        "sequence": 448
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0449": {
+      "hashes": {
+        "setup": "070ccfe3430de12479f5ab5598a2e6375cdb927cf0ca0eb1391c10f6a6fc5266",
+        "punchline": "a91c594bbd307b4581f704892bb1ffd793083f79ca9887e5b07b5016e5c0e561",
+        "combined": "76f949d879f3d74f47b1001111368ccf1468fa676914f75ee989efb2d07986ed",
+        "tokenSignature": "been-book-bought-hasn-how-i-it-months-online-people-s-scam-since-still-t-the-to-turned-up"
+      },
+      "lengths": {
+        "joke": 69,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 449
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0450": {
+      "hashes": {
+        "setup": "160cef2dc51ab65043f1b37719c8deb581b9225a342840a2fa73e4f4463c10d0",
+        "punchline": "0ac8552173612bea3613e8a82892cbf7113f246dc377f293e40d6f09fdc3e3d5",
+        "combined": "361595c8cd76fa1ba06272822e03d2067286187c38dacb1b8051649fa7e05241",
+        "tokenSignature": "a-bad-cause-clover-four-idea-iron-is-it-leaf-luck-press-shouldn-t-to-why-you-your"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 450
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0451": {
+      "hashes": {
+        "setup": "29001f8e43a2996f721024862d0fbfcc3f8a77280cdfa0aa171f967f60776412",
+        "punchline": "45f12899761e907b0599b5199a93c067d5f02e2bbf96baacb059acdb53d50c6d",
+        "combined": "1b7d70ddd0fce3901bfebfb866bdd70a9c13cc7be2a6b63a4956c5dc6a9cdcf9",
+        "tokenSignature": "a-damn-did-fish-into-it-say-swam-the-wall-what-when"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 5
+      },
+      "source": {
+        "sequence": 451
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0452": {
+      "hashes": {
+        "setup": "06e3c62f030a3dfeee3458a69d2b76009a0cc8a9d9b215386687a3a39668385d",
+        "punchline": "192f322a43d52f4a1f8cfd8496bb3c5404d4913a5718b6e8e7c2b2d2a652019a",
+        "combined": "98ad3ed84bb0cecdee253319b03543094386ce8d6b010e7499ce1e78f2171a6c",
+        "tokenSignature": "a-accidentally-be-bottle-drank-hospital-i-in-ink-invisible-m-now-of-seen-to-waiting"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 452
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0453": {
+      "hashes": {
+        "setup": "60dbae45a169956fec8084906ae9617042c5aa4786a16c598b97bc63d776bdd2",
+        "punchline": "14dd0ea1711d6c312f6455e5bb4511af518ac982b05caebf70c38762f3497c19",
+        "combined": "5a7d39429a17797bcd1925abf9b134d564f22a69af6fe4fb8ae79b4d53d420cb",
+        "tokenSignature": "be-because-does-doesn-he-only-spotted-stripes-t-to-waldo-want-wear-why"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 453
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0454": {
+      "hashes": {
+        "setup": "ef1bd639bfeae828cef0a81faa9a8a6d8524cfc797151872f24bba0d1a449141",
+        "punchline": "92d2df276cd01f0b1756bc815b080af185dc5d44d4c7abcd1904f0c695aa742a",
+        "combined": "7e300076adcbcf3e43d68ad7ee6dccb32f5d274ca59680137a0e70ab4559dd5d",
+        "tokenSignature": "an-award-because-did-field-he-his-in-outstanding-scarecrow-the-was-why-win"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 454
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0455": {
+      "hashes": {
+        "setup": "0335be744f39461e984cc75f790a245f505d5854d1a629215794309003a8bbf9",
+        "punchline": "f47512f95467dfe6d59ca95cdd9d73f1753bd57ecc41618e5fde46d443a9dc90",
+        "combined": "1f860f838aad340e947f21bff59f518a7f0cc74db658d4e483dd358de2d9e276",
+        "tokenSignature": "americans-can-cause-confusion-from-kilograms-mass-overnight-pounds-switch-t-that-to-would"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 455
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0456": {
+      "hashes": {
+        "setup": "d569f468b50aed8b5e82a45faa8505fb1cec0e63c34b37673c018a0f41892100",
+        "punchline": "5d5b30efd6240215bf130a3651a235cb3fc10b3f8c04dbb98647d21c85671349",
+        "combined": "5df32a73b2342cdedaa3e6d3c4af2511cb21d58d0d7e7d084f3427286a26e31e",
+        "tokenSignature": "a-an-apple-away-bullies-day-enough-hard-if-it-keeps-the-throw-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 456
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0457": {
+      "hashes": {
+        "setup": "83b9cbc87e5af6b6f8f668afa62a63536905475ec7233469be674f06c9c843f7",
+        "punchline": "92b89219b1cc8b72d14dbab3f9a434a1577c54b1a118f72630b98123a83e734c",
+        "combined": "6066f3b3f49b0f7f2567d67289e9a45ce200808c372131e1d52c6be3519feb3c",
+        "tokenSignature": "a-because-dinners-does-get-he-invited-is-superman-supperhero-to-why"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 457
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0458": {
+      "hashes": {
+        "setup": "d68534932e819190ba431c9b626cc6a6da173a95f264e7f8bb6d330c30b18b7e",
+        "punchline": "790d28cc412dbea8a82eac168f45f94ac29d6cd86ac4f2a48ca25d4fa074f19e",
+        "combined": "4ac102b8f43ae1a3fc957793e95d4504948fcf4eb056476cef562f2522725fed",
+        "tokenSignature": "a-because-dracula-friends-he-in-is-neck-no-one-pain-s-the-why-with"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 458
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0459": {
+      "hashes": {
+        "setup": "dab8c9bfbce7a28c0f1ab3527b54219e4037fb7c41a3693ed36377cf0530a6db",
+        "punchline": "ccc14afb84739a73f50daed76ea7509010b60d7f9884cf5feb1bffc97804e32f",
+        "combined": "c7699c2f06c147b681c4785ef1cdd49f23acd8b59b9f1ab9720471862f02d1d8",
+        "tokenSignature": "a-alright-because-but-can-coke-drink-got-he-head-hit-in-it-man-of-soft-the-was-with"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 459
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0460": {
+      "hashes": {
+        "setup": "0a549bdef0587460918377e3a876c912eb24326bc93b919e49bdc828f256b056",
+        "punchline": "a6bd2c949a2293ade6c7b8bb28ea51a6309151f8430406669ee1a49fedbac76f",
+        "combined": "fb1ec9b6ba7d3c4de9ac9357f7d05e8a5776e0c42ddfa5b684e8777291e809b6",
+        "tokenSignature": "cause-dry-is-leading-of-skin-the-towels-what"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 460
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0461": {
+      "hashes": {
+        "setup": "ea0a23bf1dab649d283cbe162ccd717505140c50f1512b14e0793458349966d7",
+        "punchline": "f7e21ba5f0e41ac87f1723154f74d85b20725ce9174b841a249bb12f5c7bf8d9",
+        "combined": "135848d946a23cabb880600cba59bd2c8c162f71f987caf26de405c5aeac08a5",
+        "tokenSignature": "a-and-arm-asphalt-bar-beers-for-he-his-in-man-me-on-one-please-road-said-some-the-to-two-walked-with"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 60
+      },
+      "source": {
+        "sequence": 461
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0462": {
+      "hashes": {
+        "setup": "e6dbee0813463ef1966154c1291b6483c5dd628ec6b8f369180ab4ab0de2b387",
+        "punchline": "e3a4f643a14264aa40d3622f713afe57e2c563f90afa5b21483aa788394630c3",
+        "combined": "b0e65aedb79f9bdcd47bd4bcca1f17c65b5f9514727be93e2a63905c3e70452d",
+        "tokenSignature": "actually-cooked-did-first-france-french-fries-greece-in-know-t-the-they-were-weren-you"
+      },
+      "lengths": {
+        "joke": 70,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 462
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0463": {
+      "hashes": {
+        "setup": "aa2a9b7dcbd1c5b60e3dc9cc7a841328a0b1ddc69835e43cdd739bc95e31338e",
+        "punchline": "c8a10f643e8f88abecc57c2bbb727edd8bb057f37398c3f4985ca402e0637d73",
+        "combined": "66cf55e21deb14b1e4257683b1bdc5a4ac7cd71236166351c8eddf29f2e5f5ef",
+        "tokenSignature": "about-german-i-ll-re-sausages-something-tell-the-they-wurst-you"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 463
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0464": {
+      "hashes": {
+        "setup": "f5fce87a7b2d7359a13e3f120132a1a11e0078803d10c40eab34a35fab32d2f0",
+        "punchline": "cd33b425a76dab4314ee144ada4d53000c97eb76f315368845d575d861d4b8ae",
+        "combined": "0944165444b44f56036d5b5b7dcc028e10aa3c952955bad75119c5e3e9261aa0",
+        "tokenSignature": "a-captain-did-from-get-hand-his-hook-second-store-where"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 464
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0465": {
+      "hashes": {
+        "setup": "16e71b4f91b12483fbe4bb5b6c62263505b178aad59c7a55a14ec6813eb1db88",
+        "punchline": "e044264e0b72ed7fcb001254832b6e83ce0ba6e8c55b203415758d4ca27fccf3",
+        "combined": "2310c095e156e69b169457634ab0b377f07ae09dbb1660a461b686f6fc21f5d7",
+        "tokenSignature": "a-apparently-fired-florist-from-got-i-leaves-many-too-took"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 465
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0466": {
+      "hashes": {
+        "setup": "a81933d22b9bf7e91fca771a3c1f5fb576de102de7a261cbcdaf05cf1e27f9a0",
+        "punchline": "a47838b4d0caf300c0f3a59beca2d0ed527587d5759b40c6296bf14b2fb4cc52",
+        "combined": "031c8c59d802f57a1c315215cad451883ba70e40c3c3156fe6bad837a332fcba",
+        "tokenSignature": "a-ended-had-in-race-silk-they-tie-two-up-worms"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 466
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0467": {
+      "hashes": {
+        "setup": "9041724041d04ab31dbef0e552dd67564b3007d7b2eb8a6d683a99816f2b22f8",
+        "punchline": "9758dffe681af172aa03df2025aaeb1ec18268ea0b8208a87eaacc33a38f0ca8",
+        "combined": "61d098e83240360cc604061af126ccc4adef739cf43881b61dd8a9b774a7cc7f",
+        "tokenSignature": "didn-enough-factor-fired-from-got-i-on-out-put-shifts-t-the-transmission-turns"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 467
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0468": {
+      "hashes": {
+        "setup": "c41eda1837f871ab5dff64317c13c6c4bf016d5418ebb0b24f9459a65dcfe439",
+        "punchline": "2ac811ea363be1a67778fbde48531678391ce9e2abf261716b4d3a29e457db4c",
+        "combined": "c0745ff91b10a572c29a03043717c2fed1a765d3a747f294e89ac1283431a469",
+        "tokenSignature": "ateria-calf-cows-do-eat-in-lunch-the-where-young"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 468
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0469": {
+      "hashes": {
+        "setup": "1d3387a25924010f21f5cc4f26293972eba9c3c4cd07e5f1f457dda9af896345",
+        "punchline": "df88fc2734c70d01f2b4e3c33b40e83420033b492a6bd6aadfdc0c54f52056cd",
+        "combined": "90d33812d2bc59c694073aebf39055a2241388954bf42d450a9bdb43e51fcae9",
+        "tokenSignature": "a-bone-does-french-hello-how-jour-say-skeleton"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 469
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0470": {
+      "hashes": {
+        "setup": "2ee82fbdebf246aa74a78a83ae32cc1943daa1f1c31b97d807b2e5b072d07f94",
+        "punchline": "4ca2c45f54059bdd57971198ac1283d02903ed8a2034b22cd727693962429962",
+        "combined": "265b226810ac12dbf3d2e43fe43bbeeeaf3c9964e3dd7cd8ee57fa835c134dc2",
+        "tokenSignature": "a-because-big-cat-cheetah-disqualified-from-it-race-the-was-why"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 470
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0471": {
+      "hashes": {
+        "setup": "01191832cb2390367b027cd0388a0c39d3079c54e460ab9aa75f8cbed15ff367",
+        "punchline": "c77c58ece2609816f720c7eb342f8cd7f21232abad86a474daf74a0facc0f0b3",
+        "combined": "3fe75c2e9edad2d16ac4c328834a24c8626569d222bb04080cd1d5c5e532cf3e",
+        "tokenSignature": "call-cell-do-each-other-phones-prisoners-to-use-what"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 471
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0472": {
+      "hashes": {
+        "setup": "a94ab7772dc685e7e8dcd03e39cffc6c32e1d4b9a040dda916cc4e555080e248",
+        "punchline": "54f14098731803b03236d1a5c69c813b5846a4ad64a7a9885de98b2d506447b5",
+        "combined": "a8b6d60399657f8734e1e755bac837bdef531c2ac9ad0aace4f0885532145f73",
+        "tokenSignature": "e-for-got-he-legs-little-only-s-short-t-what"
+      },
+      "lengths": {
+        "joke": 22,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 472
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0473": {
+      "hashes": {
+        "setup": "1fa5c9af42f46a7026008b5b952cb2acd9a07f7cf2dbd8a62fa91cd0ed5a8e4e",
+        "punchline": "fcb407a65455c0f4fe785ba90d9865204cb1dbbfaed5a3c0e4cbcc40c54173be",
+        "combined": "8272bb6686b6516e98bf3708eb0c6c55f9395c04cc9f15e13d5fe7bc786b7937",
+        "tokenSignature": "a-award-dentist-did-kind-little-of-plaque-receive-the-what"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 473
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0474": {
+      "hashes": {
+        "setup": "908b3ffa45de5357b63ed48db2a4d350a69415dec302215415829046c02aab60",
+        "punchline": "8408b8b90c03372910e78bbf16c79a3dbf291d376eacc5a4d13964d1131f5da9",
+        "combined": "9895beda0813ab56f37265d9811f82b35f6d85a888312d9f329dc234b0b091d4",
+        "tokenSignature": "a-at-but-entirely-first-got-grown-i-it-living-made-me-new-of-on-plants-recently-s-suit-sure-t-wasn"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 44
+      },
+      "source": {
+        "sequence": 474
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0475": {
+      "hashes": {
+        "setup": "73e3a05ff76d352b98953aaca08ec9197b5ae5291672d84824c6ea7aba548fec",
+        "punchline": "eea24595ef765753454036b167850785aff2f3c07d2a298389b7677a55a06511",
+        "combined": "859622e18f680590c92f86011c891b37ee23289a695c0701a3d1497745487e6b",
+        "tokenSignature": "broth-bulk-can-chicken-do-get-in-know-market-stock-the-where-you"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 475
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0476": {
+      "hashes": {
+        "setup": "bd677aa761363f261222c533e84526e00c1d98bcdf40e322571ee0568dad7228",
+        "punchline": "7ec076db0419f8864896cbe8adf976a760d00b0f92c7257ed721b96bef0ce7e1",
+        "combined": "97f1c429876f45e6d339eec63a14b38816b2d9609ab0e3526c16cddf10503734",
+        "tokenSignature": "a-and-carrot-like-orange-parrot-s-sounds-what"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 476
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0477": {
+      "hashes": {
+        "setup": "0889e5254c11c1e5aaa6e67f0e4df1ebb213f7d2929f84edaa91492ca814da45",
+        "punchline": "ed0b015bb4a267d43be2ef7883909a369af0d00a1e32a677da87a0b198538d1d",
+        "combined": "aa11514163ab3c84c5cbdddc002741303236e5a4d246c54e2c8e71d4b3d1536f",
+        "tokenSignature": "a-bar-bartender-don-food-here-into-sandwich-says-serve-sorry-t-the-walks-we"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 477
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0478": {
+      "hashes": {
+        "setup": "16df90dd7d0bc1ed8dc8bf9b5876284d112c2594409e168bee16c93050d00dfc",
+        "punchline": "ca59c762dea1773b2b1bc37f2d0e60d571709814c85a819847e58cfb1df54a04",
+        "combined": "746091ffcea608a47b61e91ea0c1bff41b4f64a23e809229c1976afba16354bf",
+        "tokenSignature": "apple-arms-do-from-get-hanging-sore-trees-what-you"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 478
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0479": {
+      "hashes": {
+        "setup": "757efe1890a66c51564d01399e32e20722f2ec890cfb84e7a2d08c7823c8b973",
+        "punchline": "38cbfc16aaf483bc484c846a0e4843d635597ba63e28a797674e522f6aa893b0",
+        "combined": "59f3c74e1cc51698af68e8a0abc23dba4338f8618de75e32fe74ab2140552f4a",
+        "tokenSignature": "about-all-almond-an-but-diet-going-i-just-nuts-on-s-that-thought"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 479
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0480": {
+      "hashes": {
+        "setup": "16f35ba0f08a7222f7d6d1fd51cee7d6a432b824305d2adbe06d908f056da94e",
+        "punchline": "a8f4fe7a3b3e514adb94fbf390275f1a6edb14f172cab55598fa1b297ae6f0b2",
+        "combined": "c7e216293c3acf05ba76f60fd7887126e5c1455885fed7cdce815b362e82b3e6",
+        "tokenSignature": "because-doing-don-enjoy-for-i-it-just-kicks-m-play-soccer-sport-t-the"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 480
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0481": {
+      "hashes": {
+        "setup": "8b9dfe28c62f07a75350d6484873f5705bbf90fd2ca4058d5ec4ff308e2058ae",
+        "punchline": "638f749784d3cb3c1da2c60bc1efba37d80ecf32c70ae11d4ac7f94a829b7d25",
+        "combined": "8c23173fb5e3a3745b05c4f581865dc67c58abdf227b62a5038d4a8f494b25e7",
+        "tokenSignature": "a-but-club-from-girl-herbivore-i-m-me-met-never-recognized-said-she-sure-today-ve-vegetarian"
+      },
+      "lengths": {
+        "joke": 56,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 481
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0482": {
+      "hashes": {
+        "setup": "aa67dacad0b5be87d9167ed8f5e091e2cd4317a252ad0e1e1543db588984d5e4",
+        "punchline": "9fb9552bde96dd428d7e0b2ab7619cb1f73e8bda7e863b48088215e76e6d04bf",
+        "combined": "b004a8e71cb1777e0c070a7f082744bde75143e3a566f9a25f259694d9423180",
+        "tokenSignature": "a-do-how-organize-party-planet-space-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 482
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0483": {
+      "hashes": {
+        "setup": "fb06cd9cd299b27a496c02ba7fed0a94f05fac811594abc9a6ddda9b57d46afa",
+        "punchline": "2a98e4453d9e0a3bca80fd8e074a71fba2795371b1f088e64eed1f90786a6c9f",
+        "combined": "2d9508264be56a0754f1c1ea6af60a58824a0a0ea23df869baeb2ae354f14d34",
+        "tokenSignature": "boil-do-hell-holy-how-it-make-of-out-the-water-you"
+      },
+      "lengths": {
+        "joke": 27,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 483
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0484": {
+      "hashes": {
+        "setup": "869d204adea40ef5ef5235a30b9e0dac34894e74f0efadcec4b7ae9e10c4393c",
+        "punchline": "da5acef59495a7c5912907615c76f87980df2cee81ec4dbc9d08fb36a9d5fa49",
+        "combined": "f1fae2a3421e96f1cb73832c93f65e2671f9c8f230c9de2712838ad74917aa44",
+        "tokenSignature": "a-asks-can-car-dad-his-is-just-man-son-sponge-t-the-use-washing-with-you"
+      },
+      "lengths": {
+        "joke": 57,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 484
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0485": {
+      "hashes": {
+        "setup": "30b58b30795cf322d0cf00e0be87307a532afbbb325fa7a70283fa969db404ae",
+        "punchline": "f270146f8f25c54cd14eef40fb1bcbb67e1c763974238e43e012ff7cc8ff5dca",
+        "combined": "07d90d90ea442667f1382aaee0dfffb85c418dc82fc69fca324c37b4180df864",
+        "tokenSignature": "an-angry-do-does-face-gets-it-jalape-o-pepper-what"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 485
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0486": {
+      "hashes": {
+        "setup": "316dbd323ca699f6caf53bec0f592252186d7891b04d4edc1db4bbeb2e0daed0",
+        "punchline": "67aa53a41ca91ef53f040fb2f4f8c848e89f95a8e5484401297fc255c9577f9a",
+        "combined": "97309d468d416cb4b80b7474db9160efd5b62f18db7cfb92f689049ca1577c84",
+        "tokenSignature": "a-at-because-buy-can-don-florist-flowers-friars-monastery-only-prevent-t-you"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 44
+      },
+      "source": {
+        "sequence": 486
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0487": {
+      "hashes": {
+        "setup": "6dd9da8cc903e714cc15e43b5f42eaaf6e64ea5606eae7e4c0e364ff448ad6ec",
+        "punchline": "5fd6408db383b776b993dca6d9f353de066e6b4ae626c7f83e904242d7d240ff",
+        "combined": "ff1fec4894539f600ffe0d54dce97b9ebfd7114f7b19841621ca4a232aca8ce2",
+        "tokenSignature": "a-dad-do-down-have-hostess-of-preference-sit-where-you"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 487
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0488": {
+      "hashes": {
+        "setup": "871690555f1c0fffb5c682eef722d8507537deb6f081103c81c2b4cc5ca3eb16",
+        "punchline": "5c76f9b2d3aa3fecdae3719eaf5daeaa96d875ac4c66458bb9b9f4ebe1c6fc06",
+        "combined": "385f8382529d846182efc69d2419c535a033bd1bc648c3eb14793e9a3ef276e0",
+        "tokenSignature": "a-about-did-dive-hear-industry-it-really-submarine-the-took-you"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 488
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0489": {
+      "hashes": {
+        "setup": "b28f8dcaf2914bf28871a9918916497a1c28edc2b7fdf3ed2fd145a0518ec8fa",
+        "punchline": "5ac8121863b7deefa943d09dfc366efd6ba611c67c97a33756f961cea0a9cb48",
+        "combined": "4296d4aaefd1832a4fa8e65fb554d2585ea4c03296ab2d2cf0a0c27ba793e92f",
+        "tokenSignature": "acquired-arthur-at-biggest-cumference-eating-from-he-his-king-knight-much-pi-round-s-sir-size-table-the-too-was"
+      },
+      "lengths": {
+        "joke": 67,
+        "punchline": 45
+      },
+      "source": {
+        "sequence": 489
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0490": {
+      "hashes": {
+        "setup": "9dc8076c6880725c8c39d3949ebdf702d9e8e07c861a6b98d8f293bf5bc4ae68",
+        "punchline": "b074af2c79ec72bafa9549c9164fe74d6cfd824d86c9f1f8457706997540f990",
+        "combined": "3099a7d3fae22a713dfaf77a6f5a3bd92a4da24bcb0747f6ee1e7a5af7ace83e",
+        "tokenSignature": "a-alien-baby-do-get-how-rocket-sleep-to-you"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 490
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0491": {
+      "hashes": {
+        "setup": "a45ee3b9a150d5ab8f70e3cadfe08dbfe8fab744a2a2826b97063507c73e706f",
+        "punchline": "9d1e3e9111b7751de081807f8d4f996fa572184d31067c69f38d1903d6e10e43",
+        "combined": "4e2a00945eedeedb47868d5f1909e87594e419f1e7a4e806a302b69241d1a978",
+        "tokenSignature": "alphabet-always-at-c-do-get-know-not-pirates-stuck-the-they-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 491
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0492": {
+      "hashes": {
+        "setup": "c3c1fa0142ab75326ec5ef1be5b46867656fa8afa27013924b655bf51cf58ada",
+        "punchline": "eae6340b1f7e1b6b3325aa619fb23cc940c510b57e148ef75094e44a827982f2",
+        "combined": "86601fb408bb157f9405d0c9f6ac3c91609617920734493dff22ec4069c994be",
+        "tokenSignature": "a-all-and-basket-carrying-clothes-fall-full-husband-i-ironed-it-laundry-my-of-saw-trip-unfold-watched-while"
+      },
+      "lengths": {
+        "joke": 86,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 492
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0493": {
+      "hashes": {
+        "setup": "7fad12fa9446a6b837f430db872234c985007d8ad8222cbed669112b735f83be",
+        "punchline": "5f604e634f7b3863a3d26cf0ea43093a025a2c3560e0ea9fc80071cc34c53ade",
+        "combined": "86692a3cd60a967cb7692b4397f2de2c013aaff84b567849633231e363c3bfdd",
+        "tokenSignature": "a-about-chameleon-change-color-couldn-did-dysfunction-had-hear-reptile-t-the-they-who-you"
+      },
+      "lengths": {
+        "joke": 59,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 493
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0494": {
+      "hashes": {
+        "setup": "694b1698231b0d084e844b78582a7d31775466415748851c1c764dbe9434aab3",
+        "punchline": "8376ff78b381210e7ebd203218efebd4bf1b337a1848dfc3004dcdb5a99ee55b",
+        "combined": "b611a8ef9398a3b52ee03028ee5a97f7110e20c658f9dc6c734e65d09b2d684f",
+        "tokenSignature": "did-doctor-go-having-house-it-panes-the-to-was-why-window"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 494
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0495": {
+      "hashes": {
+        "setup": "51f9f434669c07c0a86e71537e0e24f2ff5292e36ab4831a3affd607ecd6fd0c",
+        "punchline": "fa653ac5d81ffa8286f08039a84f38deb68034137078d3a3edb18b1ab2f069b3",
+        "combined": "77ab069643ef6dc968c7c83052efabb412daeefe77536fea23401b2a1373ff66",
+        "tokenSignature": "a-and-call-cranberries-eminem-for-from-has-hiking-i-it-made-mix-music-my-peanuts-playlist-the-trail"
+      },
+      "lengths": {
+        "joke": 85,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 495
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0496": {
+      "hashes": {
+        "setup": "b11bcc15f90f98f870a6e80eaebd22538596e68528a29fdb7ad2973e47ee9cbc",
+        "punchline": "2fcbcbbd8525fc3ba30cc105409c03f4136855d678a0b3fc1a91833bd33113f9",
+        "combined": "3d9cd71b2a594e4dc13ba24cdf4183fb2d009fc4498ea715a9f7cc5e02f2ebde",
+        "tokenSignature": "a-call-definition-dictionary-do-drugs-high-on-what-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 496
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0497": {
+      "hashes": {
+        "setup": "ed0216ca597865afdc73996a39faffe74e5babc603e58b589f8b5c7d8b63f773",
+        "punchline": "4cf94d41a46ae81a0775b3c02d879dde911254d46ad4b9f2bb1363033ae36eb2",
+        "combined": "728e77e69b825d7bcea900652ae772badd22d116cacb10d314e83b9ea9ceacb4",
+        "tokenSignature": "chips-computer-do-eat-guacamole-how-robots-with"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 497
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0498": {
+      "hashes": {
+        "setup": "e5674826a599603999e2c44a80b54bc6f64a91eceeea8c09086810c645efbed3",
+        "punchline": "4ec4cb897b9f9966afbec31005ce7e103d299262e1d5f06b323f98ca2c1943b2",
+        "combined": "c84d057efa1ba7285f22d3c0a83e8679eae64f2caf080b1035da8b3b8a15ab91",
+        "tokenSignature": "11-a-and-asked-book-brian-burst-can-doesn-have-he-i-into-is-know-mark-my-name-old-son-still-t-tears-today-years"
+      },
+      "lengths": {
+        "joke": 69,
+        "punchline": 56
+      },
+      "source": {
+        "sequence": 498
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0499": {
+      "hashes": {
+        "setup": "7bee802239cd0123b0abc4bbd9b46b35a18fbecf63a1b0e6976120c071544ae9",
+        "punchline": "04d379d89c091316956cddb0d60771b24046e07b4b79ff92f2d92dee2ef9aaad",
+        "combined": "0b697ab9aad0979f5e7b8291c193eed672d173f74c526b46438cf5ed0739027d",
+        "tokenSignature": "a-apparent-become-becomes-dad-does-it-joke-when"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 499
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0500": {
+      "hashes": {
+        "setup": "e9c4bd22e4b5c44a945a85ffdaf200c331f9dd4a9c3ec0c42826de1d813f4be9",
+        "punchline": "35ec126d05987b397b014b49935162a7089ca271205ca1346c60420379aeda4c",
+        "combined": "07639fa5ae48da038a5552f2180e610b41209686f5853657b50bc786af3ccb12",
+        "tokenSignature": "a-and-bell-brown-dung-like-s-sounds-what"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 5
+      },
+      "source": {
+        "sequence": 500
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0501": {
+      "hashes": {
+        "setup": "edc094619c6f9353bab9f9ad2d4a80a8c877262802887824f650f0b07f561b62",
+        "punchline": "030ec1574e445a68fb1f315db40dbabb31aa2384ccccb572b46fe97d013b41d4",
+        "combined": "cb95af962440dd2acbb99b758fa29e08b43b0e4e8d2aa60121adceaf5296f0a5",
+        "tokenSignature": "a-bed-can-has-in-river-sleep-t-that-what-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 501
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0502": {
+      "hashes": {
+        "setup": "1bc2137cd3c3831f3236f9490cf421ef100dba4460aaab9e231c3e1db90164d8",
+        "punchline": "f68b11fe7347a81f8ac2a7c89116bc58c3b174648a23fd16306b0a36ff6a466a",
+        "combined": "84b43c729c6323a773f48cf0d15ec0a0b491e9e67da6661fe943b9aae51bfbbd",
+        "tokenSignature": "because-charity-crabs-do-give-never-re-shellfish-they-to-why"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 502
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0503": {
+      "hashes": {
+        "setup": "56364ed59330ff812a547727c86c21791806ec7c2c3d36de93935fcb2135606f",
+        "punchline": "13a214592bcc1edae6d1eb9961e5ae4a6fe396a7e5f652292888fa53a0de8df4",
+        "combined": "95d4fd82c365323e07993cc715262f30ad2a25f5730502e722dc2a3f6f54f72e",
+        "tokenSignature": "a-call-do-eyes-pig-piiig-three-what-with-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 5
+      },
+      "source": {
+        "sequence": 503
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0504": {
+      "hashes": {
+        "setup": "9256f40b83e3f5163d9c6b895e41ad835a4c4dc819a62c3cddf4269891272378",
+        "punchline": "938db88e3d4008081d640e136eee97518a3329ba5c2e65174a1432469bd01b44",
+        "combined": "a3e93735f7d5b3ac6dced9de2935b3d694499626d8b71f77962e4b50c84e7352",
+        "tokenSignature": "a-boogie-dance-do-hankie-how-in-it-little-make-put-you"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 504
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0505": {
+      "hashes": {
+        "setup": "700928a46d0a582abaef1403e73df28c5370e85e9cbbfae9775514bc9d21f5bd",
+        "punchline": "5bf0a1fcf384618333732fee4b2c0cf0a832bba4391055c5497ac9b4f6d1f731",
+        "combined": "3fcfeba0508a5699ba526f6eec2af4604e4d473c1882f38685d726317f5d8911",
+        "tokenSignature": "are-commissar-pretty-re-repulsive-revolting-sgt-the-troops-well-you-yourself"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 50
+      },
+      "source": {
+        "sequence": 505
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0506": {
+      "hashes": {
+        "setup": "d01446dab1e6ae2abdc21e376c0e244587e7b660f7446bb9780c92d73fdec31e",
+        "punchline": "9ccc771587f929acf90291cf50da051bf7524bac20e458e3349588b947348d58",
+        "combined": "d357250b8ddaa901f5116c22e1a2a5e3e95c85bcbdb82c09baefebad1399e1e3",
+        "tokenSignature": "a-about-been-day-ever-head-i-in-it-listening-my-other-s-since-song-stuck-superglue-the-to-was"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 506
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0507": {
+      "hashes": {
+        "setup": "7d13458337804eb7d3495e868129f639b3654fd319360009da626030712d1ab6",
+        "punchline": "5122e1006cd6ea0756424de0df54e7752e9abebd6997f0e88195d316a6a38d22",
+        "combined": "22ef87d4143775bf2e98807a45afd70023bab1c459366bb4942322ca791a80e6",
+        "tokenSignature": "because-cantaloupe-don-get-married-t-they-watermelons-what"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 507
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0508": {
+      "hashes": {
+        "setup": "a31b03a1f74b422067c8a01c3f89e2119e613b0e1792be4b530d6896d4c1899c",
+        "punchline": "7b56a2def93d0341490cd8ee244cc36ef576c0518b14532f6b13b6952a08cce8",
+        "combined": "d941b8bd18a8e1d1e21c00facc7b96bff59ea4ac897cfb89dd6b63b2221fd0d8",
+        "tokenSignature": "a-and-christmas-face-for-fridge-get-if-it-light-of-open-re-someone-struggling-their-them-they-think-to-up-watch-what-when-you"
+      },
+      "lengths": {
+        "joke": 67,
+        "punchline": 66
+      },
+      "source": {
+        "sequence": 508
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0509": {
+      "hashes": {
+        "setup": "dffe0ff1ccf8debf101ca93cd45f175c9348f63b984856e5cb783ef58bf6e0c5",
+        "punchline": "d3ae99342f0d496fda833c3ec41938fdc0853ed7ac573d30653d6ff340e2fc36",
+        "combined": "cef4094b624833d5ae69a828dd68c36a92a8e8dbe7392ede05994442f7052cad",
+        "tokenSignature": "about-cheese-dairy-did-hear-it-legend-saved-the-was-who-world-you"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 509
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0510": {
+      "hashes": {
+        "setup": "2cc775e86f9c68301c2b112bab88df649ba596fdcf1f68b633edb72058fb189c",
+        "punchline": "563ea4cae93307b1c7bd80f564a94f24340948a02b037059eb86a880b0707636",
+        "combined": "6646f26f8f234a51f477ac868be4dc1a3d98704474a34c7b46f3d11b3b204a35",
+        "tokenSignature": "by-call-cheese-do-itself-provolone-what-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 510
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0511": {
+      "hashes": {
+        "setup": "cd254dc4035bb8d96905c7847cec7d55878f27125c965561c6fed1ab3882f0b7",
+        "punchline": "5c2eff416c66fcdeebdcf3bf6d19986af4475a1a6f124bc753c40c68adccafd8",
+        "combined": "188f053043f364dc68fc82a112df79e746053fe8985d1bf4953643e4c62d171a",
+        "tokenSignature": "a-broken-do-fix-how-paste-pizza-tomato-with-you"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 511
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0512": {
+      "hashes": {
+        "setup": "09c52f378c7dfb29feaa295e763917e61e2e9c0395d262128ef8e2da9f5678ab",
+        "punchline": "584d4058bbb4779bbd4b11bcc13472e0df06463cbe3985f7d128d0110384bec1",
+        "combined": "509b2e85bcaafd2e1f297410483110f2c66a672a818ab52d558236b8c4c93639",
+        "tokenSignature": "a-and-bad-brick-for-red-s-teeth-what-your"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 512
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0513": {
+      "hashes": {
+        "setup": "fbf7fa626c41495bfcec234171691004c4039b6df9d7cb9c61f5289a9bbf8a48",
+        "punchline": "f724b066e36542852befa21f942cae2b428ae06e7cdec38bd9042b82d23cbedd",
+        "combined": "167a8cc72d330f2f0be9ffefa37f92e55a72a19cc28db4e38ac76b097a580c7a",
+        "tokenSignature": "a-called-everything-have-heard-i-moderation-new-store-there-they-was"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 513
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0514": {
+      "hashes": {
+        "setup": "8e3014e12f3df49f65ed63c397500765bbbd59816911d8980718543bb1579fe7",
+        "punchline": "c51c696f910f68225ab0d1b2bae7b81993b2d9945f76d0e9b2fdacce71b588f1",
+        "combined": "41074ad208708d027ce6ec01b2adca3ffd5166dc8bd7836571e13ed6092aad39",
+        "tokenSignature": "a-after-at-beekeeper-charged-confessed-embeezlement-he-him-indicted-of-stealing-they-to-was-with-work-years"
+      },
+      "lengths": {
+        "joke": 73,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 514
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0515": {
+      "hashes": {
+        "setup": "6d4d331352a28ab578f76816ab8b2ab9b9c875fd66bd99f8aa2a0571dadcbbb2",
+        "punchline": "5ac8527131813001d1ad179caab576159f81c90e34e69616f86613328504d8bd",
+        "combined": "31c14551d59c6fa028bbefac9b6fa5720c1f41442a51e3a3a0dfaacf11d69e0d",
+        "tokenSignature": "a-can-crusher-drink-for-i-it-pressing-soda-soft-to-used-was-work"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 515
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0516": {
+      "hashes": {
+        "setup": "3adc46e8fc02533d5bbe3f6fb123aa9e2c3c4d3306fbcd9806cc68cd6c84cc4b",
+        "punchline": "01a039f03b6fa8c0cfa4665ea35ddd85f7be710b0613a820642c49666a3c678c",
+        "combined": "c04d75aeb763c763c4e07e0bd3dc129ac2414d5f5e04702984cbc9a66add569b",
+        "tokenSignature": "a-chicken-did-for-fowl-get-penalty-play-the-why"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 516
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0517": {
+      "hashes": {
+        "setup": "926f95cf508d21f152dc338965ad978f1ef5afe40fc5021834b0cc4eddeab9e6",
+        "punchline": "c5a4da9388a45a2992a9e8ed71abe6021a6982517336ee6365123d3cc649e02f",
+        "combined": "a2437d2db3fc6e4e2cd960a70b7a0cad52c139fd389b8eae0c9b51095c6d8526",
+        "tokenSignature": "carpet-cat-don-feline-i-it-just-my-on-s-sick-t-the-think-was-well"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 517
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0518": {
+      "hashes": {
+        "setup": "35395786e4929a3f312a72623706463909d6a396b1b99e4e183fcb1aa575ec75",
+        "punchline": "4fcbe2607c450a2ac7f94d37d19057379ec6493fef21bb9f0abbe693095da831",
+        "combined": "8c1730a38439c9f8449327ff58f0e1be411fdc2e77c9b4eadfdf42f557cba589",
+        "tokenSignature": "burglar-did-framed-hang-he-his-mugshot-on-prove-that-the-to-wall-was-why"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 518
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0519": {
+      "hashes": {
+        "setup": "cce0ecd1707518d6cc173158dcc054246a0a13eb86f93ca2ff8547cd23bb778c",
+        "punchline": "e5c49ef09b3b2bae2fcd33984dfeaa8c10240c92603e225e3c41177bf23b51ac",
+        "combined": "a809a7bc5a0aeccfc792380d1740c9bb64bb36a477cbfffe2b518a2e3ef85a76",
+        "tokenSignature": "a-about-an-dreamed-drowning-fanta-i-in-it-just-last-made-me-night-ocean-of-orange-out-sea-soda-to-took-was-while-work"
+      },
+      "lengths": {
+        "joke": 72,
+        "punchline": 55
+      },
+      "source": {
+        "sequence": 519
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0520": {
+      "hashes": {
+        "setup": "4321004317b1d44fd02a7beee9cec829a391af3236d960982f6a8a5fbdce1e2b",
+        "punchline": "993bd36172e340a1ddb62ab33c37ebd72e9d527876186644bdd44a37fba617d4",
+        "combined": "812cb75eff03bfbab616d0a5e72e2910fa0891535d23b7555de00bf8e55ff332",
+        "tokenSignature": "a-dream-exhausted-had-i-last-muffler-night-that-up-was-woke"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 520
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0521": {
+      "hashes": {
+        "setup": "0246326cd7bec0b3dd655876f321392382eeff44d7a259cfa448c73047c3f28a",
+        "punchline": "f731a9e79e83825f74d3257d9ce2c369c0f0a0525289d9916e861aeec9bc0d02",
+        "combined": "57d061f0fe7f923dad663de58ee0dabe705327eec83999790ff7675a40736f48",
+        "tokenSignature": "a-after-but-can-car-dad-his-just-says-son-sponge-t-the-use-washes-while-why-with-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 67
+      },
+      "source": {
+        "sequence": 521
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0522": {
+      "hashes": {
+        "setup": "747efd70947ae04690a517d630e3a2a6aec3051165d6f4184b08e95fa931ae29",
+        "punchline": "b187ae0a389f4b942ee8db1f60e22d5eacb00bad1dc3ffae24e7554a372a329a",
+        "combined": "5a527ca8a56365146686a46c507150cab20daeca43cfc64d73bffed64d41e39a",
+        "tokenSignature": "addicted-doctor-don-follow-got-help-i-m-me-t-to-twitter-ve-you"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 522
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0523": {
+      "hashes": {
+        "setup": "a77d7bbb3580e6872f026b47808f84600219c4e55e9c0095892e8573fa848384",
+        "punchline": "69b7f6f5f644a75b0e424d6d11f581b3e2ee98987d87dd3ca6e0da81cb99c919",
+        "combined": "c5d781ffec1773ec880e1295acd9a815e7af80089417509cfb421cadf159e7a1",
+        "tokenSignature": "at-broke-completely-fine-finger-hand-i-m-my-on-other-the-today-work"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 523
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0524": {
+      "hashes": {
+        "setup": "db7076ef8c9e3f3bb900c55152603bcdb2a727aaf65396b5fdb8286fef666345",
+        "punchline": "4ef7bc21f942944424318495355f11cdf7d42d4b71d45e3ca80215969f88c0b1",
+        "combined": "27a08a40ff6f51fa24435b2ab624520e66006d392abd5e76a84b4039c267dbd7",
+        "tokenSignature": "a-and-asked-book-defeat-help-i-if-it-me-purpose-said-saleswoman-section-self-she-store-the-to-told-was-went-where-would"
+      },
+      "lengths": {
+        "joke": 79,
+        "punchline": 52
+      },
+      "source": {
+        "sequence": 524
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0525": {
+      "hashes": {
+        "setup": "27545f38ab1059ffbd549285688d7cb760f1d538344a19a96f33e7c696b624ad",
+        "punchline": "49fe75805cc00d649d60dce7211833db654116b68391295615166e618e9c4525",
+        "combined": "30a010eac4d023abf363e722cfc71494cdacc68109fc358b7ba4a5481c67b757",
+        "tokenSignature": "a-breath-does-experi-freshen-how-mints-scientist-their-with"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 525
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0526": {
+      "hashes": {
+        "setup": "f9f5272f2395208b68cec6acf9ba8bd182e0c1471870e1598284904af8fa1b7c",
+        "punchline": "f901f4ed7700bf8701cd3a98653f0afa8f6ca5922974014340da94f3aeb12c52",
+        "combined": "5d0e7157d82abca69766492fe2ca870f8173e6ed20e23545827b7e22fe14e89b",
+        "tokenSignature": "a-but-cannot-corn-ears-field-has-hear-of-what"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 526
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0527": {
+      "hashes": {
+        "setup": "71724e7817a76ef0bedfd6341a2ade8380645bdb828c64772d419140d5ba20a0",
+        "punchline": "718eb0ac531503fb12d02353902063b92b09a4efa555342b3dcedbdd0b107a9e",
+        "combined": "46e01c7b8bb5325eea2bd28b43bb790e5ad8158ee247f8718cd78bb73bb7fc62",
+        "tokenSignature": "christmas-darth-did-felt-for-getting-he-his-how-know-luke-presents-vader-was-what"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 527
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0528": {
+      "hashes": {
+        "setup": "6b3ab1294499c11b737c3f601a54cbe9c49a14853ba4dcfdb72937a6704fda68",
+        "punchline": "f288ee9ddc247fd1f315cfd83a5ee8add115b89e395a9f7b3de3f512ef243d30",
+        "combined": "2a05adc3b6974f162144cdf5b4de9840a33c882e5636e9a3c3307eb7cc671547",
+        "tokenSignature": "a-an-and-between-difference-ion-lion-s-sea-seal-the-what"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 528
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0529": {
+      "hashes": {
+        "setup": "aa7cb96279f59604acf50cc14d4d4fc07cd9797e6147af932356adf0f126cec6",
+        "punchline": "f4bcadce394af2e13b25641b3f95337a94c667889ff4fde1835baac2c3f22461",
+        "combined": "3e55dc90074f2438e813b60b209707c72c5282abcaf4128009ae7752a597744f",
+        "tokenSignature": "cool-did-dorito-farmer-other-ranch-say-the-to-what"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 529
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0530": {
+      "hashes": {
+        "setup": "1d944a1df07a5a3d599f2bd69e3169fc9999d8d69838635e19bc45b30c49bd1f",
+        "punchline": "6ae2b4ae05fa594725919f8724728f48a2bc60c8d33902474b2ca57374a4e202",
+        "combined": "7b465c649d8508fbe7171db660bf2b11d87aa68ae898ffa1d9d5b70490b985d3",
+        "tokenSignature": "a-and-asks-bar-but-don-for-ghost-glass-into-of-says-serve-sorry-spirits-t-tender-the-vodka-walks-we"
+      },
+      "lengths": {
+        "joke": 78,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 530
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0531": {
+      "hashes": {
+        "setup": "59d707a51a9130a7e9a9f8fa414dffe83b6a5910ca5baf409703cd87dada5f18",
+        "punchline": "e19c94d94d89b3946522b8ccf2665db18a8ab4fee3e1b5ac9c7f31de204b3a34",
+        "combined": "cf8aaf20507919aa70d15d0b01f0ff32df03f5a255fe66565554f138258ca771",
+        "tokenSignature": "a-bat-breath-clean-day-do-prevent-teeth-their-three-times-to-why-wizards"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 531
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0532": {
+      "hashes": {
+        "setup": "d124140061e6ee8a2f4928482d4f113e835409c0b9ea5b1c540dd4841be207fd",
+        "punchline": "19f82121b01d1e3db58accccc4c95381b8c8208094c79706754c113cfdfc46d4",
+        "combined": "c35ed045083b2d480f7d08fb6d48178d27cdae437e016967f39ea3f6557c3627",
+        "tokenSignature": "a-alphabet-asked-but-complete-guess-i-it-letter-me-ninth-of-right-s-someone-the-was-what"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 41
+      },
+      "source": {
+        "sequence": 532
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0533": {
+      "hashes": {
+        "setup": "002d8bbfa8f9cd964d0cff718d7b1b929462f48fd59d0964a2075cd6148ef8f1",
+        "punchline": "2170e7cf1b94527d788705898a349179ef942bc269b774d61cbb572fc9877ac4",
+        "combined": "b129157d4d4c670094d4b23bbf49d4392c599a8bd6b056ac438636562675f2f0",
+        "tokenSignature": "18-3-5-bought-but-feeling-finished-i-in-it-months-myself-of-pretty-proud-puzzle-said-sesame-street-the-years"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 81
+      },
+      "source": {
+        "sequence": 533
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0534": {
+      "hashes": {
+        "setup": "91b635c4308aeac462a27a6e017ebdf612e3c5af47f6f16da37ea2c5edd5fbde",
+        "punchline": "d8c05aab378a896c0eee8831752ea3d1552806b35db2362b65e3019406cb131e",
+        "combined": "d87f461ff0870669d142786f06ff6d36b84e732357b87e37621bc3d0bc29d208",
+        "tokenSignature": "are-because-fish-in-live-schools-smart-so-they-why"
+      },
+      "lengths": {
+        "joke": 22,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 534
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0535": {
+      "hashes": {
+        "setup": "aec4a81884e7c4a957a080c41daccd82c3171c95f9d2ede2fa4b1b0faf200d97",
+        "punchline": "d4c2c869d586f1cbaba206c25cb95635e1258731321841cf489900fb9b9cd168",
+        "combined": "36ff0189c576c85a2c5d78f0c26f8d27c4d5d4a739c6a2565d6f58bbc5dbd0a7",
+        "tokenSignature": "cut-does-eclipse-hair-his-how-it-moon-the"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 535
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0536": {
+      "hashes": {
+        "setup": "9dedf857777130bc2fd397c9fee771a09a5042dde57ff3dc52d31d07e05ee532",
+        "punchline": "cafdc2079391d094a3083a1785572603cc9c3a8791fb9904925e0f7ba55b897b",
+        "combined": "7ff9fd6913f36a44fad7108226a4bcc21c41853e23d1bf44706199ac958efe10",
+        "tokenSignature": "concentration-did-factory-fired-from-get-juice-lack-of-orange-the-why-worker"
+      },
+      "lengths": {
+        "joke": 59,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 536
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0537": {
+      "hashes": {
+        "setup": "191e93d89e8b6fdcc1f0c5675976cee97317599943ffa0f7a86405ef70a6cd83",
+        "punchline": "4423abeeaea2d9580815bb75e95bb586d59e710474a4e09188a7547794087733",
+        "combined": "e939a38096cf9bbab6cee5370d010aaf4d1ec00f614ba7835a4f9f8a574379bb",
+        "tokenSignature": "a-at-booked-completely-couldn-get-i-library-reservation-t-the-they-were"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 537
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0538": {
+      "hashes": {
+        "setup": "c7e5d8b4ed3e103d5701bca1ae2b532df11877704968cf2062469bf9bbae421b",
+        "punchline": "bfd82feea77f05683ec29ebbb1ef49dac31e5c8baebec49d239594337ef032c7",
+        "combined": "e390a77a36acaba9c6534498bde333549bff464cbfbfe019b1e07881750966ad",
+        "tokenSignature": "can-dad-don-fit-i-ll-me-my-on-put-shoes-t-they-think-you"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 538
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0539": {
+      "hashes": {
+        "setup": "8de21783fe883589bfab546015a2ff81baa9c053d988f9223417adbf8263b592",
+        "punchline": "6cafde052e34f78bc197f17693cd98d1711722b7e60b777b4cddbc85934c4f25",
+        "combined": "879b07a722e52763bd28d52f2576a344539ee507a465c718ef236fce5ae1c767",
+        "tokenSignature": "a-and-car-do-drive-england-get-how-in-start-two-west-whales-you"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 539
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0540": {
+      "hashes": {
+        "setup": "68177498099502b2803c8aca573dc08f6b13ca5f4f977e747f19215e2e183484",
+        "punchline": "72534c4a93ddc043fe3229ed46b1d526c4ccc747febdcd0f284f7f6057a37858",
+        "combined": "b6ad7d9671a13224ba724cea17a3b5c01286cacbb87cf1666e57ae17db37f252",
+        "tokenSignature": "a-an-argentinian-call-do-roberto-rubber-toe-what-with-you"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 540
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0541": {
+      "hashes": {
+        "setup": "bc270bf4a3365e78c035671241126aef9972c106259cb90bdbfa4ef4e6e13c2a",
+        "punchline": "46d5055baaf160c435c3bb06c517a914a353d0cfa12a52b834b95833a29fe5bb",
+        "combined": "67a510171ff6da92f7c2da8b4d76b1fb528e752b413df887eea4493514b694eb",
+        "tokenSignature": "a-all-bit-but-farmland-grainy-high-i-local-of-out-photos-resolution-some-taking-they-tried-turned"
+      },
+      "lengths": {
+        "joke": 60,
+        "punchline": 37
+      },
+      "source": {
+        "sequence": 541
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0542": {
+      "hashes": {
+        "setup": "52ae3c3656bafb5aedd61855ed697736be55ab5b4bf144e5b9c76ad897b88f6a",
+        "punchline": "10071369ac535dc43f7a408562482909d85b91c0ee3ece0d297cb05dc20246dc",
+        "combined": "ca1eeae06f1fdc8d55ea46f72be0c89a92eb032260698191e7433e021358d884",
+        "tokenSignature": "did-it-just-nothing-ocean-say-shore-the-to-waved-what"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 542
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0543": {
+      "hashes": {
+        "setup": "02bd7e228911b7b3209476acdb32c77d619e828dcc077e5cfe0656b3b08dc7dc",
+        "punchline": "b70d2dc5dfd5e1d1f446815fd6259aee7f4d219b51d69ae9f71f551fdf39db9c",
+        "combined": "569441926715297c12bb69f2318d439f17e187a9b2523f395ba3c12a90f9c827",
+        "tokenSignature": "a-day-dog-i-in-it-one-only-other-shitzu-the-there-to-was-went-zoo"
+      },
+      "lengths": {
+        "joke": 62,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 543
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0544": {
+      "hashes": {
+        "setup": "128fd2caf928cfd7c5f9aeb68ecf8fcafdc9f294647b5dcaf38ac117c401ea24",
+        "punchline": "03f795188517b3f982877dfb019ccb01ffe6fc80d219ace7bee0e8717a52db4a",
+        "combined": "522c4766970d6938af66d9e1419af37f52aec320c6d9c8df75d1f7a20e89cdce",
+        "tokenSignature": "asked-dam-hold-i-me-name-said-someone-structures-that-to-two-water-well"
+      },
+      "lengths": {
+        "joke": 56,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 544
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0545": {
+      "hashes": {
+        "setup": "2d31c11e1c41018300e66a8fb6ba4ddace66eafdf5eb90910435578076af4a71",
+        "punchline": "41f1db0c32777eb5f5f3fb7fcf353e2274cf323886dd2aa43c8e52a4955f9163",
+        "combined": "73cb035ecc936f1a9a2f5c4f78649ce1a82e7e6d5048c29f7d1b559dcb0b6ddc",
+        "tokenSignature": "all-away-batteries-charge-dead-free-gave-i-my-of-today"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 545
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0546": {
+      "hashes": {
+        "setup": "98f90f5a4f420174db6e52c0b29a0a863a9907dd97fe84e002332feced04c7e0",
+        "punchline": "cdd5e52bce6fb13dd4ec211ae44902f4a1cd9e4faaa8a3e93bf5e045f6ee0bb4",
+        "combined": "d85959d8fd8ca5b35d3964ea9148431a0ccdd7cc13d055c7a061dda230df9c63",
+        "tokenSignature": "and-are-by-did-fed-fedex-from-go-going-hear-merging-name-news-now-on-re-the-they-to-up-ups-you"
+      },
+      "lengths": {
+        "joke": 22,
+        "punchline": 78
+      },
+      "source": {
+        "sequence": 546
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0547": {
+      "hashes": {
+        "setup": "020c43ddea62894242f528b026354a1d947c64ef42e2a5cd996f7f5d98695861",
+        "punchline": "aefedf927abfcf171ee1dcc93517d0ad6629bc4abc0d9cf181d32c83852c3ceb",
+        "combined": "69af2e672805a0baf0fb77e658729a2d4e2981c9c955fed242a03fc51f447952",
+        "tokenSignature": "2-4-because-didn-get-he-into-is-nightclub-number-square-t-the-why"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 547
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0548": {
+      "hashes": {
+        "setup": "007a44e2617118ec5371a0b7ae3f9503a905cf925a494655a6ae4926de329cb7",
+        "punchline": "2bd3f752b1fa4c5270dd97e6ffc812ae7c8a7dd11713372b482fef1edb1ec000",
+        "combined": "1dc6ecd7f161721a5c12a49cc435cafbbe239e23612bd7eca3deb4f4aa7a85a5",
+        "tokenSignature": "a-call-cloud-do-legs-no-sheep-what-with-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 548
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0549": {
+      "hashes": {
+        "setup": "908390ae637172e1d1812d487985a0303c8812140af09965730baed5d0f6901a",
+        "punchline": "a8c4b2cb538116026992820a8452ea65a111993d4e600ae79fb2b17a278fe72d",
+        "combined": "25408eb5580c0ef0060d104b2a2e5d4e6b5bfaa2b1232de75494e574dc217d8e",
+        "tokenSignature": "a-be-because-did-go-it-m-school-smartie-the-to-wanted-why"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 549
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0550": {
+      "hashes": {
+        "setup": "2f35d45ac72b028c3c15fce228ad550dbc3c65c056770ad34070e6b488c3f191",
+        "punchline": "0159bb3b4bb2012fc03d68c60616c3c445ded5084b254e827c31bc3392420ae7",
+        "combined": "a83e1c35819094147df55fa063624aed4fbea3e615e37b40b24d1a1005ea69b4",
+        "tokenSignature": "call-dav-david-did-have-hear-him-his-id-in-just-lost-now-prague-that-to-we-you"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 550
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0551": {
+      "hashes": {
+        "setup": "d5f66faeff294cfac04939c31d8599a854cd1072fd1549ae42bb84e7380d64e1",
+        "punchline": "6cc77c47f041c7112548d056ddb3e5723927648332076687cad1fdf5c1f9453a",
+        "combined": "e6d0a09b20e2e7d5493ceefb72826dca89f55a8c8f74ec2f05ec06affd02e018",
+        "tokenSignature": "a-crazy-diet-enough-fruit-full-house-is-it-make-mango-my-of-on-stuff-the-to-tropical-wife"
+      },
+      "lengths": {
+        "joke": 64,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 551
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0552": {
+      "hashes": {
+        "setup": "13d1497747605f62f4140e3bab4465bbbbcd0ef271928359f964634b186bf310",
+        "punchline": "5681e4146255eedb652dd59a17412383532829785690e304743ce9e0ad10d4bf",
+        "combined": "ccb7885a5c04f0f80317d63e1c9c97339b2cf9d11e611abd6f9bd15b0129e892",
+        "tokenSignature": "always-are-basketball-because-dribbling-eaters-messy-players-they-why"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 552
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0553": {
+      "hashes": {
+        "setup": "51e218fcda5759ca8b303cba2785a49c3d9c56b570c22f41484efe24222f0d1b",
+        "punchline": "2e58109d856050c700304952fb76546312448a47ccb4ba86e0f21e283d7c212b",
+        "combined": "24fdd91f6e31230aa159f280174209423b66e7b7c9f5f35b21c222dc284c1655",
+        "tokenSignature": "because-do-hate-indivisible-it-mathematicians-s-the-u-why"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 553
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0554": {
+      "hashes": {
+        "setup": "38e02a718c52336a0c763dea99ba5aed70243f98240fc095052b971f5b612cc0",
+        "punchline": "8903e505de17646152d38b49cf04c67bfc01eee21280c1040349b69780ffdbe4",
+        "combined": "030e80b682e49a0c05b565dbe8611545d237e880d8834c4f1da9af72c897f3ab",
+        "tokenSignature": "a-ate-because-eel-feeling-have-i-knew-little-m-now-seafood-shouldn-t-that"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 37
+      },
+      "source": {
+        "sequence": 554
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0555": {
+      "hashes": {
+        "setup": "20b3bf64b2a72a02fadc10fa45873b8211a966b2af0b8e42c479e4869bb49839",
+        "punchline": "4bddf10f9868d62c9af5355f682f10757b2760d51ae47a8144cd10017cd01766",
+        "combined": "41e0efaa6c19e1805d15fed92eefdd506e85353874be938ecd91ef42fc9168ea",
+        "tokenSignature": "a-and-bar-future-into-it-past-present-tense-walked-was"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 555
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0556": {
+      "hashes": {
+        "setup": "1b867f653feb8426706bee9a71474bf7c0b66a3ffb4dee5d98f77a5664067a9b",
+        "punchline": "93f8f427464c2b725125f7332fa1d8dfde2152510280acdfda94a842204e5dd2",
+        "combined": "45ccfeff6e4471932752852e8ca42c2a289d91bc3b6be28c777c85742fa34660",
+        "tokenSignature": "about-bread-burning-business-did-down-factory-hear-is-say-the-they-toast-you"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 556
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0557": {
+      "hashes": {
+        "setup": "ada050f27d36fd86a3a869de54c8639f949cdf0bb3de00ad61f40b254834e0c8",
+        "punchline": "d163c5ab01c7d1a9ad5341aabab50df43732c1011f0df0b6cf8545c3cccfd95c",
+        "combined": "e027260697a3f72ed245c9de2220e9359ee67efe0a1a7f58dad58b97a7a4c4bc",
+        "tokenSignature": "a-be-boss-fire-going-have-he-hunch-i-it-me-might-my-person-posture-that-the-to-told-was-with-worst"
+      },
+      "lengths": {
+        "joke": 76,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 557
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0558": {
+      "hashes": {
+        "setup": "7d78a728a58b52ba4bd66e7b11c495442b52389e655fa3c0a93a3069a50fa104",
+        "punchline": "1c5948aa665608d0d84a06a703e5032717aa1e9c78bc7fd625bef751739e1397",
+        "combined": "e86a932a918ae5d40649a5ca4602114e535c1b02000eff057404c576dc9cbfab",
+        "tokenSignature": "all-and-black-newspaper-over-read-s-the-what-white"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 558
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0559": {
+      "hashes": {
+        "setup": "1e16cd7748a9b646179ef6a64c7af518d3d89b21bac8aa436e6df7da1a2d9b23",
+        "punchline": "0cf0cb997003c314998c01c1018296420243f92a6b43ae2e00d3b7774f567771",
+        "combined": "1d55f3921f4d9fbb1c0b5eacd29ca3c3bffad73c6203ff105ebcde232e5ee41e",
+        "tokenSignature": "are-because-calm-gets-nothing-skeletons-skin-so-their-under-why"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 559
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0560": {
+      "hashes": {
+        "setup": "d25859c91d420062eadd9b654c6774a632257693f0776ce29ef0039ccfa2e02e",
+        "punchline": "39c481109563f1d7f8935035d361acbfa07c064a86b199e55b25d477974d8396",
+        "combined": "83a02706719b83f5ff00871196171c3e2512ee4d8602ab0c56260521ca622946",
+        "tokenSignature": "a-foot-have-hold-i-in-it-m-my-on-pretty-s-shoe-something-sure"
+      },
+      "lengths": {
+        "joke": 8,
+        "punchline": 58
+      },
+      "source": {
+        "sequence": 560
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0561": {
+      "hashes": {
+        "setup": "9f19f7fe85d9f23f0194d7df86e365330cdf50aba9b57308a8b7221dfcf7aba0",
+        "punchline": "ad83205e66af4839548158b5a5fd20b1f64664d5ea75d1941dcbec1fdb98de7a",
+        "combined": "a1bbe91a853d790acbee1214066892ddb9edc025a28eae7e758f7d8e872a3234",
+        "tokenSignature": "about-because-constipation-film-have-haven-heard-it-not-out-probably-s-t-the-yet-you"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 46
+      },
+      "source": {
+        "sequence": 561
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0562": {
+      "hashes": {
+        "setup": "57a4673d99e4881f8bef225980224e49232fb39bebaac5a933e9171ebb04f650",
+        "punchline": "d033ebaa7f5fc4eb4610a2c1c3f62ae616f67221cb0d3261570db948526a88e7",
+        "combined": "09d8120928b2e9ac040615c2cd8852491d4f7038137ff5fa646977653bf21cd8",
+        "tokenSignature": "a-albert-all-did-einstein-he-i-just-know-person-physicist-real-theoretical-this-thought-time-was-you"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 61
+      },
+      "source": {
+        "sequence": 562
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0563": {
+      "hashes": {
+        "setup": "4f3f569faa230cc741d2d6d367078c08fd9544a4533ae364dcc08a9f8d5680b3",
+        "punchline": "6672eadd00fed24ef94073cf8fc80bb4cdd62f21d6284c0790d2a0c951099ace",
+        "combined": "56e10c23379cd90619f480a12128b9cab04e8c4a6d9a30e37f63e6e4f0305bca",
+        "tokenSignature": "hate-i-lines-perforated-re-tearable-they"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 563
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0564": {
+      "hashes": {
+        "setup": "7bd7e8124ce676ee923cf39f1778730af03907e29e3a60945055b6b47f102019",
+        "punchline": "d0b8127ca30d4dad079272895ed15d2054dae0d61422f41ef67d81c4b46e655e",
+        "combined": "83532091a3b6db4eb0a88fbe05e1b5942b992aed5f40f246bdc96657af21afec",
+        "tokenSignature": "administer-ahead-anesthetic-asked-could-go-i-if-knock-my-out-own-said-surgeon-the-they-yourself"
+      },
+      "lengths": {
+        "joke": 80,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 564
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0565": {
+      "hashes": {
+        "setup": "d060a9e284c5bf4a79d36e6ef053d3414e653b86dd1140d11045f2cc51a3414d",
+        "punchline": "7891688ad8645eb8ce81ff25a311efcc3c37c2b85132fb39b8a4ff4c45905d56",
+        "combined": "c591ef811c1695226eb7903fe5de42b3a688bdeb1d55dacce6d8fc9e6d200302",
+        "tokenSignature": "a-barber-cut-did-he-race-short-the-took-why-win"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 565
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0566": {
+      "hashes": {
+        "setup": "ac88eadf12fa6198b1880bd2ab3261db5671e0e3fa26bb09bab97a30c9f21b78",
+        "punchline": "081ec72159158d31243aae68f70a44e1959e9c4b657c593c00ead869c06a1438",
+        "combined": "f1f80cb6774fd5e2b9cf9991010b432370e01ca560f54030ba8a34e60ed75776",
+        "tokenSignature": "a-armed-beat-because-did-fight-in-it-octopus-shark-the-was-well-why"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 566
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0567": {
+      "hashes": {
+        "setup": "f7891664995b5f6484bb3a53b42ba6b5965ae304da929953875a36d800a550dc",
+        "punchline": "f214d8c563d7a07d10172b95c0990d97049534699f5890c7093c56a5b44ea4c2",
+        "combined": "2cd795b8cf6ce0356b1319a22a2004d5ff2f8b80b7ed236c29136f23e6fcb7cb",
+        "tokenSignature": "broke-did-doctor-gingerbread-his-icing-it-leg-man-say-the-to-try-what-who"
+      },
+      "lengths": {
+        "joke": 65,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 567
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0568": {
+      "hashes": {
+        "setup": "b23ee6fbc88fff4418b1880f1d81768768b5526b9b2ef855d561147f2f88f157",
+        "punchline": "208894ed48a97c775c599095de8a64b2e32718cb5e7c3b8c4487dbe97cefba3c",
+        "combined": "4f530a6f0d2b5eff394803437039551c4ea67b882af9ca5b0f58a71be456f6ec",
+        "tokenSignature": "and-but-dentist-did-do-judge-nothing-pull-say-swear-the-to-tooth-what-whole-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 74
+      },
+      "source": {
+        "sequence": 568
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0569": {
+      "hashes": {
+        "setup": "39e3d7f08e9a31dfc2e52efc9bc50eb94710d7a59099f415f47ce08e148f302e",
+        "punchline": "b3af17c3657aa240849034a9f12359ec9dd20db5d4cf5b3f40e2137c2f7ce1ac",
+        "combined": "1343a7f0a720d65eba7e51d2f2f2eb7a9b77a942f83e163cfc38dd2c1f2ce2da",
+        "tokenSignature": "changing-don-i-is-it-keeps-know-t-time-what"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 569
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0570": {
+      "hashes": {
+        "setup": "31ff6abe415e1168bad0ebd97a89371e5b14f6e2d875e37194c4492973787114",
+        "punchline": "5b0bce6910af3e2b6037cc7f93a050e2324a8e2075584403ec003e02abfd0e5d",
+        "combined": "7113bbdc7145ac28f4a2400b98567354455226f9c8738c109d25f24833edab03",
+        "tokenSignature": "a-always-can-down-it-ladder-let-t-trust-will-you"
+      },
+      "lengths": {
+        "joke": 25,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 570
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0571": {
+      "hashes": {
+        "setup": "1d7394ba09d929bb0d8f86ee9241e683773e8f661bb3d8efee9fdc6d59f7f0cc",
+        "punchline": "ae3182c596e39d37f0f7d15c49ff39ba9d0bdf17e8ce3faa4cba601414b6fc84",
+        "combined": "774f199fc4a6fe017934ad85970e15ae3dcc937cf0303cbcc8a6ec1a82d5e85e",
+        "tokenSignature": "a-anything-buy-i-it-off-rip-s-t-total-velcro-with-wouldn"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 571
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0572": {
+      "hashes": {
+        "setup": "59e2631c0129239bca5d9ba6e73eb98602a36dd86ec4638bc5c74261c1827b2c",
+        "punchline": "9d4bca64e48db00e2017ac1714bc2f57a3f7af9947da7ead06f05eb65caf08f5",
+        "combined": "d9f17a03c871e592cb133f7d346c1a45bf51ae9a4182993d627292e66efc9c34",
+        "tokenSignature": "and-are-days-of-rest-saturday-strongest-sunday-the-week-weekdays-what"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 44
+      },
+      "source": {
+        "sequence": 572
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0573": {
+      "hashes": {
+        "setup": "3cc601b759025514c7ea6d0b6d7b1aba4b6e07f8c501d29e6793811f3fe788fd",
+        "punchline": "25837c445570eced94eca135ed9c1abfd6938cbb336fbf146133de85ab99e0cf",
+        "combined": "1f4e16b28679435f2706bd9cccf7f5a47c69860eff1ad9e68c9aac32de18b6f6",
+        "tokenSignature": "a-and-back-bad-day-dictionary-from-front-goes-had-i-it-just-my-pages-ripped-rough-somebody-the-then-to-went-worse"
+      },
+      "lengths": {
+        "joke": 97,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 573
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0574": {
+      "hashes": {
+        "setup": "065215618a3e1c51036bc308b8ff1fb63a121b3a72194f26cea1e0b1f267c148",
+        "punchline": "0ddc4790b95da159def57ac15812a5ccfcda4b25cc9cfb06000f89b0800808c0",
+        "combined": "6b69a1cf30497821e8e781c04edb50fe294e8ab807b51078d2d96a842dc6b73b",
+        "tokenSignature": "a-adopted-as-blacksmith-bolt-dog-door-for-from-got-he-home-i-made-my-soon-the-we"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 51
+      },
+      "source": {
+        "sequence": 574
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0575": {
+      "hashes": {
+        "setup": "af4ad0239bbe52ee4174a59b9e5d310d428921043355a47ab9ce9a87bcf3d0da",
+        "punchline": "dcd4e0dff321f88c25e5c86cb86bc3c567781449b1462cf20392daa51f58cb81",
+        "combined": "31c14344741fe5b2e1a5d871ccd61e47fe2db25c5450177264803900625f61f4",
+        "tokenSignature": "bathroom-batman-batroom-does-go-the-to-where"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 575
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0576": {
+      "hashes": {
+        "setup": "2f08585344cfbdc3fdae21d6acf086b1fdfa76a727c67c44c090956886d286d0",
+        "punchline": "cd81c2cf916c4134908176a61725d288e5ba02e75fd3cbcb496aa10f28e2f8c3",
+        "combined": "f7230f5ddc503d9e2fdce01736a63e5bf5c34eccdb72c99b03ed6fcf886c45b5",
+        "tokenSignature": "about-are-bright-bulb-burn-but-comedians-don-jokes-know-light-many-not-one-out-people-re-say-some-soon-t-talking-tell-that-they-too-watt-who"
+      },
+      "lengths": {
+        "joke": 133,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 576
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0577": {
+      "hashes": {
+        "setup": "1dbc81a4a6c0ead26dfd05f3a2fcf812e4f266689521bed3496389e7a9cfb2e9",
+        "punchline": "220afedd1010596e300d6ff1f7580e9b04bce0493e4254c106fa0121f008fba6",
+        "combined": "a43ed684964ba5b6e156788a09c54132665f4431a3a0344c77d2df8bca6f039a",
+        "tokenSignature": "a-another-asking-bartender-boyfriend-broke-but-for-he-her-kept-shot-up-with"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 577
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0578": {
+      "hashes": {
+        "setup": "f24b9cb37814d822ea0fc2b14ce03a69c8edb84e5f8c7f73b6ec0ba095a1460b",
+        "punchline": "c1c0e7cefd307071cb9cda33300fd4a7ec67c423c26333582e5ab2121fae7294",
+        "combined": "343f252263490e28cfd1edb47a315d749ce433e6d2b9cf3123f54b0db484568f",
+        "tokenSignature": "a-call-cow-do-milk-on-shake-trampoline-what-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 578
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0579": {
+      "hashes": {
+        "setup": "f972c4c499bf3af475844e07b7e97b1decb2468c0f06241a3df1370db4b240fe",
+        "punchline": "26d30e9a26fa99b02947ebbded4895878df48939fc2253910df7161268bb8e54",
+        "combined": "5bbff5896251e8b574207ca35fba5d8e74256b5cc9cebfc5041431269056d853",
+        "tokenSignature": "a-call-do-javelin-nervous-shakespeare-thrower-what-you"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 579
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0580": {
+      "hashes": {
+        "setup": "d71b0e99ce290871e2fcb12d71ef99f131b2d32f3c3da15d21369219360fdcdf",
+        "punchline": "7b73e7c5acbd1557ae575abb29c4418b332408234f049d67b286a1204fa22aa8",
+        "combined": "5cb651d80cce1c1380acc5f09f0c0d5612b193b3597af7347b2d85684ab6bf4a",
+        "tokenSignature": "an-call-can-do-eagle-piano-play-talonted-the-what-who-you"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 580
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0581": {
+      "hashes": {
+        "setup": "83cda7fc620daef1698c4b49f530de7aba0134a46cc37465e2501e0aa286bb64",
+        "punchline": "0280f5914e4d4054dbeb61314a41996202deb79ace03e398df04adc953387836",
+        "combined": "102e75551317a3140b9ff07c1371dc477b71c39b601fd4bfca5e4135629e292b",
+        "tokenSignature": "a-back-boomerang-call-come-do-stick-t-that-what-won-you"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 581
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0582": {
+      "hashes": {
+        "setup": "197712efbd4949efb20643b620917811ba371adae825910d8d3e1375906c168d",
+        "punchline": "f6aa99c7996faf381eeba4122f71a43d93a5e0da9f8a4b5f06417e1ac29b6331",
+        "combined": "709a165719193250ee37cf6a7d057ae9da4c2fdd3672f62a6158c85eb7cf4820",
+        "tokenSignature": "a-all-call-do-duck-gets-quacker-s-that-what-wise-you"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 582
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0583": {
+      "hashes": {
+        "setup": "1b1461377c6b8ec7db0182893967132c95fc3aa9e188b659b9374ec647f2da04",
+        "punchline": "30674386343d020d9fccec83c4c8bdd632e6bdbb7224322e339c941c8ecc2fb4",
+        "combined": "1c7e9b1a21216a576c3d71834e5081863d14a25e7d94782a6295e4bb68ddb113",
+        "tokenSignature": "a-broom-it-nation-new-of-out-s-sweeping-the-there-type"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 583
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0584": {
+      "hashes": {
+        "setup": "79fb3860b39ea6aa22dd34c72186f2e60073de3180075c397c065a089f4aed64",
+        "punchline": "564d59a8b6c95cbdaae3915d0b0c3d4edcf713a55a29654579f4088e046e81c7",
+        "combined": "d08d403330d57513701bdd97c61979fac85f8521c32b90cb360f3ba9ad88b502",
+        "tokenSignature": "a-book-do-i-it-just-not-on-psychology-read-reverse-wrote"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 584
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0585": {
+      "hashes": {
+        "setup": "5ec5092eb2487bf87dd96587cba0e433bd6a98a0a6a28ca4dc00c9b0165024d1",
+        "punchline": "ebdb05e99ebf30c41838ceac61f8193ce1868deb4dc1d1efcbe34181813d451d",
+        "combined": "3a99b6a394b55050297a3e36f8570c9da058733d30fd0080f7e0389881bb8d54",
+        "tokenSignature": "bay-be-because-d-don-fly-gulls-over-seagulls-t-the-then-they-why"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 585
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0586": {
+      "hashes": {
+        "setup": "24e4e67efbad1997cb7354891c3662cf673c028329bd95e3ff513593940375fc",
+        "punchline": "14fc8d897a1199045a0ef52c7cb480b3f92a7cf432628e857e8dbe90a4bc0af0",
+        "combined": "972a3656fab5681241bbf30fec6a253dec7b6f8f5c207215d113e95b6a98ef0a",
+        "tokenSignature": "a-common-have-in-it-lines-ll-meet-much-never-parallel-s-shame-so-they"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 586
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0587": {
+      "hashes": {
+        "setup": "5f94a176b152b4b40ff04af855c7318b2d070e19786840d7df2054cf9adb62d4",
+        "punchline": "0bf29573db872a9b60ed43a01e977a03209741c1da8403bcf8e376e4591d7ffd",
+        "combined": "5e12c5bb3c6715745103edfa46b3c6cbce82ef668e051476f8f99f05491f0b98",
+        "tokenSignature": "a-call-do-has-ian-lost-magic-magician-their-what-who-you"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 4
+      },
+      "source": {
+        "sequence": 587
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0588": {
+      "hashes": {
+        "setup": "462f846c7e426046ae3fa2b2a0d2b72d448eeb074394e29867dc956e429027c6",
+        "punchline": "6bbdb89febe8b643fe2e57358310e8ebb7fa265ea014d314767b1de01ebc45ed",
+        "combined": "260425a013a6244c97c30bd5f743548ade2a56e4e32ce2efb00a60e883e97010",
+        "tokenSignature": "because-do-fish-in-live-makes-pepper-salt-sneeze-them-water-why"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 588
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0589": {
+      "hashes": {
+        "setup": "f8fef56ce5aefaa54e27aae21342354590cb3d1566ba2b9c471f9f977be9d3d5",
+        "punchline": "eea1785acc9a6a663d5253c3ab792839e88434e4d59f824fa1a2eaa21e147514",
+        "combined": "0916db16c6d548b67fcdf2501410e90e26e6acccbc96053f9e46439ecb539b61",
+        "tokenSignature": "angry-do-doctors-get-of-out-patients-run-they-when"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 589
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0590": {
+      "hashes": {
+        "setup": "a1c3c6552497a5f6694f2b4f6cbac601b15fb49eee9945c4910fcc8ce0205088",
+        "punchline": "9dd309d4beceabd03f86eed335c71c992635c98e44d1f01c92ac44bfd4a972a8",
+        "combined": "1b364650ce3274055fc54840077758dcc4667401f528f8fc27396d32f1158495",
+        "tokenSignature": "a-coffin-him-i-last-man-me-need-s-sell-that-the-thing-to-today-told-tried"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 590
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0591": {
+      "hashes": {
+        "setup": "d08729f80c60dedfd2158d484f398027181d8bb91fa4534e310be20ba260974b",
+        "punchline": "94786d098c8e407277d628fc5f60273953ab840290d9cf70ec350d9f9bc11a9e",
+        "combined": "aa13c5757ff028340b72282054091d0c385e82fb62b727ab0e4678c1a10bfd3d",
+        "tokenSignature": "be-doesn-envelope-how-it-matter-much-push-stationary-still-t-the-will-you"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 591
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0592": {
+      "hashes": {
+        "setup": "a9fb9a87588d3b5fc1059b7072fcdfae9e6a5e953aa99b9789a77345f2defa1d",
+        "punchline": "513d761b9d5cbc2c24188085d5957ea6831d69d3260f495b6f82cfb3c493e682",
+        "combined": "393745843b151b37b733c966d14cdf2c5787a335777b4d9e4e69527229613a47",
+        "tokenSignature": "a-boulder-did-for-little-pebble-she-shy-that-the-was-what-wish"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 592
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0593": {
+      "hashes": {
+        "setup": "926ed5b8bda0b7cc233e875b5d3940f6bdb8c4ab710c70e1099f1497a14a26cf",
+        "punchline": "320d12c525276386f1fbb0706ef43277bd5d11cf79a007791cda4af30093e1bc",
+        "combined": "56d95c95bb37d91beccc58578795f1363a1c5c767a4b5d438cdc40e94522b01c",
+        "tokenSignature": "a-belt-did-go-he-held-of-pair-pants-prison-the-to-up-why"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 593
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0594": {
+      "hashes": {
+        "setup": "44cad3632d552974122241adbfffcaf47a0ab2d7185be735b150afdec2ac6c0a",
+        "punchline": "7a07f38be08dec0176767ec19ed89c2389690b57be150f38b56706c43cd01ce0",
+        "combined": "902ed510b93650bfb6c9b1eb6ed476b26a83ada8c3d560eaf310a07a000df9be",
+        "tokenSignature": "a-be-cool-developer-drinks-guy-had-instead-it-killing-me-of-out-some-spider-take-the-to-told-wants-we-web-wife"
+      },
+      "lengths": {
+        "joke": 60,
+        "punchline": 58
+      },
+      "source": {
+        "sequence": 594
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0595": {
+      "hashes": {
+        "setup": "762fbee38573686455e169f85c12633b4bc37f2e181dbdec6b4c838fe0b69565",
+        "punchline": "79146a9a6baf1bc957458d0ab52de6cfbc112296116f9c5b0a038046510c1664",
+        "combined": "47e09dc62eb52994c92a30ff4feeed94c3953444bcdb15eeabac986bc794365f",
+        "tokenSignature": "be-can-cheese-nacho-never-what-yours"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 595
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0596": {
+      "hashes": {
+        "setup": "8e5859de584979a1e74dac70fbabcb7aae06933a06ac92fcd760fa5ea98e2ea5",
+        "punchline": "7d24c7c839a9cb035890ef9b5675ca0853032400c029e9263511deadf088a802",
+        "combined": "6962d40452edf673af9d05d78e13b816f49063d91956055ca73adddcbff85b2b",
+        "tokenSignature": "a-blood-favorite-fruit-is-orange-s-vampire-what"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 596
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0597": {
+      "hashes": {
+        "setup": "a28604f34a3df8331c103a977d17b1958756056330479499c0e88e57acd322cb",
+        "punchline": "ed915da04d3e4f823ad12d0a13740ac202d91bafe8fdff52fd92eb631ff02ea3",
+        "combined": "700b2c57ac58c6f92edf147437caba4793468d7e4d1a37e215bc2077790606d9",
+        "tokenSignature": "a-because-cookie-cry-did-his-long-mother-so-the-wafer-was-why"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 597
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0598": {
+      "hashes": {
+        "setup": "d69b0879c396547018c02381005cdd3167ef2b6a457115706bb6bada6694beb0",
+        "punchline": "7c16ec1ec84abb3ead08c0a3c04d32dfc29579ff85515206589f0d0aa1a00dee",
+        "combined": "f356d771fd6f71df9ba097f2fa81ff92c11572969bc53ede18bb9856a1f9f900",
+        "tokenSignature": "cheesy-hear-it-joke-mind-my-never-pizza-s-to-too-want"
+      },
+      "lengths": {
+        "joke": 27,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 598
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0599": {
+      "hashes": {
+        "setup": "356fccdad2f21a6a6ec050662f418a9742be330ba30354ec467d218906ccabfd",
+        "punchline": "ea7e14064f55cdcfcc076edbb02f8e1d1e8a8570f23f8ab6fd6147ed19aa0ad3",
+        "combined": "35f46e6dbcd3236bb5970cbae30cfc0d5e8dc6a965831888c22a844621b81b13",
+        "tokenSignature": "a-did-do-got-grape-he-let-little-on-out-stepped-the-what-when-wine"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 599
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0600": {
+      "hashes": {
+        "setup": "aeff6995dc01030f7febb932a69c24f1486dd0402ddfe9cd29dd5953acca444b",
+        "punchline": "4c4525e38ae58546ec54f2b316f369929cdda26e759048e4fc7f15cc570a12da",
+        "combined": "f16edaf70569d2ba57fda039b0702e9525350c4824f1c0453a6bd0803231b622",
+        "tokenSignature": "0-8-belt-did-nice-say-the-to-what"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 600
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0601": {
+      "hashes": {
+        "setup": "f5c77dcec66f6ae7c454f69af0ca5000befbea40625d2fbc89b64fd328e375b2",
+        "punchline": "5a8c82c9ab02a5e429502111adc187d02f22b6ae0091eb756bf2b604de254041",
+        "combined": "25526aa60a074c716e41344d5508f3fc83778c29fb3d9549f781060250d344af",
+        "tokenSignature": "framed-it-picture-prison-sent-the-to-was-why"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 601
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0602": {
+      "hashes": {
+        "setup": "1cd60abab6594b76eb55db16b58d044090ce5e9f4e456115e88f0516ce4ebdf3",
+        "punchline": "dc17dc2dac2af91eec74d90fb79ddf278ea9d04249e8f301e6315325112f16bd",
+        "combined": "0d194e7cb74048d77f7fc2e7fe6c390fd1f37a2927f3f361dd4c57437c710f59",
+        "tokenSignature": "2000-burned-calories-food-for-i-in-left-long-my-oven-the-today-too"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 602
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0603": {
+      "hashes": {
+        "setup": "38fe80a1d83f21f02118259103fbdc87a0d6e3ee6dad7ae0a2a57708048cceeb",
+        "punchline": "dd00894d9964ae9527239ea0ab37fd4fa7d16face1679cab6cd14e612f532aed",
+        "combined": "aee3fcf929a81cdd170b1ebca959b31c6bfcf400e80fb1a03a190c03a1213d4b",
+        "tokenSignature": "a-about-an-and-be-botox-can-cosmetic-eyebrow-nobody-now-raises-subject-such-surgery-taboo-talk-to-used-you"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 58
+      },
+      "source": {
+        "sequence": 603
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0604": {
+      "hashes": {
+        "setup": "5762378a4a15582595b693c7e9547a83bcb5c56ed3375520a998b32648e45754",
+        "punchline": "e6760938fe87038122bcf3376682bbe0762265f4cc8a2f258049c8b51454ca00",
+        "combined": "91173be9f370d55a70c74c988d6fb6edd5ce9093c2b2c46dff2f68e8a5a4b0c9",
+        "tokenSignature": "a-can-coffin-cold-has-how-start-tell-they-vampire-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 604
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0605": {
+      "hashes": {
+        "setup": "f193694ae1227d3680223d5b719594fb7595865b3af00c85421bcb750bd86c9a",
+        "punchline": "a7ec5565ba98671c0d91744d9f83ed9d91d7a71c6e9952bbd66508a06444c58b",
+        "combined": "76a0c4da1f7e20044fd323e0376e32981d521cbeb9366b6960b3dc07982774a8",
+        "tokenSignature": "and-at-boxing-but-dad-dogs-for-got-he-hot-into-line-match-of-out-popcorn-punchline-stay-the-to-wanted"
+      },
+      "lengths": {
+        "joke": 80,
+        "punchline": 43
+      },
+      "source": {
+        "sequence": 605
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0606": {
+      "hashes": {
+        "setup": "5fb6bc4433f513a7b216482fda6bc6874531c574a69fd8f068e20aa80c1bb6c6",
+        "punchline": "1eca5ab060d91a05ddc8bafd2a04ca4e20dd4796333ca8d99f1ee26b46d08a40",
+        "combined": "d5efbaa85e048fc58dedb0f880a58ccf6a880aedac1432a89e9d7ae1a963e5f0",
+        "tokenSignature": "a-all-cut-dad-did-get-got-haircut-hey-i-no-them-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 606
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0607": {
+      "hashes": {
+        "setup": "1541db7d860df92da8d42fd17d6d37616c0126e06638599925ba25b4cdd2c634",
+        "punchline": "da266cac36b50e445f162a94a29a1bc81ce4e5ba677aaa4d0839af89ab95a780",
+        "combined": "8c62911dc03fcd3376f05b368fe65d29a973d53f17e5aa43b660f5477cf55263",
+        "tokenSignature": "a-always-are-around-because-cemeteries-dying-gate-get-in-is-people-there-to-why"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 607
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0608": {
+      "hashes": {
+        "setup": "5003bd78a155c30bd845081cac2dff20c60fd37277f992daef736e909b308c44",
+        "punchline": "6960d1eed1b7fb8d3d37a4df5f977770e21c5d93aada44073f4c79f5a901ad55",
+        "combined": "8d238eb062b3c5f869959d8fe8c2c915f24584023029f4085e75a738b3e440b0",
+        "tokenSignature": "a-asked-frenchman-games-he-i-if-played-said-video-wii"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 608
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0609": {
+      "hashes": {
+        "setup": "8241879331e51a5fdaa685fbd50232e584bd88f1e5f6f26e678cce0c8c55d9d2",
+        "punchline": "c4b7f7746694dd94241b5f741580344db74ded44281d532127da90894bc4ee77",
+        "combined": "474575f3d02c2d06c292e847a79abb00d1a1d068a833b33b908fa3fcf8fb9716",
+        "tokenSignature": "a-best-dentist-even-has-he-is-little-my-plaque-the"
+      },
+      "lengths": {
+        "joke": 22,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 609
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0610": {
+      "hashes": {
+        "setup": "93048910d92d3c1b08b5d8c512469ed61ab2fb858e77c0509ce2dd3b56acc688",
+        "punchline": "836a74ffbf9c6b5bab6f4e90b315f4a6854b06c736fb6ccd4f381c9fe97e87a5",
+        "combined": "8ceb6dfece2a5bb9dd6fcf62f9272be4a003042dc111f7c4a69a55e0f66cfe0a",
+        "tokenSignature": "about-any-be-beef-between-but-cows-don-heard-i-it-kinda-offensive-pun-s-say-so-t-there-this-to-us-want-won"
+      },
+      "lengths": {
+        "joke": 76,
+        "punchline": 45
+      },
+      "source": {
+        "sequence": 610
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0611": {
+      "hashes": {
+        "setup": "349f2820af9742c10f64337534e0c1903da4e7e2b75321822ea72eb9095b9fe5",
+        "punchline": "495a39349e8b1514278fc96a243742f114cd57129ec284eff2a4361619ea1bbc",
+        "combined": "26dfde764e9e29ff9c2149c42d0cd3287372640bbe4e779a9368637225ddb8fb",
+        "tokenSignature": "alexander-and-common-do-great-have-in-middle-name-pooh-same-the-what-winnie"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 611
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0612": {
+      "hashes": {
+        "setup": "b9f2cb706a2ca05644bc8a90cd889581ebface42889042c40691643c180b021b",
+        "punchline": "90e5a909fb48bec4c9405ccaf1a50a797905d612bf877cfc27deddd0c575adfc",
+        "combined": "20f4f42c69905b24840c0b8121e726e5762f7f255cdd0829e6a54ec072065cce",
+        "tokenSignature": "do-kind-listen-music-nep-of-planets-to-tunes-what"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 612
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0613": {
+      "hashes": {
+        "setup": "e9f7522244cf288e90529949a9723241ab145bdabe72115f10f41679202c4a16",
+        "punchline": "45793e12b99a486b0e31182c793d9e4e75d09ac0a1adb47e3d10e5a75ecb3ce8",
+        "combined": "a8ab9a1260b4ef615be38f8503dd92144cfa52fe148e6b27b10fc4238881f42e",
+        "tokenSignature": "can-grandma-hear-my-only-out-s-she-shout-that-the-to-way"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 613
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0614": {
+      "hashes": {
+        "setup": "fcb0f3ca538a23638d280917c454829195cb67d8e4aa17dda5cb4b9b42b0ebb3",
+        "punchline": "747dd9cb441545d3dc524266e83bae1166da463d40527a7c3a14f15cb909a345",
+        "combined": "4d15ca46be140235b069f534c577093f86e4cdfbea09534025237e9d6c067fca",
+        "tokenSignature": "broom-for-he-late-meeting-overswept-the-was-why"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 614
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0615": {
+      "hashes": {
+        "setup": "fdcec89f722ca13b3b4b2a6d2d2b319460f82711b4db26622daa8643395b1d87",
+        "punchline": "4c0aebf28c9353b9e5af4d74478f8577b735bcafee28b3d70986beb5d3bf74a5",
+        "combined": "ca78ba67052e8959b58cb8e740909ebeebd576e2049f8a988c04b92773dde4af",
+        "tokenSignature": "a-date-from-girl-great-i-it-keeper-last-night-on-s-she-the-was-went-with-zoo"
+      },
+      "lengths": {
+        "joke": 67,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 615
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0616": {
+      "hashes": {
+        "setup": "7e2094d9ce23903988a0a43d4dbc955fdc9102fdd11e2810f1748ec9db5e597a",
+        "punchline": "3c79fc5b65a23150b9c76b613e70afb751cbcd15d0924ac7526abe084f6c06d5",
+        "combined": "86d6d34b8597c6e4781f6c50d723a380dbd0bb52a05b2bdc6766bfd72f0953eb",
+        "tokenSignature": "at-because-do-elephants-good-hiding-in-it-never-re-see-so-they-trees-why-you"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 616
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0617": {
+      "hashes": {
+        "setup": "c4a1cf5f184e669591524e8124cdf0e0b8213b5b76a1f0a491f549aafbdfcf11",
+        "punchline": "db8aa349b99d3e3915f24360ce6c7122d3153b63f81d3c47245f2adb64e9fb7e",
+        "combined": "ab88c135fdc99dcde4f0853ca0ce9b5021ea79a010fa6dee833f5295f054807a",
+        "tokenSignature": "a-also-an-and-as-ate-bad-barefoot-breath-by-calloused-calluses-diet-feet-fragile-frail-from-gandhi-halitosis-he-hexed-him-his-impressive-know-little-made-mahatma-most-mystic-odd-of-on-produced-rather-set-suffered-super-the-this-time-very-walked-which-with-you"
+      },
+      "lengths": {
+        "joke": 225,
+        "punchline": 66
+      },
+      "source": {
+        "sequence": 617
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0618": {
+      "hashes": {
+        "setup": "dd0c3e937b3dc5ff0417d82024d15d2dc8787b09961a6384a20c6e48de87062c",
+        "punchline": "a96242ba0e8b7c9bc268440621645ec9855808d10e23266d2493545c3c1d845b",
+        "combined": "37dc8985128b88dceac499bf77bd9ada46c04b0f2e8e92045e1f0cf3f4dd4f6d",
+        "tokenSignature": "a-alligator-an-call-do-igator-in-vest-what-you"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 618
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0619": {
+      "hashes": {
+        "setup": "ab29f0cdc8d4df2ad4d6452406be8089962b3aeb5d505575026ad812780348c4",
+        "punchline": "359f8bbb25e48348e69f466eb18a400b9494823c6687d5fb931484fcea745d31",
+        "combined": "5838fc38daeebfef769df077cfb82593f4d5ae0362874ecaead1e3f499dfeb01",
+        "tokenSignature": "all-broke-carrot-celery-did-don-for-girlfriend-he-his-i-me-really-right-say-she-so-t-up-wasn-what-when-with"
+      },
+      "lengths": {
+        "joke": 57,
+        "punchline": 54
+      },
+      "source": {
+        "sequence": 619
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0620": {
+      "hashes": {
+        "setup": "30c4232fb88bbfece32bfa7d03b44a9a530b605f25d122660c46979c237db197",
+        "punchline": "07c3c3997154b99852d243a9b58d66fbee5de1763d251197e6e4a0032727cbae",
+        "combined": "6a8687d6768da331cc86c33d4d5cc2514cd54cb5a31c8a4364fc7dd9fab074f5",
+        "tokenSignature": "a-explaining-for-it-lot-many-me-means-thanks-the-to-word"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 620
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0621": {
+      "hashes": {
+        "setup": "7721dc2514be8c94ca6e225756a8ef1b8f8da788c0827296746e37c48531937d",
+        "punchline": "0280f5914e4d4054dbeb61314a41996202deb79ace03e398df04adc953387836",
+        "combined": "5f254286053d2a83a682b5c27b1a50c416f3cc8c886686b844c9a4a266c47c53",
+        "tokenSignature": "a-and-brown-s-stick-sticky-what"
+      },
+      "lengths": {
+        "joke": 24,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 621
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0622": {
+      "hashes": {
+        "setup": "3c48df98c459041d2154a93fd89453ce80d5a14c91dc9bf16a259ea933d59d17",
+        "punchline": "254322cf3cd3e12894a2b1460d374aade5bf3eae5d71a08f772604306cf2f05d",
+        "combined": "0ebb0f5f655215a0c16b73af57a6d344922cd435e026b2ad9971f30981a1cf55",
+        "tokenSignature": "a-biscuit-does-like-person-short-shortbread-what"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 622
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0623": {
+      "hashes": {
+        "setup": "9399a81885ae5f5ddd8ee18319aaf5522abfbfcbbd6cc04c029c177bce8f86e2",
+        "punchline": "9a3b0baf411c01570c07f408abc5841f047ed136572879ca87cfd882e075b435",
+        "combined": "25522d4391852409a04d620172c7c2e15d3cafa4804517b1abdd8b67ba0e49dd",
+        "tokenSignature": "because-depressed-elf-esteem-feeling-has-he-helper-little-low-s-santa-was-why"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 623
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0624": {
+      "hashes": {
+        "setup": "552f1b72dba303c88b7c9b580334233a81c25d52f66ae52983e34214a51c5c43",
+        "punchline": "4abe11ab5ecc3f60cf0be29b883737a2572667ec1d37f7afb71c61d4f98638ac",
+        "combined": "ed0172ead5b5b6370d1bbd93cb4f968afac92ca62d05c1b390d02b6cea164c6b",
+        "tokenSignature": "barcodes-battleships-could-did-of-on-painting-scandinavian-sides-so-start-sweden-the-their-they-why"
+      },
+      "lengths": {
+        "joke": 73,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 624
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0625": {
+      "hashes": {
+        "setup": "7cd62c28e9b5fb96aec9787e818eacf99981ce3ef46fac40aa56ada02129a0bf",
+        "punchline": "ff247867091ee2898e9957b47713a13c4d3cf2d9c7d180ee11489f971ccf0b89",
+        "combined": "7325a29d08dc82fd83c49cc2eab589d666f47ba330d54f645a0ce32cb39eb6bd",
+        "tokenSignature": "a-chimney-em-first-got-hear-house-joke-of-on-one-s-stacks-the-to-want"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 625
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0626": {
+      "hashes": {
+        "setup": "f498480d5ce60a6137dbc258a19c300122fbdf5ddd8dbb587d0aec03d742a773",
+        "punchline": "932c0f3832bab7fac2fd79d5400249a05ba48c2072dc1d686d398961af379a9d",
+        "combined": "ab33699248b1aca3e202cbc2ccbc3dc7bfdd6b9c8ef50b8a8a68c5ce4af864cc",
+        "tokenSignature": "a-call-chop-do-karate-knows-pig-pork-that-what-you"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 626
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0627": {
+      "hashes": {
+        "setup": "bb23acc7b1077977a40b75cc70dc91b801aea93684d8fe9d68cb2dc6d6ea554c",
+        "punchline": "eb032b5d4aae621ec7ff52f20a934fe58f3ac5dc74802860dce90acd492c5b44",
+        "combined": "05aca01d0cd08ce871fb7935e66e3bec0f163343b4db6e1caa00b60124e967c6",
+        "tokenSignature": "an-are-argument-beef-considered-having-if-is-it-still-two-vegans"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 627
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0628": {
+      "hashes": {
+        "setup": "72c4c572c3b3ce2d6873c8f6395701fe307cfee88b03d3752bd0ea61a1d72f85",
+        "punchline": "4ab56ee021f5e2052274ec7dd3530ac44bbc8d4270ab7316573204a9f2c3ca36",
+        "combined": "ee02466d3648771194043fc7497de7fbf014122dcaaca8c24e0dbbb87415dfd9",
+        "tokenSignature": "abacus-an-beads-count-day-decided-for-get-i-it-little-my-s-some-that-the-things-to-valentine-wife"
+      },
+      "lengths": {
+        "joke": 71,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 628
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0629": {
+      "hashes": {
+        "setup": "220021870c0cb4e5ef26ba5ca65d6ee75c36b86ade9d4d684d7465a17d1e3226",
+        "punchline": "1ac1130ddf6706bea8aa11091319ce0f6c0fa7624588c22c07b7cb374f10f403",
+        "combined": "4d6f615bfd571b4d5657976cfe82cc0d6a2aaba69179af356d84c4cea97815d0",
+        "tokenSignature": "about-ancient-babylon-class-history-s-teachers-tend-the-thing-to-what-worst"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 629
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0630": {
+      "hashes": {
+        "setup": "64bd3ecc6c9b3ba32f4d2cc662092a448b6fb5e48265deb6b2534693c8d319af",
+        "punchline": "e1684bdaf4d0e0c51a9f8fff52f4a5a1fd231ebff6a56caa4f7243bf81b408b2",
+        "combined": "b6191ee87f3054044035f085af73eb306d07cfc9f13df86094380e1fe61c0cc4",
+        "tokenSignature": "bad-d-fact-i-in-is-it-my-new-s-say-so-terrible-thesaurus"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 44
+      },
+      "source": {
+        "sequence": 630
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0631": {
+      "hashes": {
+        "setup": "0ae00a0e1657f806e4d2d0b2f26ebbf379c10919fb5af07449a44f12c1d8e6d9",
+        "punchline": "2d0346c9fd86746c273909f2f446ca2c758ae79ce632d3eabcd833cf27d48292",
+        "combined": "eaead8832ab5e7fc78f6291e97e28ca54059ffd587230f49b6e65e7bfb4bdcb1",
+        "tokenSignature": "balloons-do-hate-music-of-pop-type-what"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 631
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0632": {
+      "hashes": {
+        "setup": "96f750a3c7cbefd679e1a93a0cf14d7b592f6cb74cd3afb3f687b282df94384b",
+        "punchline": "2d3fb80aa37e5f64ab598beb2a02690bcf0b9f5d9959f116ccbecfcb659763ee",
+        "combined": "172db0ae4b3937086293bcd485e437903ce1f112c846422d45b4f2d90f774c1e",
+        "tokenSignature": "a-acorn-an-brief-do-explanation-in-is-it-nutshell-oak-of-s-tree-want-what-you"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 632
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0633": {
+      "hashes": {
+        "setup": "26f0a6ff2c3a3bbd49a3145432404d2696f887757d334e0e6af9db58938e619f",
+        "punchline": "c38e0de22f658cd3364b5291fec1b567ff1bcd09390a42ea46e37aa03a61e48a",
+        "combined": "2fbc628cce6c9e0d6b326352601835edc1746e18f991aa9e5359f9d8ee4c2926",
+        "tokenSignature": "a-by-come-conductor-driving-good-got-he-how-lightning-man-struck-train-was"
+      },
+      "lengths": {
+        "joke": 55,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 633
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0634": {
+      "hashes": {
+        "setup": "76ddba99c13a658c012f8c4cfbe71e6480e3349245f26b097296b3a18639491f",
+        "punchline": "cf4a25652d49f989318c48685b05cb484ec7fda11c2507387b29911e0635ac84",
+        "combined": "03a15a85564053814efe03967b8afe562374284e8fdc1dab76fcc415262da7a3",
+        "tokenSignature": "be-because-blood-couldn-dad-died-forget-he-his-i-last-never-positive-remember-t-type-will-words"
+      },
+      "lengths": {
+        "joke": 89,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 634
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0635": {
+      "hashes": {
+        "setup": "fbc3020d3afa09863d3e29e9635de5bb4a41ff31edb013be2322dc258c234cec",
+        "punchline": "5a59e32b9dab1b13c072c8935a99564ee7d863e26b69bd8c1106010273e6eb98",
+        "combined": "944b4c7cd049e4d014e07491c55210ff7bb90fec1031ec416c11707d7ad98ad7",
+        "tokenSignature": "a-already-days-diet-i-lost-m-on-three-ve-whiskey"
+      },
+      "lengths": {
+        "joke": 22,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 635
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0636": {
+      "hashes": {
+        "setup": "1a45251ca11a0ce8eda7f5e942c96627e6b98f2bbf6542b25c859debf2d28ac0",
+        "punchline": "fb0b10561616c9eff110f7df9bc6960f8f3f9cc1ebfceb79561a054076fbbca9",
+        "combined": "5e3203ca1565086c506287f6bd38bea677e31612720945d0ccd29036a1bd39ba",
+        "tokenSignature": "dark-darth-does-his-how-like-on-side-the-toast-vader"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 636
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0637": {
+      "hashes": {
+        "setup": "332513726598eb9d91afe576dac3075411dc5e9ad670766a289d55c0d89def7f",
+        "punchline": "a413cf0b90236928183ffb2831069defbbb097aef69b923365f895526b7d3dba",
+        "combined": "1f5c6ebbcfd74364765bede89341a627e1451772faf7d7a3ab5d8b0115719812",
+        "tokenSignature": "didn-it-juice-of-orange-out-race-ran-t-the-why-win"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 637
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0638": {
+      "hashes": {
+        "setup": "c6fec69d375f471d114cb80c10b3920404e939c8b7a82c6f5ea94c098a7be47e",
+        "punchline": "c1e17f2f81b4aef5e4083d12b370425eda3d3b2c5e76202418357393f5c7c8a2",
+        "combined": "50014cca37cbe49658c7839df994426359b121af4ad5e5ec21cdf6a967542317",
+        "tokenSignature": "about-criticized-did-he-hear-in-it-just-runner-stride-the-took-was-who-you"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 638
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0639": {
+      "hashes": {
+        "setup": "ecb8ccf40a8a9728f77060bc3e9a76f83fc566642dcad4e9aec41eda3c08d770",
+        "punchline": "747d815e0f69f84dc73cb60d379f1d664dc6038c96a6a4c303f16fd08381f791",
+        "combined": "99d2f3fb9cb08ddc732f4562e7771fa232d4e49aee371c95e732de70e81d0367",
+        "tokenSignature": "a-always-animal-at-bat-cricket-game-is-of-what"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 639
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0640": {
+      "hashes": {
+        "setup": "60e8956d1421ed29ee18f2b4b66e75d74356ff286687cecfeebc0933d44265bc",
+        "punchline": "ffb9541b1786dfb6f38fade40f7a7399d6ecba4182732df28b4dd2844f886040",
+        "combined": "7b6497281f125c4e65215ab3d51f136903be0f8169f60b9805e56b0f517780f5",
+        "tokenSignature": "a-because-clydesdale-did-give-glass-he-horse-little-of-pony-the-was-water-why"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 640
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0641": {
+      "hashes": {
+        "setup": "c08d675d213be4f5a97322e9d9d1828d91de602659128e1285ca484e6ec82bea",
+        "punchline": "38b6865df8afe038405fa49b7f0ad0537fbe0312d99291645372a8c62cc984d6",
+        "combined": "cb09fe6601e8f59cff6182ec9cabc1eedd0278d17970c42e0392f3fa71834e5c",
+        "tokenSignature": "a-an-and-arm-cost-dolphins-expensive-if-is-it-leg-me-sharks-should-swimming-think-try-with-you"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 65
+      },
+      "source": {
+        "sequence": 641
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0642": {
+      "hashes": {
+        "setup": "d4e10002c634dd3076f0781235a268f4a2484215d97c20e3a32f52ab86d234d3",
+        "punchline": "c421f73a5930a12046a67d6aaa8c2ba6d1fca6ada81a10eaf9be3709f702f846",
+        "combined": "d9d1b4f2262befdab91cf08442eda8aa8e04d4dacc7c648987095b18012f1abe",
+        "tokenSignature": "at-bison-boy-buffalo-did-dropped-he-him-his-little-off-say-school-the-to-what-when"
+      },
+      "lengths": {
+        "joke": 77,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 642
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0643": {
+      "hashes": {
+        "setup": "531fb7654d9afdadb34a3ab759c0760edc8fca5811b2c1a933a132fa02009d3c",
+        "punchline": "c3622dea81383a88573610d12d8d7c7719e2b8c077776c9cfc6921a985271c3c",
+        "combined": "f59976ea7557946015806da8112c4f92f33ac6ab022f37c8c9e67dc6fd134edf",
+        "tokenSignature": "am-avoid-elevators-going-i-m-of-start-steps-taking-terrified-them-to"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 46
+      },
+      "source": {
+        "sequence": 643
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0644": {
+      "hashes": {
+        "setup": "82e547889be9d352b8a8d42aeb77bf5dd13f1ac7352656f19a8aa91c56d666e2",
+        "punchline": "c914c56cbbb6f0657152905757dbaf01e5ff8aeb63fa654ac657a28915f445b2",
+        "combined": "3183c305973cb25862585e4fa047d11b47f0da6bafb81fcf37d941c0757b628a",
+        "tokenSignature": "because-bees-combs-do-hair-have-honey-sticky-they-use-why"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 644
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0645": {
+      "hashes": {
+        "setup": "afe63436b1189fce089270d43ed806d0ca1244f93e9100a9456fc060808975b0",
+        "punchline": "aae473b08c9c5548022326da83bc4186d664360d07600874ac4da04fc8691ca4",
+        "combined": "cb08e389e6e7247ac92647d1ddfaf8b5335041ca3011cd64da78955e8ee58fe6",
+        "tokenSignature": "a-always-an-case-did-extra-get-golfing-hole-in-just-know-of-one-pair-pants-should-take-you"
+      },
+      "lengths": {
+        "joke": 67,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 645
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0646": {
+      "hashes": {
+        "setup": "3901f8dc5536b983c5887a06d7329916120cb514677a280064ce8a06e943da63",
+        "punchline": "0c419d7e5fd8e51cb7601c46a198ad07ea95e4589b021490c3bebb2c84cb833d",
+        "combined": "dd06dce894b14acf53af31177fcf0941e7fbcc4cce6595d76b43a7b6c0891116",
+        "tokenSignature": "a-can-clean-could-doing-for-i-it-just-living-mirrors-myself-s-see-something-wish"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 43
+      },
+      "source": {
+        "sequence": 646
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0647": {
+      "hashes": {
+        "setup": "93cfd4b678ec198ad831b5d1bfb44b909306dbd9da6bf17d33b5a6e83887ba3a",
+        "punchline": "00072dbcc12ef90cc3ebc88418efc5be0b4f7367a9137c80f13fc35dd7877bca",
+        "combined": "fb7ef2b2f3d9bdec97afb6a5166596640968eb5660faf7fedaf5b1eea142da16",
+        "tokenSignature": "do-get-how-internet-log-on-the-they-trees"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 647
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0648": {
+      "hashes": {
+        "setup": "8ad545ec618402ad238192cebbdc6ce567a488d7d4ffd1768d35595e2fc19ee6",
+        "punchline": "43d82d16aadde24a85d7c6b5b8e5c39a0b53dbbb3432be7a3aaa5651ed05fd88",
+        "combined": "520b31dfb261f21eba313188499abaafb786ecbbe770b7cbdb66fde6696cf61e",
+        "tokenSignature": "for-guy-invented-nothing-thanks-the-to-who-zero"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 648
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0649": {
+      "hashes": {
+        "setup": "d8beeec9ec3a30bae42445bacc58c77805595a4a930231bc0f1a6122e45b3406",
+        "punchline": "15200056fd87b065f0f62020482cc3341c6807a58b6beeec09e9fc711b91270b",
+        "combined": "ec587f150ab955ce07561aecc216dc5976454dc0e2aad32eff67bcaef6519655",
+        "tokenSignature": "a-and-at-bottom-lies-nervous-ocean-of-the-twitches-what-wreck"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 649
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0650": {
+      "hashes": {
+        "setup": "40df44c071e8a719093b5bfbaa54e1ee71a15dcb5f16d21193a547689050c683",
+        "punchline": "e16d11a20bcbb24b373f9e5148e759c37854d171ea9126779381636b287b3cf1",
+        "combined": "72ee0c37a4c4f319261d74715c37eb94be27312da7b776e9ddc87e2622716646",
+        "tokenSignature": "and-blue-is-like-paint-red-smells-what"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 650
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0651": {
+      "hashes": {
+        "setup": "b3c3f8445bd090f8bf8e54630e8af5474f9eaf2702f953ddf707a09d841266c8",
+        "punchline": "bb48ed7e740ea28b1b27bf3ade1040ef2e56d8177cf3fadb3e67bc6d86472c62",
+        "combined": "02bf739c54933a38b9e244bfe7f18306b611d52bafe2964b308d950b2d71db47",
+        "tokenSignature": "ah-back-car-me-reversing-takes-the-this"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 651
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0652": {
+      "hashes": {
+        "setup": "bc8bf33f4da29c4f1d1581f6c4b689d97baf50de9213c59a668f67ea653f0ffd",
+        "punchline": "4e26d14ae984891f240525fc26fb427bad105ffd72d8916b9efc8fd672db78a3",
+        "combined": "2e4c1d7bebfd8c98bc7ac2ea715f2b2d849ff2e66505c5248277784fe0cf8014",
+        "tokenSignature": "do-going-how-know-locomotives-lots-of-re-they-training-where"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 652
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0653": {
+      "hashes": {
+        "setup": "da0dd8f747b82d1dff5528bab47d89a0c6453084434208b14fe0467ccb9d29bb",
+        "punchline": "8620f6a7de7a9d0c6d87ebce66d311a1dad48c51a55422f6af60a6f94fd9c7c8",
+        "combined": "98f89d8decbbc7b2bcc284859bc48ba458b9a597ff1e0a212acdb28c925e0a4f",
+        "tokenSignature": "ate-before-burn-cool-did-he-hipster-his-how-it-mouth-of-pizza-roof-the-was"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 653
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0654": {
+      "hashes": {
+        "setup": "ea430ee7801d2bedf1c652f60162acb9ecd94cc59fcdc93946201b1000a1f58a",
+        "punchline": "ddd55329aec5cca10c1d77cf2c08ac4e47e986fab384e7658eced3dd99dc73fb",
+        "combined": "3a2414a4df414fb23354fa931cff45c2f2088733672cb408a447ef8a95ba352f",
+        "tokenSignature": "about-atmosphere-but-did-food-great-hear-is-just-moon-new-no-on-restaurant-s-the-there-you"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 50
+      },
+      "source": {
+        "sequence": 654
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0655": {
+      "hashes": {
+        "setup": "fc9556cc85a061f2ff27c559bf94a388a6134aed542cd55f452b6493b71d755e",
+        "punchline": "dffd5ee538d1debab56475ba9d8037739a11738aca141d7d68f3d72c8d59f21d",
+        "combined": "073170003ba0f4cc34ac5cb0cc29ef9938b2aa65ac15882fd1a81de81307ad3e",
+        "tokenSignature": "a-an-b-beehive-call-do-eehive-s-the-what-without-you"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 655
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0656": {
+      "hashes": {
+        "setup": "6d501e4f00f12ebef94f204e27efec8f3ab00640fc4aba7f2e165a9cb06cbfe9",
+        "punchline": "5fe003737cfbadd9d560e79cbb3eb559c4a41f410b5978d7438878beaeac8a52",
+        "combined": "9c26a67a7d55ab96f7ef66f4dbae84643573363d288a71c49757c38b41e2a222",
+        "tokenSignature": "boo-do-ghosts-jeans-kind-of-pants-wear-what"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 656
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0657": {
+      "hashes": {
+        "setup": "12cad39f1fe9484b962b5f52dd988502c9df1eb33befe9ba26d3098bd4a748a8",
+        "punchline": "ceaf1e8071db19bf67524bc2c6f6ec1de35755069f6acd3ed8a8938f7f4d8f4c",
+        "combined": "5ee2afa758abc895b4db806d5ca3558c4e223866c7c3168fa30d2ab4cb9d639c",
+        "tokenSignature": "a-bar-ducked-guys-into-one-the-third-two-walked"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 657
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0658": {
+      "hashes": {
+        "setup": "04e9889a5bc59d49ff8abef91a38cd87e2c39e42f08510e8e081425ef8c4f222",
+        "punchline": "276f28602db023f88567252e58a6af39a208523d784f848b2520d0db0a1fccfc",
+        "combined": "f3c05b3ce958f1e1182a48390561e94f73b74ba1f16e2209fc5d626a5f3bb714",
+        "tokenSignature": "back-but-buy-cashier-checkout-dividers-i-it-keeps-of-one-putting-really-supermarket-the-those-to-want"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 38
+      },
+      "source": {
+        "sequence": 658
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0659": {
+      "hashes": {
+        "setup": "b00ec184474aee5507dc79917b8917b9270ca3f8099d3fb5fe1b5ce7e3ef7477",
+        "punchline": "17d7d58a400f244bd6a34de3b921a98f895a40cb12de9a197fa5f108ec5d5c9c",
+        "combined": "33137f073becdfc021c85608e7c712e6f57e42d33cc67fe22e361900a4630b27",
+        "tokenSignature": "a-bar-hey-horse-into-says-sure-tender-the-walks"
+      },
+      "lengths": {
+        "joke": 25,
+        "punchline": 49
+      },
+      "source": {
+        "sequence": 659
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0660": {
+      "hashes": {
+        "setup": "17186bfce9ee7ca7ad83c96c67cf7f5198fdb5c9f11997f347f8a61545007983",
+        "punchline": "2de4e9a0cbc8ac0f1484717e00cc35b12e7f7cdb246133818f3a827533b4b711",
+        "combined": "792d32a0d461cf1bf98d9434c5face4aeee25b5419e7f2b30054783075c0e3a9",
+        "tokenSignature": "a-about-did-guy-he-hear-invented-lifesavers-made-mint-say-the-they-who-you"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 660
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0661": {
+      "hashes": {
+        "setup": "d9ab9746d4c85d046b6fd8e12cffb4132cd410f80feeefbd124fe1e63179da1e",
+        "punchline": "72a264645d043d2691cc4ff256b6b163f1d0427aad215a3f0ef695afb95ab1fe",
+        "combined": "e6ec7ff30207c60e883584b8231ef3e2658623f8059093ca556abab2556be692",
+        "tokenSignature": "a-and-attire-between-bicycle-difference-dressed-man-on-poorly-s-the-tricycle-well-what"
+      },
+      "lengths": {
+        "joke": 101,
+        "punchline": 7
+      },
+      "source": {
+        "sequence": 661
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0662": {
+      "hashes": {
+        "setup": "9765ae2518c597d3de2d2de0912f38f99b809e46ed07b50e4760c37023a6e715",
+        "punchline": "9e2595f012f53775f425df113c06abb10ec51488c500d89ed728048fa9b02708",
+        "combined": "021f1ff25d156629d08a7f585139ba7789149c88f2837c1ff44d4c46d5d67b9c",
+        "tokenSignature": "a-apologize-are-because-giraffes-it-long-pride-slow-so-swallow-takes-their-them-time-to-why"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 57
+      },
+      "source": {
+        "sequence": 662
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0663": {
+      "hashes": {
+        "setup": "c6e8960d7fd2055f93db3f04a207a5e5075f81e16ea6879386cfea7945c609c1",
+        "punchline": "4d689129a72055cee255aad9d8bd820ea8f2e52c57f17178296e157b2bbb0880",
+        "combined": "4408d92b9583245871d3e92bac5f6e4509e647bebcb1756cc608cf292a020df4",
+        "tokenSignature": "dad-hello-hungry-i-m"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 663
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0664": {
+      "hashes": {
+        "setup": "be20ba11ccee38e635f2b0c26625d0455ac3d07b05425dce6f7b97951d29e507",
+        "punchline": "992127d2f3d741fda0fdd0bd585eb76a5d79a3e4c2f06f283b59840870cfdf3b",
+        "combined": "e557e5cf75862fca791d929159a2d62ee229c99ff21cf87cef0de6992f412c08",
+        "tokenSignature": "a-and-ban-diego-from-have-heart-i-lifetime-lion-of-san-the-zoo"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 664
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0665": {
+      "hashes": {
+        "setup": "ad91b13d36d16ad0bd5f2c4d6bac3daaeb7c24cf5940edb3499bdfba300c1bf9",
+        "punchline": "9380b690495bc7d18df5336534d8738599d3eeae2a69dc1f911d8a13637f7490",
+        "combined": "e512a9e3adbc43857a78aea6b159304891ccc99bcb2919a6bc052fd49d5d499b",
+        "tokenSignature": "a-call-do-doorstep-guy-lying-matt-on-what-you-your"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 5
+      },
+      "source": {
+        "sequence": 665
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0666": {
+      "hashes": {
+        "setup": "c1a70dc2905d040f107e48d708caa8e8c6ebe82bdcea6a9e7860f092eb4015d7",
+        "punchline": "d34f4e048e75891cbfdb6d61b092b05d784de752137ffb40a3a834b97f3182c8",
+        "combined": "aa0d58e6b92d345baa2e31b26490cadd287bc81e5b2c6541ce4a4c3327ba02e3",
+        "tokenSignature": "a-and-clicked-dating-don-girl-i-just-know-met-on-site-t-this-we"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 666
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0667": {
+      "hashes": {
+        "setup": "6f1e8101f0ffa690ad420c3314377e7a972a47c60f6e87072f0ef7d299800231",
+        "punchline": "98d946a89524513a8dbc5bff1576af6466b678d5da676894ab61b3192672ce63",
+        "combined": "ae67f4617d6c52e86b9a1cd6bb87caaa80a7b6a274d21865588f06f8e2d99778",
+        "tokenSignature": "calculator-can-count-did-me-on-say-student-the-to-what-you"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 667
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0668": {
+      "hashes": {
+        "setup": "5fa9109b3a49a91ef048423a3e288d9e3e196373e983d0e4fcd87761c55b5cd4",
+        "punchline": "16b1024f40010e2cb700b1ea0c1c52e00c7541912a685c1ede596cab778cc4f6",
+        "combined": "8ac21dd5fb9b22852dc8b267975807e5c49f194da6ab0cb112d3a27db63772d0",
+        "tokenSignature": "a-anything-call-can-d-do-gorilla-headphones-hear-it-like-t-wearing-what-you"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 39
+      },
+      "source": {
+        "sequence": 668
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0669": {
+      "hashes": {
+        "setup": "1c76f01870d4bf36ce9991ccdd2e1b5b9a4b2df70cb95ef6de07099533504a50",
+        "punchline": "8523d8ec2edbc629ef0fa35e36b5f085b41be1717ce1fd9e3baf873c70bc91cc",
+        "combined": "28c60e5de6e5e65fac1afbd70423b54ae4de585175f2528f6ab93dbc33d79612",
+        "tokenSignature": "about-corduroy-have-headlines-heard-making-pillows-re-they-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 669
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0670": {
+      "hashes": {
+        "setup": "2c47158659cfe64f88f31943ed7b79590cb575f5812006a264b12ccd8b90da95",
+        "punchline": "84077336f1a1ecdee358fd20167476a8e1831807a042953eca41c13223c38650",
+        "combined": "a8e366863afaf6f6e4ba04f4752b03715381189a3724458895285b9ab7c397a7",
+        "tokenSignature": "dam-did-fish-hit-it-say-the-wall-what-when"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 4
+      },
+      "source": {
+        "sequence": 670
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0671": {
+      "hashes": {
+        "setup": "dced535563d3c4e5818b560947d7cdf617433fe2c7f9886dec289ef113473f47",
+        "punchline": "0e9d3c5e7f299b0d6da0259f697d52dc7a4ab5c2d173a877bb205cee79c9250c",
+        "combined": "5b9093dfe0cc6bd6b9e2950099f78c7d0812e7bc8ff89acdd5773d516ef76280",
+        "tokenSignature": "a-boogie-dance-do-how-it-little-make-on-put-tissue-you"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 671
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0672": {
+      "hashes": {
+        "setup": "aefbd00d6ee701a2cdf7d344a36af6c0b8ff0889b5b2dc51ed382abda42df569",
+        "punchline": "c9bee42a8c72a2577ecf03d0fbff6a0c25d45982506d68fc2021b36ddc6a11c2",
+        "combined": "a5e885e700adf276913a5e027f1f532e015326037b2fcdfffb7f041a08c0c4b8",
+        "tokenSignature": "1forrest1-forrest-gump-password-s-what"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 672
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0673": {
+      "hashes": {
+        "setup": "cb0c81a1541c6a9a04fe4261baf1b93b93f289f6ece9f983aae2ccf070c16a4c",
+        "punchline": "0d0548b801890f45875edf723554953a61c219581b1f2733b96d68069e5ae8e6",
+        "combined": "75c0bdd32a6ea1adb123f76d9552a33c6b003c13eca4b67ed0ec36a640ee14b8",
+        "tokenSignature": "a-belt-call-do-made-of-out-time-waist-watches-what-you"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 673
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0674": {
+      "hashes": {
+        "setup": "9f7ed7386e8be80e3c691ca64f8178534d4077c44a70829b964ea5a3d4d48f73",
+        "punchline": "a7d44042a78f9b5c2c0a2d5f3d8c54dd304db4c5c63e4853d5c5750819960665",
+        "combined": "82ed69a5ec7c6412e59c7b207b8dd860c1b6dee5b92a554dc86e9f6e60c2038c",
+        "tokenSignature": "are-bicycles-can-on-own-stand-t-their-they-tired-two-why"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 674
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0675": {
+      "hashes": {
+        "setup": "9ccc812a225da83ec2f98f6ee8e343e80c6cb35186c59fb50e01d35af3cbe333",
+        "punchline": "745a9cbfd083e41e7a1f008ea8d9bcb8942623071a63b21b3715d616207863c2",
+        "combined": "32ec08d88a929b53ffd3052188e5d920ba922865015f20e941f06c4aad274961",
+        "tokenSignature": "a-chew-does-eat-goes-how-it-train"
+      },
+      "lengths": {
+        "joke": 21,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 675
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0676": {
+      "hashes": {
+        "setup": "5b427260d0aa5e2d155adaddc9cd3e3d11f09dae6acad9dacd561a7a28b2d960",
+        "punchline": "5f0c6a0db894f9aa494b420d5d47fa6ed3bd73c420876079112e9f9c9f5f531d",
+        "combined": "c2f9a2e0f726477806c3d4d477b8817f0d05781a7ae4a83e3012dbfa0c445c33",
+        "tokenSignature": "a-call-dell-do-laptop-singing-what-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 676
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0677": {
+      "hashes": {
+        "setup": "38ae88935ad77db93ac29fe03d309a31c8e240a79e5e1118cbc8e5baafce96c8",
+        "punchline": "270fd076df620dfc6234c4b2bae509d432be5c662b5ba77f10c856eecf894533",
+        "combined": "4b764dc804b0fa9e6839aa0a799d1a0b63f9988e5960bf479fb83944f12f7e4f",
+        "tokenSignature": "a-does-flower-have-how-lips-many-tulips"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 6
+      },
+      "source": {
+        "sequence": 677
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0678": {
+      "hashes": {
+        "setup": "d7a1eee3a9827bf92cd48361a470b6d09ddabd38c8b7f0d4dabb692f807628f0",
+        "punchline": "c73c2439657961570873ea43f4eab3d7143bf0b5a693b2e7dc1f4440b35aa48a",
+        "combined": "38af161f1cbe3f5028481eb5031e48202973363d2bfe26bc31f702198a8ec1bf",
+        "tokenSignature": "a-does-kind-of-shoes-sneakers-thief-wear-what"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 678
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0679": {
+      "hashes": {
+        "setup": "4f3b943ebfd14d661dd4b73f8a5b0767fc8542b2d6c65c32df364d7637022cd0",
+        "punchline": "094cef6404a35cb79dbb94f422276f2a9a6deaa66712085bfe70d6c0352fb41a",
+        "combined": "c13df59239ae305a176408da554c027c3cabd0a4d5d7f3532ac077e280dccd36",
+        "tokenSignature": "best-dentist-go-hurty-s-the-time-to-tooth-what"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 679
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0680": {
+      "hashes": {
+        "setup": "8bf73b25b9d5a03d581bd4fe503f763a5373a8ca667efeed3289673a228c1fc8",
+        "punchline": "f450cf95e6588d5bb1c9ca5cadb2309ba9e3ea68fcb3cee0683876eaeda9dd39",
+        "combined": "56432c7c702da7e3a43aa0e029e720a6ec56e10f1e536ffa14754ab8b6d618ad",
+        "tokenSignature": "a-broken-it-knock-mind-never-pencil-pointless-s-there-who"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 680
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0681": {
+      "hashes": {
+        "setup": "74f81a368d1d3a9f6864701a9d45913d78647b34a90f6622eec13f4112df073e",
+        "punchline": "3dc5b1a36b443f766a4da48659d50755b7b663b8be721def0e8c1feaabc0ba51",
+        "combined": "3a2f60c00931b88c43727119905674094561749548087051e78afbc68983b66e",
+        "tokenSignature": "cows-go-knock-moo-no-s-there-who"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 681
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0682": {
+      "hashes": {
+        "setup": "679deb7ce9523549cf043555f9c0d6f3a01f3317afd439a5f9b99701e933e722",
+        "punchline": "e68b307c9d8a41465baa424127be5263671ef653add1cc78067a28e176a0330b",
+        "combined": "a682e388cc9109509bddd13f09a20facd132e980f8211ce02d9c3427b7d78f68",
+        "tokenSignature": "could-didn-i-knock-know-lady-little-old-s-t-there-who-yodel-you"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 682
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0683": {
+      "hashes": {
+        "setup": "7d6758f72556581ad028379f463d6186e330d54c3ea3f8e332c1500990df18eb",
+        "punchline": "2780cf5d6c833229200492449497e27d193a210b0eb058b62c0bbfa71a4d2b3e",
+        "combined": "07247794bc07ebdc3cefe254150b844d9197eeec2ee2eb5d7d2ff30dbc191c30",
+        "tokenSignature": "a-adept-at-become-c-good-guitarist-he-in-programmer-riffing-s-why-would"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 683
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0684": {
+      "hashes": {
+        "setup": "8add74bbb9f000d10fa094352a6ba551e0ed3edf9f6c7919376fb9561b91448a",
+        "punchline": "9771661e842f6ac19a55fdbadac3e7d92fa99c9f8c6d7c8af397b8890e89a306",
+        "combined": "be22d66b4a64989b8d1edf73bacb62c23efc0031ffbab5208c3bbb181d89c034",
+        "tokenSignature": "a-about-best-bit-boolean-by-even-if-off-only-re-s-the-thing-what-wrong-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 684
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0685": {
+      "hashes": {
+        "setup": "97aeb57be840c0d27032c0134ba1e443a7b3c9ee41d6b3320cfa0d5581d82e77",
+        "punchline": "40c079d137e820257717088a754a1670f357ade4757e17af530590a5bd9de74b",
+        "combined": "f6019b013ae207ef1299966a55a1059002a2bfc4184f57c2d3a807141b952626",
+        "tokenSignature": "become-inheritance-object-oriented-s-the-to-way-wealthy-what"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 685
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0686": {
+      "hashes": {
+        "setup": "d986276c7fc953ee01c34097cb97c754d652b6735e27f9dae4dd7256d1fa1507",
+        "punchline": "8a58b4925ce2ed1237ebe24c9fb0db16b422915eb2552f4f29a0aca18505cc22",
+        "combined": "a791c8581ded9eb98f15c3817d4544b5c5add94b76b1e18e87d2d804392c582f",
+        "tokenSignature": "bar-do-foo-hangout-like-programmers-the-to-where"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 686
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0687": {
+      "hashes": {
+        "setup": "29488e469166935e0bac0425201e1822f0ad2602e7b422f99880666ec54c07c4",
+        "punchline": "4f3dc2cfd1ad0bab8cc7648eb3fa85b633922714c0652a3cda36e085f1948099",
+        "combined": "4e03726cc0bbdb73654ec020cf9ef7d1d28572ecd77eae3d991cc0f6d2d09647",
+        "tokenSignature": "arrays-because-did-didn-get-he-his-job-programmer-quit-t-the-why"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 687
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0688": {
+      "hashes": {
+        "setup": "7b7cc7e5d5c24b0c94ed659afe177f44eb1d916f1e04343d01dd81d77166bdfb",
+        "punchline": "d90893c35f1501680cfa221aaf5083e433905c2d321d5309e31b9558e3bb7bf4",
+        "combined": "22e7a1c57266e0b1359d8e60540e7f923c8d6e87bc4874dace3e9721a38dc78d",
+        "tokenSignature": "a-about-did-ended-hear-in-it-race-silk-the-tie-two-worms-you"
+      },
+      "lengths": {
+        "joke": 48,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 688
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0689": {
+      "hashes": {
+        "setup": "1704f287293e56c3167eac6b4093266c3e6ae91eb361781580946db100ccb945",
+        "punchline": "ef7c7ab2c164ed4aad630797e5f250103e3abef03dfca1d321adaa4c62cf7907",
+        "combined": "2de6e582664c3ed02349dc6caffcc9dc2de9a7abcabaa236f593d5d1b86d3597",
+        "tokenSignature": "a-call-do-laughing-motorcycle-what-yamahahahaha-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 689
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0690": {
+      "hashes": {
+        "setup": "3a507611361dd1642b3c51555e7b12b4c23e81334c05f751095fcb33194b12af",
+        "punchline": "61f6624b36905b5f85b77a9a7b798df0932ca0aabed0b6d3ede65085774075f8",
+        "combined": "af06f84e48984122c3973fa20c6ddf76441bab4885d9679de401b3822401be66",
+        "tokenSignature": "a-and-bar-into-is-says-tended-termite-the-walks-where"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 690
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0691": {
+      "hashes": {
+        "setup": "ca59d7e6db1633a0459d1a06d4737b1177c18e260eedab5c6b3710a3140c73d3",
+        "punchline": "06549b781344c1b90d68bc37cbc35f084bbfa4557896517be3ff8238bc07c478",
+        "combined": "db4e12488224ac0d78c2c80f735d12573e1f9f3581561a2ccecbdba4e20dde38",
+        "tokenSignature": "at-back-business-c-does-his-keep-lewis-narnia-of-s-the-wardrobe-what"
+      },
+      "lengths": {
+        "joke": 54,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 691
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0692": {
+      "hashes": {
+        "setup": "24f95fc53378e9d8b0d1417781b981d240e6633d72f783cd8979cfd6fe644a9b",
+        "punchline": "4f1117d1c6b596cfc5e0b398662767b2bcd29a98ca2fc1fcdffe1239c80e93e6",
+        "combined": "2f81a138ca565dcacea0e368bc732f845b1f6e4ae11aa94e655a01846e5be08f",
+        "tokenSignature": "a-and-asks-bar-can-i-into-join-query-sql-tables-to-two-up-walks-you"
+      },
+      "lengths": {
+        "joke": 64,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 692
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0693": {
+      "hashes": {
+        "setup": "c213e34a40a11b9495220ff11f467e5d0bc5e051da331f60a0193aae727c250c",
+        "punchline": "b280810212be26d03ec1817dbc583ecf77b62615ba7e88794ebe2bc9b6b97850",
+        "combined": "5d3d2f8a18df325636b44e641989fd5b42e73f06d2a15d41c9e18eebf8a400b0",
+        "tokenSignature": "a-change-does-hardware-how-it-lightbulb-many-none-problem-programmers-s-take-that-to"
+      },
+      "lengths": {
+        "joke": 56,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 693
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0694": {
+      "hashes": {
+        "setup": "55715d3b1ce8d7328474eddc8caa8508abce87fe8ab054380ed917c21bd8265a",
+        "punchline": "5df8545e1ec05e5422f3e67a6f70a71e07a5a3b2c3d724d382a4943199a1b17f",
+        "combined": "95b50ab6022d7055a0a7a286d38edc52a898cbcc1ec7c088dd1d52cd061ce3c0",
+        "tokenSignature": "a-at-eventually-if-java-keyboards-million-monkeys-of-one-perl-program-put-rest-the-them-will-write-you"
+      },
+      "lengths": {
+        "joke": 101,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 694
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0695": {
+      "hashes": {
+        "setup": "b4d0f95582531162f68070a39031756abcd0c68f742061355917c2f313752219",
+        "punchline": "f7dcfe7998ae3f523ea268a4e42a927b298698c5dac722f7de30fc9ccbcef168",
+        "combined": "600083dd8a121e9c7828b8807bfc964a69efe453a1d5a541fddc047e9fd7501f",
+        "tokenSignature": "array-hip"
+      },
+      "lengths": {
+        "joke": 14,
+        "punchline": 15
+      },
+      "source": {
+        "sequence": 695
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0696": {
+      "hashes": {
+        "setup": "5ef4ebe1f730e9b3c03579870728be71a76444162c732219b9696ed28bc19b1c",
+        "punchline": "a85000de4674b5fc34f2ace641714fbc1c384365d156235148102bca43fe8600",
+        "combined": "517ef32a442bded88adcc63b54165a325094abdff76d35962a4f764eeaa210aa",
+        "tokenSignature": "first-is-must-recursion-to-understand-what-you"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 43
+      },
+      "source": {
+        "sequence": 696
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0697": {
+      "hashes": {
+        "setup": "d9ce16243e708c061e281ba21d10b03bd1a3e48b8c12d5457f9e7880f17ee29c",
+        "punchline": "47de7265411e4a97dae637d1a1ca03b96439ba80b8613a2211e520f54012540f",
+        "combined": "0c245af76f0909dd24b3bfa584c304f824ef2c9bea196ad60daa4aa236f46cb7",
+        "tokenSignature": "10-and-are-binary-don-in-of-people-t-there-this-those-types-understand-who-world"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 697
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0698": {
+      "hashes": {
+        "setup": "1f5927d1a58e80085811d9e7f71f42c349b17efa0c764112fa48120e751431f4",
+        "punchline": "899baf12d474db4b3a31b129bde3b1ec37fa7e5afb79aeb3d445bc53039240e6",
+        "combined": "260c632e10ddb7ba97247d8ef933292644cc006e9f252d4c7890ec53cb9c1b2c",
+        "tokenSignature": "bill-bought-did-duck-he-it-lipstick-my-on-put-say-the-what-when"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 698
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0699": {
+      "hashes": {
+        "setup": "53c66a41c47250b36d8df590e96f75b0335a84b7782eea83909452d7808a7c22",
+        "punchline": "698dfd38e87e2d9da1982a390956720b42e20fa029a2d9f27e6b7b20b043e6a3",
+        "combined": "d66003ee34450abb848d39aa2bfbcb939320677a8eac89a7ec5f860666144910",
+        "tokenSignature": "a-away-breaks-car-down-frog-gets-happens-it-s-to-toad-what-when"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 699
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0700": {
+      "hashes": {
+        "setup": "24367ca15151319e39dac74978c99aded07885f11aa25090332324809ba19a3e",
+        "punchline": "6ff1a02afb0fd223466e67239aed45f25098f21e155fc86157bc61a34315ffc1",
+        "combined": "0d8c1bd2cdd069c72baaa472c34963fc828c7e835f31bffa55bb98cddcd8e20b",
+        "tokenSignature": "cooked-did-first-france-french-fries-greece-in-know-t-the-they-were-weren-you"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 700
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0701": {
+      "hashes": {
+        "setup": "4ad34c24df6bd971d8c4831e7cf703c10fb9e494f527554138d109ed76ce3b19",
+        "punchline": "1f3c7bc606b50ebdad57aed216df28a9d2c80af9fa49c592976160f551fe8817",
+        "combined": "c9b95392d33facf77e3342f221f2c8b1c519aa730d2ec2f71512296d41ead9c2",
+        "tokenSignature": "an-avicii-can-catch-exception-me-sing-song-t-which-would"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 701
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0702": {
+      "hashes": {
+        "setup": "4501ed009c5fb94681225ca5638d699f8572901417e8d46c4696234e28ffc14c",
+        "punchline": "7a2ed70d244da5c93e31981c6eca1831772d2f8d81c648969ab8b868219517f8",
+        "combined": "42f465a2a366b8b3ddcfa50c32a4fc6e2221c7cb76edd51a3a0a65178828cd4b",
+        "tokenSignature": "come-doesn-impossible-is-knock-knocking-opportunity-s-t-that-there-twice-who"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 60
+      },
+      "source": {
+        "sequence": 702
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0703": {
+      "hashes": {
+        "setup": "04bbb985e1964dc488f8234d9d81d5487774878d817c4ca5b69f0a1363884942",
+        "punchline": "351924f739ecf049358e75454bb073bee05fce7a6dc88337dc42d8e1ef760d71",
+        "combined": "9cf952aebd199a534327b0c5f0f6720b740e7d2852b5e4511cf1ef45fb355b18",
+        "tokenSignature": "because-c-do-don-glasses-java-programmers-t-they-wear-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 703
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0704": {
+      "hashes": {
+        "setup": "20cbf6b5432f2f1eed1d61ff842fd195677a3c9e67eea06e214024f93afcee49",
+        "punchline": "9295c47486b614388d3419deccebf9ebca42afc5b21fc470d439bcd7d98952dd",
+        "combined": "87690bdf0dbdb37c2ded6904a9c16dff89918954be4f28d889edbd6441d90bdd",
+        "tokenSignature": "a-because-did-fungi-get-he-invited-mushroom-party-the-to-was-why"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 704
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0705": {
+      "hashes": {
+        "setup": "7ad8f21d8b5d9d49145315e01a7f8a6102e96e78ded46a2655bed7d22d8c5ded",
+        "punchline": "98ab7bfd22a997588997ec30fe6e4d14688b65f9a4377aad6a69d5d94333f67e",
+        "combined": "bb6bd9c5a124218d1edd2c956470860037e14d76fd5338f62bb245be72594533",
+        "tokenSignature": "before-do-initially-is-know-the-was-what-word-you"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 705
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0706": {
+      "hashes": {
+        "setup": "b4128cf80a48ce46518076c3e4cb859f1f44d2f4e316e5def87d728741d21fcf",
+        "punchline": "f6e4f86148dcdee1e9b7ae71949ef47ded2211c4dbf0ca8a455eae61f8d801c7",
+        "combined": "76c5fc6d41386e4c4ddd9c0b6165cb464660837ab6401649b9622c4cce2623aa",
+        "tokenSignature": "a-about-anti-book-down-gravity-i-impossible-it-m-put-reading-s-to"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 706
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0707": {
+      "hashes": {
+        "setup": "3821f28ee378b58ba6f618299b982c0a51d2224eda4c7791c6ac0864f811b060",
+        "punchline": "e39cf4518fca1824beb1130beba7e8ac8aec0cf91346bc00da7814a81bf44f69",
+        "combined": "161dc02d5e41f7b62cafa02c7fb74de8e6bd857c0f31fea352489dbbd97ced07",
+        "tokenSignature": "american-and-are-bathroom-come-european-go-if-in-into-out-re-the-there-what-when-you"
+      },
+      "lengths": {
+        "joke": 116,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 707
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0708": {
+      "hashes": {
+        "setup": "a6ccc4e3a9fa38bd1c09a6b914a812e36a16933171836a05b54dbeef98eb04d0",
+        "punchline": "e74246f952e3d00c3581441a8d3fd6512dacf3cb27c91e4481b051e9f60587ab",
+        "combined": "3159c6625a19ec67c884dd47b6ca1ea032f8b4b7a3ae868407b621c976cd1def",
+        "tokenSignature": "a-about-hear-it-joke-mind-never-of-paper-piece-s-tearable-to-want"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 708
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0709": {
+      "hashes": {
+        "setup": "2fb13c5364af376d58a016f34f14ec3a73e27980c539db82cdc3f413d3276323",
+        "punchline": "2d3c1be6eeb7993c02e7c211a8e1b16850853d1461f62a19fb9c4debff14394b",
+        "combined": "4e152879233f8509cd1bba4bc0dc9f477866f2e21f2617fc5dc3fe98d380724c",
+        "tokenSignature": "a-about-beavers-best-dam-documentary-ever-i-it-just-saw-show-the-was-watched"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 709
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0710": {
+      "hashes": {
+        "setup": "437961fe0e8767b1b7c1f58b2ebb5db0909f1f0eed21c6ee63faeb8c397d5993",
+        "punchline": "240ff0f6b8de7fdcc8129b18217aa06c29ac60cf01c220c3a550a6a935cd1d02",
+        "combined": "d2bfb78759057f74ea6eb9b8901fa8e1a85df41a131396b8429baa6c0491ecea",
+        "tokenSignature": "a-an-apple-at-does-if-iwitness-make-robbery-see-store-that-you"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 710
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0711": {
+      "hashes": {
+        "setup": "94d0733d8a92c10dc9a0b01408a1c0131ed063d866dcf087153357ce83b9e40e",
+        "punchline": "86e1e5c1949ba2ac483f31ccb9fd67d870712999f3c20f7ea7f3f34c88db23ba",
+        "combined": "eb2ac201e149cbf0caf028df4f91f884fef8c47f150e74cb48e9ba3d1533ea00",
+        "tokenSignature": "a-and-bar-bartender-beer-don-food-ham-here-i-into-m-orders-sandwhich-says-serve-sorry-t-the-walks-we"
+      },
+      "lengths": {
+        "joke": 73,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 711
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0712": {
+      "hashes": {
+        "setup": "cf868edc0acf59831e235607aa819343756f3d658ced23b01a9eb14942b4918b",
+        "punchline": "33a6f57767fd1c0addc9c94b2ab76f2c83a79ef300e9edee8b769fbafb2e89fd",
+        "combined": "00b731843c0297129b84b19d7ca2a01035f948b103b4167c2d415c4d3be55389",
+        "tokenSignature": "a-boil-clown-do-get-if-laughing-stock-you"
+      },
+      "lengths": {
+        "joke": 22,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 712
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0713": {
+      "hashes": {
+        "setup": "c7d37f7cd8782f7ded46af4a78663edb2e8b52624605aa9733e558e7255ca430",
+        "punchline": "853e50ec437bae7304428a12cf1da71c4486ac984e8271326d03d43e879b55a5",
+        "combined": "b3a9e3987f8a3cf1137cab3acb6bf27e2f6086ce2bf71266dccf76d0e90528be",
+        "tokenSignature": "all-around-day-doing-finally-he-his-loves-my-nothing-plant-pot-realized-sits-why"
+      },
+      "lengths": {
+        "joke": 66,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 713
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0714": {
+      "hashes": {
+        "setup": "549ded4e1a6f63b84d643f0c40845446ea8eaa46367b302806406f887385ddd3",
+        "punchline": "524b5783e9ccdcc8ff37c06f225d4bd301d891c2942b232ab6609908982f4887",
+        "combined": "3e5b0bb68a4ae4a7dffdd27fd2a207ec1d6d9c8ed9712126f0239e6c022a12ed",
+        "tokenSignature": "a-at-colander-don-eclipse-eyes-ll-look-strain-t-the-through-you-your"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 714
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0715": {
+      "hashes": {
+        "setup": "aa68f6c8701566c8b53d9675c08051550d561287dfc8e44b575cec408c78ce88",
+        "punchline": "fba1d8e92e7d6f157cd549b2e9f577ff26f3b7cfd4f64b50456fd54a5f95e623",
+        "combined": "a8dfacf77c43bcf3076bdc57d9214ccc0520a077c77db5d7862d88611cfc6396",
+        "tokenSignature": "a-all-bought-but-day-dealer-don-drug-from-he-i-know-laced-shoes-some-t-them-tripping-was-what-with"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 65
+      },
+      "source": {
+        "sequence": 715
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0716": {
+      "hashes": {
+        "setup": "086e660440f2ba2a13821b75569e0fc0bced448071f0c92f6251eaba6745c4b9",
+        "punchline": "25cf8bb4440d026605a5132c7140d5e0c19310c5702d3d70c78fc0f6734bdff9",
+        "combined": "c1c1a7d67209d52bcbc6d586270260798aa78d2f9667c534da07c0d601b1acb3",
+        "tokenSignature": "be-because-chicken-coops-do-doors-four-had-have-if-only-sedans-they-two-why-would"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 54
+      },
+      "source": {
+        "sequence": 716
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0717": {
+      "hashes": {
+        "setup": "a69c597ab98f30923a0fc5d1ee8c4b8f69cc0b7f5eea92fd4866740c951511e2",
+        "punchline": "2774aaaf92c111919f51d440849fdbd9df6ae09664292917ffe94a9c460294d2",
+        "combined": "35784ce929054ffe8cb944121fb9b2bc6c93c2369ee26f899f2b50ac648f267b",
+        "tokenSignature": "a-call-do-factory-passable-products-satisfactory-sells-that-what-you"
+      },
+      "lengths": {
+        "joke": 56,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 717
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0718": {
+      "hashes": {
+        "setup": "835dd0bd928e6913fce77b9e8fd98bee421a728213a1067ece7ba4b8d6b8e344",
+        "punchline": "bbf6a640d54a863c5a71900d33c03910f5378a33c8cd672347b90e1d15974cae",
+        "combined": "a22b0a72032a16f8427c4c4337ee6cd064bec3bcaba4ce94ebc1e7a209e035d7",
+        "tokenSignature": "a-are-cemetery-dad-did-drives-dying-get-graveyard-in-just-know-past-people-popular-s-that-there-to-when-yep-you"
+      },
+      "lengths": {
+        "joke": 75,
+        "punchline": 42
+      },
+      "source": {
+        "sequence": 718
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0719": {
+      "hashes": {
+        "setup": "061ed00ab4d88171361eb0f17fd3782ade6468d5832d80d4394751c07493e12a",
+        "punchline": "6caa7386d2eecb5b1f4d5d8e6fd49439a1502936b7ecdc3038be051bce94d851",
+        "combined": "6557ec16c6dc8b6520ca9aa2d2d38a835ce60b93156b4db430916358383319ae",
+        "tokenSignature": "couldn-did-doing-down-he-himself-invisible-it-job-man-offer-see-t-the-turn-why"
+      },
+      "lengths": {
+        "joke": 50,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 719
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0720": {
+      "hashes": {
+        "setup": "8b2ab4612f5afc014027dea778dbfd3b3f41b4cf94579161729745455a84e4ac",
+        "punchline": "089c23e75322b5be416a390056d9bfcd7c353429cf8388e5f17d0f885289582b",
+        "combined": "58d2be543939a639dbb9bef4ff4b2a3d827da5c256fd7d77fd65a6ead2f4cbd5",
+        "tokenSignature": "a-check-do-explorer-how-html5-if-internet-is-it-on-out-try-webpage-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 720
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0721": {
+      "hashes": {
+        "setup": "e757f4bc78b6dd0e135cb93a86edba0aa72bd37e2203bb4c72aaaead837efed6",
+        "punchline": "30747faa66c82c8a675abb032309bc1ba4bf3186a466c956e85e1ac745463226",
+        "combined": "f27568dc86143f87497d475b83d159ae127cd3f27cd15aae23d6610a8e8f464d",
+        "tokenSignature": "a-another-car-drop-dropped-have-i-in-morning-my-one-pair-pear-should-then-this-would-you"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 56
+      },
+      "source": {
+        "sequence": 721
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0722": {
+      "hashes": {
+        "setup": "69f31c03365bcc4cf42cf9f3f19110a1a78ddead06eb9992a8fe4697ef8dfa33",
+        "punchline": "17c0532508eeb42af74a13ebaa3a9b16fdea7ad628571b737391a37e15500b7f",
+        "combined": "5cce48bbf08124a56ca49908dfb0ab5bda16854e09351c0c398e3fc0af5cec08",
+        "tokenSignature": "cruel-do-dude-how-i-in-lady-love-random-spread-this-world"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 722
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0723": {
+      "hashes": {
+        "setup": "a576fba74257a65914adac137dc31c64b10faed750d3d98fc9156368dda8fa33",
+        "punchline": "82dd33c7518d61caced3a55cd3c4e3a0d41afbd9a95c330dee2f0c1cca77c809",
+        "combined": "727c4dad936952d476512381fa6073e7cf079ec094caad52a5a0b2b31071c9d1",
+        "tokenSignature": "a-explain-good-have-if-interface-is-it-joke-like-not-that-then-to-user-you"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 51
+      },
+      "source": {
+        "sequence": 723
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0724": {
+      "hashes": {
+        "setup": "cf82bfd89f1f37f7ef9e95723c7792be937d2fe27bbb7de362180c9f281b1ea7",
+        "punchline": "a34d0e70e08501a52249b1c5a289b52e09fdd1801b3729e6a93124f17635d85c",
+        "combined": "0cfac6f2a58bb2278f86965a6d3a8bcd2f46a056893387e6b88005839e0872df",
+        "tokenSignature": "bless-hatch-knock-s-there-who-you"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 724
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0725": {
+      "hashes": {
+        "setup": "9249bf65d280737db2f7ee8caae6e1ccecc88c04bc58fce7141cfa71310c4fd1",
+        "punchline": "51f7b9eb9ab7a862c1668040f52470e472726dcb4eeec09b76b2546420f27413",
+        "combined": "4d739ba26de575452a4e8a670f9a774d779c1a5cdf8b2742340d19684125e3bb",
+        "tokenSignature": "call-coffee-despresso-do-sad-what-you"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 725
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0726": {
+      "hashes": {
+        "setup": "9b9fd8db74d9b3776ae42978e6eff3285f46a5aa3fbac40befa0f57900f8ea50",
+        "punchline": "bee4264c1a339ef50d8b0af373454d7eba4061a928421dcb6f4ae7642fcb9553",
+        "combined": "26083d30dd0d14d5db03712441715ccd05a5773aafeaaa9f159f46d1d7bdef2d",
+        "tokenSignature": "at-butcher-did-ends-extra-hours-make-meat-shop-the-to-why-work"
+      },
+      "lengths": {
+        "joke": 49,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 726
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0727": {
+      "hashes": {
+        "setup": "6a3478032b66e0f87938f8387040f314c8929aa35513faa8bbdd11d18ee1411b",
+        "punchline": "0f562c97690fdc9e713a83308cf54a37cdfa25bbd45326440fcc0ee7dfbe34a8",
+        "combined": "22816df890e0bec3589a7afb1c9223d221667d71ccf235fd3fd3e68e4f9c8e41",
+        "tokenSignature": "about-back-clock-did-four-hear-hungry-it-seconds-the-went-you"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 727
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0728": {
+      "hashes": {
+        "setup": "6f2dc0966ba0f2fbdd7d9406676b5ab0cd4df301262b35f6899ef220534262f1",
+        "punchline": "d379f83e5004bc315b91ffc807fa20193baf8594dbb3c96561d38fc35924c887",
+        "combined": "981cebefa26d8bea632840c4dee86a2c6f61346370516022e560b2c308febcaf",
+        "tokenSignature": "a-deep-s-subject-that-well"
+      },
+      "lengths": {
+        "joke": 7,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 728
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0729": {
+      "hashes": {
+        "setup": "50202d3d188e5dd2096c077f8ccfa48fd56ead011c1252c2ed1e8d2bb04fa8d6",
+        "punchline": "b53dcc6f17a28042146f9c90b53760348756383015f96fe38284ca6ad48bdffc",
+        "combined": "0d335bffe78680b06fc2b6010da4512653c5418fa66a80f0e9041781b053c892",
+        "tokenSignature": "about-cheese-dairy-did-hear-it-legend-saved-story-that-the-was-world-you"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 729
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0730": {
+      "hashes": {
+        "setup": "137352b369d5bc148a07e7ecf2e36d6c9062253ad37bdec6f0dde82e008e7cb8",
+        "punchline": "bb67c3abd286d46a3bf5746c9eb1babc96014678e225b8ca756671473504408d",
+        "combined": "b3d8b546c327fb3b127486f233ead0fa2e26bc182f1281026606ad88b98f5415",
+        "tokenSignature": "book-comic-did-graphic-it-movie-new-the-very-was-watch-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 730
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0731": {
+      "hashes": {
+        "setup": "2483c9a2f6794f850c65e62e25b56c12b28722ccc95d086ae2ba18efb7dd62b2",
+        "punchline": "9927da362f16b485647b333241a25d9cc86704a08780bc9b04f8aedfd14d5c58",
+        "combined": "cb639257dd1a66a76c2a40c19ecff9761ccd936b01e3407951b126c240261032",
+        "tokenSignature": "a-are-attic-business-going-i-in-making-my-new-roof-sails-started-the-this-through-yachts-year"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 37
+      },
+      "source": {
+        "sequence": 731
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0732": {
+      "hashes": {
+        "setup": "1f33e1ff1430024957e7b955488da5f13fe8314d3a66a6a85ce9c93e8d697c58",
+        "punchline": "d2f4b3ce356336d2d191b709dec6aab500e1eb8ff7d77dcc84739d90e92e6a3d",
+        "combined": "3c9b191f2c65a1e4af8c26cdefd852830aa1d0ac81eadadcb0434866cead2451",
+        "tokenSignature": "a-but-by-can-didn-drink-got-head-hit-hurt-i-in-it-much-soda-soft-t-that-the-was"
+      },
+      "lengths": {
+        "joke": 68,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 732
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0733": {
+      "hashes": {
+        "setup": "b7692390f0599418ea478e1a34fae17f150412130f33dd14c601a59805cec65a",
+        "punchline": "2791225bb193716e205961580375a0672f8b5f67bb7a45ae349092134b5d2bc2",
+        "combined": "425c6ea325c98366dfd0c42085c8c89d3a26f59d8d1594b82d82341494bf3234",
+        "tokenSignature": "blender-can-giving-i-if-it-keeps-like-me-mixed-results-t-tell-this"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 733
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0734": {
+      "hashes": {
+        "setup": "098797d527b83cad533859879b3018ba7c91badad6a37d7bcf7c96fa9a25274f",
+        "punchline": "350c6fcb0b368801b81219a24c7e2d3ad1751e65104577bcf2d33ab82c7737fb",
+        "combined": "1a1df9fb75001f13a7af26d926bb4e84c3f70ed9919a154b91b71e2fa454ccf1",
+        "tokenSignature": "a-at-booked-couldn-fully-get-i-library-reservation-t-the-they-were"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 734
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0735": {
+      "hashes": {
+        "setup": "2d1baff68b7133c94dd79cc662cd756354b166e1324618a6cadfc97f76a20fac",
+        "punchline": "f121d810ca76bfcc1f0121580fddffd71fd634886bb9405f108a583bc4df1968",
+        "combined": "9527e1052bb7ff227c944653c1987253faf3d945bd3cde048d675bad4b24a3b9",
+        "tokenSignature": "a-about-but-get-gonna-i-it-joke-might-not-tell-udp-was-you"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 735
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0736": {
+      "hashes": {
+        "setup": "d4d674583d15b6c288643a648834955bb31c8dc01a491f6fb425ad2614389a10",
+        "punchline": "f9d1958a11939c836dee76e8d39801192f6f714b493dd1350fbb50dd581b6ab8",
+        "combined": "a1950eceda19607dd658fa787784dc57a44844e50b5dc27803eb699915f74714",
+        "tokenSignature": "arrives-before-do-jokes-know-often-problem-punchline-set-the-udp-up-with-you"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 39
+      },
+      "source": {
+        "sequence": 736
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0737": {
+      "hashes": {
+        "setup": "9855af9f38f6d0bce42e9fa4871314f557bd2887cfdbb1922990ba7b2f54bfce",
+        "punchline": "3fc00bde77bb3dac64def9c0e45b4c5ed716c73ca74133a5fae7b09cb0137103",
+        "combined": "2f53514e22d25ac53978243e01cfd92981a467578e48e236e05a1f2fcc13a171",
+        "tokenSignature": "a-and-because-breaking-c-developers-do-java-keep-keyboards-language-strongly-their-they-typed-use-why"
+      },
+      "lengths": {
+        "joke": 60,
+        "punchline": 43
+      },
+      "source": {
+        "sequence": 737
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0738": {
+      "hashes": {
+        "setup": "b7eac12ae658f93eec3775ba768563dc7c509bf24ba0535e3fd67233e07416f1",
+        "punchline": "bd99bc161256dc536445680e7fdd2787e36591eaf2699291e917a168ddf84d7e",
+        "combined": "f69c5ef86ff426ee2d25b9507c2f9bcfc65f7822761660e0e05ff7a4f7f04882",
+        "tokenSignature": "a-do-give-in-lemon-lemonaid-need-to-what-you"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 738
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0739": {
+      "hashes": {
+        "setup": "83a8b79ef6835590540053947891310ba6c8bcbbbee70bfdc304ea6b2c6bf82b",
+        "punchline": "19163dc794fce3b492497e109ff9471464022c2d32a994cb5c2242bb23f4e2f6",
+        "combined": "096eaa425183d54949d9b932bfcb0ea97fb143926c741f8aec73b661e8542884",
+        "tokenSignature": "a-bar-bartender-before-can-for-get-goes-i-into-never-pop-says-served-the-ve-walks-weasel-what-wow-you"
+      },
+      "lengths": {
+        "joke": 112,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 739
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0740": {
+      "hashes": {
+        "setup": "f90546c74b6637bca789cedd33bf3c53f8dd689d62cce2bfefabe965e4202e52",
+        "punchline": "322be6b147f67d75d43a0a329cbc8dab32ad879819d7cd421947645f32153098",
+        "combined": "424561e86a4d18d2de036c5c48380b78f720075eae6d03a328600aa25c218bef",
+        "tokenSignature": "but-can-don-i-it-on-t-the-turn-tv-watch-yes"
+      },
+      "lengths": {
+        "joke": 19,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 740
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0741": {
+      "hashes": {
+        "setup": "089888bda166ee695ab43052b40458266459a9c873d18c681fcb400c4a99ee94",
+        "punchline": "bcc45575da500ce24fa2d761734cc173424fe3424991d4ae7a33f7361e491310",
+        "combined": "860eed83517a5d679303d84d6788c391e57b82eb46177f8b37992eb69dbbcf82",
+        "tokenSignature": "call-do-friend-ghosts-ghoul-love-their-true-what"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 741
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0742": {
+      "hashes": {
+        "setup": "f8bd1af0dc1a83a16bc85569004067db27d1e44407c6ab64f3a837b8c64a35d9",
+        "punchline": "3d5d1ebcddbfeb75789e30f0e99d5e5df37127e2f8b92d5cf1bd39b6b5178878",
+        "combined": "9355b02f8ece4f4af72d13d0b0f7c51d16d70f7dd5e1d8ce27f50b2b3bc691d4",
+        "tokenSignature": "are-at-excel-good-how-i-it-point-power-you"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 742
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0743": {
+      "hashes": {
+        "setup": "87f800db89cd5ba3f352f901911d8f04349a07385ce93d3d60c1a89767dfa027",
+        "punchline": "6eb05ff604740d43879b47dd71910a4f3e2b63a5e8e5effbb20ecd8b8881ff9b",
+        "combined": "5eb8faa76d4bee55041b51c810620759572241f914a961478b012b80f2bb3a97",
+        "tokenSignature": "12-2nd-a-april-are-etc-february-how-in-january-many-march-seconds-year"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 59
+      },
+      "source": {
+        "sequence": 743
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0744": {
+      "hashes": {
+        "setup": "e81690503f5ea30ec485da4f1c2e8bdac422bce75fa5ce447878858ac2a9116b",
+        "punchline": "ea7397c91b5840ea7257761484093699a82165f1f1bed97a9636f8589fc42065",
+        "combined": "8343dbea14db915d1538272e01697571f407992dac6ca4bbc223ffbfbade41a7",
+        "tokenSignature": "200-50-cent-dollars-in-name-s-what-zimbabwe"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 744
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0745": {
+      "hashes": {
+        "setup": "b22c1df822ae72976f690540f29d1014d7d9919b663be4470b09a9aaebb354bc",
+        "punchline": "d6acce58810d89e5a423471d83cbb0ed7c85ad9dd1080e35af7a384ce01ca140",
+        "combined": "989c17ec5220c771f8a14d6a3f903c699ad9a5dbf0887f95a4db55572fc8615b",
+        "tokenSignature": "anywhere-been-bin-haven-i-s-t-the-where"
+      },
+      "lengths": {
+        "joke": 16,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 745
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0746": {
+      "hashes": {
+        "setup": "3752637fa6d81b0554ffbe9308a08ab340e30450ead0ecefd4379ad2499f56bb",
+        "punchline": "2d1aaca818a6d029412b85a6d3ebf03a5b95d6995beb79208a83b49864c6aac6",
+        "combined": "60a09b695a883638566aea23e6194fa4383c497f49f8321cb20017d8fd2ce10f",
+        "tokenSignature": "a-condition-is-knock-race-there-who"
+      },
+      "lengths": {
+        "joke": 12,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 746
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0747": {
+      "hashes": {
+        "setup": "a10ddf246c3c01e408a2aab6a66d6795566ce7f64b8c9f035b9b4cbd843ff414",
+        "punchline": "6bd8d2261b4552f14f36e83c5632d18f9793876bb76fae55f8bc13a2ed71aab7",
+        "combined": "404147b102aca3bd51ca6af1e44c373760c6e5db8e06ef12eacc2c7bb06d1d6c",
+        "tokenSignature": "about-best-get-i-jokes-keep-part-s-tcp-telling-the-them-to-until-what-you"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 46
+      },
+      "source": {
+        "sequence": 747
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0748": {
+      "hashes": {
+        "setup": "1648455b52c3bfe3d30aa5ea5261fb46bfd4098e24847d3cf345bb6c11ea4464",
+        "punchline": "49c0993e6f2a14760ce76a14f0e64746dd08ab4378727fb61413b796c91f11e8",
+        "combined": "622a2953543c47f08f128983113be0227ff7021d46a32df558e72f5f7d9ea10d",
+        "tokenSignature": "a-an-and-bedside-before-case-doesn-empty-full-gets-glasses-going-he-his-in-on-one-programmer-puts-sleep-t-table-thirsty-to-two"
+      },
+      "lengths": {
+        "joke": 73,
+        "punchline": 74
+      },
+      "source": {
+        "sequence": 748
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0749": {
+      "hashes": {
+        "setup": "46adc3b51fe60d8a1c3a38bd9a1bbe2e943eedb42d8f15ccb9204632f008347a",
+        "punchline": "7d9622c90d293154f083de06fef915b4493c290e3d2717c86940c68852378bb8",
+        "combined": "5671279425259c861e2c304fb926bf927ab17608632f8a7bba4e8c1570847ed3",
+        "tokenSignature": "a-and-bar-didn-either-first-guy-guys-i-into-it-ouch-says-second-see-t-the-two-walk-yeah"
+      },
+      "lengths": {
+        "joke": 27,
+        "punchline": 78
+      },
+      "source": {
+        "sequence": 749
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0750": {
+      "hashes": {
+        "setup": "180fd7034a1ddec7c21e536ebebf8266848aaeda533478be981d465904c80cf3",
+        "punchline": "cd2085f071c940d735cf26f6be05ca218a64c6578265bfd78e5157415db276d0",
+        "combined": "f794534466fdba87030504957be30cdad75fef8469157e97524ea1e38238a06e",
+        "tokenSignature": "did-doctor-hurts-ip-it-router-say-the-to-what-when"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 750
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0751": {
+      "hashes": {
+        "setup": "bafb952159aa17781399bb88f23221d901df586b6b73d77a547ee30c125019bc",
+        "punchline": "5da84486c9504ab7c2b769d39cdb0b6bf6ca370ea938088ac14ef51791c58cea",
+        "combined": "71e6294dc663bd82edbf8e0411a0c4052ab64b5f2913c62d92d8f7e1492afe01",
+        "tokenSignature": "an-goes-he-house-ipv6-is-nowhere-of-out-packet-the-walking"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 751
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0752": {
+      "hashes": {
+        "setup": "3a1020317b2510105dc14cc5ad872d8c7998f104e87c28fd62a2a96e9082b11e",
+        "punchline": "4b82e541552647d76f41d12940fd1b7da7cc4de1dcf95d026b532208371570b1",
+        "combined": "fbd9d55decbe9db4bd0ff6e9b167b4b5779c9c74ce7c62f4f2062381dc34ce28",
+        "tokenSignature": "a-an-and-asks-back-bar-bartender-beer-but-dhcp-for-here-hour-i-in-into-ll-need-packet-says-that-walks"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 59
+      },
+      "source": {
+        "sequence": 752
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0753": {
+      "hashes": {
+        "setup": "d0be4ee7b47d14dc128bc1ad1cf9e5f6306f3b865f9a6247b0b3e308b749045d",
+        "punchline": "90b7780249360261429945027045b22a600fb3a34e60252f3e1cd59184274122",
+        "combined": "da11a6a39c3f4b0895d38091abd6013727828b32b8f1b3640ad70303aa5c4533",
+        "tokenSignature": "3-a-bar-couldn-find-into-nosql-out-soon-sql-statements-t-table-they-walk"
+      },
+      "lengths": {
+        "joke": 59,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 753
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0754": {
+      "hashes": {
+        "setup": "2288a7657e2f6d1b716bc36d68ba89b98e61d940565949b0a4053d6e3e5646e8",
+        "punchline": "fb5c89259f011a339f113c1bf82453766d7d1bd863fcb91dfb3d4c6cd2616648",
+        "combined": "f230108774497c5cbdba8e380599fe5ba525fe2ef4a8f14e68281d1e9d7e9586",
+        "tokenSignature": "1-a-couldn-craigslist-down-for-high-i-is-it-nice-on-saw-says-seller-stereo-stuck-t-the-turn-volume"
+      },
+      "lengths": {
+        "joke": 83,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 754
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0755": {
+      "hashes": {
+        "setup": "d1ca007dfc7a3529df9dbe34c4d066802b53bf754e2fbf57ebf12b7695af4e54",
+        "punchline": "869b7800784680ca2cedfe76a0a3aaabb9e00813f82ddff3a02ac3a1a61146be",
+        "combined": "0c06553e1cde32dc152dc5e5f21c48183f357a67ea0697349c8b8383aed0ce2c",
+        "tokenSignature": "a-bee-call-can-do-its-make-maybe-mind-t-that-up-what-you"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 755
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0756": {
+      "hashes": {
+        "setup": "00c85a6af4fcfb8f3f927bd93d2b589e09ba93a41d4404e3dec9736b962ec959",
+        "punchline": "3a7e70924fb06c6c7b7bc257e57dd64c31d2742204ef1d1a6e8ce90d0c781902",
+        "combined": "78f9b87eeb4399f66e35ddbcdcaefa1f3b7fd97560ea6317269bcec2f885692d",
+        "tokenSignature": "away-ball-because-cinderalla-football-from-of-out-ran-she-team-the-thrown-was-why"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 756
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0757": {
+      "hashes": {
+        "setup": "e0afdbf7349522a37c03469f4bb0b9302e2754ad817d1a73dc2f852205065603",
+        "punchline": "2a6e87b5ff758ebc22c21665168135d3d9ec4a7614afe8e78abd3bb4b81c08bf",
+        "combined": "4300cd4b6fe0d1ed7be9fed7aa44391b9c8002befab3d4ba93655bec2cf37848",
+        "tokenSignature": "do-heavy-kind-like-metal-music-of-welders-what"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 12
+      },
+      "source": {
+        "sequence": 757
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0758": {
+      "hashes": {
+        "setup": "9c90cd5f8090c07060844417acafa47bf6a0443efbb45be7621f2069b63aba3a",
+        "punchline": "c2fb21e6952a891a8b697546e915a850bfc7c66c423d4f6127617284e50de99c",
+        "combined": "650b9eec899197eff96790ef131c7c1cdc16a745e005b1c44410fec410e55999",
+        "tokenSignature": "apparent-are-because-dad-good-is-jokes-punchline-so-the-why"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 758
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0759": {
+      "hashes": {
+        "setup": "0ed8711f205d93fc4376ec23a8d821adacbd146f395d131b2f8af4bd41b9113a",
+        "punchline": "90be8ad8f0f111526d09250158c43c952c2a0e7dd488f5de145cea267c174005",
+        "combined": "818a85c285c90c352499b67d304fcf864efe868c02348fc21641f0dfd9cf1ee0",
+        "tokenSignature": "because-developers-don-dot-glasses-net-see-sharp-t-they-wear-why"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 759
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0760": {
+      "hashes": {
+        "setup": "445b17c7b313b8e4ff6f73c1c159c4ea180a34c7dba69542ee4f571c3da5ca62",
+        "punchline": "c895da0443a01b2a3af45796ad9cb392a1a7603eb1a86ca606109117b471d073",
+        "combined": "df90465ec473198460ff5fb7736c4efc9fba2c6a9e845fe289217b7fa9598f49",
+        "tokenSignature": "ate-because-bigger-is-nine-seven-than-why"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 760
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0761": {
+      "hashes": {
+        "setup": "a112c3edd5ad9e5f749bffb7404dbc99760ada069773d449a265d6a50d951c4f",
+        "punchline": "a6bb88c7be7d1457d30d7033f372eaa3c33d75fae598fefd1d30980c6815fd8d",
+        "combined": "69f92ae449d53aa2fb20ab9d8652e872dc92716ad1ab102a7740d598d7ed40fc",
+        "tokenSignature": "a-an-case-do-extra-fathers-get-go-golfing-hole-in-of-one-pair-socks-take-they-when-why"
+      },
+      "lengths": {
+        "joke": 64,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 761
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0762": {
+      "hashes": {
+        "setup": "aedef15ebfdf0a34e64e7fb979ad6e95916ec7121adef61844c5b3fd3936ca65",
+        "punchline": "5d11339ba565bff5d4b2137a28fe440999af3f54980c36e6c6b76f012c28f6c5",
+        "combined": "d882bed238fa3d9a6d41580df5d56d2f49efbc93017f1ca203b50f6f0bb3020d",
+        "tokenSignature": "a-asus-call-do-laptop-looking-suspicious-what-you"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 4
+      },
+      "source": {
+        "sequence": 762
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0763": {
+      "hashes": {
+        "setup": "e9546a0df13b68c0d8be816792eb66d2aadf9055a8c9799e333d9f92f66cff0d",
+        "punchline": "b30fd3eab7a27cc4ef9566bd4590e9679fda6a8c92a84f89ef80bc6b2ad39611",
+        "combined": "431e0f7d5291ce7598a98616cf39cdfb0705f04326fe3cfb43332ba67a066444",
+        "tokenSignature": "c-class-code-did-got-java-no-say-the-to-ve-what-you"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 763
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0764": {
+      "hashes": {
+        "setup": "6f40746981b463cc8c83cd68823557df25181abc355440c32830d0412b86d886",
+        "punchline": "5ba4b2912089f5503fff53b3860c4796ec2d1fc5038a55c83ec347da50449780",
+        "combined": "54847c548d08dc144febe1793869b8b10a44217dfb4389ac85de8cb7987a503c",
+        "tokenSignature": "in-is-language-most-profanity-programming-the-used-what"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 764
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0765": {
+      "hashes": {
+        "setup": "7a23b8efc0389ba8969ccb14f7faee59d5e96e63dcb23408524cf6a88837168b",
+        "punchline": "67f8e7d92776704745845dcbe6196cebd56e8979c8d5386312c85f689e00e2bf",
+        "combined": "0b3058a1e7b4cdbb70c10b61b0dc241df1dbde0b64da061e7a7c2d29f0e8446a",
+        "tokenSignature": "25-31-always-and-because-christmas-dec-do-get-halloween-mixed-oct-programmers-up-why"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 765
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0766": {
+      "hashes": {
+        "setup": "6a38093ea64e9f8fb9f804c2ad3defc3607c617661b4038fa6c4123e446f8f95",
+        "punchline": "c899a89e733f1edc8038b61f68fa196c7532fa7fbe91abe37e10102fc6c9a23d",
+        "combined": "55ab75bbc9755b9275f5c4bb47f22bc5c77238cb6d764ad8711e57dc95bc62c2",
+        "tokenSignature": "after-goes-usa-usb-what"
+      },
+      "lengths": {
+        "joke": 20,
+        "punchline": 4
+      },
+      "source": {
+        "sequence": 766
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0767": {
+      "hashes": {
+        "setup": "6d0620adbd0c48d39ec19a253ca9a2c033d7e3902430fb55b9ac374f921e549d",
+        "punchline": "ef15a992bf1a8da5f4b7f890eaaa7aa715abc0cbc1088bb7d098b25aad97a599",
+        "combined": "b1cc353d1c200a9aa9dad1c6dfa9468c6c4095cd6dd3d3901750c5dc29e52301",
+        "tokenSignature": "because-crack-don-each-eggs-jokes-other-t-tell-they-up-why-would"
+      },
+      "lengths": {
+        "joke": 26,
+        "punchline": 39
+      },
+      "source": {
+        "sequence": 767
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0768": {
+      "hashes": {
+        "setup": "ea18d09a8b293068c2d1103b8af8c5874d2d78f0247362f5ed2a520e10e9abd8",
+        "punchline": "4882645d942c5829e5b5ffde5e78cc7aededbe62337dbaed0a5ffb599215b25c",
+        "combined": "cc39ef732d305b0c9f0504b02d4c5adae56f2bad6ae94b0858bb8a9ca5b9c2ab",
+        "tokenSignature": "add-and-disappear-do-g-gone-how-it-letter-make-number-one-s-the-you"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 768
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0769": {
+      "hashes": {
+        "setup": "dd3c52fbdcf1165f44be7bede76d844290ad4403425159b458e448d1587d912e",
+        "punchline": "752ab3bde8e108e89187c70e6aaec8a8434db3ad6b3e04a617c550402fa703c5",
+        "combined": "f464eca1a1081a548100fdfca21b4e994c60ef590f61d2f8219c9a4228307272",
+        "tokenSignature": "always-and-books-brother-comic-conclusions-draw-had-i-last-me-my-never-of-older-own-pages-the-to-told-tore-why"
+      },
+      "lengths": {
+        "joke": 85,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 769
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0770": {
+      "hashes": {
+        "setup": "4add4938cdf3f0f18105d00c6afcb518e462c5f5ccc345df8a39d0bd32bc717a",
+        "punchline": "58f6a3656b29c9c5e42ac98cdea8f1cf889010c53c6210af0b74969f73a8a3d2",
+        "combined": "b8d64aa6b891e768f9dd4d78c1717a49b6ff392080d3a4e1ee1d315fa9370f70",
+        "tokenSignature": "at-camouflage-didn-growled-i-major-morning-much-see-sergeant-sir-soldier-t-thank-the-this-training-very-you-young"
+      },
+      "lengths": {
+        "joke": 102,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 770
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0771": {
+      "hashes": {
+        "setup": "6d369997773a894bf726c402d089774c22e4e65c2174f2c34b3f431a7e8fbce7",
+        "punchline": "ed05a2624b0cc99b63c28a2c287ddb37eb1f42b7b95e67856bd354850949a71d",
+        "combined": "58d91d81ce360b0382b06f0535ff66abd25e402877b8d4ec63c766ae7c9feee3",
+        "tokenSignature": "did-fly-kid-out-so-the-throw-time-watch-why-window-would"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 771
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0772": {
+      "hashes": {
+        "setup": "a77296579d6e39bc8c0854be5b85f8d705560281f4fe0ac40c233c2822a72056",
+        "punchline": "c09747221a33c3089bc4575a8b15bff081e43b8ca089c1b604e461aa76f165ca",
+        "combined": "177e5fb67971af1dc4274f8229c4b691de0c0eb9b0cf6604764ab2aadb50ce3f",
+        "tokenSignature": "api-did-eat-go-restaurant-the-to-where"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 772
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0773": {
+      "hashes": {
+        "setup": "4deab9d879b86e587f4ce22f5e7233d2912c9052042d5ed07e52498a6b00c781",
+        "punchline": "641f900c2cc04450fda9d9042acef4e05b4c9450fe53e3bbbc47df5a3ca1bd25",
+        "combined": "eafad0ca5ed82021dd586a27cae901135900d212248335cacbdd84b9f685f625",
+        "tokenSignature": "at-chickens-cross-did-he-heard-hot-kfc-pretty-road-rooster-that-the-were-why"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 50
+      },
+      "source": {
+        "sequence": 773
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0774": {
+      "hashes": {
+        "setup": "cfc68b15b9ec32bc0d9022a81b85d1b4bce8f282457a731b7036c21ec0bb6acb",
+        "punchline": "413ebba7d809e6cb3793e42f6e635f70a43090d1970a3a1e53bec3c68d86e462",
+        "combined": "923b27efd393879f9a53a59c8349b476a79dd2f530d0bef9ae5ef84666b8ba51",
+        "tokenSignature": "about-again-bjorn-did-he-hear-reincarnated-the-viking-was-who-you"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 774
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0775": {
+      "hashes": {
+        "setup": "516665b9e9ffa4cad2ecea506d1f48199da25f347fe5921d62fa74438649ffd9",
+        "punchline": "3dc6c82fcd2fb94f5c92576865e48596c69397667b27122f73b792a5d5dd252b",
+        "combined": "d35384fe435c8947b8984f9a6f15da9043fb509b4f7ac6ccc6c7cca4a119aae0",
+        "tokenSignature": "algae-bra-class-does-math-mermaid-the-to-wear-what"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 775
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0776": {
+      "hashes": {
+        "setup": "8f07322b3922218480e30ada518c02acf69e5f16e6a471cafe5d866b27b13a6a",
+        "punchline": "45e3fdfcac435855fd647c04fe9ff07f734d30817d0d915f3354021920d3d0a4",
+        "combined": "b8386b99facf146b416cfc3a52e897f6db46efb13831930443e40160ba0951df",
+        "tokenSignature": "about-crime-did-garage-hear-in-it-levels-many-on-parking-so-the-was-wrong-you"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 776
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0777": {
+      "hashes": {
+        "setup": "527305dd35260ee8eac550bdbed5e764e99d1a998be981d77fb26e74b226789c",
+        "punchline": "101526027732d211a87f600a3aaaa107f3f67d32c5105ee920676bf969d06c25",
+        "combined": "7a6af1e7c3c9941715c4c9147cd7a95c30f75be4716200a46fe5e9508530675f",
+        "tokenSignature": "a-hear-hey-html-joke-parsing-regex-wanna-with"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 777
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0778": {
+      "hashes": {
+        "setup": "b61cf933c07cfffbd4fc77c4c09bce1e5f12e2707e0876d1df315f5dcec65b49",
+        "punchline": "150e83fd1934197763f05d5ab0798bf0e56dda82e6e74b8c9534cc2ddffabc36",
+        "combined": "aa4057559dcd1a76991932c7a9be1462b65ae82b45b90f1dadee61342ae81f8e",
+        "tokenSignature": "because-didn-for-go-had-it-nobody-prom-skeleton-t-the-why"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 778
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0779": {
+      "hashes": {
+        "setup": "1bcb4f014a8102216395c45d1609671668e0733a3999c6032a1e046592ec132d",
+        "punchline": "a4be21f4d35f902bdca4a5797841be91382c80960b225303c8ad0ccaa107f008",
+        "combined": "fd0cc3243dcc8515338e8cb7258d20cb885b5e16a64f4a751365cc05f88acd4e",
+        "tokenSignature": "a-asked-bag-carton-cashier-fine-grocery-her-i-if-in-like-milk-my-no-store-thanks-the-told-works-would"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 779
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0780": {
+      "hashes": {
+        "setup": "b2518fc5325f67d86a04cd68c233222863284cd0043d915272fd0b9df65f3c54",
+        "punchline": "1a7f6ec55ce54387a67852a380ca50a30a864ce9af8e24372a9398892ceee16a",
+        "combined": "cdf96968a6589c663702c197042ae92eb423d06d97a63eefdb890752a751e8e0",
+        "tokenSignature": "1-9-99-are-belong-dumb-fortunately-i-of-people-remaining-the-to"
+      },
+      "lengths": {
+        "joke": 29,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 780
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0781": {
+      "hashes": {
+        "setup": "4426db68dd6d5f4ba44be2bcd5611c0a36c2e69ec5bf08da2de10f2b433447e9",
+        "punchline": "34629a76a86e6043bf7c430549e0181c38fee0f788fda98c19e89f96c371e6b7",
+        "combined": "1dfe6b4e1eb00534a246fbe0ab47bc86c462cd07fc0841feb9d25e811c1f15d6",
+        "tokenSignature": "at-enough-factory-fired-from-got-i-in-job-just-keyboard-me-my-putting-shifts-t-the-they-told-wasn"
+      },
+      "lengths": {
+        "joke": 53,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 781
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0782": {
+      "hashes": {
+        "setup": "71ef58b3817e3a43dbf95f72c470e4241eec112d6d8227449783128eada36e83",
+        "punchline": "4de4cb9911107c3d5083625784ea7ff74a42340558391062de6357ba64011417",
+        "combined": "e84ad14400205ebc8e58647bdab74666665a1031e5237069f70dfad37f5949f1",
+        "tokenSignature": "are-areas-aren-funny-hill-just-mountains-see-t-they-you"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 782
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0783": {
+      "hashes": {
+        "setup": "3359c2bab167af1eb948f956f7ffbcd35e5742a9243345d265b7cd7abdce6e8e",
+        "punchline": "7a2d7b84712d0a21e124a2b2d543fdbb580af5e376d00a341b08ef9b40db1a5a",
+        "combined": "0408927965637fde517177469830390b44e1a67ee14f818598a58a0545ac4fb0",
+        "tokenSignature": "do-elf-elves-ies-media-on-post-social-what"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 8
+      },
+      "source": {
+        "sequence": 783
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0784": {
+      "hashes": {
+        "setup": "bac9980567e6b64b3da1d81257f32fb2f4c183b54189975da39f4d16db3f312f",
+        "punchline": "c7f77846d073e2d235bd6e410b514ae4ff5e4711b2435fb47fb4ff25b9c810d2",
+        "combined": "7f600d8d512dcb3a7d06175787670c4420c328af23893b6a60c4f48704c28bbd",
+        "tokenSignature": "decided-equations-expression-face-friends-have-i-math-me-my-on-seen-should-sleeping-the-to-up-was-when-while-woke-write-you"
+      },
+      "lengths": {
+        "joke": 70,
+        "punchline": 62
+      },
+      "source": {
+        "sequence": 784
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0785": {
+      "hashes": {
+        "setup": "b5ec4309c5fabceafcf5c5a03d7576cb485310a26ad561ff518f1ffbb7f67a91",
+        "punchline": "c7d1e44cd642f6a0b58aef5848a8323fc32c9f93d214d904ec9979ac5c44b170",
+        "combined": "01275f421288cfa1b3c9ad61bf7a5da1524512329cd190cd6d02721b6385052a",
+        "tokenSignature": "a-above-allowed-can-certain-complaints-decibel-due-ha-hawaii-laugh-law-low-not-only-passed-re-to-use-where-you"
+      },
+      "lengths": {
+        "joke": 97,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 785
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0786": {
+      "hashes": {
+        "setup": "b922eec8506990a4005eab85c9622e7a9e3c5760336f8f4fb397f86f702f46b8",
+        "punchline": "77d3863c43560f06b76229a6029ea2b189b2d57e4f09e01781e786af096fa050",
+        "combined": "05e043dcdeb5f8e00b26f03bc8f997e3083392db62db88cc9982423d51fcc0c1",
+        "tokenSignature": "a-are-because-cool-every-fan-football-has-in-it-seat-so-stadiums-why"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 786
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0787": {
+      "hashes": {
+        "setup": "dd4ce59ece5857b0de53026948fd7486620733aafc8a141a52a0f3fdcbf39d1a",
+        "punchline": "96ee4a41c09f64d60be26372a0aa7fb41565ce2d808aaf1c2d85f9513ef567dd",
+        "combined": "102ebeb510f33c556c85b9d3dc28b2bc1a7304a32932c18f17f5d4ae7fe396d9",
+        "tokenSignature": "a-and-do-exit-front-generate-how-in-of-put-random-string-tell-them-to-user-vim-windows-you"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 57
+      },
+      "source": {
+        "sequence": 787
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0788": {
+      "hashes": {
+        "setup": "75ff359eb2c8fc5480fefe6e217690f1ac1b15f75d95e3f9b020c48e57cb79eb",
+        "punchline": "213a31584aaa4271cb6d0b267bfefe54f4813de9b5914f5e34aaac1426aa1f36",
+        "combined": "f992d5b2637e9ce7527c4e2dcf69b80d1ea1e495eae06027df504fd4dc22a385",
+        "tokenSignature": "arguments-because-calling-constant-did-each-functions-had-other-stop-the-they-why"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 788
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0789": {
+      "hashes": {
+        "setup": "362246f4c4e55bb9622e2989631506e4ee431c71f5c0b35cc749e0fda1ca0dde",
+        "punchline": "bdc94082a0de5afd303bacf18b7e8b68c5fc505195e0b3518641640ec029c7ac",
+        "combined": "93ec117073a5ce1461e7c8918947c188b6a3d9be924e98690899dd8a5832c2ac",
+        "tokenSignature": "because-break-classes-did-each-never-other-private-saw-the-they-up-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 789
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0790": {
+      "hashes": {
+        "setup": "c227f141cbf6028f4ee4c5c34b7ae22cef0c118efe99e55a8d8df558a49107aa",
+        "punchline": "4f3dc2cfd1ad0bab8cc7648eb3fa85b633922714c0652a3cda36e085f1948099",
+        "combined": "893c567afbb79c75e512e2abcad2a59acaf2934331f9a609534a93202526b22d",
+        "tokenSignature": "arrays-because-developer-did-didn-get-he-his-job-quit-t-the-why"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 790
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0791": {
+      "hashes": {
+        "setup": "3387e9fe79be6ace9d6e5f892b2249e0ee7bc6fca2b12c11d3d0ad343eefd2fd",
+        "punchline": "2112169414cf4f6f941ca8cc221c170ce04753d11a22823ea148f43ce8368072",
+        "combined": "bccb38deea44c0cbf14cba52208e9d680b0988c39aea7312721ebb44d78196cc",
+        "tokenSignature": "a-change-dark-developers-does-how-it-lightbulb-many-mode-none-prefer-react-take-they-to"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 791
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0792": {
+      "hashes": {
+        "setup": "dde21d95eab7cc9c4fb42a98dee921ef9d520e2d2c604951ff0b8f50878612f6",
+        "punchline": "f9e2da9bf754de6d0dcadc7c7d967298d51ebe48d86791cdf89563690c4fbe07",
+        "combined": "3ef81da0c20f0f059bfd03a93bf19840e047f091f5215b0237d2b7c109555a81",
+        "tokenSignature": "developers-dom-don-like-nature-prefer-react-t-the-they-virtual-why"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 792
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0793": {
+      "hashes": {
+        "setup": "98b1f2358afa96e1c1833dda85991b7845dba54fed520e19d1941f28e0314dcc",
+        "punchline": "440480fa14c8fedf3d5133dc27b9efbe8ade5b79f40f67620dd51fd073b13f11",
+        "combined": "2f4f6fd430cc15f63cdea0b17797909392e5963a625c240fe298881fb80d87f8",
+        "tokenSignature": "a-component-cross-developer-do-function-get-mathematician-react-what-when-with-you"
+      },
+      "lengths": {
+        "joke": 70,
+        "punchline": 21
+      },
+      "source": {
+        "sequence": 793
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0794": {
+      "hashes": {
+        "setup": "7702e6fe369d4e08e2da8e3b92abcae35c54a5121614cf34408b76e5e2c3b851",
+        "punchline": "a694e2570ad840ecd4716e24d0b3aafb63c57eefea492ebee6b3fe30d034ad6e",
+        "combined": "d11eb8a7ede9cdc5253706dc937e304509fa5c0bb595f4f464d97634ef2a3798",
+        "tokenSignature": "and-any-bitcoin-broke-buying-bytecoin-calling-developer-did-didn-get-go-he-it-kept-t-the-why"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 794
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0795": {
+      "hashes": {
+        "setup": "c8cec798a26627c2eadc2a2887e9185522704cc1ca3e59568aacd6399dbb8a12",
+        "punchline": "3e11c6777f148def86836a532e0ba4caad5a59f57cda96b0a3bbf6cfcf71441e",
+        "combined": "df5ea4cbcb7b4742b8eb7dac987c6fa05404426bf63de507539d151ee50faa71",
+        "tokenSignature": "art-box-code-did-go-he-how-learn-outside-programmer-school-the-to-wanted-why"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 795
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0796": {
+      "hashes": {
+        "setup": "ffabdeafa63148aefb82f1db806145e4039740af3f90f6841b28b7778af17fbb",
+        "punchline": "2b5c98bbc0661500e492bcf5396edb3eb27d0c81877b6b2021e8d340213c2ba6",
+        "combined": "36a56a3ccb66b4fee244ba026ed45ea9e464aa54cdbfb63ff3af95af0cbc3762",
+        "tokenSignature": "commit-did-didn-he-him-how-know-leave-programmer-s-t-the-to-why-wife"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 796
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0797": {
+      "hashes": {
+        "setup": "156880e56f9d24db16256681b38234795965a14b50f01cd7faf3154092bede93",
+        "punchline": "c22bcce53ea5fc5dfe082929eea7e925525d8ed26c4f584e1565fe83eff1921b",
+        "combined": "c08271059e53045b606f057ab51574d1d26104860eab4a3a1932c592c1fc6462",
+        "tokenSignature": "because-bitter-chocolate-code-dark-do-it-like-prefer-programmers-s-their-why"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 797
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0798": {
+      "hashes": {
+        "setup": "56cba4faec1f7415003a1febc545f85ceed2ac4d885eb32d8f8eef750daaeeb7",
+        "punchline": "24735f7f2272a92961d0128122cb4f1a73f673067682cd9a5594f7395fe423df",
+        "combined": "ed3450e943d1d470eec54ebfe53dbeb72e0848d566f844bf92e714913e7c3f96",
+        "tokenSignature": "all-broke-cache-did-go-he-his-programmer-the-up-used-why"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 798
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0799": {
+      "hashes": {
+        "setup": "482a56fefd39cff71ecdcbd3db58c39067b7fdc9b1c3d5b21dad82ab770eaf2c",
+        "punchline": "9926ac340b2c372c68bbef10d88ca697e87d3b47cc8d55cb7abbe802375f8029",
+        "combined": "305f821151eb9119c242f91bf23da9c9742cf9a4b71feaf1c74d5ed28a6b9184",
+        "tokenSignature": "25-31-always-and-because-christmas-dec-did-equals-halloween-mix-oct-programmer-the-up-why"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 799
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0800": {
+      "hashes": {
+        "setup": "c9482a8c6b434cdfa54143911e785f574ac189f67359199d952e3dfb274e0d26",
+        "punchline": "9c02ac5c550b318bf0b1852e06936277091dee1ccb4c70eea4ba46c39f768471",
+        "combined": "cbd61a16548ecf8d3f678a9e2d1e092b5fe3fb65c1368509e41326b681a8900a",
+        "tokenSignature": "bugs-don-like-many-nature-programmers-s-t-there-too-why"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 22
+      },
+      "source": {
+        "sequence": 800
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0801": {
+      "hashes": {
+        "setup": "bf557024065abf457ce090faadb25fb318b9c3a4e975e22fedbd512db889d53d",
+        "punchline": "7442b27a564d1886e3e06d2a88c797bd4404e76677a21b03ea8969ba9f71bf6f",
+        "combined": "152dcc3a0f53894e931118a6f979bbc82653c14e19a5b687742203e7f65cf053",
+        "tokenSignature": "developer-didn-feelings-he-his-how-javascript-know-null-sad-t-the-to-was-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 40
+      },
+      "source": {
+        "sequence": 801
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0802": {
+      "hashes": {
+        "setup": "4733e35dc985bf2fa2019c50dcb7fee919ecd96d90e734cb5f8a5e92001cb435",
+        "punchline": "789315824e52d11c7f941ae7988e8443851884c777ed78f82d5fb9ac6a8d73e2",
+        "combined": "5ac86a058c138fda601d16fcb773384acf411c015c64d2997dead077f2704aec",
+        "tokenSignature": "bicycle-by-couldn-it-itself-stand-t-the-tired-two-up-was-why"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 802
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0803": {
+      "hashes": {
+        "setup": "8548bc771407d24b394c5f032c3e3164568d0c838641571985a1795ebe46b91b",
+        "punchline": "c91b93e295f58519ce9cce86722ae4cad95ac35b67981640a6d04dfcffed56a5",
+        "combined": "7da43604308c4ec4ac8270f2e13011c65bf4edfa25e0f572968125d894f1fe3f",
+        "tokenSignature": "because-book-did-had-it-look-many-math-problems-sad-the-too-why"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 803
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0804": {
+      "hashes": {
+        "setup": "4f2a11e958a4897762371e8296bf261eb7f6e150d4879f21859e074ed5287adc",
+        "punchline": "f52fd62695def0ee025746c1f229b6d6f715093141a25ef939433c2b50d78a40",
+        "combined": "1c6957b7552645fad239b3c4e69dd93c9b834ad80efb92fb2a4d195e9c9fef17",
+        "tokenSignature": "a-computer-favorite-microchips-s-snack-what"
+      },
+      "lengths": {
+        "joke": 35,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 804
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0805": {
+      "hashes": {
+        "setup": "2bbd9782fde54056ca2f7df2d7b49562a62d158c8ea1dde40fe5cf9130517ea6",
+        "punchline": "e3b2e2419455717dfd83b0336683d9bf5552515f531b608aa08647a2987af77a",
+        "combined": "547ac9fa58bf64b06442606476d1a5bcddf6cd701460a21e43d592e5adefb6c7",
+        "tokenSignature": "closet-did-he-janitor-jumped-of-out-say-supplies-the-what-when"
+      },
+      "lengths": {
+        "joke": 58,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 805
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0806": {
+      "hashes": {
+        "setup": "bfc2e27a170ca98453df9459bb8b44ac7c57be5c46831ae5d8b773e690af2501",
+        "punchline": "62fea14ac493eab395ef489be0d1a7a636c9134c88d96ed3e998e7359f4cfb97",
+        "combined": "0cc36d87fdd06a21ab2cc0f9ece3decc28c1b15d90c2b91c76687257b5230d41",
+        "tokenSignature": "did-just-nothing-ocean-one-other-say-the-they-to-waved-what"
+      },
+      "lengths": {
+        "joke": 42,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 806
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0807": {
+      "hashes": {
+        "setup": "e0926209ba078d6e20091dfadb80097c3570e4e1b76036330b2a1e079c1d9bc3",
+        "punchline": "857a6670161dfdf1803018b21d4f52e685142660dbad847320721e2abf9f3161",
+        "combined": "5e4c199e2eb313de8b8d80b6763402c168d4acd417b928497c4dd39e8035fb5e",
+        "tokenSignature": "a-about-best-big-but-don-flag-i-is-know-plus-s-switzerland-t-the-their-thing-what"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 43
+      },
+      "source": {
+        "sequence": 807
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0808": {
+      "hashes": {
+        "setup": "a82eddf136a9f62f0d7e62905958edaf1761b00bc126167546715d08c615c626",
+        "punchline": "62e89142b93a11403e1242cebabeaf6eacda1538f6d75e9408518910948d7c03",
+        "combined": "c19f7cc6af3e4043db989afa2a74db77740be8b4e160475021c0c0227a0e2a8a",
+        "tokenSignature": "a-bring-case-did-golfer-got-he-hole-in-of-one-pairs-pants-the-two-why"
+      },
+      "lengths": {
+        "joke": 44,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 808
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0809": {
+      "hashes": {
+        "setup": "fa215373155eb039e49df92f948ecced743a631024179ea2c1a397a1746097d6",
+        "punchline": "e4d8a609f14d805cd3ab1794e306b10f6554b61fd6cd298feae4dbd78a23fc03",
+        "combined": "8dc58fe651249256a134eb83be77bc3103038cc1c4c169f7f0aa46a1e1f64159",
+        "tokenSignature": "chicken-cross-did-get-other-playground-slide-the-to-why"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 809
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0810": {
+      "hashes": {
+        "setup": "9ac28f2ed7b6488c5f740f704bbb5009a3b5160c49f26ebc44f12521b8554c65",
+        "punchline": "eb4e3bba7846a47b1fa79f454df693a242025e799ace6649263a190f9c2c659b",
+        "combined": "c180d4760dacd8bb85afdfce3ca731aaba576cecacad31e8feebb530b3adf947",
+        "tokenSignature": "atoms-because-don-everything-make-scientists-t-they-trust-up-why"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 32
+      },
+      "source": {
+        "sequence": 810
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0811": {
+      "hashes": {
+        "setup": "e214dc6dad8030e0137cc9d0dc7f3f39be50f4de9a408aa243de93b3b393a2b8",
+        "punchline": "f68b11fe7347a81f8ac2a7c89116bc58c3b174648a23fd16306b0a36ff6a466a",
+        "combined": "e200117ed5af52ecc44d8bc806bbc50f2c51920a95e9a03bb7f6ba27240b08f7",
+        "tokenSignature": "because-charity-don-give-oysters-re-shellfish-t-they-to-why"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 811
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0812": {
+      "hashes": {
+        "setup": "8d2724551dd3d981e4ed577e3f28bcdab93904ebbad26e1e4c26e46e3a51a65d",
+        "punchline": "43f96185410869223321356f92baad7ea38d3efa9787e198a1dece8215dfab51",
+        "combined": "9b9c059a3125d27ca606ddadf56cd5d2e861e5917a66b9dd3654c65d8316fe94",
+        "tokenSignature": "because-cookie-crumbly-did-doctor-feeling-go-it-the-to-was-why"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 812
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0813": {
+      "hashes": {
+        "setup": "672e1053d264fc4eebd69a31857bb30c40329d5253193575c05148364f41459c",
+        "punchline": "936581f8d9252f8478d5c4920173fae8a630ac5499afd35280062f5871b06914",
+        "combined": "cdf6ba12d04960fc8cb5cd77c1c9c7930190a06014ac8c1ca3a078bbf7e5364d",
+        "tokenSignature": "a-call-computer-cursor-do-lot-mouse-swears-that-what-you"
+      },
+      "lengths": {
+        "joke": 52,
+        "punchline": 9
+      },
+      "source": {
+        "sequence": 813
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0814": {
+      "hashes": {
+        "setup": "8f8dac86fb945b2dbc28c2a2502394e1983a42f5ff32ee3254b79904d9fd47b5",
+        "punchline": "2255ab43667e01fdd6a9909e6ef084ad46146276cb4d61ed72bfdb4dba8df0c5",
+        "combined": "e5a344a8fff8207f53fa4b5747676676240264bc9ce6ac6a8e87dc3ff7cb51a6",
+        "tokenSignature": "because-break-designer-did-font-it-t-the-their-type-up-wasn-why-with"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 814
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0815": {
+      "hashes": {
+        "setup": "257fd70e76bb2c1f989a1bbf027eae391bfb6e1ca7bb5e20b4c5235eddf25d2d",
+        "punchline": "7ca8ffd20a8f6197e189329d688c8e573bfbaedc21dc3c703bdc3f4c8e0d72b9",
+        "combined": "1c170a1fcd6b262a438f06020bf39c2f41212f0deb173c7607bfc08a08d11996",
+        "tokenSignature": "arrays-did-didn-get-job-programmer-quit-t-the-their-they-why"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 23
+      },
+      "source": {
+        "sequence": 815
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0816": {
+      "hashes": {
+        "setup": "e95931d3455b660786da3f547f2bd2a70cc7b0bb7c7f99583aff901fc1e3bbf2",
+        "punchline": "6567138f1b89dcd96ba62d048ecd7a32ac27a312be7a00342e3d7d639c686cb6",
+        "combined": "35003a75bdaf2c4d6356233f07a472e9615e2f6d4cce9e91e2e79cae6ae9282f",
+        "tokenSignature": "all-broke-cache-developer-did-go-kept-spending-the-their-they-why"
+      },
+      "lengths": {
+        "joke": 31,
+        "punchline": 35
+      },
+      "source": {
+        "sequence": 816
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0817": {
+      "hashes": {
+        "setup": "6a2e9c45f520002f62e981c7794d3fcdeed60a9b84f9ae76e0ca5a3ebff33948",
+        "punchline": "1585c60700cfc261535fbab8c4367ab5cd4c758de8afd6a4c8dbb8e4a8a7904c",
+        "combined": "5a15c4ecd81081115526b86f04d3c8f6af6f4f8f834d7fb126c93b204c70d9f4",
+        "tokenSignature": "a-between-comfort-designer-do-elements-give-how-some-space-the-them-you"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 49
+      },
+      "source": {
+        "sequence": 817
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0818": {
+      "hashes": {
+        "setup": "c9482a8c6b434cdfa54143911e785f574ac189f67359199d952e3dfb274e0d26",
+        "punchline": "849a9707e3c60b2373cd5e19076d2dd664dc6edc4dd1c02c0c6f1b7db78df3fd",
+        "combined": "5563de1b687cc4815956da3641caa253a42231cd60f30c7040c5f0135ae8889d",
+        "tokenSignature": "bugs-don-like-many-nature-programmers-t-too-why"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 818
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0819": {
+      "hashes": {
+        "setup": "6168a026f2fa05a3c7ec5452eeebc2a9b30c1a867da10dd3d8f6e429adb6e001",
+        "punchline": "bd85d5dc1c5abcb475498c506326c700a9c692e22dcaa4c93bb223e649af7e5e",
+        "combined": "84e72c493e7e76169e5688dd4df34bcb9b2fbe43ecd00c3d14595ba11b6c1b91",
+        "tokenSignature": "a-be-bring-code-debugged-did-from-heard-higher-ladder-level-needed-programmer-the-they-to-why-work"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 62
+      },
+      "source": {
+        "sequence": 819
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0820": {
+      "hashes": {
+        "setup": "106c4e437170842668ff6fd977dc66518c19312a6714578726fac8d030c65c77",
+        "punchline": "2672d5da4c44627dc50179b994c7431598b1bab3c0af1153eb2a72e6511967c5",
+        "combined": "b46d36b0342dcb98af569445eb790f44d2a620f1564b0ac5ff301aa30908edd9",
+        "tokenSignature": "always-because-calm-developer-exceptions-handle-how-knew-the-they-to-was-why"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 43
+      },
+      "source": {
+        "sequence": 820
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0821": {
+      "hashes": {
+        "setup": "4444c67532b3bd2d14fa10d59678036125fe46dfd80a71a06046e8d8efd264a5",
+        "punchline": "4003a28341ac304091aba375ec7f6e7a3366b4612f719c0bec0dfe20ce9b5ca4",
+        "combined": "abdc388829e20be173d326c9ce7af11b3922fd9554f4f9e659bfe02bff774025",
+        "tokenSignature": "always-bold-font-it-the-tired-was-why"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 19
+      },
+      "source": {
+        "sequence": 821
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0822": {
+      "hashes": {
+        "setup": "504296c93303984fb97df73b2d0d82e2b5032b0d3c2ff87163aface1aad07f9f",
+        "punchline": "7dbb915b9da0b8d1c82969c4cbac6dfac15e829ed2262b7aca5ef1d0344950df",
+        "combined": "7d58e370cb2c8aee1703221e534685ad90723100f3699eb0f8c4e65f205c4996",
+        "tokenSignature": "developer-did-go-had-issues-many-the-therapy-they-to-too-unresolved-why"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 822
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0823": {
+      "hashes": {
+        "setup": "5aefb63940ef28412ddbad4cb400bb23f2d1c7786c3e55dfdfb3288925cf4c55",
+        "punchline": "17f483a2d4e8227bc5fdaba3d60fd953a49a54e3e9821296d16f1b61eb273c7e",
+        "combined": "ab4c635734ba479e5b0aad9f5d87052ec5cb619cefe16e704d5e57de0630907b",
+        "tokenSignature": "always-because-cold-designer-ice-much-olation-the-they-too-used-was-why"
+      },
+      "lengths": {
+        "joke": 33,
+        "punchline": 46
+      },
+      "source": {
+        "sequence": 823
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0824": {
+      "hashes": {
+        "setup": "0b32d0b7bf1c1b58effd331c0519da4709bb47fcd59953441ad4e18dfac96c9b",
+        "punchline": "0843ffa28d37be600449a1b7a466cbcc8c6c3e546863be0e1b838b6fa4b179c8",
+        "combined": "855a6f0f4df9419560fd24428cfb30aa7eedb064c8dda958edd409e258303396",
+        "tokenSignature": "a-all-bring-broom-bugs-clean-did-programmer-the-to-up-why-work"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 824
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0825": {
+      "hashes": {
+        "setup": "ca60e23a347b6fedc042b4ca485f6102e4f31a833fe78464e659d514de08f43f",
+        "punchline": "f1087206063a3ed622c6b01ab8d8cd1269c838d18b2419b8b2410b1e0f56f631",
+        "combined": "4af2e7639b721ff033f7b6b9eaa098aa05226c8a7e1aaebfeb4e6bcc6a005e4e",
+        "tokenSignature": "anymore-break-developer-did-it-just-keyboard-t-the-their-type-up-wasn-why-with"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 825
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0826": {
+      "hashes": {
+        "setup": "666509dea63b231f27232b9ab972f74ae1911a907e2d26f4f2c76e9d4e4f2123",
+        "punchline": "619771457b12e3f4d66800dfec3e508a29b8a0e135c91b6414da0f20d5988b0b",
+        "combined": "951fd213868707458690a00bed71765dd72fd7e1e242607c2f0461bd00e356ea",
+        "tokenSignature": "a-always-c-carry-did-in-pencil-preferred-programmer-the-they-to-why-write"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 826
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0827": {
+      "hashes": {
+        "setup": "71600a9fbec5b34e38b41c86f421a07e348bca01500235990819a68c07f79583",
+        "punchline": "eef24a8ae8f2925291432e036a39a5a842b6abe5fa7ce13acb98f4576d30959a",
+        "combined": "8840a9900bbf39af950786b2bf751203af01e2fbe6a1fb7211cf7c87fcb531e9",
+        "tokenSignature": "don-each-fight-guts-have-other-skeletons-t-the-they-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 25
+      },
+      "source": {
+        "sequence": 827
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0828": {
+      "hashes": {
+        "setup": "9fb091fe23a28b4a58454b9e1404d09a1b799c50b1d3a46df4d545aa430f4242",
+        "punchline": "e847e79d655bbd2a4361c5e21772362537724ab100f7710389517831ff3f4ed3",
+        "combined": "2a7b64c87de05a3b7a1d9ce17e4c5d74bb491b7ee834eb680e95a3667d6e85c1",
+        "tokenSignature": "an-call-do-fake-impasta-spaghetti-what-you"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 11
+      },
+      "source": {
+        "sequence": 828
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0829": {
+      "hashes": {
+        "setup": "405aaa7d7d0028f8ea579e3e7748f4825211de8b5f24e7ac3513db490cd222c7",
+        "punchline": "113386f679d519337f784e7e160d243b5308dab0bc02ce42e7719158756f2256",
+        "combined": "f5f510fd2a6febcd09f432d96ac237fcf8a69edd73687c39d0b520c104d9ed6c",
+        "tokenSignature": "a-alligator-call-crookodile-do-thieving-what-you"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 13
+      },
+      "source": {
+        "sequence": 829
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0830": {
+      "hashes": {
+        "setup": "7d6758f72556581ad028379f463d6186e330d54c3ea3f8e332c1500990df18eb",
+        "punchline": "2780cf5d6c833229200492449497e27d193a210b0eb058b62c0bbfa71a4d2b3e",
+        "combined": "07247794bc07ebdc3cefe254150b844d9197eeec2ee2eb5d7d2ff30dbc191c30",
+        "tokenSignature": "a-adept-at-become-c-good-guitarist-he-in-programmer-riffing-s-why-would"
+      },
+      "lengths": {
+        "joke": 47,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 830
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0831": {
+      "hashes": {
+        "setup": "a6ccc4e3a9fa38bd1c09a6b914a812e36a16933171836a05b54dbeef98eb04d0",
+        "punchline": "e74246f952e3d00c3581441a8d3fd6512dacf3cb27c91e4481b051e9f60587ab",
+        "combined": "3159c6625a19ec67c884dd47b6ca1ea032f8b4b7a3ae868407b621c976cd1def",
+        "tokenSignature": "a-about-hear-it-joke-mind-never-of-paper-piece-s-tearable-to-want"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 26
+      },
+      "source": {
+        "sequence": 831
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0832": {
+      "hashes": {
+        "setup": "50202d3d188e5dd2096c077f8ccfa48fd56ead011c1252c2ed1e8d2bb04fa8d6",
+        "punchline": "b53dcc6f17a28042146f9c90b53760348756383015f96fe38284ca6ad48bdffc",
+        "combined": "0d335bffe78680b06fc2b6010da4512653c5418fa66a80f0e9041781b053c892",
+        "tokenSignature": "about-cheese-dairy-did-hear-it-legend-saved-story-that-the-was-world-you"
+      },
+      "lengths": {
+        "joke": 61,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 832
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0833": {
+      "hashes": {
+        "setup": "137352b369d5bc148a07e7ecf2e36d6c9062253ad37bdec6f0dde82e008e7cb8",
+        "punchline": "bb67c3abd286d46a3bf5746c9eb1babc96014678e225b8ca756671473504408d",
+        "combined": "b3d8b546c327fb3b127486f233ead0fa2e26bc182f1281026606ad88b98f5415",
+        "tokenSignature": "book-comic-did-graphic-it-movie-new-the-very-was-watch-you"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 833
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0834": {
+      "hashes": {
+        "setup": "2483c9a2f6794f850c65e62e25b56c12b28722ccc95d086ae2ba18efb7dd62b2",
+        "punchline": "9927da362f16b485647b333241a25d9cc86704a08780bc9b04f8aedfd14d5c58",
+        "combined": "cb639257dd1a66a76c2a40c19ecff9761ccd936b01e3407951b126c240261032",
+        "tokenSignature": "a-are-attic-business-going-i-in-making-my-new-roof-sails-started-the-this-through-yachts-year"
+      },
+      "lengths": {
+        "joke": 63,
+        "punchline": 37
+      },
+      "source": {
+        "sequence": 834
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0835": {
+      "hashes": {
+        "setup": "1f33e1ff1430024957e7b955488da5f13fe8314d3a66a6a85ce9c93e8d697c58",
+        "punchline": "d2f4b3ce356336d2d191b709dec6aab500e1eb8ff7d77dcc84739d90e92e6a3d",
+        "combined": "3c9b191f2c65a1e4af8c26cdefd852830aa1d0ac81eadadcb0434866cead2451",
+        "tokenSignature": "a-but-by-can-didn-drink-got-head-hit-hurt-i-in-it-much-soda-soft-t-that-the-was"
+      },
+      "lengths": {
+        "joke": 68,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 835
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0836": {
+      "hashes": {
+        "setup": "b7692390f0599418ea478e1a34fae17f150412130f33dd14c601a59805cec65a",
+        "punchline": "2791225bb193716e205961580375a0672f8b5f67bb7a45ae349092134b5d2bc2",
+        "combined": "425c6ea325c98366dfd0c42085c8c89d3a26f59d8d1594b82d82341494bf3234",
+        "tokenSignature": "blender-can-giving-i-if-it-keeps-like-me-mixed-results-t-tell-this"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 836
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0837": {
+      "hashes": {
+        "setup": "f8bd1af0dc1a83a16bc85569004067db27d1e44407c6ab64f3a837b8c64a35d9",
+        "punchline": "3d5d1ebcddbfeb75789e30f0e99d5e5df37127e2f8b92d5cf1bd39b6b5178878",
+        "combined": "9355b02f8ece4f4af72d13d0b0f7c51d16d70f7dd5e1d8ce27f50b2b3bc691d4",
+        "tokenSignature": "are-at-excel-good-how-i-it-point-power-you"
+      },
+      "lengths": {
+        "joke": 32,
+        "punchline": 14
+      },
+      "source": {
+        "sequence": 837
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0838": {
+      "hashes": {
+        "setup": "e617c408e5c07a13499f260cdb5bbb82606c4d73bd3d7f0632c9c120e7901ff6",
+        "punchline": "bff13324189fc94aceefdd09b13afd659fe1c59919fb56038d69c46e301ebf07",
+        "combined": "df51940fac2db8c5d24d85a42ca1d2a0cb5a82a78dd30e20e9813f4c7f0091a0",
+        "tokenSignature": "a-as-because-beef-can-it-not-password-s-stew-stroganoff-t-use-why-you"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 838
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0839": {
+      "hashes": {
+        "setup": "a10ddf246c3c01e408a2aab6a66d6795566ce7f64b8c9f035b9b4cbd843ff414",
+        "punchline": "6bd8d2261b4552f14f36e83c5632d18f9793876bb76fae55f8bc13a2ed71aab7",
+        "combined": "404147b102aca3bd51ca6af1e44c373760c6e5db8e06ef12eacc2c7bb06d1d6c",
+        "tokenSignature": "about-best-get-i-jokes-keep-part-s-tcp-telling-the-them-to-until-what-you"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 46
+      },
+      "source": {
+        "sequence": 839
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0840": {
+      "hashes": {
+        "setup": "1648455b52c3bfe3d30aa5ea5261fb46bfd4098e24847d3cf345bb6c11ea4464",
+        "punchline": "49c0993e6f2a14760ce76a14f0e64746dd08ab4378727fb61413b796c91f11e8",
+        "combined": "622a2953543c47f08f128983113be0227ff7021d46a32df558e72f5f7d9ea10d",
+        "tokenSignature": "a-an-and-bedside-before-case-doesn-empty-full-gets-glasses-going-he-his-in-on-one-programmer-puts-sleep-t-table-thirsty-to-two"
+      },
+      "lengths": {
+        "joke": 73,
+        "punchline": 74
+      },
+      "source": {
+        "sequence": 840
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0841": {
+      "hashes": {
+        "setup": "46adc3b51fe60d8a1c3a38bd9a1bbe2e943eedb42d8f15ccb9204632f008347a",
+        "punchline": "7d9622c90d293154f083de06fef915b4493c290e3d2717c86940c68852378bb8",
+        "combined": "5671279425259c861e2c304fb926bf927ab17608632f8a7bba4e8c1570847ed3",
+        "tokenSignature": "a-and-bar-didn-either-first-guy-guys-i-into-it-ouch-says-second-see-t-the-two-walk-yeah"
+      },
+      "lengths": {
+        "joke": 30,
+        "punchline": 78
+      },
+      "source": {
+        "sequence": 841
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0842": {
+      "hashes": {
+        "setup": "180fd7034a1ddec7c21e536ebebf8266848aaeda533478be981d465904c80cf3",
+        "punchline": "cd2085f071c940d735cf26f6be05ca218a64c6578265bfd78e5157415db276d0",
+        "combined": "f794534466fdba87030504957be30cdad75fef8469157e97524ea1e38238a06e",
+        "tokenSignature": "did-doctor-hurts-ip-it-router-say-the-to-what-when"
+      },
+      "lengths": {
+        "joke": 38,
+        "punchline": 17
+      },
+      "source": {
+        "sequence": 842
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0843": {
+      "hashes": {
+        "setup": "bafb952159aa17781399bb88f23221d901df586b6b73d77a547ee30c125019bc",
+        "punchline": "5da84486c9504ab7c2b769d39cdb0b6bf6ca370ea938088ac14ef51791c58cea",
+        "combined": "71e6294dc663bd82edbf8e0411a0c4052ab64b5f2913c62d92d8f7e1492afe01",
+        "tokenSignature": "an-goes-he-house-ipv6-is-nowhere-of-out-packet-the-walking"
+      },
+      "lengths": {
+        "joke": 43,
+        "punchline": 16
+      },
+      "source": {
+        "sequence": 843
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0844": {
+      "hashes": {
+        "setup": "3a1020317b2510105dc14cc5ad872d8c7998f104e87c28fd62a2a96e9082b11e",
+        "punchline": "4b82e541552647d76f41d12940fd1b7da7cc4de1dcf95d026b532208371570b1",
+        "combined": "fbd9d55decbe9db4bd0ff6e9b167b4b5779c9c74ce7c62f4f2062381dc34ce28",
+        "tokenSignature": "a-an-and-asks-back-bar-bartender-beer-but-dhcp-for-here-hour-i-in-into-ll-need-packet-says-that-walks"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 59
+      },
+      "source": {
+        "sequence": 844
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0845": {
+      "hashes": {
+        "setup": "d0be4ee7b47d14dc128bc1ad1cf9e5f6306f3b865f9a6247b0b3e308b749045d",
+        "punchline": "90b7780249360261429945027045b22a600fb3a34e60252f3e1cd59184274122",
+        "combined": "da11a6a39c3f4b0895d38091abd6013727828b32b8f1b3640ad70303aa5c4533",
+        "tokenSignature": "3-a-bar-couldn-find-into-nosql-out-soon-sql-statements-t-table-they-walk"
+      },
+      "lengths": {
+        "joke": 59,
+        "punchline": 27
+      },
+      "source": {
+        "sequence": 845
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0846": {
+      "hashes": {
+        "setup": "2288a7657e2f6d1b716bc36d68ba89b98e61d940565949b0a4053d6e3e5646e8",
+        "punchline": "fb5c89259f011a339f113c1bf82453766d7d1bd863fcb91dfb3d4c6cd2616648",
+        "combined": "f230108774497c5cbdba8e380599fe5ba525fe2ef4a8f14e68281d1e9d7e9586",
+        "tokenSignature": "1-a-couldn-craigslist-down-for-high-i-is-it-nice-on-saw-says-seller-stereo-stuck-t-the-turn-volume"
+      },
+      "lengths": {
+        "joke": 83,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 846
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0847": {
+      "hashes": {
+        "setup": "9c90cd5f8090c07060844417acafa47bf6a0443efbb45be7621f2069b63aba3a",
+        "punchline": "c2fb21e6952a891a8b697546e915a850bfc7c66c423d4f6127617284e50de99c",
+        "combined": "650b9eec899197eff96790ef131c7c1cdc16a745e005b1c44410fec410e55999",
+        "tokenSignature": "apparent-are-because-dad-good-is-jokes-punchline-so-the-why"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 847
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0848": {
+      "hashes": {
+        "setup": "aedef15ebfdf0a34e64e7fb979ad6e95916ec7121adef61844c5b3fd3936ca65",
+        "punchline": "c360dba82064996fd3299bcd7ea1885aeb3ab83b15e5914d4164d89a236302cc",
+        "combined": "5d7cd63c4cc39e2e2ef22bb9151571f19487c01af779b4c107c61549d9840f95",
+        "tokenSignature": "a-asus-call-do-laptop-looking-suspicious-what-you"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 5
+      },
+      "source": {
+        "sequence": 848
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0849": {
+      "hashes": {
+        "setup": "e9546a0df13b68c0d8be816792eb66d2aadf9055a8c9799e333d9f92f66cff0d",
+        "punchline": "b30fd3eab7a27cc4ef9566bd4590e9679fda6a8c92a84f89ef80bc6b2ad39611",
+        "combined": "431e0f7d5291ce7598a98616cf39cdfb0705f04326fe3cfb43332ba67a066444",
+        "tokenSignature": "c-class-code-did-got-java-no-say-the-to-ve-what-you"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 20
+      },
+      "source": {
+        "sequence": 849
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0850": {
+      "hashes": {
+        "setup": "6f40746981b463cc8c83cd68823557df25181abc355440c32830d0412b86d886",
+        "punchline": "5ba4b2912089f5503fff53b3860c4796ec2d1fc5038a55c83ec347da50449780",
+        "combined": "54847c548d08dc144febe1793869b8b10a44217dfb4389ac85de8cb7987a503c",
+        "tokenSignature": "in-is-language-most-profanity-programming-the-used-what"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 10
+      },
+      "source": {
+        "sequence": 850
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0851": {
+      "hashes": {
+        "setup": "a112c3edd5ad9e5f749bffb7404dbc99760ada069773d449a265d6a50d951c4f",
+        "punchline": "a6bb88c7be7d1457d30d7033f372eaa3c33d75fae598fefd1d30980c6815fd8d",
+        "combined": "69f92ae449d53aa2fb20ab9d8652e872dc92716ad1ab102a7740d598d7ed40fc",
+        "tokenSignature": "a-an-case-do-extra-fathers-get-go-golfing-hole-in-of-one-pair-socks-take-they-when-why"
+      },
+      "lengths": {
+        "joke": 64,
+        "punchline": 31
+      },
+      "source": {
+        "sequence": 851
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0852": {
+      "hashes": {
+        "setup": "a77296579d6e39bc8c0854be5b85f8d705560281f4fe0ac40c233c2822a72056",
+        "punchline": "c09747221a33c3089bc4575a8b15bff081e43b8ca089c1b604e461aa76f165ca",
+        "combined": "177e5fb67971af1dc4274f8229c4b691de0c0eb9b0cf6604764ab2aadb50ce3f",
+        "tokenSignature": "api-did-eat-go-restaurant-the-to-where"
+      },
+      "lengths": {
+        "joke": 28,
+        "punchline": 18
+      },
+      "source": {
+        "sequence": 852
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0853": {
+      "hashes": {
+        "setup": "527305dd35260ee8eac550bdbed5e764e99d1a998be981d77fb26e74b226789c",
+        "punchline": "101526027732d211a87f600a3aaaa107f3f67d32c5105ee920676bf969d06c25",
+        "combined": "7a6af1e7c3c9941715c4c9147cd7a95c30f75be4716200a46fe5e9508530675f",
+        "tokenSignature": "a-hear-hey-html-joke-parsing-regex-wanna-with"
+      },
+      "lengths": {
+        "joke": 23,
+        "punchline": 24
+      },
+      "source": {
+        "sequence": 853
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0854": {
+      "hashes": {
+        "setup": "dd4ce59ece5857b0de53026948fd7486620733aafc8a141a52a0f3fdcbf39d1a",
+        "punchline": "96ee4a41c09f64d60be26372a0aa7fb41565ce2d808aaf1c2d85f9513ef567dd",
+        "combined": "102ebeb510f33c556c85b9d3dc28b2bc1a7304a32932c18f17f5d4ae7fe396d9",
+        "tokenSignature": "a-and-do-exit-front-generate-how-in-of-put-random-string-tell-them-to-user-vim-windows-you"
+      },
+      "lengths": {
+        "joke": 36,
+        "punchline": 57
+      },
+      "source": {
+        "sequence": 854
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0855": {
+      "hashes": {
+        "setup": "75ff359eb2c8fc5480fefe6e217690f1ac1b15f75d95e3f9b020c48e57cb79eb",
+        "punchline": "213a31584aaa4271cb6d0b267bfefe54f4813de9b5914f5e34aaac1426aa1f36",
+        "combined": "f992d5b2637e9ce7527c4e2dcf69b80d1ea1e495eae06027df504fd4dc22a385",
+        "tokenSignature": "arguments-because-calling-constant-did-each-functions-had-other-stop-the-they-why"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 855
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0856": {
+      "hashes": {
+        "setup": "362246f4c4e55bb9622e2989631506e4ee431c71f5c0b35cc749e0fda1ca0dde",
+        "punchline": "bdc94082a0de5afd303bacf18b7e8b68c5fc505195e0b3518641640ec029c7ac",
+        "combined": "93ec117073a5ce1461e7c8918947c188b6a3d9be924e98690899dd8a5832c2ac",
+        "tokenSignature": "because-break-classes-did-each-never-other-private-saw-the-they-up-why"
+      },
+      "lengths": {
+        "joke": 37,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 856
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0857": {
+      "hashes": {
+        "setup": "7702e6fe369d4e08e2da8e3b92abcae35c54a5121614cf34408b76e5e2c3b851",
+        "punchline": "a694e2570ad840ecd4716e24d0b3aafb63c57eefea492ebee6b3fe30d034ad6e",
+        "combined": "d11eb8a7ede9cdc5253706dc937e304509fa5c0bb595f4f464d97634ef2a3798",
+        "tokenSignature": "and-any-bitcoin-broke-buying-bytecoin-calling-developer-did-didn-get-go-he-it-kept-t-the-why"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 857
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0858": {
+      "hashes": {
+        "setup": "ffabdeafa63148aefb82f1db806145e4039740af3f90f6841b28b7778af17fbb",
+        "punchline": "2b5c98bbc0661500e492bcf5396edb3eb27d0c81877b6b2021e8d340213c2ba6",
+        "combined": "36a56a3ccb66b4fee244ba026ed45ea9e464aa54cdbfb63ff3af95af0cbc3762",
+        "tokenSignature": "commit-did-didn-he-him-how-know-leave-programmer-s-t-the-to-why-wife"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 29
+      },
+      "source": {
+        "sequence": 858
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0859": {
+      "hashes": {
+        "setup": "156880e56f9d24db16256681b38234795965a14b50f01cd7faf3154092bede93",
+        "punchline": "c22bcce53ea5fc5dfe082929eea7e925525d8ed26c4f584e1565fe83eff1921b",
+        "combined": "c08271059e53045b606f057ab51574d1d26104860eab4a3a1932c592c1fc6462",
+        "tokenSignature": "because-bitter-chocolate-code-dark-do-it-like-prefer-programmers-s-their-why"
+      },
+      "lengths": {
+        "joke": 41,
+        "punchline": 36
+      },
+      "source": {
+        "sequence": 859
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0860": {
+      "hashes": {
+        "setup": "dde21d95eab7cc9c4fb42a98dee921ef9d520e2d2c604951ff0b8f50878612f6",
+        "punchline": "f9e2da9bf754de6d0dcadc7c7d967298d51ebe48d86791cdf89563690c4fbe07",
+        "combined": "3ef81da0c20f0f059bfd03a93bf19840e047f091f5215b0237d2b7c109555a81",
+        "tokenSignature": "developers-dom-don-like-nature-prefer-react-t-the-they-virtual-why"
+      },
+      "lengths": {
+        "joke": 39,
+        "punchline": 28
+      },
+      "source": {
+        "sequence": 860
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0861": {
+      "hashes": {
+        "setup": "106c4e437170842668ff6fd977dc66518c19312a6714578726fac8d030c65c77",
+        "punchline": "2672d5da4c44627dc50179b994c7431598b1bab3c0af1153eb2a72e6511967c5",
+        "combined": "b46d36b0342dcb98af569445eb790f44d2a620f1564b0ac5ff301aa30908edd9",
+        "tokenSignature": "always-because-calm-developer-exceptions-handle-how-knew-the-they-to-was-why"
+      },
+      "lengths": {
+        "joke": 34,
+        "punchline": 43
+      },
+      "source": {
+        "sequence": 861
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0862": {
+      "hashes": {
+        "setup": "6168a026f2fa05a3c7ec5452eeebc2a9b30c1a867da10dd3d8f6e429adb6e001",
+        "punchline": "bd85d5dc1c5abcb475498c506326c700a9c692e22dcaa4c93bb223e649af7e5e",
+        "combined": "84e72c493e7e76169e5688dd4df34bcb9b2fbe43ecd00c3d14595ba11b6c1b91",
+        "tokenSignature": "a-be-bring-code-debugged-did-from-heard-higher-ladder-level-needed-programmer-the-they-to-why-work"
+      },
+      "lengths": {
+        "joke": 46,
+        "punchline": 62
+      },
+      "source": {
+        "sequence": 862
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0863": {
+      "hashes": {
+        "setup": "ca60e23a347b6fedc042b4ca485f6102e4f31a833fe78464e659d514de08f43f",
+        "punchline": "f1087206063a3ed622c6b01ab8d8cd1269c838d18b2419b8b2410b1e0f56f631",
+        "combined": "4af2e7639b721ff033f7b6b9eaa098aa05226c8a7e1aaebfeb4e6bcc6a005e4e",
+        "tokenSignature": "anymore-break-developer-did-it-just-keyboard-t-the-their-type-up-wasn-why-with"
+      },
+      "lengths": {
+        "joke": 51,
+        "punchline": 34
+      },
+      "source": {
+        "sequence": 863
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0864": {
+      "hashes": {
+        "setup": "666509dea63b231f27232b9ab972f74ae1911a907e2d26f4f2c76e9d4e4f2123",
+        "punchline": "619771457b12e3f4d66800dfec3e508a29b8a0e135c91b6414da0f20d5988b0b",
+        "combined": "951fd213868707458690a00bed71765dd72fd7e1e242607c2f0461bd00e356ea",
+        "tokenSignature": "a-always-c-carry-did-in-pencil-preferred-programmer-the-they-to-why-write"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 864
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0865": {
+      "hashes": {
+        "setup": "c8cec798a26627c2eadc2a2887e9185522704cc1ca3e59568aacd6399dbb8a12",
+        "punchline": "3e11c6777f148def86836a532e0ba4caad5a59f57cda96b0a3bbf6cfcf71441e",
+        "combined": "df5ea4cbcb7b4742b8eb7dac987c6fa05404426bf63de507539d151ee50faa71",
+        "tokenSignature": "art-box-code-did-go-he-how-learn-outside-programmer-school-the-to-wanted-why"
+      },
+      "lengths": {
+        "joke": 40,
+        "punchline": 47
+      },
+      "source": {
+        "sequence": 865
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    }
+  }
+}

--- a/data/quotes-manifest.json
+++ b/data/quotes-manifest.json
@@ -1,0 +1,12181 @@
+{
+  "meta": {
+    "generatedAt": "2025-09-20T19:22:52.879Z",
+    "total": 553,
+    "categories": 12,
+    "hashAlgorithm": "sha256",
+    "tokenSignature": "unique-words-v1",
+    "fields": [
+      "text",
+      "author"
+    ]
+  },
+  "records": {
+    "adventure-01": {
+      "hashes": {
+        "text": "55096511e06f509dba5157071fe61aa0d40cd0172e097d6079d86f2045196ffe",
+        "author": "022e4626b2e871085490580d6c93eb21de2baf043a57dc8351accad49887bd16",
+        "combined": "c889c9ab19a9f7b062d3f07f275ea56fa6277c2805cdc7ebc04eff590980909b",
+        "tokenSignature": "a-adventure-and-coelho-comfort-danger-days-ease-is-of-paulo-the-thousand-worth"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-02": {
+      "hashes": {
+        "text": "48c4b6d28efd84d7e304b534fa8af1e771f04dab1c78585c68066616138b9a75",
+        "author": "7ed49fd05f369e68ccd924ee9b7f31c0e055a75746743f75aeda21f85bb5a1e4",
+        "combined": "acc1c116a48f0d83ca680b987048e037087859c3fccadbe3c6a443b1a5bb1741",
+        "tokenSignature": "a-and-augustine-book-do-is-not-one-only-page-read-saint-the-those-travel-who-world"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-03": {
+      "hashes": {
+        "text": "a1abd604b8d7120e9902fdadcbd0130585c4c6c1f459f0185a494f33d9064338",
+        "author": "ca7a7b4d4f3ae1eb0546d369c447b1dbddd980eb42fa452a8fbde9a9d44d0284",
+        "combined": "11cb842a525fb476ec1c99c7568d0cbfcc26a601a145a7ed90439798b89ed1dd",
+        "tokenSignature": "d-feet-have-if-in-instead-meant-of-one-place-rachel-roots-stay-to-we-were-wolchin"
+      },
+      "lengths": {
+        "text": 71,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-04": {
+      "hashes": {
+        "text": "d63559cd8d6d85fb865e81b33e7e245ace5d9b9aa8318d03f798c894bee62edd",
+        "author": "8efb46e0d0e614f2f850d1024984f5d9619cf9155d6918e704dbbbd624696844",
+        "combined": "8a9894dd87e5d918694bfd65b8352ba1ccff796b0e418aa2a49e971f5a152adc",
+        "tokenSignature": "always-amazing-angelou-are-be-can-how-if-know-maya-never-normal-to-trying-will-you"
+      },
+      "lengths": {
+        "text": 82,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-05": {
+      "hashes": {
+        "text": "c65e1797aa5fe8c9b3ee9d7925f6174d58e51e9c0c6513228a5b5a3749ecab29",
+        "author": "e975576533a7494402684dfe70c67d3e28f05651da40e6dc2b67f89f16dbab7e",
+        "combined": "097db5d6d77a8579d820e5147bd4b343de5a6508ed0f63c698cf197c4a548804",
+        "tokenSignature": "a-and-do-emerson-go-instead-is-lead-leave-may-no-not-path-ralph-the-there-trail-waldo-where"
+      },
+      "lengths": {
+        "text": 87,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-06": {
+      "hashes": {
+        "text": "7230f88eff586d0b0809581e1b7abb87f6f41a38fba75101ab9a14798ff63e28",
+        "author": "f98a1539f718e5df90aa3cea8b3ebad8c528e3835d344563b2e88fcc9ad636c0",
+        "combined": "52db7a8e20e2ebde371798f1bd0349c99f672e49febc271ff0674a59ccd70515",
+        "tokenSignature": "a-flaubert-gustav-in-makes-modest-occupy-one-place-see-the-tiny-travel-what-world-you"
+      },
+      "lengths": {
+        "text": 75,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-07": {
+      "hashes": {
+        "text": "b43f39dc629ce8a8d81c6aeb2182948e10ae4fbb02e28c765b7a41cf184b2a18",
+        "author": "43260725da0d34b6f28adb92fc405fea47218fd84c976bc79e7240ea2e109377",
+        "combined": "26bddde1bd9d8dfe61153d4a60d5af8aa6065411eafd97a45f755df3998a091d",
+        "tokenSignature": "a-are-built-but-for-harbor-in-is-john-not-safe-shedd-ship-ships-that-what"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-08": {
+      "hashes": {
+        "text": "c0378fc3077ffbdc09b11ac6f0584176b7be1dcecc4d8e2920c99ab2a0e6cdf7",
+        "author": "096f4cb5cadb942fd64c65b75cb9bea6411adaff0ec60b7e0816baef21c6a1b2",
+        "combined": "95d11adcabd9c3a728fbd6fab20cbb7ffbe75e7804bb60a9022296a8b3527ab1",
+        "tokenSignature": "bennett-don-into-know-made-of-re-roy-step-t-the-unknown-until-what-you"
+      },
+      "lengths": {
+        "text": 68,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-09": {
+      "hashes": {
+        "text": "2db38b6a01dcc199f7296bdb5a96f2167f2bcd89b796a88bef14ab1dda894a2e",
+        "author": "bd8d218beeec48b9f2062a9bc477342ad0945fbe02d89b2faf2a3a45e209ad3b",
+        "combined": "5059547759961a9ddf24bd42e43d583439caf9f6c7b10da53997bbf3ca52b1ca",
+        "tokenSignature": "exist-in-is-just-live-most-oscar-people-rarest-the-thing-to-wilde-world"
+      },
+      "lengths": {
+        "text": 65,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-10": {
+      "hashes": {
+        "text": "1a378dbd7fcb6ef95c9979db5c254dc38accb9d45cc9ca1840f24e11ea2121ab",
+        "author": "37ef663ce10e6487420e232ffedc9f72866b7879c142ca6b4ad5de819a94cd5c",
+        "combined": "cd57140d1e467570ea28288134f93d7b569bca3bd03de6897d91f5dabfc07e75",
+        "tokenSignature": "can-eliot-far-find-go-going-how-one-only-out-possibly-risk-s-t-those-too-who"
+      },
+      "lengths": {
+        "text": 75,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-11": {
+      "hashes": {
+        "text": "35c213ad29d813a496347313cf5c4f0de19c393aebc900b59f15c46256b2d766",
+        "author": "8efb46e0d0e614f2f850d1024984f5d9619cf9155d6918e704dbbbd624696844",
+        "combined": "eb420c65340e86d2f54e707e647d38ad04c01f230e4dabbed0833159816c0f2c",
+        "tokenSignature": "about-angelou-away-breath-breaths-but-isn-life-maya-moments-number-of-our-t-take-that-the-we"
+      },
+      "lengths": {
+        "text": 90,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-12": {
+      "hashes": {
+        "text": "0e1e9093b40c4e680f06e1f4c9c92047599b1771a440cc7943c6030873e368ae",
+        "author": "cb58d4d75d62b57727accd1b2fb7dfddfa0e9442a368e61509a55338a29e09ca",
+        "combined": "c493f8ea0fdaa235a3cfecbdefb529acb68cfa8ab71bb4bbe64af21be5d672e5",
+        "tokenSignature": "a-busy-dolly-don-forget-get-life-living-make-making-parton-so-t-that-to-you"
+      },
+      "lengths": {
+        "text": 65,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-13": {
+      "hashes": {
+        "text": "5ad140d30a634278b204540aa050942d3fb21866e83b0b1a5032c66405d903a1",
+        "author": "2e04bf3499fc58c99ea4c0dac0b0d50fa0bfcf3052d64ab324358a14dabb51c2",
+        "combined": "7ff0a17189606101da6a49cce50ab8a2feaae498466bf1ac2458f2c8d90f48c7",
+        "tokenSignature": "andre-cannot-courage-discover-gide-has-he-lose-man-new-oceans-of-shore-sight-the-to-unless"
+      },
+      "lengths": {
+        "text": 84,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-14": {
+      "hashes": {
+        "text": "ec93e2d5a23fa8f3e852e7a427f291e5140797506423a7f2c7b0d8f13488de73",
+        "author": "d9243e2d0ea076c4bbf3e2192cb514c87bdf17390fcb6e24329bec17d6a19513",
+        "combined": "61a00d2b83f9e8e5613b82b5b6120dcfec4ca860e2f5f96765c7218d4798f842",
+        "tokenSignature": "and-are-awkward-brian-can-comfort-feel-grow-if-move-new-of-only-out-something-to-tracy-try-uncomfortable-when-willing-you-your-zone"
+      },
+      "lengths": {
+        "text": 129,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-15": {
+      "hashes": {
+        "text": "da8cdc6c34340270eda4508d6d4ab12e7baa73f49da2b8348d58399d7c112203",
+        "author": "1d9aaa9a9b9fff69c691bc646b15d06db2f522ae49d57e78b31667b349b59a39",
+        "combined": "38c5802256d9949e7447b845b1e2fb7b036215995818da4ef767cde284b57fbe",
+        "tokenSignature": "all-are-j-lost-not-r-those-tolkien-wander-who"
+      },
+      "lengths": {
+        "text": 34,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-16": {
+      "hashes": {
+        "text": "8db1b2b275f8d478df770a42b029eeafb149285d8f2255ce1ebcf288f3220539",
+        "author": "118d3a27ea9af6f75da5dbde1dc9213cc68273dcbde57fdf45c92c9b5c3fb14f",
+        "combined": "f3db4ac9990259ba80dda12a23fe5d1960b51aabf5afe499fc0eddae1c47dffb",
+        "tokenSignature": "dies-every-lives-man-not-really-wallace-william"
+      },
+      "lengths": {
+        "text": 43,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-17": {
+      "hashes": {
+        "text": "42d69576b9047ad2049f5cdbff1f81bd8ef28c7fa1e2d30b968f993c237f48ed",
+        "author": "d5d0ea2a1fdb3d4afac82aa2c3aa713d07c20fb08d4befbccb6917fcc3a469aa",
+        "combined": "76169ff28aefec2bb1b56a5828e2fc1df75bf526d877e185ee29899730d7f17f",
+        "tokenSignature": "can-do-is-nothing-pratchett-terry-the-thing-worst-you"
+      },
+      "lengths": {
+        "text": 38,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-18": {
+      "hashes": {
+        "text": "cc5fa4d87a9478e677c9a3b1bdced21ade2e02dee7aeecc8c04fa87abd593186",
+        "author": "3b32d2914c290067e8389e7db23c1eb26cf861709a5a6ff8b780b4ed3f1e26cf",
+        "combined": "18058a467cdc51dec04fabd780ae6ecd86ecefc29831a5df566d49503dbc6ccf",
+        "tokenSignature": "bernardo-evolve-is-pierre-to-travel"
+      },
+      "lengths": {
+        "text": 23,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-19": {
+      "hashes": {
+        "text": "de4098bfc990973cbb1889e178691097441caa7f7da573c638a52ad3fb50394d",
+        "author": "e975576533a7494402684dfe70c67d3e28f05651da40e6dc2b67f89f16dbab7e",
+        "combined": "61ac55c3a1edb23f9a43423105e7374a55a6cd4ac8935ad2b8ab92703ca99479",
+        "tokenSignature": "but-depth-emerson-is-it-length-life-not-of-ralph-waldo"
+      },
+      "lengths": {
+        "text": 44,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-20": {
+      "hashes": {
+        "text": "6d8e687ffa71148a74cf29d0fd1bd40634dada26bcb184cd10f118270b6e51b0",
+        "author": "34dd58d69bc65629c0ce4d0be1689a8b2c11542bf0a1264faeb6bd00d7c97eae",
+        "combined": "ed51f5b96230edf2b28a96f63970549884c62e95c5a4d44d5a3760ff3d1faa42",
+        "tokenSignature": "at-begins-comfort-donald-end-life-neale-of-the-walsch-your-zone"
+      },
+      "lengths": {
+        "text": 44,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-21": {
+      "hashes": {
+        "text": "c7e911276cd8f38bec4ed7efeeb3dce36810eb3c008943b25d593290c775f349",
+        "author": "c218e141671404883df7ed7f397a1ba3745fec048d7442b1996bf1c59dcd9604",
+        "combined": "d54c98dac7faafec277f857759a598dd04420ff0c9c0c89697888d4ac1d48217",
+        "tokenSignature": "david-enough-far-meet-mitchell-travel-you-yourself"
+      },
+      "lengths": {
+        "text": 37,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-22": {
+      "hashes": {
+        "text": "7dece61f003e3e3159a3e93711701eb8e77625043aa1e6aae35059063c85dc60",
+        "author": "e234866d973d7c753d9c2b51c6f5d503397fa04d7b1fdffc59664c17729da3b5",
+        "combined": "ea60602a7ca54a661215dfdb048937efcf178ed75c006aa7c59db894078feb00",
+        "tokenSignature": "adventure-ask-don-for-jim-rohn-security-t"
+      },
+      "lengths": {
+        "text": 42,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-23": {
+      "hashes": {
+        "text": "9284726e36d4342c374d8c38a1e6c3950f597cf50e76fe94d89c06a0266b6745",
+        "author": "081d71bb7bdd02bb7abefc204a69843180c327dfd5860a92753eb57c79df8487",
+        "combined": "93555ff5c5a9198db7062b5d424f4099810a70bf5ad3cd9b9241be10354861a8",
+        "tokenSignature": "a-by-clock-compass-covey-life-live-not-r-stephen-your"
+      },
+      "lengths": {
+        "text": 40,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-24": {
+      "hashes": {
+        "text": "ff9fc5e44e783b8835b08da04be921f523695661fac0988c11e2f7c6ab08c3e3",
+        "author": "4772150b2bfeef03edc13691bb588e8d979acec7aacc6b3534bb5c0bb90e3640",
+        "combined": "61fec3e56af01feafa3e09204efb39df49cde8583ac3f9b8f2d523718e3a466d",
+        "tokenSignature": "adventure-amelia-earhart-in-is-itself-worthwhile"
+      },
+      "lengths": {
+        "text": 34,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-25": {
+      "hashes": {
+        "text": "3b482748674f539c3073ad7c1441071ffae5e75b372d2f7092713d2e2720dc1c",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "90ec7709c739af02d5316a987c3ee02f458d9225ce18aa5e9e628122bd1610bf",
+        "tokenSignature": "buy-is-makes-only-richer-that-the-thing-travel-unknown-you"
+      },
+      "lengths": {
+        "text": 55,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-26": {
+      "hashes": {
+        "text": "5d0a1d48d03f2285c2a2d35a1ec354a3f19863a4ee516907920a298da9408e03",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "1e4fd1344fdc4fff5a90ff7ae565c19edfa128d76cbe14ef1c6c1094816d39a1",
+        "tokenSignature": "and-is-life-short-the-unknown-wide-world"
+      },
+      "lengths": {
+        "text": 36,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-27": {
+      "hashes": {
+        "text": "1cfe1bdb588c9c4dad225e8bb4a8c50c93559b9f2a08b2716428e8a58ec49b14",
+        "author": "f92ee0d2e3185db5930c5f76c85df774aca6ed580fe9619b0724b5798aa137af",
+        "combined": "24228a0881c37f880d42a3e3e84a11810c6941786eb3cacfb1b71d0c37833bd8",
+        "tokenSignature": "a-been-before-dalai-go-have-lama-never-once-somewhere-year-you"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-28": {
+      "hashes": {
+        "text": "e64be21b1a2e8a4784f62b781e551229ec8a1245812944bfc4779ba89080f3d3",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "e8d327e98b86cffd321f964af5abff9bfd61f4ba42915a0ff826d1bdec292edd",
+        "tokenSignature": "anonymous-die-dreams-goal-is-memories-not-the-to-with"
+      },
+      "lengths": {
+        "text": 44,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-29": {
+      "hashes": {
+        "text": "653ed6356cf740458a52c6c5f2533715b3c54d702fadb600c84b0c176fa702c1",
+        "author": "4a14ef61e1a959fecc9414c129a719873307fcbe0d5d9175926b9ad360443b75",
+        "combined": "33cb5a66c271007dbf3e16eab8648e1431056e13d8526122a9045b790a2a5efc",
+        "tokenSignature": "chief-footprints-leave-memories-only-seattle-take"
+      },
+      "lengths": {
+        "text": 42,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-30": {
+      "hashes": {
+        "text": "9188353bc9527786c6967e078eee10b8556568063a30f296a6d84e8eb2f193ee",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "eb3ec496e209947f42e844c2b8616f95623323da619f3428ea958d0a126d004c",
+        "tokenSignature": "adventure-an-anonymous-is-it-life-live"
+      },
+      "lengths": {
+        "text": 30,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-31": {
+      "hashes": {
+        "text": "852065951cdc180ececb3e565e1d095e1421aef1a1ea4f72c867b059b69d917d",
+        "author": "8825859c768dcc0daad58594ffc4d9f0e3828f24225a6ca69de3e2342146fd3c",
+        "combined": "7005c0b46ddc65114d023b890470c4e30b89b358e330e9b7b29d9380df2bc724",
+        "tokenSignature": "an-in-investment-is-karsten-matthew-travel-yourself"
+      },
+      "lengths": {
+        "text": 50,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-32": {
+      "hashes": {
+        "text": "5c544721cf3227aeb3d0895d877437d06bd0b3da1dfc664bd3b2961de8cbd29d",
+        "author": "0112c62badb6e5b8a5b40a0b72198c4d5cd02ad15e349021dd7f39709b878712",
+        "combined": "aa157167c66df12c9606bc2c654a3f23ecf12eafde2a256530f05de78bf1f124",
+        "tokenSignature": "75-a-and-call-don-it-life-live-robin-same-sharma-t-the-times-year"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-33": {
+      "hashes": {
+        "text": "10e443324f199cfcbae76b7c688114963e661e38d821838876010aab73d2a34b",
+        "author": "e975576533a7494402684dfe70c67d3e28f05651da40e6dc2b67f89f16dbab7e",
+        "combined": "6a4cb7339374501c5a102db370645c25574fae902f218930198ea55063a1eb61",
+        "tokenSignature": "all-an-better-emerson-experiment-experiments-is-life-make-more-ralph-the-waldo-you"
+      },
+      "lengths": {
+        "text": 68,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-34": {
+      "hashes": {
+        "text": "bc1bbf19c010929c760e5be22b2cffc04b8f4a89016d4dcaf5db8e24ff4c5316",
+        "author": "0c798605789434dd31e95ff5a3e531c2e72d8eca656eff5fd465ecd6de22edfd",
+        "combined": "1c9e87355285a58b1424d0210fb9c8341a10247016e7f1edfc5027c273f30f33",
+        "tokenSignature": "and-eagerly-eleanor-experience-experiences-fear-for-is-it-life-live-newer-of-out-purpose-reach-richer-roosevelt-taste-the-to-utmost-without"
+      },
+      "lengths": {
+        "text": 141,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-35": {
+      "hashes": {
+        "text": "cf7aa9a74cca1def2c3df491d16cf486d52fac1115bf768005549ff24ad23cb8",
+        "author": "b7cf0feb97b6dc27847cf3ed49dfe40838cced1effd8ac30b40ae651b8768661",
+        "combined": "f6318f50b17d25f79bb0cbba7df9655edcc67a40bb1ac044606a566dc90b9ae9",
+        "tokenSignature": "a-about-asian-better-hear-it-once-proverb-see-something-than-thousand-times-to"
+      },
+      "lengths": {
+        "text": 65,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-36": {
+      "hashes": {
+        "text": "5dd6f8b3d5c6575ceee10e14885fbf64af33e287d379cf21f06dd8601a59de94",
+        "author": "022e4626b2e871085490580d6c93eb21de2baf043a57dc8351accad49887bd16",
+        "combined": "cad6c119edd431048c2104159f484ef80268128c4218189403c16ad79c68915c",
+        "tokenSignature": "adventure-coelho-dangerous-if-is-it-lethal-paulo-routine-think-try-you"
+      },
+      "lengths": {
+        "text": 63,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-37": {
+      "hashes": {
+        "text": "d1c3f03843e3b674de90a9152f7fdd06bec34492b94b5084ce1e98fa5cc9e9a1",
+        "author": "f4fb49f850fa81650c9105bd6d58426f661c1fbc1779d8e018a8c164d70979ac",
+        "combined": "85161b1cb69598b8af735fb6d24bf56176fbca8d1eea4b34a240cc2279afcdd7",
+        "tokenSignature": "a-flaubert-gustave-in-makes-modest-occupy-one-place-see-the-tiny-travel-what-world-you"
+      },
+      "lengths": {
+        "text": 75,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-38": {
+      "hashes": {
+        "text": "f4aadad4f6666d67005c9d2438f1c22f53b306a2f5cdbfbd23d5f5f2492a02d2",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "f3f316bfb82ede5207d00dc682abfdf9e53a33ba8351a482862bd49d29e99cd6",
+        "tokenSignature": "as-be-can-far-in-life-lived-long-meant-much-not-one-place-s-to-travel-unknown-you"
+      },
+      "lengths": {
+        "text": 109,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-39": {
+      "hashes": {
+        "text": "6fbca38a0451c7dc10032591a2df2ba64444e3de0d97fd99336867abbbb1dd16",
+        "author": "e99e4fbd08fdc5298a7364d02ac2dfb0c45419cde8e7cd30ec716cc12229c7d0",
+        "combined": "234d112feb246b30da95eb2101e32e7933d5829a88166249959e22dec86e2686",
+        "tokenSignature": "but-consists-discovery-eyes-having-in-landscapes-marcel-new-not-of-proust-real-seeking-the-voyage"
+      },
+      "lengths": {
+        "text": 92,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-40": {
+      "hashes": {
+        "text": "c8062d189410bfcaa5511bb13c2fbbdd51bce4c152a38813e329435dbee6da83",
+        "author": "45da60f2f3d993a300bf6c6fa27a8e72e7d11b259180c517d9aeb90e1218f309",
+        "combined": "94d2c9b705b85ba10ad6eeae3fdf5292c1065b8282d7bf1198893192a2bce66c",
+        "tokenSignature": "a-alexander-and-i-it-little-of-own-rather-sattler-see-than-the-world-would"
+      },
+      "lengths": {
+        "text": 88,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-41": {
+      "hashes": {
+        "text": "ebe6c4485714a72c4d52ec07211b1966b3e21618d0d72df78846bfceade6c11c",
+        "author": "912e2c45a97125f0d27a926391d63b856d14cd6f0373203f4b02d4714e62bde6",
+        "combined": "8d225f7b082b8bdc13d2073b2ea1f7a09730fb6a980a89420fa434948148301b",
+        "tokenSignature": "a-battuta-ibn-into-it-leaves-speechless-storyteller-then-traveling-turns-you"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-42": {
+      "hashes": {
+        "text": "cf4491547214b09878fb792df2134671ca67f54f9f69bdb7d4e8852caa13ffae",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "82663d5fa3f3cbd7874db0d7e068281aa68c1cdeaa68f61ff89005bb660817c6",
+        "tokenSignature": "and-anonymous-best-by-experience-exploring-going-is-it-outside-the-to-way-world"
+      },
+      "lengths": {
+        "text": 74,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-43": {
+      "hashes": {
+        "text": "b259d3be18bcb39282eb13ee77d33a8a0013d0efe4246b326dca961a2df9e113",
+        "author": "2bccb6996e84e59a78877063820c6a0bde25c97ea62abf9a24937645d10b91fe",
+        "combined": "a0a8e1c1097021e1539c9a1591f76572a404b88b553514ea7f775fef62d7cf94",
+        "tokenSignature": "and-because-carew-going-haven-how-i-it-m-makes-me-much-need-not-papritz-realize-see-seen-still-t-to-travel"
+      },
+      "lengths": {
+        "text": 126,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-44": {
+      "hashes": {
+        "text": "0175f08b4e899d8aaaeb4d6d11e04ec289d04ec395cc65cfe506455aeb54fd63",
+        "author": "9e4afb7a4c065e73a23750df64d53f907d5bb686c85f40f988c23d1dc38985ee",
+        "combined": "1fbb961620b00d6f8e01083bdc137585f55958881ad2da37207c6955462dee6f",
+        "tokenSignature": "affair-anywhere-but-for-go-great-i-is-louis-move-my-not-part-robert-s-sake-stevenson-the-to-travel"
+      },
+      "lengths": {
+        "text": 109,
+        "author": 22
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-45": {
+      "hashes": {
+        "text": "7f00961ae836c97cdbfd3704ebdeb4e16bcb25880b224c7618e9a55eada5ef62",
+        "author": "726b891cd518a7d404e9317eafd8b8abbb993c63506907aeff52aaf76af824d4",
+        "combined": "7e0b1a5f6ef6c975b62e827a66df670d316caebcca0ec8bfc0ee03a8cdfa94d2",
+        "tokenSignature": "a-back-by-can-dimensions-experience-go-holmes-is-its-jr-mind-never-new-old-oliver-stretched-that-to-wendell"
+      },
+      "lengths": {
+        "text": 85,
+        "author": 25
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-46": {
+      "hashes": {
+        "text": "8bff4701dcc5213ba25837cff6f50faa93a405dce8d2bb2b9af7ecf0f088a45f",
+        "author": "c32e664c8565ae26c40eb6601bc9f3fbc051a02ce093babd81646df1c60154a9",
+        "combined": "bb0cc20a636b3d5ab578671b930ca6986003e50fd67574af69816be98b4469c8",
+        "tokenSignature": "a-and-arriving-fixed-good-has-intent-is-lao-no-not-on-plans-traveler-tzu"
+      },
+      "lengths": {
+        "text": 65,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-47": {
+      "hashes": {
+        "text": "554026924f6afaf058671ceda7a54bb24a0f20d7bd0976349d48d5ccaac3af7d",
+        "author": "e143ef29ac6bb9f267d165cffd870b73f157210d3ac615103b6ebe50dc412bbf",
+        "combined": "55edd44c04faca4010656250803c3b59b632bb949a23c26c2876f35d380994e0",
+        "tokenSignature": "adventure-biggest-can-dreams-ever-is-life-live-of-oprah-take-the-to-winfrey-you-your"
+      },
+      "lengths": {
+        "text": 75,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "adventure-48": {
+      "hashes": {
+        "text": "d848de5cf1e0156f1f7ac4a207c7a655b5125ff80d87e6df1fbd0212b8964cac",
+        "author": "65d6efc6dcfdcbcca15d89974d6aa45ac4d732d8954ac427b938e0ae403b9db8",
+        "combined": "5bc977dfde38ee63494af82e6204f725cb2bd60b421faf92ec3e9bf19c1f29f1",
+        "tokenSignature": "beginning-discovery-do-frank-herbert-is-knowledge-not-of-something-the-understand-we"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "adventure",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-01": {
+      "hashes": {
+        "text": "755df15892bd627c44110d40e2fef55e6171fa35875141b9db903e1d67aa55a6",
+        "author": "cffbbaca84f7ae50d14d644acb46e87b33c3047f7f06d2e35e256a88fd521f45",
+        "combined": "c083ad553e8d1fbf188777f6200bac1b2eb160816e5e906f403a4a6924499d6d",
+        "tokenSignature": "and-are-leo-most-patience-peace-powerful-the-time-tolstoy-two-war-warriors"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 26
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-02": {
+      "hashes": {
+        "text": "18d628d25e39db9775c6475cef4fd48f05634ae9e236808c1a179cd8d45d2086",
+        "author": "9bd3d2cdb13d078f75490b39cf5099ea56b6b4be9c418ebe2901c6d366d88b42",
+        "combined": "cc8489e16e8f761e46125a29bd781cb6d0330aeabaeda9f06f96165a49721b57",
+        "tokenSignature": "but-fruits-is-most-of-penn-solitude-time-use-want-we-what-william-worst"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 32
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-03": {
+      "hashes": {
+        "text": "f01fa6e1b44c4808bbfe4e3cc74bc37b06e24815380da7740a4869b55e8d67fb",
+        "author": "b91bb830f0cfee43948ba0a399fad0845c71a6826de1436e11ce25e2953106de",
+        "combined": "08ad560cfbec0edf1e9dfd86dc54711c4d412663a2ee08078900131fe33401e2",
+        "tokenSignature": "all-decide-do-fellowship-given-have-is-j-of-r-ring-that-the-time-to-tolkien-us-we-what-with"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 44
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-04": {
+      "hashes": {
+        "text": "97e514a805518d76d1bede45800fb58fc7578eff6f2634d5892a84406caf434c",
+        "author": "e28bde4d9e57a3098c72a914df85bb4be9afeafc77bb7dd3d55e6e03f3e25c57",
+        "combined": "4afd4fc41515b3dac21dde467364bc0593157a98ebdb731deb36f11c2bdb8664",
+        "tokenSignature": "all-have-is-jobs-most-precious-resource-steve-the-time-we"
+      },
+      "lengths": {
+        "text": 47,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-05": {
+      "hashes": {
+        "text": "ccd85fa0aa5de259e0ec6e8e7b257e037ca1e3fdbe246ddecb49c932443068ed",
+        "author": "c90685bd397f8aba0b4990516ecb24cfbcacc52a202183035c6a85962bd9448f",
+        "combined": "bbca37e8914950760bb69630703cd76a5acad26bb5fad46f1ebdc6940e236250",
+        "tokenSignature": "a-has-margaret-matters-of-peters-really-showing-time-us-way-what-wonderful"
+      },
+      "lengths": {
+        "text": 59,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-06": {
+      "hashes": {
+        "text": "3757489bfa7bab2101aeb54ac59a5fe2a586cc6c8e2543b583f314c0104d866d",
+        "author": "c32e664c8565ae26c40eb6601bc9f3fbc051a02ce093babd81646df1c60154a9",
+        "combined": "73ede29b0a030c9121fb09879a87a0aa76a4e1892d65e320a0284298bafc1382",
+        "tokenSignature": "a-created-don-have-i-is-lao-say-t-thing-time-to-tzu-want"
+      },
+      "lengths": {
+        "text": 80,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-07": {
+      "hashes": {
+        "text": "76ef377940a777d69f5a40343bbb8b09a337884cf75689c8e45cf5f19a11227e",
+        "author": "385324e8284410c6041461df260ab6c20330d4bbc078d0c2ef445a4e84a59399",
+        "combined": "040945aaf0ddbaa2f85b480021060f43a2f89e15847cb6655dd193c171dea22c",
+        "tokenSignature": "before-boss-early-goes-groucho-his-leaves-man-marx-no-the-time-unless"
+      },
+      "lengths": {
+        "text": 58,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-08": {
+      "hashes": {
+        "text": "8cbed9e75e54a5dec05828db6a6eda98e418b30cdaffd4843b55848ae9846adc",
+        "author": "cdc0e7cad4ae54f78b4db7e40b159690bb917e3c84dfdae24bc2130f0e5a01d1",
+        "combined": "d0913a8a100241e42ec96c6ff05744737429e1ad6c5a7b6f24d48e0d5939cba8",
+        "tokenSignature": "back-but-can-free-get-harvey-is-it-keep-lost-mackay-never-once-own-priceless-s-spend-t-time-use-ve-you"
+      },
+      "lengths": {
+        "text": 160,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-09": {
+      "hashes": {
+        "text": "480324879765f59c235ac1af5f759cdb6082240b9cc39cec76bd62a956fb464b",
+        "author": "848f2611f93ebfb4786326ff7d501554394306d45220d48b9577ac24c9450b50",
+        "combined": "d9f446088549b5e1cffdc4ff9c15be3077b89232599cf2b4830b67b8b1f19ff2",
+        "tokenSignature": "an-at-c-does-everyone-future-he-hour-is-lewis-minutes-of-rate-reaches-s-sixty-something-the-whatever-which-whoever"
+      },
+      "lengths": {
+        "text": 117,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-10": {
+      "hashes": {
+        "text": "b77c37c47b0188c6297381e088722e73841a1daa06411d5d999ac81a0ef32489",
+        "author": "e344d8f8c6bc964c0ea4c99cc44ea7195cd203b3dfdd74590706f8d2b4960f2f",
+        "combined": "ec7c7521f725f37283aad07c67542737dd6f87d326c45f36cddc742327834ce5",
+        "tokenSignature": "altshuler-bad-flies-good-is-michael-news-pilot-re-the-time-you"
+      },
+      "lengths": {
+        "text": 62,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-11": {
+      "hashes": {
+        "text": "d9812c1fea65a3062ba15d9c6a41f0c62a596394f69bc2afe9eb4eb7cce62a5c",
+        "author": "98dfe46464fe6370a93db1b726aa31480e5dcd8ae103c1ef630da999679f8dde",
+        "combined": "de8cfd6ef6dda5cb23ac3ce02a9baab45cca20d66d40dbd3e77264ebed03f579",
+        "tokenSignature": "and-christopher-it-leo-more-on-one-only-our-precious-s-spend-than-that-there-thing-time-we-who"
+      },
+      "lengths": {
+        "text": 81,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-12": {
+      "hashes": {
+        "text": "cef6d3b491bda654cdfc399f777b635b928dd439a2885df32fe65d3ca30bae97",
+        "author": "c536567a7e5ee0eb131877b5af42d7d5eed5d1cffd1da95905b543790534c43c",
+        "combined": "185d9db94325aa9393bf48250aa24763b64577d4db5e2bb9808350fa817f3e66",
+        "tokenSignature": "an-but-buy-can-chinese-gold-inch-is-of-proverb-t-that-time-with-you"
+      },
+      "lengths": {
+        "text": 93,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-13": {
+      "hashes": {
+        "text": "85a55506b4a99fe37c204ac3f36df17274c8559eb0a3947e58d561d10458a695",
+        "author": "7e788cf4279ff1da91471a26bf53be7c429df5c0f7b9d2b4f9d490e2263e439a",
+        "combined": "8885f346c686383a8f007ef32edc46025fa9395e21f44c95bc341fa1dd771308",
+        "tokenSignature": "always-bergman-but-do-enough-it-jack-never-over-right-s-there-time-to"
+      },
+      "lengths": {
+        "text": 87,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-14": {
+      "hashes": {
+        "text": "78ca3a5b411607b381a8eef7ba13de5d708a07b1f75101775c9207be3c685a39",
+        "author": "48dc728cca0217f5f094b9686982de68e8e9099a5029359322a9ec0877989e86",
+        "combined": "f1ffaf7d751a86c9bb6a1275d5269a879317bd9e45dab07753566afb2b5c601a",
+        "tokenSignature": "a-an-charles-dares-darwin-discovered-has-hour-life-man-not-of-the-time-to-value-waste-who"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-15": {
+      "hashes": {
+        "text": "c0f3c98e09f09839dcc61072bc41c099b65d025930fd1f7965f5d69f2bf228cd",
+        "author": "9534d53acedcff35f87de4c0d30a5eb5427b91bd3a14145bb7492ec103f86876",
+        "combined": "96885eacb766e7e09c9ccc2267abf8353e6ab6c35555f0f416b2c195fa9fc4c3",
+        "tokenSignature": "davis-isn-it-main-miles-only-s-t-the-thing-time"
+      },
+      "lengths": {
+        "text": 47,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-16": {
+      "hashes": {
+        "text": "77305debc0a8e809c4db6a8df4f014b8068bf5b3c625d384370213ace456921c",
+        "author": "fde3afdd40e594fc4430f69e1dab3d044636f5e88210132738d277230027b9e0",
+        "combined": "63e54c8ff22da885fb9112ce55008ac9d5cc19fc6033c063bfa1a7af84d0b646",
+        "tokenSignature": "am-eduardo-enjoy-galeano-i-in-interested-it-not-particularly-prefer-saving-time-to"
+      },
+      "lengths": {
+        "text": 70,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-17": {
+      "hashes": {
+        "text": "fcda6e7a2701c415f5ab1ab3fcd87a226619453c52a2a30ee2cc1bcae05267be",
+        "author": "260b9847f181a1b4dab468898c71a555662596757448d4fa9b2cf636be8048c9",
+        "combined": "cf844912e9613a504b9e61621fb52e2e3afd669b051607778610ac7b95c3f476",
+        "tokenSignature": "behind-but-faun-flies-hawthorne-its-leaves-marble-nathaniel-over-shadow-the-time-us"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 36
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-18": {
+      "hashes": {
+        "text": "d74df8b0941312d41d83bbbef0e48f74fca3034c8b522afa333ea4faa019e165",
+        "author": "2df96bc0a71a5ebf4810e6a3a5d775d4cf73e7a69bc08d0d52251ac380d52a88",
+        "combined": "83edf3d61d153bcab5da739d5fa897a30faa0d362d9035877bc33193d751711a",
+        "tokenSignature": "at-atom-cummings-everything-from-girl-golden-happening-in-is-keeps-once-ray-the-time-what"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 41
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-19": {
+      "hashes": {
+        "text": "5f753b48ad0807db701b15fe4407d0a4a05c205d30a2fe029544f00cb69febbb",
+        "author": "1aa42de957aa4c529a279992df281b7f3b3ca62125481fbfa44bedbda6993e2f",
+        "combined": "d64c41ad13780c4007e7bd2ede57c89765d29c5d04966e222a77ebcd5df9df28",
+        "tokenSignature": "a-but-deal-good-have-it-little-more-not-of-s-seneca-that-time-waste-we"
+      },
+      "lengths": {
+        "text": 76,
+        "author": 6
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-20": {
+      "hashes": {
+        "text": "dc12f94f276eb7935ae62302cff63bf9ff92e912e669887981200030fa4026ff",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "1f8e5d462d31debdffd76b6b16da77d678d87df13cd01ece103c1d57531233a2",
+        "tokenSignature": "and-back-can-clock-could-find-i-longer-love-so-sooner-the-turn-unknown-wish-you"
+      },
+      "lengths": {
+        "text": 80,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-21": {
+      "hashes": {
+        "text": "0d0ec8844b898a39b7ec1c57d2dac8b7d229427ce351d939781bf782e02340d4",
+        "author": "aa0ca8687ca9639ee4dfaa210b5e3f64f0d5320e2c02f9ed3ee39f5dc544bd2b",
+        "combined": "68cadd3c227de83c223c80e46e0a592e5f76755eafb87b3eb1c94a197c8af1f2",
+        "tokenSignature": "alice-but-color-moves-passes-purple-quickly-slowly-the-time-walker"
+      },
+      "lengths": {
+        "text": 38,
+        "author": 30
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-22": {
+      "hashes": {
+        "text": "e10ad6bfce0d0d652c0705aa04acfa874c5dc70e7a86ea7551aeede823d8f698",
+        "author": "7a9393f566680f8d5f8a1f3ebe170ff85c0592e365fa5bd9093c39b6a69af0b1",
+        "combined": "373fbbf290406222bca808eb1671345ca0049f937b00a836b2579c6b6a1c3b9a",
+        "tokenSignature": "anything-buxton-charles-find-for-if-it-make-must-never-time-want-will-you"
+      },
+      "lengths": {
+        "text": 74,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-23": {
+      "hashes": {
+        "text": "efeef4f3eb34d602058b5c4bee63f7da0bf68da9a4fdfef44195d78b5e5453d7",
+        "author": "201ee53ddb2ed65e577812328a397e3fc995bf39e3d0eea5d1fd29195405c541",
+        "combined": "3c79657077bd37c25632c55932f1a887e431860530d4a93d21572c88d0ce8601",
+        "tokenSignature": "all-and-bill-by-calvin-do-enough-hobbes-never-nothing-s-the-there-time-to-want-watterson-you"
+      },
+      "lengths": {
+        "text": 57,
+        "author": 36
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-24": {
+      "hashes": {
+        "text": "802d7f21ece1effd9824da8c30400833c5888a9f99d87d6205d7bbd487a459c9",
+        "author": "46eba338abb4ce4f17287ebf49afed3eadffa3b6bce92ac7dc9182339d263a35",
+        "combined": "8623e8c8794e31a4942041e0168d50a0b29309614402c0ba63e402b0911f4bdf",
+        "tokenSignature": "actually-always-andy-but-change-changes-have-of-philosophy-say-the-them-they-things-time-to-warhol-you-yourself"
+      },
+      "lengths": {
+        "text": 83,
+        "author": 42
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-25": {
+      "hashes": {
+        "text": "af38cb8e03ea8bc6077f2bcde031cde2eec7a2d037dedf7bade2dd74e4891976",
+        "author": "bd8d218beeec48b9f2062a9bc477342ad0945fbe02d89b2faf2a3a45e209ad3b",
+        "combined": "558bbd6e7d0c8b5da79dae98bedc24d977f449bc405ee2922bf0a73ba5c26300",
+        "tokenSignature": "a-is-money-of-oscar-time-waste-wilde"
+      },
+      "lengths": {
+        "text": 25,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-26": {
+      "hashes": {
+        "text": "386a662dd957fa43b0a753f674b51cf7ddc7272fa2d0f4d05cc04a177cf27245",
+        "author": "2ef67ccc5fba3f2ae80f11966510bdaefe50ef397f7ec7081ac2422ae07ed8ca",
+        "combined": "4653d3e01a4b18c2410f0e6d76e1915f543730bef3d6905f929d80c4848298d3",
+        "tokenSignature": "a-beautician-but-great-harper-healer-is-lucille-poor-s-time"
+      },
+      "lengths": {
+        "text": 46,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-27": {
+      "hashes": {
+        "text": "d4ee10134b95aa5a04db1c700b866d7f71a859f601ec0082ca9aad8b1b9d7321",
+        "author": "3f4f8a2665063145c1a14cbd7f9007c2132f7ee447917e7abcd1441972e820fe",
+        "combined": "7b98e76c6081ca49ac7b6ba5380de86b7226208b327815f9d5b29ae7cb107df7",
+        "tokenSignature": "be-breaking-but-dawn-enough-forever-let-long-measure-meyer-no-of-s-start-stephenie-time-will-with-you"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 30
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-28": {
+      "hashes": {
+        "text": "05ed03e6f50d478907d1825e65c8eefa44b482fb19d4c329f4183774ccfdc64f",
+        "author": "4072dbc63b3b07a6ded5285c43f407e4962a2018298cd7780fa2f2399d98dd9d",
+        "combined": "765aa3b4b4ff144934561d7b63d9f2a7fea491418ae596be4b14cc606e2559ea",
+        "tokenSignature": "again-back-bonnie-but-can-clock-it-prudden-t-the-turn-up-wind-you"
+      },
+      "lengths": {
+        "text": 60,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-29": {
+      "hashes": {
+        "text": "b6183d87f847c2b452c4d86aca21016bbd7096689b0c8e2e7c28895cdf7cbd20",
+        "author": "6f84c7f1f07f72c283c1b2e1722f89b49147b82d83765dec5a8f3bbbe8a91ff7",
+        "combined": "64b22470207cc813413898ce4d36c787e73f6f66a0770340a83b36156d332d96",
+        "tokenSignature": "30-a-always-and-but-for-frost-man-no-of-robert-stands-still-tide-time-wait-woman"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-30": {
+      "hashes": {
+        "text": "b6c4ae27ededdff8e62d6b7dc2c99bcd7f08107028980b7a65d7ae925a72ff83",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "c58e6d0db4e317c39d718fd5cb6b86e52a1b09bac14c6f52735ed6a910c978ef",
+        "tokenSignature": "has-in-love-meaning-no-re-time-unknown-when-you"
+      },
+      "lengths": {
+        "text": 40,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-31": {
+      "hashes": {
+        "text": "50027ed090162dc261dbd58b9c537fa0c698f76273b7ec0c32dc9251b54dc365",
+        "author": "b6cad3b4bf039387ce4f681bc2ed3439bde92a52565e28f5aa022701906f0223",
+        "combined": "d3e2db1d669f48852a658d0fc33ba525b5af2d3ee13a5b8f14f916d069dd99b3",
+        "tokenSignature": "better-hours-late-merry-minute-of-one-shakespeare-soon-than-the-three-too-william-windsor-wives"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 47
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-32": {
+      "hashes": {
+        "text": "c4017722335df6fc1c286e95c0a0af7c027bca5c1d873f36d6ee376e0f6e8c50",
+        "author": "1f1cd8c867d240c59d889eae06fd91fd543f905291c6f87a1a75fa284598b636",
+        "combined": "f4b2250386ffaea5312c46c2195a0faf7ee8499249c9ac8d1111102dd5144e56",
+        "tokenSignature": "a-about-accidentally-dessen-flashing-for-forever-happens-heartbeat-in-is-it-love-moment-never-or-place-sarah-single-the-there-throbbing-time-true-truth"
+      },
+      "lengths": {
+        "text": 126,
+        "author": 37
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-33": {
+      "hashes": {
+        "text": "cff11e790c681bdce9e7f0346b3740d9514fb418f4c74c68fabc790660639e55",
+        "author": "5f4e657884f2936b570c9264eae55398a28383a9e00f946b4e7a2779f245095f",
+        "combined": "325ba889a14f3d7f6ac6576157fe5a55de78817f824b0b9ab5a5cad75a810108",
+        "tokenSignature": "a-and-chanel-coco-for-is-leaves-love-no-other-that-there-time-work"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-34": {
+      "hashes": {
+        "text": "93f808ce8b9094c5aecbfc63d733587dcaca183fec3b9fb1756970a560820e7b",
+        "author": "b61e3e01484a52cc1c100bb5f2d531e3e0cdc01a30a93c90f47d0d867df347e7",
+        "combined": "47a8729a372e972fe43fd2a61bf7113b25611189df22bf6e7082e9eeeebd1e3c",
+        "tokenSignature": "between-distance-glass-is-longest-menagerie-places-tennessee-the-time-two-williams"
+      },
+      "lengths": {
+        "text": 48,
+        "author": 39
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-35": {
+      "hashes": {
+        "text": "0da607c95b9f56317f4a25a59293cee1adaadde5c53ea6c268a2bfaa60311cea",
+        "author": "d25edc57bfd0628212efe43b37dd1c028a5c57a5557e09146695ec04e99921fd",
+        "combined": "1ad94534e52d3288d98a5f3d76717cb49e535432bcd3331f363e1d8cee8b47dd",
+        "tokenSignature": "anything-dickinson-else-emily-for-is-it-leaves-little-live-so-startling-time-to"
+      },
+      "lengths": {
+        "text": 65,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-36": {
+      "hashes": {
+        "text": "2c25d4cbec5b1e6e4dee88d32cf45b6d619edf7ce8b1174671e37f100465b2eb",
+        "author": "cfae05b47ede4ff1640d3a09d629a908f29b6e6def26a0832a14fd3164319a12",
+        "combined": "31bb0996d910a55b5c3e2755ac72f7db231ff0969517ba1e0840193b182b5495",
+        "tokenSignature": "again-almanac-benjamin-found-franklin-is-lost-never-poor-richard-s-time"
+      },
+      "lengths": {
+        "text": 31,
+        "author": 41
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-37": {
+      "hashes": {
+        "text": "d45a578b65a184c2f021c3346ef4f11794abdf32ac5d80dfa44c77841dc23cc6",
+        "author": "b3de298fc1dd3007b7c95be8bec4386b0bd0a44091f3657124240515cdd8c017",
+        "combined": "7d5d5b37443d881f28521fb30ca282b0ba622d04277f1d6d3d1b1e6436160737",
+        "tokenSignature": "albert-at-doesn-einstein-everything-for-happen-is-once-only-reason-so-t-that-the-time"
+      },
+      "lengths": {
+        "text": 70,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-38": {
+      "hashes": {
+        "text": "4ef35b5fdf1cecb6a64664cc5ec79758b4c439b83483edc85657adc4396fb687",
+        "author": "49bde1fc12cf5024d1ac249ec66e86a4f98cb1c27c2d6854bc6ba89de5e0022c",
+        "combined": "3659e7cea5a724fa02a1e61381f8f8a0cce4a9e1831541b74998865cc636b0b7",
+        "tokenSignature": "enjoy-john-lennon-not-time-was-wasted-you"
+      },
+      "lengths": {
+        "text": 42,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-39": {
+      "hashes": {
+        "text": "5904ab6b08036c186d7672f4b097507df2d75d5ca3accfef2358b7309a4d0a2a",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "d4349671db24857ff83e5721c8100ea68d6553cd43468ca5476678ae5292b36e",
+        "tokenSignature": "is-it-make-people-precious-right-spend-sure-the-time-unknown-with-you"
+      },
+      "lengths": {
+        "text": 63,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-40": {
+      "hashes": {
+        "text": "2a1977153f35da0a0a74f055701f8fc038d62c17a884e985545a7445cc1b66d7",
+        "author": "fd38f5a93359a85d41f4bdee8b6fe5b06971464d71afcdeeb3834e13362a1b0d",
+        "combined": "cb820d1a7bf96c0fd91537e10d34c3a8f6418884f6735525b3a4ef2786986363",
+        "tokenSignature": "1984-controls-future-george-orwell-past-present-the-who"
+      },
+      "lengths": {
+        "text": 87,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-41": {
+      "hashes": {
+        "text": "7ff79f926e178731b2dbf39a03184a673837a8e2fda158727d41194ce4d83d63",
+        "author": "e99e4fbd08fdc5298a7364d02ac2dfb0c45419cde8e7cd30ec716cc12229c7d0",
+        "combined": "3c16645f169502cde35b3fc1b10313e7c0c88c4e4cecfadcb2512fa60d1d1f1b",
+        "tokenSignature": "alter-changes-does-have-image-marcel-not-of-people-proust-the-them-time-we-which"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-42": {
+      "hashes": {
+        "text": "92b5f2fe21953cd51adbb5b2f473e29c1025df78e7de170f6cfdac0a1ae65c6d",
+        "author": "b3bdb63c995e85a64b977ead92e5b6aa2bf2068230b42b3958ccd058bb5a2206",
+        "combined": "22f10344eb1a8bff8027aedc5892cb22d24dfb40dcac6f348401fbbe5ef27517",
+        "tokenSignature": "have-if-judge-love-mother-no-people-teresa-them-time-to-you"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-43": {
+      "hashes": {
+        "text": "0be5a0594733e2f0913193d0c3c4796f66176dce87c2ca3ac20faabc5c7198a5",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "52bc319057ecc64499d531f882cc22f5c8aa5b906465ad6c1619551db0323da0",
+        "tokenSignature": "are-few-hours-i-spend-the-thousand-unknown-with-without-worth-you"
+      },
+      "lengths": {
+        "text": 80,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-44": {
+      "hashes": {
+        "text": "5fd3816bd1df9b39da01c6ffab03dc1ff71188018301118572898fa044e5e407",
+        "author": "9a0ec78436a5360fbcdde039e9ad6a7d55168a4e06d8894f90cd836a97224043",
+        "combined": "651cbc1fb4d32590c8da4958eb25e3502fc55651c1143256ca06cf45d962ad0d",
+        "tokenSignature": "a-about-bruce-done-get-if-it-lee-ll-much-never-spend-thing-thinking-time-too-you"
+      },
+      "lengths": {
+        "text": 76,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-45": {
+      "hashes": {
+        "text": "0772856cbc6e099f7390fb5d5ea810e566b6707fc278ab9d21392624451d1055",
+        "author": "852aafc287fb1d2135187cc9b95305dcc648f1cfdb892e09335c2011d478b403",
+        "combined": "07ef8a3588f26dc759d5dc0784536d9e8e981ac8c73bdc3ea898c629d5271c78",
+        "tokenSignature": "boucicault-dion-killing-kills-men-of-quietly-talk-them-time-while"
+      },
+      "lengths": {
+        "text": 56,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-46": {
+      "hashes": {
+        "text": "ccc44a1b4bd311e07acd73cd5ac493c6624b7e967f9689ef68a2b5f9f656d9f7",
+        "author": "2c0a5a674d660ceb3e0fcb5e90d4444a008ee57bf4da57037114d4f8071520a9",
+        "combined": "4550c54ead3be7fb62501eb6d30a692d975b0b025b4efb116fd6bc2c45ff62a8",
+        "tokenSignature": "and-anger-be-bennett-don-grudges-heart-in-is-life-light-regrets-roy-short-t-the-time-to-too-unhappy-waste-worries-your"
+      },
+      "lengths": {
+        "text": 95,
+        "author": 38
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-47": {
+      "hashes": {
+        "text": "f70f7eaf3680e6682589ba2ca55a44ba1f6f2e1d4364cb02790eaeb1024adce8",
+        "author": "3f48005741d8556b3fa77f617c6fc960e0bc5829c5bfd7cae069288cb640d85a",
+        "combined": "a2f846f3a33661487556db62bc9cb43603021e656626e0c7b27e30df19168246",
+        "tokenSignature": "antoine-de-exup-for-have-important-is-it-little-makes-prince-rose-ry-saint-so-that-the-time-wasted-you-your"
+      },
+      "lengths": {
+        "text": 99,
+        "author": 26
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-48": {
+      "hashes": {
+        "text": "7c425706b0f0973dfff114d7473a59af62b5afdd2c62038d9d69a495d47ae958",
+        "author": "4efa1cdd16eebd92c3a53496de7b12035969a083f324cb0117889c8b6a6ecd8e",
+        "combined": "399bc9f2585899e97b757ad3115f4226b0fafda2ae2ebe34e27429b27306ae55",
+        "tokenSignature": "brian-norgard-or-own-time-will-you"
+      },
+      "lengths": {
+        "text": 31,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-49": {
+      "hashes": {
+        "text": "236d97264c3b742ead8ccb4b9d55598d9f875c48be4cf03705774a1c68e914ae",
+        "author": "095fd460de7a3f57143b4dc94d5ca4f4dfe870851ed055ba499c007e506b712d",
+        "combined": "5d9037a8c963c1d6c35130bc428ff46678e1a34bc62fad77a3eb3ac068325180",
+        "tokenSignature": "dorian-gray-is-of-oscar-picture-punctuality-the-thief-time-wilde"
+      },
+      "lengths": {
+        "text": 33,
+        "author": 39
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "time-50": {
+      "hashes": {
+        "text": "4b876e14a2e7582812353b6d686e7260ebd9d7b13d65962c2d68a3d8069599ce",
+        "author": "a0b3bf0f7df75eedf803defbe104f597c8a7f71825434f2be4df96da49f0e0f3",
+        "combined": "5312089a43e098447c1bd3f07c2750d4ca8b5be70e81bdec312edff0bfbb57d3",
+        "tokenSignature": "alighieri-annoyed-are-at-dante-loss-most-of-the-time-wisest"
+      },
+      "lengths": {
+        "text": 52,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "time",
+        "sequence": 50
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-01": {
+      "hashes": {
+        "text": "dc2cb8c6b49316a07aebc68d51231538037c0ed09bc3419c0eac715a92996dd1",
+        "author": "90a8ae562f7f5154fbc270fa72caafbb7e0ea603a01020f8064a19caa5fdcb0a",
+        "combined": "ac15ac7a7514cf5443e14c7982cb810bfbbcf658d1d2328b1d8cc5860580b8ef",
+        "tokenSignature": "attempt-could-fail-great-h-if-knew-not-robert-schuller-thing-what-would-you"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-02": {
+      "hashes": {
+        "text": "840bbbc2303ef1aab4dbb5276a3682915d8f14fe6853706257e4b4beb3b3d710",
+        "author": "50ffa97ff4e8a0f4503b456753fe27dbff00253bcbf11f93f7eae483bd28768a",
+        "combined": "79e1589020a45983457f1cea71a7c8b959dd6d175d0f381b27480401497b2a10",
+        "tokenSignature": "about-and-business-comes-connections-cuban-everyone-it-mark-money-not-or-outlearn-outwork-s-the-to-when-willingness-your"
+      },
+      "lengths": {
+        "text": 122,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-03": {
+      "hashes": {
+        "text": "9c593b31f9848922cfc6e5f3442b47c6c48ec651b59a81d9de70ccddb3e1e465",
+        "author": "4f9c0f40a55353793d5d4f209c4eaf70fca1b7a2a14984d27b57e98afcbfa8e2",
+        "combined": "e3d4e214579238af7cd98a668b9c096c9f747bc2abba6193c986a86368210942",
+        "tokenSignature": "churchill-continue-counts-courage-failure-fatal-final-is-it-not-success-that-the-to-winston"
+      },
+      "lengths": {
+        "text": 86,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-04": {
+      "hashes": {
+        "text": "c08d5f1f6e93d2b580ac2449223fa2a5044afb6ab85b5f4cba784b7a376689ab",
+        "author": "3d7f1923e013e064d014596a2a7d29d00d260b80f41b3d89ae55056626175f56",
+        "combined": "ddacd9d93a2e7587803aba37f18af58ea7b87a7a324a3ef195a99743f5f33701",
+        "tokenSignature": "don-done-re-snipes-stop-t-tired-wesley-when-you"
+      },
+      "lengths": {
+        "text": 52,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-05": {
+      "hashes": {
+        "text": "c880b2f9ccdbb35657551e73434594b148530daeccce4550bf188eded6820c5e",
+        "author": "078a760cb66fad920eedf2112de67fdf9240245f9225a72563f688422e4b4698",
+        "combined": "654dc52d0a2b1accc86c629e850bfd9b59fa04fa807012ac4bd78c4e70ad03f0",
+        "tokenSignature": "among-even-for-if-land-ll-miss-moon-norman-peale-shoot-stars-the-vincent-you"
+      },
+      "lengths": {
+        "text": 66,
+        "author": 20
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-06": {
+      "hashes": {
+        "text": "bddc5104dfbfe669134c20e5a2357d33af4baef1b3b9214f6931dbb09ee3ca82",
+        "author": "c32e664c8565ae26c40eb6601bc9f3fbc051a02ce093babd81646df1c60154a9",
+        "combined": "79a4b2d04fa96ad85ad45f836a204a4e4abff10d0007d07b703815be93762170",
+        "tokenSignature": "a-begins-journey-lao-miles-of-one-step-the-thousand-tzu-with"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-07": {
+      "hashes": {
+        "text": "89236cb40654abc0883cfb65ced97bacc4ee789d99cac3c56818d1c5e71ba48d",
+        "author": "c2e8f8562bba54be1d1234969534188773fc4ca013dc4d99191de18445b5d15f",
+        "combined": "74a8d2114a57223bfc48b4f1ffc0ed512f8dd2bbc3999c9701b15d4ab91699ba",
+        "tokenSignature": "a-act-as-difference-do-does-if-it-james-makes-what-william-you"
+      },
+      "lengths": {
+        "text": 50,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-08": {
+      "hashes": {
+        "text": "ef0504c8b85303aae02eccfb6ad3e0bc00d7291a042d1f664ec10c2fa70dce4f",
+        "author": "9801f89d3943cfe6dcddbd625ead22b8c0c95cec3f1223c3904cab1d81562c10",
+        "combined": "0e7ec87e9f98cb720fde607a0e95d5e2ba00fa040f8809bac599bef338d058cc",
+        "tokenSignature": "a-always-and-another-at-avail-difficult-if-is-mandino-no-not-og-one-step-take-this-time-to-too-yet"
+      },
+      "lengths": {
+        "text": 120,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-09": {
+      "hashes": {
+        "text": "326be4bc437afb4f175f0573f8600125b0f9c17fd912aa0bf24488ed11d5e15d",
+        "author": "c87ea6f35e2449cac51e57b229964c96ed19d5621326ae70665e040e801c12e9",
+        "combined": "1eca628ff201cc5232c493ccc9aeb2d652fe5d926172c7847ee5499e95253473",
+        "tokenSignature": "but-can-crawl-do-fly-forward-have-if-jr-keep-king-luther-martin-moving-run-t-then-to-walk-whatever-you"
+      },
+      "lengths": {
+        "text": 139,
+        "author": 23
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-10": {
+      "hashes": {
+        "text": "5e7e3ace26f88c663731afe6f3e13e0cd7c4c67f0743ed4707e285eb4acf1df3",
+        "author": "81623cc8e4e3af35ac0cd5613a93739579351adbe15b23088a621df56de6d147",
+        "combined": "c00184ca05577ecd96f56e4cc2d05e274268ef44b2deb130042a55409fb2292e",
+        "tokenSignature": "effort-euripides-much-prosperity"
+      },
+      "lengths": {
+        "text": 29,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-11": {
+      "hashes": {
+        "text": "f29498cf57206ac9ed5acdca834230fb2a1a88c3b89fa193f0b15033e65a75d7",
+        "author": "2a1017e7a3101175a24d07956c239fd60761ee458422ed2001cad62fe579fec9",
+        "combined": "b047eb9a1392e39f8eb670717eb71b3167095ba079354a6f085a09da1554b353",
+        "tokenSignature": "a-edward-for-good-h-harriman-is-lack-little-lost-more-much-of-the-work"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-12": {
+      "hashes": {
+        "text": "7a4c95b7cd9432ffed503076c34998913abd9bf001b2b11742eccd0f80d6bbd6",
+        "author": "e52aa38bd60af1c9aa914f89e46760a91441ff694958d7ebc42b490d990f6d99",
+        "combined": "a1e23f62892aa45f3cc488636afd6cade1b96cabdcc1772781c715ea59f208d0",
+        "tokenSignature": "biggest-but-contributing-didn-do-dreamed-failure-find-godin-guts-is-of-seth-t-the-thing-to-you-your"
+      },
+      "lengths": {
+        "text": 93,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-13": {
+      "hashes": {
+        "text": "ced9be5ea69210a1023cdd78260a582cbf9fdbf5759cc6c8253010a1872ef089",
+        "author": "8f30191ce47d82ce6b3c0688bcf4130e3c590af094e3e10efe66dd5ba39ce5b2",
+        "combined": "a4491a231408879c609d57c584aa72701b18707167754b65e69b378d7591571c",
+        "tokenSignature": "abraham-achieve-all-as-can-great-is-it-lincoln-others-proof-some-success-that-to-well"
+      },
+      "lengths": {
+        "text": 84,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-14": {
+      "hashes": {
+        "text": "3df0333dcd7aad7f58cc96e2f9d5fae471cf35950d1489c55e0ac6d354794472",
+        "author": "e85ff2980337df6eb885bdb71fbc014e83deee9e993a2234216dff5dcf50f928",
+        "combined": "e9e90c38880ea84bad655664dc6cd83ca96e5ef1b91e6082c133c8848f0cce9b",
+        "tokenSignature": "babe-fear-get-in-let-never-of-out-ruth-striking-the-way-your"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-15": {
+      "hashes": {
+        "text": "33b864d60f91325208e80328e7ff9c2c7757bdd8fc1d1907334ead4b6986d836",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "10b4d80e0ad6f51da474a644f36eb53832536af034ddfa03576a749bcba5bcb0",
+        "tokenSignature": "anonymous-hustle-introduce-longer-need-no-to-until-you-yourself"
+      },
+      "lengths": {
+        "text": 54,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-16": {
+      "hashes": {
+        "text": "0dd25d98498ca3f89f717be8965da186d6d44cf012ce2aa15e753b360b4d44e4",
+        "author": "55a28653913cb231e1ab117818e133777489c81ee8c2ae270bd8c9e397b53226",
+        "combined": "24bf4cf526caf32b8b5742d6bf1afe6184634493c0544cd8550fba923259a1c9",
+        "tokenSignature": "and-attained-but-by-companions-flight-great-heights-henry-in-kept-longfellow-men-night-not-reached-slept-sudden-the-their-they-toiling-upward-wadsworth-were-while"
+      },
+      "lengths": {
+        "text": 152,
+        "author": 26
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-17": {
+      "hashes": {
+        "text": "e91ff4ef45971d11278ae80cb15a73055cc0230ae192f9243e85b3f4ab39186d",
+        "author": "c1d36deaee271e258f498770771ed1848ad7b001a27d73fc6b15e5bf41f7f832",
+        "combined": "682a7281253eef99abc1efa690175b3d2577c1979533dcf1994ce4a1d89d873c",
+        "tokenSignature": "accomplish-achieve-allen-he-james-little-much-must-sacrifice-who-would"
+      },
+      "lengths": {
+        "text": 100,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-18": {
+      "hashes": {
+        "text": "b56f8112461c5f3d60880454dd05a19ba7bc78240da10f3205a09f1eab180035",
+        "author": "c32e664c8565ae26c40eb6601bc9f3fbc051a02ce093babd81646df1c60154a9",
+        "combined": "0b4119cf2d462023b6f2f95bb04e0f805b073d416daeaf88f0c6eacda116778d",
+        "tokenSignature": "act-as-be-behind-front-if-lao-out-then-to-tzu-were-wish-you"
+      },
+      "lengths": {
+        "text": 60,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-19": {
+      "hashes": {
+        "text": "3fd2b251cc10d37e4f705c6be11d33df7b293dc8265ed79819b8e866731c13f5",
+        "author": "c304ce4e1db8c6c28df72044cf54801af22eda999408d65cb2af41aab7dd15c9",
+        "combined": "7ab5adcc3a256c7bd51d3561951669b8264e04af613b0ea15f40f8930e7a68d5",
+        "tokenSignature": "failure-is-jordan-key-michael-success-the-to"
+      },
+      "lengths": {
+        "text": 30,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-20": {
+      "hashes": {
+        "text": "81c7fae6e81b12eb6c485ebb2efd1c6d07f00938b8382a0b9e904154f1d202ca",
+        "author": "d4e0c46aeaa152e06609840f8b52d1084350eed3a8fcba37f593357ba296a5b0",
+        "combined": "31074d67d5cf260374659ecb431e26ffdc87083a1dae6dfd9729fc59c611c608",
+        "tokenSignature": "early-for-formula-getty-hard-j-oil-paul-rise-strike-success-work"
+      },
+      "lengths": {
+        "text": 55,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-21": {
+      "hashes": {
+        "text": "30b0023489f895b9db5a41fc2099b47811be883106702bd36bbd08568f0a8185",
+        "author": "4f3b963cf180b7a663b2bccb961287f6d45ba030d20a1e14d928584128eecf2f",
+        "combined": "bb3f52f5aac2aacfb8d7fa9a6ab84726e1251a2d198941e12a56f9c518820ae0",
+        "tokenSignature": "benjamin-deep-franklin-plough-sleep-sluggards-while"
+      },
+      "lengths": {
+        "text": 34,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-22": {
+      "hashes": {
+        "text": "ac0688bd1733a41ece71a43b72f62277477f16aa9b13d1189e1b8d2d096d486c",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "a4cc7501d0cc43847babb5eba496a909edc7a000ac90fc9bd2741716bdfdb1c8",
+        "tokenSignature": "and-anonymous-be-hard-in-let-noise-silence-success-work-your"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-23": {
+      "hashes": {
+        "text": "3872472c3b82950fc5de1e44d7393c9eb1de9256def572019c45f4ed7abf65b1",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "e9364d4df779f0a70e938f7da0fbc0d7ec3e1bbd0f236dce88b554619edd34ad",
+        "tokenSignature": "anonymous-don-proud-re-stop-t-until-you"
+      },
+      "lengths": {
+        "text": 30,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-24": {
+      "hashes": {
+        "text": "98eb3c5a5703936a12f34a2fb9fb5783db4256099a8b92a4a580b7553d11eef0",
+        "author": "a8e10fe13a65fed6b88e4749706d073e5c315347a8d20a1ba4a438847e287bcf",
+        "combined": "749e5d1f62592992fc739bba769d54cf5c87073349a9dbf0d7a6f0d1d43db726",
+        "tokenSignature": "action-determined-is-massive-path-robbins-success-take-the-to-tony"
+      },
+      "lengths": {
+        "text": 58,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-25": {
+      "hashes": {
+        "text": "f3924acc99ad512e7a69f883187ed6cf8dc3c3aaad4588e7d9e8dfdf244dcce5",
+        "author": "d1af17d23e40aa23437138302e344086c4730a3dfe167f0b82ddfb378bc55506",
+        "combined": "f8c0d0e211dc5d1b59a132bcbfdbfd0b2a85b59eaa55660110758feca21b15be",
+        "tokenSignature": "a-an-blair-excuse-find-if-important-it-ll-not-ryan-s-way-you"
+      },
+      "lengths": {
+        "text": 73,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-26": {
+      "hashes": {
+        "text": "9b2f3ecf8d2e2648556eea663974debfd1c430b202839cc48180226e6ff9b42a",
+        "author": "59d1b1b99ffa9411f4a012e8e2fd8a2878f3a742b118a69eeb6c7b7554ac490d",
+        "combined": "f0387f47836eb5204bf6e11715a1a2777072e8ecfec633e68adb8910d8189c26",
+        "tokenSignature": "action-are-by-clason-favored-george-goddess-good-luck-men-of-s-the"
+      },
+      "lengths": {
+        "text": 54,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-27": {
+      "hashes": {
+        "text": "128f950dca8ef1137fdd664d6cfce1e3d35cf318b943b35cff45dc15566915d7",
+        "author": "c5664a0a1c80638e0a807454fc16b911c000670b24630279ece23608991a6b98",
+        "combined": "d7f51ce886f91accf80b29dfcade81767f10c971cf36e11a8ac7d611ef586923",
+        "tokenSignature": "a-and-burroughs-did-john-nobody-once-somebody-to-wanted-was-who"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-28": {
+      "hashes": {
+        "text": "5ad140d30a634278b204540aa050942d3fb21866e83b0b1a5032c66405d903a1",
+        "author": "2e04bf3499fc58c99ea4c0dac0b0d50fa0bfcf3052d64ab324358a14dabb51c2",
+        "combined": "7ff0a17189606101da6a49cce50ab8a2feaae498466bf1ac2458f2c8d90f48c7",
+        "tokenSignature": "andre-cannot-courage-discover-gide-has-he-lose-man-new-oceans-of-shore-sight-the-to-unless"
+      },
+      "lengths": {
+        "text": 84,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-29": {
+      "hashes": {
+        "text": "1a0bb7c4232459caec3ad8de84fd2e5b782bcc88714637d9b68ee8faadb93486",
+        "author": "371c6011a643cbdbe874c54b75f1f1f333132430642a239ecc9efbe99067da54",
+        "combined": "7f25803a043ad8a55fe6d72173b38bb26b09d09d458521423200ee2c897207b2",
+        "tokenSignature": "a-believe-bristol-can-claude-do-if-it-m-thing-you"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-30": {
+      "hashes": {
+        "text": "7dc80778e2e5641225877594d58e2552d910de4944f2afffee496ba39678797c",
+        "author": "347592cdcc86efb8d144942915e256f264c751c10b6dc6b4b2627e33461f751e",
+        "combined": "3c581d426ccc4ff9ff28bf095f4c94785bace669c38f93f9393f74fac5ed9482",
+        "tokenSignature": "action-all-foundational-is-key-pablo-picasso-success-the-to"
+      },
+      "lengths": {
+        "text": 46,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-31": {
+      "hashes": {
+        "text": "1d7a086a331d913b40feda00983e4d0ad560fdeb9deb0674bb40ea7710ed04f2",
+        "author": "c1d36deaee271e258f498770771ed1848ad7b001a27d73fc6b15e5bf41f7f832",
+        "combined": "17081a69bdf3ee7b7e857c2d0791722856831009b99b4cc363930755b7299eb0",
+        "tokenSignature": "allen-allied-becomes-creative-fearlessly-force-james-purpose-thought-to"
+      },
+      "lengths": {
+        "text": 60,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-32": {
+      "hashes": {
+        "text": "26eada6047371207cb0bd341e4ee1243c1409a2e7feb20a3ba101dd3781f9eda",
+        "author": "0112c62badb6e5b8a5b40a0b72198c4d5cd02ad15e349021dd7f39709b878712",
+        "combined": "1b7930ab171467d3550fb048bc2afbb7dfec0a70c34efc24eb5c17656a265427",
+        "tokenSignature": "am-are-cares-doing-i-is-matters-only-others-own-progressing-question-race-robin-run-sharma-that-the-what-who-your"
+      },
+      "lengths": {
+        "text": 104,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-33": {
+      "hashes": {
+        "text": "c76479047bbc592964273c6823bcfc3fbf4a2efea53953fa20ef0ec4cfabf840",
+        "author": "a2bff15a76dce53d6fc014d661d0add175a13fed87049b034d60bc8e68771464",
+        "combined": "be6404645d2158306d71de2a0f48c1715b7e55d999f01a7ea753a97ed05699c7",
+        "tokenSignature": "16-a-ain-and-anything-ball-beat-consistently-do-effort-else-every-everything-got-has-in-just-lewis-me-my-not-nothing-on-person-play-ray-s-t-talent-team-that-the-there-to-with-years"
+      },
+      "lengths": {
+        "text": 204,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-34": {
+      "hashes": {
+        "text": "7eb551fafff4b00e11fb7c30032b9cafb6e3fa6efebc15de5b0958c1e2d591f4",
+        "author": "9ad9573be8f675e523be0d5decafef275126095ae17fc1ad639f9e8f40637a8c",
+        "combined": "7c385d0b3a961de5ff82ee4a3a04a481e6878f6b2ac2a2c9506896d0f7110363",
+        "tokenSignature": "clock-do-does-don-going-it-keep-levonson-sam-t-the-watch-what"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-35": {
+      "hashes": {
+        "text": "f70760c95a7fa7440e8e7b07ab834a3074fcc0c2c17642e18e4260d2d082e235",
+        "author": "79080ff8573043682f1f945dd8b8625842455b18d7cf2abeaa9ae3ab1e3dd9ca",
+        "combined": "b876cdc7d91a22b1c994fa20baf19b9d2a98a6d4750e093bbd598be3483c8762",
+        "tokenSignature": "a-as-discipline-embrace-hand-hard-holtz-it-losers-lou-love-making-of-off-on-other-punishment-re-see-the-they-to-trade-win-winners-work"
+      },
+      "lengths": {
+        "text": 146,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-36": {
+      "hashes": {
+        "text": "a0e7ff0043a86c67f1c307a95a514b9968cfb27a300798cb9287801c941fa057",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "75473c6016b71a5e12ae0e799307bec2fc164259ad60239f8c4dde424e55d7b1",
+        "tokenSignature": "anonymous-because-do-else-for-going-is-it-no-one-push-to-you-yourself"
+      },
+      "lengths": {
+        "text": 61,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-37": {
+      "hashes": {
+        "text": "a23f611cf949c8d44f6783949759be06cbc0c6cdb3ef017c200b65e23806588c",
+        "author": "ff8aac824046b8c4a4237be9238b83fd8a06c533c5ed687094071cfef9f080ea",
+        "combined": "d240c061a1d02b83940f941002da96b9911ff931932db478388cb404c51ba80f",
+        "tokenSignature": "anais-courage-expands-in-life-nin-one-or-proportion-s-shrinks-to"
+      },
+      "lengths": {
+        "text": 55,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-38": {
+      "hashes": {
+        "text": "62c54ce2dc6eb19490fb3f3e431027e981da3f080a2fa3a2a7249dd4a7e49c4c",
+        "author": "108af1ffb64d876694de375c56f53428fe8d44428d926755c268ef6c2ccb810e",
+        "combined": "ab971de9e1d86f00e82a37ef440156fcffbbae065b9dfc48f1f1b49aa3ce4e30",
+        "tokenSignature": "difficulty-doing-effort-having-in-is-it-means-nothing-or-pain-roosevelt-theodore-this-unless-world-worth"
+      },
+      "lengths": {
+        "text": 94,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-39": {
+      "hashes": {
+        "text": "d0ee0f7ac0320e1e2f2528264bd54a65c9412d2a474072548d03cea42e84fb36",
+        "author": "0d28ea4a9a2d59a93ab13ac64c56af220e9e3d3ab1d7b2d0e4506d1b1a8df242",
+        "combined": "b887732aeefeab5d3f2f26608b362522db3432ed4c33cfcbe2d92bb14e456d07",
+        "tokenSignature": "boccaccio-for-get-giovanni-grab-in-only-this-what-world-you"
+      },
+      "lengths": {
+        "text": 45,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-40": {
+      "hashes": {
+        "text": "bc6bb9fb658e0983b70638412dabcfbb43c91e8d7a8e85acae9f304e9c42c1bf",
+        "author": "ead29034421e8e979a6bc21172e150a65bafdfcda6c8334194712d73c64591ff",
+        "combined": "c0a821d4cf133e81b58e17f1e7e50e73b1198cb723392db138846a86590534a1",
+        "tokenSignature": "a-and-be-become-believe-courage-determination-george-having-means-meant-person-sheehan-success-the-to-were-will-you"
+      },
+      "lengths": {
+        "text": 120,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-41": {
+      "hashes": {
+        "text": "11e31a0ff31e3d6558aa37c0e6ab0c43a1b5de1de3c2d6aa0e6700e53b0d812e",
+        "author": "f32574d1871d1dacb8a0c151fec13ef3e73b1cec2f973061dca20d704d724697",
+        "combined": "d142da1474365c9b5740ce15d92cbf51c3fc41cdd8debd6517707a4e37be45e0",
+        "tokenSignature": "best-create-drucker-future-is-it-peter-predict-the-to-way"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-42": {
+      "hashes": {
+        "text": "2445bd08ed8ee0a52d500b1f6ad815b6f33ae0cc3121b0f5238baade8aa71e21",
+        "author": "3acaab10117858cada3c40a84c11fd4c1e22394a80d1fe8dfabb445b541fdc6a",
+        "combined": "c81e4fe5d295996f96e420d8ff355b7c71ba1f06d8dff1a03ae7e6972383766c",
+        "tokenSignature": "andretti-control-enough-everything-fast-going-have-if-just-mario-not-re-seems-under-you"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-43": {
+      "hashes": {
+        "text": "5281e42fede2a3d2846e3bfdb24d86977b19f44b434fe34a38d720479f5ff707",
+        "author": "788eb6dfd566d68437acbc8b7c9eb2026750e68537686b58ac309c6b2fa80517",
+        "combined": "a9587b0c4e3d136e09a2d23e890df73e6ec8beb0c473706c09dcb1757d6904ec",
+        "tokenSignature": "be-but-do-everyone-gary-nobody-successful-the-to-vaynerchuk-wants-work"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-44": {
+      "hashes": {
+        "text": "ca741e2c25222e63185c0df0cafb93b597847f5fad94248ae9368e9f77007dbb",
+        "author": "0bd0eb6e2794cde701a7ac5a4b741c986898b9c03f3468cbe014803e3bfe92fe",
+        "combined": "a8db120c44f551e66a50b02cb1d40e29d555da73cbbb9e63f52d8cb83ee4e848",
+        "tokenSignature": "be-can-good-ignore-martin-so-steve-t-they-you"
+      },
+      "lengths": {
+        "text": 33,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-45": {
+      "hashes": {
+        "text": "e318f770512a85859a8416388630235b54f783096de9b29be8b2e4b169124b05",
+        "author": "c536567a7e5ee0eb131877b5af42d7d5eed5d1cffd1da95905b543790534c43c",
+        "combined": "9d526a63ac2515d58fb022a02993ac1867aafa5bf10b46219d7171e1522d4b64",
+        "tokenSignature": "afraid-be-chinese-going-not-of-only-proverb-slowly-standing-still"
+      },
+      "lengths": {
+        "text": 64,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-46": {
+      "hashes": {
+        "text": "3df68a949bc08445a1ae65e29b3ec955a668198632e494fbe704d144fb019ddd",
+        "author": "022e4626b2e871085490580d6c93eb21de2baf043a57dc8351accad49887bd16",
+        "combined": "7499643577207ba395c19657e87714e607dd8d16119fdd23ff8a4229af2946d9",
+        "tokenSignature": "are-around-become-becomes-better-coelho-everything-paulo-strive-than-to-too-us-we-when"
+      },
+      "lengths": {
+        "text": 85,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-47": {
+      "hashes": {
+        "text": "1fe0ea205c9b1cca60dbc7d016bef8e8aec0f67b8ec55850dd10b7d42a57f2c7",
+        "author": "108af1ffb64d876694de375c56f53428fe8d44428d926755c268ef6c2ccb810e",
+        "combined": "dcb65b115ea16c57624c43013fe62107c56ad96fd78366207436d7c4cf7b3d4d",
+        "tokenSignature": "anything-discipline-is-most-possible-roosevelt-self-theodore-with"
+      },
+      "lengths": {
+        "text": 48,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-48": {
+      "hashes": {
+        "text": "11d1fe2130b5802656d9963096199a50800e9fd18903ea824a32888d32448718",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "dec75d3c52e00aad19ad4f16d9df0edb0f734298a954ffba898c05d5e7385741",
+        "tokenSignature": "all-anonymous-called-do-not-of-secrets-so-success-the-unless-will-work-you"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-49": {
+      "hashes": {
+        "text": "38078bdce8543920938214779be0c8d7a6bbb5d29f0c7aa552ed021635f90538",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "ac351e5b57ed03780f3d8a835ae234a35fec18f7d27d259d10d0d0ecbbffca30",
+        "tokenSignature": "anonymous-are-dreams-grit-of-on-other-side-the-your"
+      },
+      "lengths": {
+        "text": 47,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-50": {
+      "hashes": {
+        "text": "759e5716d19886be5bdacf7b09a395ee03bcac83e9c89b06d5c7f282b543bf2b",
+        "author": "47f173d6502dab21563d0260a3ebc3cd505dd9a675dbfa947eff84a07b669555",
+        "combined": "bfef47295a7dcf6d6f7553f1b699e33b8f6d836f543ddb0c68779535ea21b77e",
+        "tokenSignature": "carl-dream-first-happens-nothing-sandburg-unless-we"
+      },
+      "lengths": {
+        "text": 38,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 50
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-51": {
+      "hashes": {
+        "text": "dff88936175d968a1dd5a2867b8d386345d22e1133b85a413aa46346dd34ca67",
+        "author": "fa60d36b3071d5898d78c49804681a680398c4e2e9c23e2f254517d744fcbc86",
+        "combined": "631cbe86625f7eb437102290a8bb0e278d4a8e60329e4747aaff9bcc15bb019f",
+        "tokenSignature": "achievement-activity-for-john-mistake-never-wooden"
+      },
+      "lengths": {
+        "text": 39,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 51
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "motivation-52": {
+      "hashes": {
+        "text": "adbbe09c4197c7c9bf91dba21852b17007b76b2a42cc413335d08f690b234193",
+        "author": "d9243e2d0ea076c4bbf3e2192cb514c87bdf17390fcb6e24329bec17d6a19513",
+        "combined": "dc962cf4c16491864c5e6fc4d5edc24a07746c7fbc510ef96b8e57ae4d283713",
+        "tokenSignature": "achievement-are-brian-fuel-furnace-goals-in-of-the-tracy"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "motivation",
+        "sequence": 52
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-01": {
+      "hashes": {
+        "text": "b4049d0e09a4fb9a2f8c2ef822710773900c2f4e28818b76402f75bfccdf2240",
+        "author": "25a74e300b2ab704b38d24df5e89067cc287fb4d69578d7d1a7f9b9ca2474acf",
+        "combined": "54316981313af40e828703a17ed3f916b306dd9edbd76c9ae26e9e77408d7e14",
+        "tokenSignature": "a-friend-in-is-of-one-out-real-rest-the-walks-walter-when-who-winchell-world"
+      },
+      "lengths": {
+        "text": 71,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-02": {
+      "hashes": {
+        "text": "9f74768fa349de4644a355c69d4123281a84a014c61bf09d84b2fe53add16647",
+        "author": "3e30f3a11dcb5bccce5e39b3bfb1359ce0ed6c6cc7bfa738fe96b02ac0c13156",
+        "combined": "ce01b3d075ffa2d1c67f8e090ff40b10a798264976d44216db3bb5227dddf60c",
+        "tokenSignature": "a-and-dislike-friendship-is-like-makes-sallust-same-solid-that-the-things-to-what"
+      },
+      "lengths": {
+        "text": 75,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-03": {
+      "hashes": {
+        "text": "39c55b7dad1c5895e85bf427ed823f92c9614c60ea1c0a4ba7c455025c37f119",
+        "author": "536cedd73dab448a079ce46b5a4e18d915e76ed0ebc443a1708faec14369c63c",
+        "combined": "681d52bd9750d041cfb0fe38524e1c6d449d83c845787bafa188a0b2165001c4",
+        "tokenSignature": "and-are-crazy-friends-i-keeps-matt-my-only-s-sane-schucker-that-the-thing-us"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-04": {
+      "hashes": {
+        "text": "43cc2edf06e7f833eb549418151c5ae2a0c71818f647987ddf6aa45d54a97447",
+        "author": "a9ec6cfea9b4d75750455cc49d7ce0a3c3e3442d9ef03fec7a27d20d8cd86d2f",
+        "combined": "8f98bdc59f31e5f48cad21a3b0635bec886048739141a3ebfe6c2555372fd668",
+        "tokenSignature": "and-are-because-finding-friends-funny-hilarious-i-in-is-issa-life-lives-ll-my-of-ordinary-pretty-rae-so-stick-the-to"
+      },
+      "lengths": {
+        "text": 149,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-05": {
+      "hashes": {
+        "text": "a2eee7bc041b0f308be6d7de4b1be19112d9bfd949fea8a361188d4f8e9e2208",
+        "author": "6c1aa54e33de898349ce6980bfb56a1dc547f8e236bac30e3985cb6a17b6bf2d",
+        "combined": "b3191dccc91888f6af7a79157213dc56cf4be8d3ab8ca466a3f5277f6b92d0f8",
+        "tokenSignature": "a-as-be-bff-can-d-denying-girl-go-gossip-less-little-make-much-no-rich-s-them-there-we-without-wtf-you"
+      },
+      "lengths": {
+        "text": 97,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-06": {
+      "hashes": {
+        "text": "9160811f77489ae93c094167faa30825e8968e362d3cc9324b20108ff5b87e34",
+        "author": "15178c5f456a582d50effb8b02fad359fec1b9157f1679093eb7a8450a219754",
+        "combined": "a9bdf471dd01805d102ad992a579e851a118df0c0c7f13c5a33ecd8420482d75",
+        "tokenSignature": "a-and-arnold-at-bad-friend-glasgow-good-h-jokes-laughs-loyal-not-problems-re-so-sympathizes-they-when-with-your"
+      },
+      "lengths": {
+        "text": 121,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-07": {
+      "hashes": {
+        "text": "1a30ac3cdd9ed4f0f4292ea7d9fb40f9d4b9d5b2f9fd1907c2a3a3a251c3fe90",
+        "author": "e509e190b735b5c4c548028d3a8fc9e4c7181de1557a1264df9ae06b1b25b67c",
+        "combined": "fadefce81cbc276f0fb920a45cab61dff014321caf34007f7a6cf6866c49573b",
+        "tokenSignature": "a-an-body-dead-friend-good-hayes-help-jim-move-old-will-you"
+      },
+      "lengths": {
+        "text": 79,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-08": {
+      "hashes": {
+        "text": "3f5bede600996663150d547b0921e6e337ab88e4b2631181c37e1db97122fcc3",
+        "author": "55e40a6a769b963b135a23dd5e56d9452899cdcc6b4721a3f6995b1e08b9da0e",
+        "combined": "abb40866d58f920c09de1b58bf4ffcb72eb6121b715f034e2aee4b25670829d2",
+        "tokenSignature": "a-bronwyn-easy-friend-friendship-had-has-is-never-obviously-polson-says-true-whoever"
+      },
+      "lengths": {
+        "text": 70,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-09": {
+      "hashes": {
+        "text": "2570eded1d39255563a792d5058117835051382df5971e0559daf06b7db2da79",
+        "author": "0806956e047b68cd0c5acf0cc47ae74bff868c02bab24934703e22adc589bc71",
+        "combined": "ddc153ee4cc8b4443b07ff37058fa0e966001775fd3ab3bb4b2b9cd964a94699",
+        "tokenSignature": "a-day-drop-friend-honey-inside-is-left-like-of-pooh-pot-single-the-winnie-without"
+      },
+      "lengths": {
+        "text": 80,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-10": {
+      "hashes": {
+        "text": "0dbcce58bbdd9c63e08b42667fa9bc2bb851d4c7eb157dfcddc135271df500fa",
+        "author": "b8bb6efc900e9c84a7a6022d296e449d3606944e80f2ac90d96fc132f6abfef6",
+        "combined": "616fc625394f464d3fe0755c4af7448fc55104ead76d89b13a76085c237d1dea",
+        "tokenSignature": "a-day-depends-em-friend-give-good-how-inside-live-love-much-shel-silverstein-you"
+      },
+      "lengths": {
+        "text": 120,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-11": {
+      "hashes": {
+        "text": "2a6b8e81b88fb41a2ae09a1bd6e9070c725d3e4c507918706172a448a409baf1",
+        "author": "33ee14613faa7eaed646c26a7b4abae816938927893aa970a8f9687f6a6c72fe",
+        "combined": "3bd047502549b11ae39f74d2fb2394c5d2968ba3b6f642d40634f6f8f88560aa",
+        "tokenSignature": "a-are-bernard-cracked-egg-even-friend-good-he-is-knows-meltzer-slightly-someone-that-thinks-though-true-who-you"
+      },
+      "lengths": {
+        "text": 111,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-12": {
+      "hashes": {
+        "text": "e83533a93c85fe607ac8c16146863ff4721f058ff3b996f8c9f3b6bce75c1f33",
+        "author": "dc897d0aa49770d604ad4b2b702fe37b6af52acde6ecd22ac802ac81775a4336",
+        "combined": "818f97085bd1267c8e14be7f5a53456edbd40b21134c82658554d7e604d4f797",
+        "tokenSignature": "a-better-chocolate-friend-grayson-is-it-linda-nothing-than-there-unless-with"
+      },
+      "lengths": {
+        "text": 76,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-13": {
+      "hashes": {
+        "text": "90e5a3255d840ea67c01fc3ca2181a7c09ae9bc9ae7398b30df9d29ac116e3d6",
+        "author": "15178c5f456a582d50effb8b02fad359fec1b9157f1679093eb7a8450a219754",
+        "combined": "6507d5cebb298e588c448072d642e88adf44f9bbd8347eaafb949c9ce9e62344",
+        "tokenSignature": "a-arnold-be-down-friend-gets-glasgow-going-h-happen-in-never-to-true-unless-way-you-your"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-14": {
+      "hashes": {
+        "text": "1b6b465e609c1c148a2a238bd7887f2bbf0c917fc66cf375f23d4c0cfa230ea0",
+        "author": "05059dee230ebbba04430b179982516918fac112caf19f9740e86626a373e441",
+        "combined": "f47b8d6dc2610cd555bbb4866455ca6363a8722366d7b08e76dc9d10d57ee488",
+        "tokenSignature": "a-anna-deavere-friendship-is-medication-smith-underrated-wildly"
+      },
+      "lengths": {
+        "text": 45,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-15": {
+      "hashes": {
+        "text": "170752f60e774b474f051fe91d1287bfb5990cd1c342873254882d15a5bd7ab7",
+        "author": "25d23a724bfe8f4662255516442ea7e02066b9c9b370be6174142fa6b84e4ea2",
+        "combined": "b36b864028842a492ad8a7a3df41ea972453243a143a63fee0af6ddb89e817d1",
+        "tokenSignature": "a-are-because-can-capote-friendly-friends-friendship-full-have-if-is-just-many-not-occupation-pretty-re-really-somebody-t-then-time-too-truman-with-you"
+      },
+      "lengths": {
+        "text": 162,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-16": {
+      "hashes": {
+        "text": "c2bff79d07197b6c2ca5969f8254d595b7530fca3cafbdbf051514b7d9e1fdd3",
+        "author": "f918bbf08c95c50bbcf5fc6f50dbdcfcdf2c56dddbebbc22ea6bde8ef52fa4bb",
+        "combined": "6a8cfa4ad6bc672ffc57ce09ca841e5926965adeb23affadac4ddcd525831b90",
+        "tokenSignature": "always-and-are-beautiful-bright-diamonds-friends-in-like-nicole-richie-style-true-valuable"
+      },
+      "lengths": {
+        "text": 82,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-17": {
+      "hashes": {
+        "text": "b59e3c428c0b9c47c8e83ff2050459a60831a6d93f06d17d595d5c6ab8c8a7a4",
+        "author": "c970595c4a5258b22ab91291cc64cbacc910b2f5dc7bbf1fed0bc0f2f738bff7",
+        "combined": "57337a5d3169f43b27f267aa94302bbf503c49a2d1734dc10952acb7770056f8",
+        "tokenSignature": "a-are-fonda-friendships-jane-like-of-power-renewable-s-source-women"
+      },
+      "lengths": {
+        "text": 57,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-18": {
+      "hashes": {
+        "text": "b796130fbe93eedf8d7b91889f2964ef37756782db9907d0f3d2c3c5c3a714f4",
+        "author": "79d6af785dc3376eda9797452bc797687528526989b850110d4504f0e5ee512a",
+        "combined": "02d7b200cc2292a67632260598541739b7cf06636fa6ebde903dc327e6f15510",
+        "tokenSignature": "and-answer-are-ask-cunningham-ed-friends-hear-how-people-rare-the-then-those-to-wait-we-who"
+      },
+      "lengths": {
+        "text": 82,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-19": {
+      "hashes": {
+        "text": "576ea1bfdc6b437f5b85853115875f3df7a2ce1a2533a9ed72b1b425cee86251",
+        "author": "e975576533a7494402684dfe70c67d3e28f05651da40e6dc2b67f89f16dbab7e",
+        "combined": "a8a12e634785aa7b39142c8d19c7e163d46d55f157c9ec7d51f045af81bb344e",
+        "tokenSignature": "afford-be-blessings-can-emerson-friends-is-it-of-old-one-ralph-stupid-that-the-them-to-waldo-with-you"
+      },
+      "lengths": {
+        "text": 85,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-20": {
+      "hashes": {
+        "text": "f79ea45cd720cc364a36966975ddc247ae9e2c5651988b50455bcc234d3c9532",
+        "author": "36db3666c0ea257bdc9eb40b788d1d7a9c98e7104a3c1951a2344cc4adfae352",
+        "combined": "2a9e2016261477d9c124cecc9dfdfb2c1d435afdf9e164ac9aec211b63e22c7e",
+        "tokenSignature": "an-any-best-clear-computer-darynda-die-friend-history-if-immediately-integral-is-job-jones-of-part-s-to-you-your"
+      },
+      "lengths": {
+        "text": 99,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-21": {
+      "hashes": {
+        "text": "27c870798320b219ed96926a9dfbd6ccf61d09aafe6ae4ee6d82bebe80311165",
+        "author": "0f3ee73ea916ff97f63bd21e50b61221c62fb41b75c2fd80e4eb470b01315780",
+        "combined": "faf895f49b81497df99cccb68d0094ee68aa96981cde4189b53f6cbaa0a49ef7",
+        "tokenSignature": "a-acquaintances-bach-better-first-friends-in-know-meet-minute-richard-than-the-thousand-will-years-you-your"
+      },
+      "lengths": {
+        "text": 121,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-22": {
+      "hashes": {
+        "text": "fcef63afdd2ef846fb98861da3e719258aa27888918de8e2b4bc05960eee8bee",
+        "author": "f1a839812888faf97d47a2453d48375c0f71fe475006dc194cf295a4ff1aebd7",
+        "combined": "841e9ef86a83cfc1a5fe436ca1eb9f2b50b5d56c191c9ced7430845de3d5cdbf",
+        "tokenSignature": "all-complicated-friendship-gift-hands-is-maria-of-our-shriver-simple-so-the-when-within-world"
+      },
+      "lengths": {
+        "text": 91,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-23": {
+      "hashes": {
+        "text": "175b534cff4cd33a35ee81b3c3af8c403f2ec06c0d7fb94e6cca4701cf74c0de",
+        "author": "848f2611f93ebfb4786326ff7d501554394306d45220d48b9577ac24c9450b50",
+        "combined": "55810a74d99dda72b1805ece681958d3a204cd446beffc4de9447429f42c1055",
+        "tokenSignature": "be-c-draws-friends-is-it-lewis-people-s-same-see-share-that-the-they-to-truth-what"
+      },
+      "lengths": {
+        "text": 79,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-24": {
+      "hashes": {
+        "text": "739d15ab15bc5556f27b2440fe8e8e0e2ea7f0b26674227fd8f2544dea2917b6",
+        "author": "022e4626b2e871085490580d6c93eb21de2baf043a57dc8351accad49887bd16",
+        "combined": "209d50bf6529a486e83a76c0b8c1de37967000fd87ec0caa702755b441492947",
+        "tokenSignature": "a-big-coelho-friendship-isn-it-little-million-paulo-s-t-thing-things"
+      },
+      "lengths": {
+        "text": 60,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-25": {
+      "hashes": {
+        "text": "b9ab89806ce107d7d5475c239291903693f6171b54e359e89f9b545472fc9ff9",
+        "author": "63644a4de0807d6eb0d2573d6fc3ca14568fde89bb2c72d74279188246687814",
+        "combined": "cf7b1bb1970423db02f464e6c3e55adbc9b5d51f2a0ab641534f3ef764f4f8a3",
+        "tokenSignature": "a-and-clover-find-four-friend-good-hard-have-irish-is-leaf-like-lucky-proverb-to"
+      },
+      "lengths": {
+        "text": 73,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-26": {
+      "hashes": {
+        "text": "332cdfba1cdd8785c96cf3b5867b5d9ab9ae3e5dad3425b32caad3b9dd5179db",
+        "author": "09a60ee96a07c8e34522e5f58917df11440af5ea7ac4bc8a01b3e1f21018d06a",
+        "combined": "5c6ebfec8b72df4fbed5facf02804b406b67e98bf2b90cef7784f057d523723a",
+        "tokenSignature": "a-an-awful-best-dessen-friend-have-is-life-like-not-place-sarah-someone-to-ugly-you"
+      },
+      "lengths": {
+        "text": 55,
+        "author": 31
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-27": {
+      "hashes": {
+        "text": "8df8a5280c293afa78923d6a96e9822b9121f19e65f18065c000099335d9d800",
+        "author": "5e865875f0889872392688272452bb7efb14d2d0f401c4b50388d5287ff56a65",
+        "combined": "f3bac79b76c8e1f2a7b001d645d7eec9da28bf18da5c7c9651616625b0ce56c7",
+        "tokenSignature": "friend-fuller-have-if-more-one-share-than-thomas-true-you-your"
+      },
+      "lengths": {
+        "text": 58,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-28": {
+      "hashes": {
+        "text": "5d3e56b0520f6f3343f534b4db91c6d9efd64e22af9cb2b00a7345d7f9a7f313",
+        "author": "ea5b01282ad0d7bd9ffeb64dfa5c6c94e889f298f1b0104a51f62aea799bd2ad",
+        "combined": "f30d1d8890a7332df3dac45b98e1a628e72db3d46af0671b8f143c6a45488cb2",
+        "tokenSignature": "ali-anything-but-explain-friendship-hardest-haven-if-in-is-it-learn-learned-meaning-muhammad-not-of-really-s-school-something-t-the-thing-to-world-you"
+      },
+      "lengths": {
+        "text": 187,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-29": {
+      "hashes": {
+        "text": "a69b846cad06e21e5908bb4741097256bffa9e944e79a8578e58d4991c2f75a0",
+        "author": "dcf63ba0c663422fab50ddcf5b267af6f41d4625331686775b4cccff596f5afb",
+        "combined": "9a1c5213605bb1e2572f73e2ae9154ba5d91d12f3701a1b44019aec493ef071c",
+        "tokenSignature": "a-and-elbert-friend-hubbard-is-just-knows-loves-one-same-the-who-you"
+      },
+      "lengths": {
+        "text": 58,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-30": {
+      "hashes": {
+        "text": "d1ce07049abf8b831b2ad8d808719ea25e5c9b65a9635473f85af75e8c24319f",
+        "author": "0127a1d38e01cb61929ce3b1ce8e691762ca845f7756df6ba1692522beb4b979",
+        "combined": "3ae692c741a0dbb19fdb1988b10ca94b68accb7ab72e8a7d9748f3a7cfff4356",
+        "tokenSignature": "a-and-donna-fails-friend-heart-in-it-knows-me-memory-my-roberts-sings-song-the-to-when"
+      },
+      "lengths": {
+        "text": 76,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-31": {
+      "hashes": {
+        "text": "1f7ca8eb742251cc5b8ab857e27378792ca93a36dc3042d7f2281755178fd3d3",
+        "author": "c7b3d576d8ca1393bb6fac9017f218cf93b600a1f0c9df61f7ae674b713ba312",
+        "combined": "5dd1d38944267ef1cf513ecc0d9243ba325ea174a753f916cbaa7fc05eb44af4",
+        "tokenSignature": "a-believe-easy-friend-heidi-in-is-it-makes-someone-to-who-wills-yourself"
+      },
+      "lengths": {
+        "text": 61,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-32": {
+      "hashes": {
+        "text": "5fca5750266ab977b408f4cfadbdb1bbf7034558f089aa019bee26a7ead90b8c",
+        "author": "1478a05f0ca2595e6fd18ad999cc2a0586f27f442247957d978f8fd237dc1e1b",
+        "combined": "49a6a5cd99d1e8ff51f33f268a0cd0af98cea115a813cd5cbd422610a0a39636",
+        "tokenSignature": "a-always-an-friendship-gibran-is-kahlil-never-opportunity-responsibility-sweet"
+      },
+      "lengths": {
+        "text": 66,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-33": {
+      "hashes": {
+        "text": "986762ae9b0df6c58f80c997c19a3365de9611fb939e8b444da395bfc5025263",
+        "author": "9068c9e824ad1bc84e24be0d28cae8efc1b941d3d7a538494b7af684bc46f928",
+        "combined": "4de5af1dc58a2b01fb8f1676df0070cf6587f25792eabb84b788a748ade80f65",
+        "tokenSignature": "a-again-and-any-are-as-back-becoming-between-built-forth-friendships-kindnesses-michelle-obama-of-over-small-swapped-tell-thousand-will-woman-women-you"
+      },
+      "lengths": {
+        "text": 139,
+        "author": 25
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-34": {
+      "hashes": {
+        "text": "d57fdb53cc478600d8bef23d31b37f519045634acc579790f780ae09e214fb1b",
+        "author": "5a34facee68bc0d0c6b096f89b8079bef299ede4f534ed8dfb433a709a9d70dd",
+        "combined": "a28f53d6ebc9de9183f434446d3e6f2dee599b7c5df9d0f31583b8d97de30171",
+        "tokenSignature": "accident-an-friendship-henry-is-no-o"
+      },
+      "lengths": {
+        "text": 29,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-35": {
+      "hashes": {
+        "text": "5e81dd72429eb1889d4b186a732ff630ad11339bd6b59458553490653369f745",
+        "author": "3c21f75dfeab1b2e10aea3d17e25959caf4f6f951d62367ee94533601cbd2b5d",
+        "combined": "1f247e16d9a5bc2a208c29b358611ee8d68f6205bdb279d270098ac320f9c5a5",
+        "tokenSignature": "along-are-dessen-each-even-for-friends-honest-hurts-if-other-ride-sarah-the-truth-with"
+      },
+      "lengths": {
+        "text": 60,
+        "author": 33
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-36": {
+      "hashes": {
+        "text": "48e8dac62b6d9653b77f4d8127665d285064e97174b39f2e92a77fe13cce97f9",
+        "author": "f7526b66a6ef46aa1b66c609c87f542e93796f59a9db18a484ec2fd4526ee30e",
+        "combined": "ab0ce558a2726be9e298806f11012f95c9a522fac3e08177bc7401dd99099006",
+        "tokenSignature": "a-be-buscaglia-can-friend-garden-leo-my-rose-single-world"
+      },
+      "lengths": {
+        "text": 58,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-37": {
+      "hashes": {
+        "text": "dd7fa29ea8ed35a1854395a025accbddf4585b57487ed46fc03e5b1365359433",
+        "author": "4c9f55f3254f3f9aa5621c201cf8e209ac144c24c636c78ef1790a13bc52f99f",
+        "combined": "3f8cc4f3b3b9e131b5e8cbe8fbf87eee8b0363145ca678db5173b266329acf18",
+        "tokenSignature": "a-angelou-be-behind-daughter-face-friend-letter-may-maya-my-s-stranger-to-waiting"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 36
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-38": {
+      "hashes": {
+        "text": "5def807c2be9b7c9bcfc682a939e35d6841861ddb667289b9ead2c3985d64f0e",
+        "author": "e4953e5f9f1cccc3512c92ef1c2b971b38d9a2d90d4b40fa2f53647d02d598a5",
+        "combined": "bbe641436e555d3177be015df25623c9268852fc4fcc8ab4142123bed550ecae",
+        "tokenSignature": "a-as-chance-francesco-friends-guicciardini-having-is-lose-make-never-nothing-since-so-them-there-to-well-worth"
+      },
+      "lengths": {
+        "text": 89,
+        "author": 22
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-39": {
+      "hashes": {
+        "text": "a3ea53a803e901e73c6328089def2b14a8fe05b97f726cfbe0f784c200da7070",
+        "author": "588a7a4cc2839140a6bbb27feaf48f5eee16e42338796421eea1dbc1cc05a467",
+        "combined": "adaf2f7ecdc9ba593b22e9ff60a22b098ed8eac3e7c2760342221cacaa4133d5",
+        "tokenSignature": "a-aniston-dependable-friend-good-jennifer-like-loyal-nothing-really-s-there"
+      },
+      "lengths": {
+        "text": 70,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-40": {
+      "hashes": {
+        "text": "d1c81b36ae68909cb421567139485c673ef764408d34d4f474e62b4c21828aab",
+        "author": "5c6ef7bfa5f9c42b5714315f8b7c2011b7cd4c481fa2f273cd69963bbd75db1c",
+        "combined": "d6fbb15c974483d4e72c53f038f93854bc419de71cfe58fc097462882a00d5da",
+        "tokenSignature": "edward-friendship-life-of-s-the-wine-young"
+      },
+      "lengths": {
+        "text": 30,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-41": {
+      "hashes": {
+        "text": "31f20b956a5100beed26588ccb27d1f57323042cd3ed491ba03e8dad1822f7ad",
+        "author": "80ffcbbaa5b4234a84a034fa3c91061ef00b7041960822cfbf34364e964ea16d",
+        "combined": "fd755b1b8d82e72ab76c0954ff3811170ae94b7e68835f6d6a008a3b39ddfe72",
+        "tokenSignature": "a-and-anna-arrive-barely-beautiful-can-impact-life-like-make-on-people-remember-some-such-taylor-them-was-what-without-you-your"
+      },
+      "lengths": {
+        "text": 122,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-42": {
+      "hashes": {
+        "text": "f33bbfcf216e72795e5933ebb7b710339171d195950826e4682a7e9b21827066",
+        "author": "66ee331e760e6231b9d6f94487909ac66e7879096b3473a7d93935a72bef3a96",
+        "combined": "5a981cd1f77c89ce6d870c4c2d2cac02bb1eaa0c79bc364df7454d6474582afa",
+        "tokenSignature": "and-ben-but-choice-consists-friends-happiness-in-jonson-multitude-not-of-the-true-worth"
+      },
+      "lengths": {
+        "text": 85,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-43": {
+      "hashes": {
+        "text": "abffe92b36ece1e675366e694245ff2d0b88e94c715960b7e6187019748fd2ae",
+        "author": "dfe3f8f75b0bd2f43258fbf6ee203e70b6942e6ce1a620f778aaee81942693a0",
+        "combined": "e51c8b7f49314a6f92b39a40fbbcb9867b31fce516294c77ad638bcb272fbf81",
+        "tokenSignature": "choose-chooses-delille-fate-friends-jacques-our-relatives-we"
+      },
+      "lengths": {
+        "text": 50,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-44": {
+      "hashes": {
+        "text": "416396e1daf23a9029959ed6785efcceca7c7fc7476e1793fad2512dc4ad9ae0",
+        "author": "28b6517e6edcbb0f1a996952754fd7f8dbf2c6e88f3f4882a2179bf9a0265e04",
+        "combined": "3715d163868072cec9447006b93f8ee79b86b6e7035d1b4fe6fdad4d69868da0",
+        "tokenSignature": "a-and-be-best-can-douglas-friend-have-is-nicest-of-one-pagels-the-things-you"
+      },
+      "lengths": {
+        "text": 89,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-45": {
+      "hashes": {
+        "text": "4bb533a27bd09d63fba434bfba12b4cfccdeee0e2476a97194713970a2fe1d95",
+        "author": "9280c8db01b05444ff6a26c52efbe639b4879a1c49bfe0e2afdc686e93d01bcb",
+        "combined": "571965e96f8ac0894b280b949f97092d619b138c5fe947fddabe77911281f59b",
+        "tokenSignature": "a-aristotle-be-but-friends-friendship-fruit-is-quick-ripening-slow-to-wishing-work"
+      },
+      "lengths": {
+        "text": 77,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-46": {
+      "hashes": {
+        "text": "2d4f589053303846fa123274c492d2d94ce518a57c6f71f32689de8469511496",
+        "author": "01a085bd6c3845beded437ce4030913a900135d5721bf0251bc0c2e74a277806",
+        "combined": "292d86fa316406f1f5a7e7bf801d7d63e929bd205d69cd9e3b5bd308aca345f4",
+        "tokenSignature": "cement-ever-friendship-hold-is-only-that-the-together-will-wilson-woodrow-world"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-47": {
+      "hashes": {
+        "text": "576955b599ed797279867f4aa2bd31a0260b73d1609d8a7da9d4a5391ce36505",
+        "author": "196b392a1eb8ce0e9b4a4ef9208e2cf5d298082f34b89d7d0a735c98db22fd88",
+        "combined": "fcc94937d472b1c415141e9e016520fb86987047940e6000e1f95777353c4486",
+        "tokenSignature": "about-alderton-dolly-everything-friendships-from-i-know-learnt-long-love-my-nearly-term-ve-with-women"
+      },
+      "lengths": {
+        "text": 90,
+        "author": 45
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-48": {
+      "hashes": {
+        "text": "abe676d51040e5a9b41408d37bef137cc8625f044e7b9bddd8f231df44475b5a",
+        "author": "e143ef29ac6bb9f267d165cffd870b73f157210d3ac615103b6ebe50dc412bbf",
+        "combined": "f51e8037fe0d9df7a9e5952950815d2446bac4bce4ad683b133af78cff5c3a73",
+        "tokenSignature": "breaks-bus-but-down-in-is-limo-lots-of-oprah-people-ride-someone-take-the-to-want-what-when-who-will-winfrey-with-you"
+      },
+      "lengths": {
+        "text": 136,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-49": {
+      "hashes": {
+        "text": "31de63ca6bc955dfd0da809ff5b36e15c8bca21fef73682f0081375b97d317e9",
+        "author": "717617b5179e6be6e5736222cd3716c50f9f8b131a19fcfe146e7e5e1e9ee2a1",
+        "combined": "eab4de570c498201bb53a884b3e448bbd565dee6ebec36e7c355968ce9cb4b46",
+        "tokenSignature": "a-and-best-did-friend-hannah-heart-hold-kristin-mirror-show-that-up-was-what-you-your"
+      },
+      "lengths": {
+        "text": 74,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "friendship-50": {
+      "hashes": {
+        "text": "1a4e4d3c51c787338e973cdac644bc16dcbb14b3f7ac6e604afa2a1bc8b87382",
+        "author": "5feedf30d09970373c0c49fa000bc2a5658418b6ba60e6296cf7655ab92e3086",
+        "combined": "ba765fb682543638dfbb9baa3dcddf482ffca90d2672abe7c7c9b33ab5c35eed",
+        "tokenSignature": "and-are-difficult-find-forget-friends-g-great-hard-impossible-leave-randolf-to-truly"
+      },
+      "lengths": {
+        "text": 82,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "friendship",
+        "sequence": 50
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-01": {
+      "hashes": {
+        "text": "5ccad25d384398f1cbd01a609cc7b35acc8cecf6bfbe6f16181248bc7fd658f6",
+        "author": "ad8030f4b75b3885a79556549b4f7811bbe6f5da8c5b5e1e6d73937fb5a2b24f",
+        "combined": "bda3fa96c92e8e0e4e2628376a2e53fff59b4a1c2ee34c9c4ee2ceb7abf65d87",
+        "tokenSignature": "a-beethoven-cannot-dream-hear-i-is-like-ludwig-music-one-that-van"
+      },
+      "lengths": {
+        "text": 46,
+        "author": 20
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-02": {
+      "hashes": {
+        "text": "1f87a62f52b3cbe18659d1133ae7e4625082fbfb5e66f1fbd5f9e668ae863e88",
+        "author": "6a0968f84b8833e9c3b24c580ac98823d5c33e0431de2bdae6bc90c57115d19b",
+        "combined": "3f75e18e91b530098d8f3b40169f1eb3208dc3608950afd8f105a7f489ba0a6a",
+        "tokenSignature": "a-be-friedrich-life-mistake-music-nietzsche-without-would"
+      },
+      "lengths": {
+        "text": 38,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-03": {
+      "hashes": {
+        "text": "2d0b28d7d74bdb5672aff3110dff572963fe291245196e5c96c13f45ab9f82af",
+        "author": "35137d72c2efc6daea34b8676b1e2cd01cc862f76023aa342e4079ccbf638aba",
+        "combined": "cc7f147b6bb76f346015e84ff3322548cb0ae6be01e1a9379d68d4cc34480eea",
+        "tokenSignature": "and-but-can-catch-chase-do-i-is-make-mine-morrissey-nothing-there-to-you"
+      },
+      "lengths": {
+        "text": 85,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-04": {
+      "hashes": {
+        "text": "f1ae00f8b17d16fb30ed0d716fe04b5b59f27f461cfeada28d9f4857a237e160",
+        "author": "87e4571bc7b47363d74a65592c50a1eccb5afdc5bd3036d119f8c84c934b37da",
+        "combined": "eb4ecd401d1a7cba06789bb6eb0b68e5c25352fb9519ad299721df80a7f93d07",
+        "tokenSignature": "a-and-everything-flight-gives-imagination-life-mind-music-plato-soul-the-to-universe-wings"
+      },
+      "lengths": {
+        "text": 104,
+        "author": 5
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-05": {
+      "hashes": {
+        "text": "715db44e7332fd9807b05a61be8203006eb2f0da33833e24fe8687c94023cf9d",
+        "author": "d55df1b071ba41d9a00341fb84678069c92ed989f5736bbd86a5a155ad49b997",
+        "combined": "cb8d03e43ca1454048b5967a10da95f7d34aeb13133c9166294d5b7e4d7b9dd2",
+        "tokenSignature": "aspirations-can-evoke-fears-highest-how-is-it-jane-laughter-music-our-swan-that-without-words"
+      },
+      "lengths": {
+        "text": 96,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-06": {
+      "hashes": {
+        "text": "d30aaf7f61b1758cea18d28afee5c7636f8ee490f32754a2ebcad478e1758b7b",
+        "author": "b3de298fc1dd3007b7c95be8bec4386b0bd0a44091f3657124240515cdd8c017",
+        "combined": "d8edded9620b3dec3cf91d8d73de786b796bc52f914838649d908063eebbce30",
+        "tokenSignature": "a-albert-be-daydreams-einstein-i-if-in-life-live-music-musician-my-not-of-often-physicist-probably-see-terms-think-were-would"
+      },
+      "lengths": {
+        "text": 145,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-07": {
+      "hashes": {
+        "text": "c6df551f17e805cd07902a303ab862c75879d8602944d646a2a8c199178e1f48",
+        "author": "4fdd88e44edd719ec46debab24fe6df0de6206f5a8e8a03f2662f6457a4137ef",
+        "combined": "978b56b1dad05486072ee3b69fe62af77c62492afbb6ef392533b9434c9c1488",
+        "tokenSignature": "a-and-bones-doesn-emotions-if-in-is-it-keith-language-music-particular-richards-s-speak-speaks-t-that-the-words"
+      },
+      "lengths": {
+        "text": 127,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-08": {
+      "hashes": {
+        "text": "c1d198e224a7ed263585314c6746abd3103fd874feeeac5eb69984bb91f68e5b",
+        "author": "26457e898ba9b255c85552d48b539ff8f8c01a918ef904152f2a9fbb12c43218",
+        "combined": "be5da96a9f88537d7353c4562a66e0e6bb791314ea4a7212b7554862c2ffea41",
+        "tokenSignature": "all-an-are-billy-by-culture-everyone-explosive-expression-from-healing-humanity-i-in-is-it-itself-joel-loves-matter-music-no-of-re-s-something-think-touched-we-what"
+      },
+      "lengths": {
+        "text": 172,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-09": {
+      "hashes": {
+        "text": "cf407e16d43025b7243441519c2fbab4a1692fe1e23789df499b3b6e12cf2464",
+        "author": "a43a98d31dbfce28f218cf6c6eaf437b9f3fb6181f83804ce50b080248fe4320",
+        "combined": "7303823d9b2e77231e206cffe6da63b6f4af46228a0166400cab4e6f071a5ac1",
+        "tokenSignature": "about-bob-feel-good-hits-it-marley-music-no-one-pain-thing-when-you"
+      },
+      "lengths": {
+        "text": 63,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-10": {
+      "hashes": {
+        "text": "47afb550766f51c50d57aea6778e1d65da1f32e247dd1b0609742d77807bc393",
+        "author": "9dff7c9212e64eb11a73dc8fcc657d6086da86ff4bee82f39ea1ea8de8beb915",
+        "combined": "efe842d09ad9eeb6a1c1fafa8fcc6f4e7723378e96f44a06ad0756f973bacba7",
+        "tokenSignature": "is-jack-kerouac-music-only-the-truth"
+      },
+      "lengths": {
+        "text": 24,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-11": {
+      "hashes": {
+        "text": "6db6574acac782456e361667840f8dbc7fa42a0a137535a84f090f2cb96f0272",
+        "author": "ff237ef0b6ba4f9b7b1d070c4f2e83c1a40ae224d28bce63457bef8e1dedb845",
+        "combined": "ba67b024c6ca5c385a1613269119208cd91c71889bf2912ac098d641b8baf13b",
+        "tokenSignature": "albert-and-are-cats-from-life-means-miseries-music-of-refuge-schweitzer-the-there-two"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-12": {
+      "hashes": {
+        "text": "66c59e0c6bf127db91b306f11e501092664e6c8a6e8c460dc3c28ae89ba66009",
+        "author": "3988e8ca898e68b128dd6640848d27b5dc622b239f4ab644eb076a876ba14a16",
+        "combined": "2a3fa6caf9c0a52dc75bf12500bccce8af1173a98327636b69e7fac4e8b98b50",
+        "tokenSignature": "emotion-is-leo-music-of-shorthand-the-tolstoy"
+      },
+      "lengths": {
+        "text": 34,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-13": {
+      "hashes": {
+        "text": "118c665d09720a3daa5c850f5b4c7f834fd884cbcdac46852540c951f3d02fbe",
+        "author": "80c0511e7077a4ded18515d5eb8e6feeb528db8bf688607372f168f31fbf7fae",
+        "combined": "80ed97c7a81019c69de7adc8c47c787a922a8e879cccda7a64fb609d27d861c8",
+        "tokenSignature": "a-austen-be-blank-jane-life-me-music-to-without-would"
+      },
+      "lengths": {
+        "text": 43,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-14": {
+      "hashes": {
+        "text": "2f353725bbb2a19ca7fea03cd4f5b28ad0c225dbea935393cdf915890ca5c56a",
+        "author": "5eb9ec81d60f252babd343fd14cc82fe7d6510c37ee12c73eda681604d2cb570",
+        "combined": "7f591fa690099758a9c4c9163aa24fb31162d9ae83a207f368c2dcca19983b2a",
+        "tokenSignature": "and-appetite-be-die-excess-food-give-if-it-love-may-me-music-of-on-play-shakespeare-sicken-so-surfeiting-that-the-william"
+      },
+      "lengths": {
+        "text": 114,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-15": {
+      "hashes": {
+        "text": "21c330b2c17519777996270fd27013ed5fedfa2ab18473db96bf05380cae0d6f",
+        "author": "8efb46e0d0e614f2f850d1024984f5d9619cf9155d6918e704dbbbd624696844",
+        "combined": "2304c96085314581bff3589ded83eb84ebfd446d1ca51f9c4c86a5497eb1bd65",
+        "tokenSignature": "and-angelou-back-between-could-crawl-curl-i-into-loneliness-maya-music-my-notes-refuge-space-the-to-was"
+      },
+      "lengths": {
+        "text": 99,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-16": {
+      "hashes": {
+        "text": "cd97566e687f5437e2f00550805cb02ef20570da5d05bf6264a6fdb4cc0eeaa4",
+        "author": "c13f842a4ad3908875aecb2ebd229c1442ed183d844a073afa3790e1074eb34d",
+        "combined": "3ab244534a36f77edd514088a2c500c91c1b062841bb78f5c1120893039c935c",
+        "tokenSignature": "after-aldous-comes-expressing-huxley-inexpressible-is-music-nearest-silence-that-the-to-which"
+      },
+      "lengths": {
+        "text": 81,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-17": {
+      "hashes": {
+        "text": "0c687806533e42babbe8562d6447f303a973c8bed01e8beb3187a463e0e50ddc",
+        "author": "14f91becbc86290021f2526df37b9510a9f8f19bcb8bf8bedcb2506381f9cf28",
+        "combined": "60160f1dba4ff8509464f448dba273caba1208ef2ac58d7a74517a3657587724",
+        "tokenSignature": "and-auden-beautiful-complex-exciting-h-inevitable-melodies-most-rhythms-seem-simple-the-unexpected-w"
+      },
+      "lengths": {
+        "text": 105,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-18": {
+      "hashes": {
+        "text": "b00bc6d2b04e515be4f9270d7381c1ed12dc5fea1c12b949b36b3a70bd0dd63e",
+        "author": "1d4ca184eedc11f33633a3b561487b2f741b0376b90d21c17ef5b2d84e81cab5",
+        "combined": "87f7b09fdf8438de466176b167359086093bff6a9448fdd972980e5e2ebae7a2",
+        "tokenSignature": "andersen-christian-fail-hans-music-speaks-where-words"
+      },
+      "lengths": {
+        "text": 31,
+        "author": 23
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-19": {
+      "hashes": {
+        "text": "08f247990c1a5ecab5f3bfb4512031882904540e82b303b13f87446f19468e7a",
+        "author": "5fbc1daee9d1fa06b7a9cb5bbb943b5be9b876d86e09b02a4f781e8c9777b503",
+        "combined": "084d3b38a3263556cb3529c3dadb507c15f05ab5ddac9b8595834b76395502f6",
+        "tokenSignature": "and-be-cannot-expresses-hugo-impossible-is-it-music-on-said-silent-that-to-victor-which"
+      },
+      "lengths": {
+        "text": 85,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-20": {
+      "hashes": {
+        "text": "7f53413c424679f0e7ed7baf05d07934f88fb3ed23642fe90a38263117bb7842",
+        "author": "4507fb61799a420e23872cdae6e87740bb279cc2f6b2fb35621b3c7f7cd9fd49",
+        "combined": "05e9dba87a44011821af2f5c7d5b0f018c76fb81c6ec4bea5b12a7b214ff9c05",
+        "tokenSignature": "and-are-arthur-dreamers-dreams-makers-music-o-of-shaughnessy-the-we"
+      },
+      "lengths": {
+        "text": 59,
+        "author": 20
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-21": {
+      "hashes": {
+        "text": "a61b8e984458e3b745fb0e01b4b77e2f91159885ac83fb1b6091f41e1a6214ba",
+        "author": "48dc728cca0217f5f094b9686982de68e8e9099a5029359322a9ec0877989e86",
+        "combined": "695962fe14a6647e932f7cb1f9b229eae5cf0d4440d147a2df42a75dd9cc15e2",
+        "tokenSignature": "a-again-and-at-charles-darwin-every-had-have-i-if-least-life-listen-live-made-music-my-once-over-poetry-read-rule-some-to-week-would"
+      },
+      "lengths": {
+        "text": 132,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-22": {
+      "hashes": {
+        "text": "7ddc8ca5efa5f9817f8b62ed1772380549dc0048366e1d9167f8a2630305f9d6",
+        "author": "e8c2cac0c75f0edabf87e74977f846a114b87256b69eea7e35504f3342901054",
+        "combined": "6924e1ad706479f64d1ee1ec8ec4d3f36cfba1a6e4a0a90bde485ced5a93cccc",
+        "tokenSignature": "a-cannot-confucius-do-human-kind-music-nature-of-pleasure-produces-which-without"
+      },
+      "lengths": {
+        "text": 71,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-23": {
+      "hashes": {
+        "text": "6d0a07db1a4845127824af493b6d1eb7deaddeb1b4edf48496a80e4bea96c6a3",
+        "author": "ad8030f4b75b3885a79556549b4f7811bbe6f5da8c5b5e1e6d73937fb5a2b24f",
+        "combined": "aa5b4f3ffb41f280d034728886e1bd9b634560e9434c0d5d92f640521e76af97",
+        "tokenSignature": "a-all-beethoven-higher-is-ludwig-music-philosophy-revelation-than-van-wisdom"
+      },
+      "lengths": {
+        "text": 59,
+        "author": 20
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-24": {
+      "hashes": {
+        "text": "5c1850da7ab4297687a2ad9acd600fd06d1baadd296676eba82efd15d9178740",
+        "author": "8a202463a79b857f6b1e3f7f4b6cab33b8ebbbd150d43c7f7b90ac238271fdb9",
+        "combined": "5062b8e8fd70994e219b2aab41b435602a5d74aa442f3e46c4eb4bf26d290cfe",
+        "tokenSignature": "a-and-beautiful-cares-day-every-fine-god-goethe-has-hear-his-human-implanted-in-johann-life-little-man-may-music-not-obliterate-of-order-picture-poetry-read-see-sense-should-soul-that-the-von-which-wolfgang-worldly"
+      },
+      "lengths": {
+        "text": 218,
+        "author": 26
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-25": {
+      "hashes": {
+        "text": "31bd9b9f066956e89c1d8c551676937cabaa06f571340150f359d92ba86d3f87",
+        "author": "c0f60a889a0b765a4e9c5a8035e7c4ba41b8e573ecdd5a8e74275c9c2d40cd73",
+        "combined": "f25bca96d7d70687ed069123e85597783545402527ce9eadeedb8a6f088e9ba1",
+        "tokenSignature": "are-is-mind-modest-mouse-music-soul-the-to-what-words"
+      },
+      "lengths": {
+        "text": 48,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-26": {
+      "hashes": {
+        "text": "69605e802c1456f9c88d148bbe951fe4f932e44be0720c8c713d52335d2f35e8",
+        "author": "b84f6f7a2b690e239f9e3d1a5f43f620ee0143b7146f6864163138bcbe45da47",
+        "combined": "028f70b124cc093ca2179af0a1c583d77713a10fae9a2322bbd3bd74c1e8e9eb",
+        "tokenSignature": "a-admitted-and-becomes-bulwer-dies-edward-lytton-music-never-of-once-sort-soul-spirit-the-to"
+      },
+      "lengths": {
+        "text": 75,
+        "author": 20
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-27": {
+      "hashes": {
+        "text": "15abb52803e3d82233b28b43ddbc9125376b9083e4ae959ce2cf9c088979b8b1",
+        "author": "ce24320bc3d26797e631f6647bff1d8e798f1778a7af553d313334409b865be0",
+        "combined": "b1b0cc1f382d8eacb535bce20ab46e0c07b7a986ca903ba28a02d898e997e52c",
+        "tokenSignature": "alone-can-depp-emotionally-johnny-music-t-touches-us-where-words"
+      },
+      "lengths": {
+        "text": 54,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-28": {
+      "hashes": {
+        "text": "2308554ff7e24394f3e38c5353b860d94ee8de5d4ec7a2e23053714c390d7a92",
+        "author": "ee61ee1e25e826fc8b156f5096779d22979bd878d8ddb7d5fa5e2020e18a2199",
+        "combined": "196791e80a79c23ae8d2a544849afda98e708768acf09377bb525d510424ac40",
+        "tokenSignature": "a-be-every-i-know-kurt-musician-rather-virtually-vonnegut-would-writer"
+      },
+      "lengths": {
+        "text": 57,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-29": {
+      "hashes": {
+        "text": "7437c2c81092f63068cfefc7d33ae17c4e2cb4dad43e1c34286cdbe2c676277b",
+        "author": "30dee2a484dd5114744aa876b9973758a12aefede839734be2a425c9c0fb6bfb",
+        "combined": "b28c7bdaa82475b69d58223c8ffdff6f7b5b5422579ff3c5854063586c75cd63",
+        "tokenSignature": "a-but-canvas-leopold-musicians-on-paint-painter-paints-pictures-silence-stokowski-their"
+      },
+      "lengths": {
+        "text": 83,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-30": {
+      "hashes": {
+        "text": "2e87119a89dd687a02c7e61fe5f16342d3333d1dda5f77ebfd084543ba54e5b1",
+        "author": "13240f8fcca31adc12661c892aadf61a076e6625fe16882d323c2c8312289097",
+        "combined": "cc4c699041ebc317c93dd3c901c2e4885eea693efb7f2a31c65077bf3e01f03e",
+        "tokenSignature": "and-bernstein-can-communicate-leonard-music-name-the-unknowable-unnameable"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-31": {
+      "hashes": {
+        "text": "1896274b7f81f9339a9803ee46bf8f92e295ec0ec8a09bc2021479f985357b6b",
+        "author": "f28ddc1a68dea4ff4ce542af37ba03a8093a6ac5a90dfa173f84466dec81222c",
+        "combined": "9ba779abaccefcedea3389324c250b151ca8594e2a32f8d96b5dc17485150a34",
+        "tokenSignature": "beautiful-i-like-me-melodies-telling-terrible-things-tom-waits"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-32": {
+      "hashes": {
+        "text": "0add76f8825c22f2c55031d0e5663fee10da2337a07b6db97ea2a635ba2fc1f6",
+        "author": "83e2192f0ab1c9d37081aacd270d1d9fdad95111f77fce4416044128ae2315f6",
+        "combined": "e48a5e34425d98b20b8a368f8f5f051d2cd6491d71dd379e547f063dcef00970",
+        "tokenSignature": "about-at-blowing-condomless-create-gaga-have-idea-irresponsible-is-it-job-lady-make-mind-music-or-re-really-s-sex-the-time-to-whatever-when-with-write-writing-you-your"
+      },
+      "lengths": {
+        "text": 171,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-33": {
+      "hashes": {
+        "text": "73ffd86d7ac1fe5adf9fc3ee84fe42a1a8f339d3d3a29f249b02fbe8e04ca06b",
+        "author": "49bde1fc12cf5024d1ac249ec66e86a4f98cb1c27c2d6854bc6ba89de5e0022c",
+        "combined": "717cc52ad2081fc02f961a20ee1a3184e6b7f00ae802ca09d0028e5e90d93693",
+        "tokenSignature": "an-and-art-being-believe-call-can-do-egomaniac-i-if-in-it-john-lennon-ll-me-means-music-my-or-respect-say-that-then-what-you"
+      },
+      "lengths": {
+        "text": 158,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-34": {
+      "hashes": {
+        "text": "112ba282d54cfa2c4de87236ff94d9500bbc17954b5bfe5ad6515b06782dd830",
+        "author": "3ffd41f8b64c2431b083c7670a0af08acbcbfd70d3a30cb1650cc2808a228b14",
+        "combined": "6aa54909902fb941955731903963825f9f5dbdfed1e34a611f5c19ab7badfb0d",
+        "tokenSignature": "action-and-blessings-dance-dreams-embrace-enthusiasm-express-live-love-make-maraboli-music-remembering-share-sing-steve-take-talk-to-today-towards-truth-walk-worth-your"
+      },
+      "lengths": {
+        "text": 191,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-35": {
+      "hashes": {
+        "text": "31db6d0655a57f67a3c00058f73c000e617bce3ca407be0fd5fba727040e2d0d",
+        "author": "8b4ac0b02e867cc9d96c22654df6203c151aa4b72fd8e6f9cd4738a471cffdd9",
+        "combined": "1b3aa4e00f06c43ee8a4b6c19df4733559cc16894fdbd0d7fe04909ecd809311",
+        "tokenSignature": "beauty-best-frank-information-is-knowledge-love-music-not-the-truth-wisdom-zappa"
+      },
+      "lengths": {
+        "text": 154,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-36": {
+      "hashes": {
+        "text": "9680b9c666241fe976bfaac15a80943356bd06aed19d94d40fce9c086dde91ad",
+        "author": "a375fe73b3f8300d461c8a1eacde13f52cc4e5d34776c5f4adaed93150f17615",
+        "combined": "47439fd460a2502f8941fb77f9438cc35790acd51df4c246bc2bcec1dfea3fd6",
+        "tokenSignature": "alphonse-commences-de-ends-heart-is-it-lamartine-literature-music-of-speech-the-where"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 21
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-37": {
+      "hashes": {
+        "text": "9d9ccab72bfacb3d5736a6b37537d3b032fd41910edfe2ad2c1c41a297b9de5c",
+        "author": "4ab96d2e656532cfa23fc93325820c412f0793e0570d7252766e2f1ef699c712",
+        "combined": "d78e7f05d55dcff8cd4dd942683fade950a62074706f28fb38f8027e10707afa",
+        "tokenSignature": "adams-and-bach-be-beethoven-douglas-human-it-like-mozart-s-tells-the-to-universe-what-you"
+      },
+      "lengths": {
+        "text": 149,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-38": {
+      "hashes": {
+        "text": "2a72c34bb2447ecc6705748451f744cde171229b905934e39d8eb1e3ce7b050b",
+        "author": "e92241c40f0cec4da1ec9c8aada33526d6c00f76b93de22dd19785e6087eb3bd",
+        "combined": "92c5eb601fb6d37320f4e46d5341bcaaf0562f1496c9dcb935ae37b1f6a8ea89",
+        "tokenSignature": "amadeus-between-but-in-is-mozart-music-not-notes-silence-the-wolfgang"
+      },
+      "lengths": {
+        "text": 58,
+        "author": 23
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-39": {
+      "hashes": {
+        "text": "274d691f7c41358eceb32e111bea919edc010cb58053ced17cd272c1377e519e",
+        "author": "bd8d218beeec48b9f2062a9bc477342ad0945fbe02d89b2faf2a3a45e209ad3b",
+        "combined": "4d92ede5331d47c424883a7102e5ab215170c9b1010e648e43ee75d156d37148",
+        "tokenSignature": "always-at-feel-gets-is-it-least-makes-music-nerves-nowadays-on-one-oscar-romantic-s-same-so-the-thing-which-wilde"
+      },
+      "lengths": {
+        "text": 110,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-40": {
+      "hashes": {
+        "text": "7f290a59be3d24e9b19cd6f5576a99457ebb9a3edfc814f7640a4c9985c449b9",
+        "author": "8b4ac0b02e867cc9d96c22654df6203c151aa4b72fd8e6f9cd4738a471cffdd9",
+        "combined": "3dfea6f9410be607dcba2fc2dc549736696c1d5077ac3f6f7a97763488a44ddd",
+        "tokenSignature": "a-be-bills-boring-bunch-by-dates-deadlines-decorate-frank-is-it-just-music-must-of-or-paid-production-time-to-which-without-zappa"
+      },
+      "lengths": {
+        "text": 119,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-41": {
+      "hashes": {
+        "text": "6fb114803cd2f697afb1b0366f0a0a131addd15db41164510e93484dfac7aba9",
+        "author": "870d7f77592874ee88aa3c32bf197956915921284712516d5f07143d6c28dbe6",
+        "combined": "4a09a5deb26ccfe8c5b07c39c54bf3959a8f532a425b48da38e1c6d195c6a199",
+        "tokenSignature": "barrie-cannot-fly-if-j-m-me-pan-peter-sing-teach-to-you"
+      },
+      "lengths": {
+        "text": 48,
+        "author": 23
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-42": {
+      "hashes": {
+        "text": "76bb3e7909dfac61844d1d6ea1dcab44213c30f1514cd2a30d0b0a587cd84581",
+        "author": "566aa0947eff33442e71e19572b4c7a2bf4f447b4ddf81aed7ff2af77a2c466c",
+        "combined": "d331e106708626719ab582da8a4a42fda3893e69cf61458810801f58faf210d4",
+        "tokenSignature": "form-is-magic-manson-marilyn-music-of-strongest-the"
+      },
+      "lengths": {
+        "text": 37,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-43": {
+      "hashes": {
+        "text": "8f2feefd73bd4af727c0e8f9b34c3335b07ca886e85d603998f66a1a070a18b6",
+        "author": "b066ea5799f387aea6c8d27625b7737824464273767d2dea1a642e74eb3c2f01",
+        "combined": "7d93dfe593055774a975e83f143a0fce1bd379d260764891fae302f505d25033",
+        "tokenSignature": "cup-fills-fripp-is-music-of-robert-silence-that-the-wine"
+      },
+      "lengths": {
+        "text": 48,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-44": {
+      "hashes": {
+        "text": "f5ee28028cf2b54e80a7b39402d0be09e14e297157c44a11653103f4d6893a7c",
+        "author": "1478a05f0ca2595e6fd18ad999cc2a0586f27f442247957d978f8fd237dc1e1b",
+        "combined": "4b9918f66a4fe3d35504779613c19fb1a49d616da1dad0da3644eccbd2ea70a0",
+        "tokenSignature": "abolishing-bringing-gibran-is-it-kahlil-language-life-music-of-opens-peace-secret-spirit-strife-the"
+      },
+      "lengths": {
+        "text": 99,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-45": {
+      "hashes": {
+        "text": "6f78722707ae55cd123c74f04133c68a014bfe106562ae6665c563a722ea4619",
+        "author": "c32e664c8565ae26c40eb6601bc9f3fbc051a02ce093babd81646df1c60154a9",
+        "combined": "fc4d2a0c9f7d63bec9244ec4d9af9457eb9fb91ae943d55f0c9a8717e660f3ee",
+        "tokenSignature": "be-by-can-heard-in-lao-music-soul-the-tzu-universe"
+      },
+      "lengths": {
+        "text": 47,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-46": {
+      "hashes": {
+        "text": "b9e087cacd72963ac59f7430dfde97cb09761bdc3f12c51c581cfcdf761efafd",
+        "author": "c8e1f00bc7331e6c318e1964752becdcc91ffb6152e90b21052a9a93a8e4c683",
+        "combined": "e0f6886f2cbfa3fd0feaca4ed6dfe52af443c2b6bb5d081c79d5e69a4d5a02d6",
+        "tokenSignature": "a-acts-augusta-closed-heart-key-like-magic-maria-most-music-opens-the-tightly-to-trapp-von-which"
+      },
+      "lengths": {
+        "text": 74,
+        "author": 23
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-47": {
+      "hashes": {
+        "text": "f477837191685bd2a974f30116841c4ece955e67adfa841c00f5e1d7aab9b134",
+        "author": "9bb3af61b25c9fd613aed3424bee79cad88d9cc4d43b1c9ff2895f7f0d0b4cbd",
+        "combined": "da709b909b90669605979c61a68ba161cdf13f3e516cbfa24dcbda35ec507a9d",
+        "tokenSignature": "a-alive-and-bonhoeffer-care-character-dietrich-dissolve-fountain-help-in-joy-keep-music-of-perplexities-purify-sensibilities-sorrow-time-will-you-your"
+      },
+      "lengths": {
+        "text": 162,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-48": {
+      "hashes": {
+        "text": "6753c2a614f88a4fe9df6ea94f1ad5dd8a7753ece68cdb55f00360dcfea5cb94",
+        "author": "243a679c3533b8f2ddd6b105197d9e3ac41f4dfb3d53268bafb6b220c5de854a",
+        "combined": "4070a276c56ee69adaf9662ead559e03a9cd8f419fdb0ac89092f1c70bf30778",
+        "tokenSignature": "an-delius-frederick-is-music-of-outburst-soul-the"
+      },
+      "lengths": {
+        "text": 33,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-49": {
+      "hashes": {
+        "text": "49e0b6fc7dfa47285f45e385a031dc86e0afa2e7ca0c9b0341a6f528be6d4d08",
+        "author": "da5e0caabcc650b4719bc854d5cf0a80850945814ea1f0259a9eb4b2c8669a66",
+        "combined": "dbb0b278ae0971d13768b18e1420bdbcb5c7b7c3ec273421069268db277c5ec1",
+        "tokenSignature": "and-are-edith-hobbies-listening-music-my-personal-reading-silence-sitwell-to"
+      },
+      "lengths": {
+        "text": 65,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "music-50": {
+      "hashes": {
+        "text": "1db3f04323d7147ee5ecb5219f46dafdebc081244fe4000c1fe47eb09dc48e9d",
+        "author": "66cf672c3937d1bdbf0e6ebe45b99a1dce05f0f888cd4d8b18ffcda514e3aee2",
+        "combined": "8e84d9fbb9574e746a3db2a9fc83b8606fdd3b7f3d3b43f9cda9ef2e42ac4890",
+        "tokenSignature": "an-and-anything-can-common-dessen-differ-else-everything-force-great-have-in-incredible-is-music-on-people-sarah-something-that-the-uniter-who"
+      },
+      "lengths": {
+        "text": 132,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "music",
+        "sequence": 50
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-01": {
+      "hashes": {
+        "text": "a7af59db32da5c74dbc3e59c087873d4c51fd00e7eb2fd2b2d16f484643fa341",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "f17bfacf3ff4126e5314f3310c7e009198cd29b976d2dc911174fe4d2e015394",
+        "tokenSignature": "a-and-book-do-is-not-only-page-read-the-those-travel-unknown-who-world"
+      },
+      "lengths": {
+        "text": 66,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-02": {
+      "hashes": {
+        "text": "653ed6356cf740458a52c6c5f2533715b3c54d702fadb600c84b0c176fa702c1",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "86e730a61eb4f74ee9ab59e25cffbca9052bbe3350d4e5f6c2ddbdc666b1e765",
+        "tokenSignature": "footprints-leave-memories-only-take-unknown"
+      },
+      "lengths": {
+        "text": 42,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-03": {
+      "hashes": {
+        "text": "7230f88eff586d0b0809581e1b7abb87f6f41a38fba75101ab9a14798ff63e28",
+        "author": "f4fb49f850fa81650c9105bd6d58426f661c1fbc1779d8e018a8c164d70979ac",
+        "combined": "407f34d6d025ed4c71db097f3e37117b1d6643cad3483f4e7384878ea77c0d25",
+        "tokenSignature": "a-flaubert-gustave-in-makes-modest-occupy-one-place-see-the-tiny-travel-what-world-you"
+      },
+      "lengths": {
+        "text": 75,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-04": {
+      "hashes": {
+        "text": "da8cdc6c34340270eda4508d6d4ab12e7baa73f49da2b8348d58399d7c112203",
+        "author": "1d9aaa9a9b9fff69c691bc646b15d06db2f522ae49d57e78b31667b349b59a39",
+        "combined": "38c5802256d9949e7447b845b1e2fb7b036215995818da4ef767cde284b57fbe",
+        "tokenSignature": "all-are-j-lost-not-r-those-tolkien-wander-who"
+      },
+      "lengths": {
+        "text": 34,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-05": {
+      "hashes": {
+        "text": "f7d8dc1c82cf3e0ec1b159e4e99de1e8ad9a3266a1cd068f8cb983f9304e5b10",
+        "author": "118d3a27ea9af6f75da5dbde1dc9213cc68273dcbde57fdf45c92c9b5c3fb14f",
+        "combined": "cc9a55b77fba263ea4e23669d1674fb3fdcc19f0fcd6d27663db2decc9044ab6",
+        "tokenSignature": "but-dies-every-lives-man-not-really-wallace-william"
+      },
+      "lengths": {
+        "text": 47,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-06": {
+      "hashes": {
+        "text": "916601da96b0431bffacbdac13074fd28fd2f69444df6966f24c1e2982eb771f",
+        "author": "bd8d218beeec48b9f2062a9bc477342ad0945fbe02d89b2faf2a3a45e209ad3b",
+        "combined": "b73fd72c4e42674853840619211a5a50c2d69db973d9832a2bb6897d5ee3e40c",
+        "tokenSignature": "all-exist-in-is-live-most-oscar-people-rarest-that-the-thing-to-wilde-world"
+      },
+      "lengths": {
+        "text": 73,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-07": {
+      "hashes": {
+        "text": "8bd97b38a092224cb5efe9255e6c9a1994b090ec5b66f6af6fc612db96168205",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "1b63df739c3e8b551cc94f90077e3fe53ea9df43c272ba3bcfbc9fef183b7ffb",
+        "tokenSignature": "a-is-it-journey-life-make-most-of-the-unknown"
+      },
+      "lengths": {
+        "text": 39,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-08": {
+      "hashes": {
+        "text": "11507a1a24656a0570933882faf2b7dd4e18ee9be95d6d68183d9a977cec76e3",
+        "author": "9514ff29f90f6b6732ef97ca1f306ed5f79f1f15aa053defaa62510a1e0ea931",
+        "combined": "c1982eb347aaf7474e403f2f3069fb1da7ff74c7411fee54568a1913b0e206e3",
+        "tokenSignature": "been-cash-every-everywhere-here-i-in-johnny-land-man-road-this-traveled-ve"
+      },
+      "lengths": {
+        "text": 92,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-09": {
+      "hashes": {
+        "text": "a1f1f10fe195eb6e3e9028b3b52558daddd0427fb357ff72239b820f2e266273",
+        "author": "44212602db9c86f956dd613ff1bbfb31bb6921a6dfb435267eebbfc9b8e551cf",
+        "combined": "a7b57f59346fca107da8e4a0d47caebfd6f2b39e376bc000424876219b4c98bb",
+        "tokenSignature": "a-always-audrey-good-hepburn-idea-is-paris"
+      },
+      "lengths": {
+        "text": 28,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-10": {
+      "hashes": {
+        "text": "3b482748674f539c3073ad7c1441071ffae5e75b372d2f7092713d2e2720dc1c",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "90ec7709c739af02d5316a987c3ee02f458d9225ce18aa5e9e628122bd1610bf",
+        "tokenSignature": "buy-is-makes-only-richer-that-the-thing-travel-unknown-you"
+      },
+      "lengths": {
+        "text": 55,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-11": {
+      "hashes": {
+        "text": "3b43a95537f1ebe2e1b4528f5e244725ad9983840efcc5091d735746de48ffd1",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "3992665b6eedd28c06c445e80990ad9c4ae35bf021626bd7d7c02446c0529533",
+        "tokenSignature": "collect-moments-not-things-unknown"
+      },
+      "lengths": {
+        "text": 28,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-12": {
+      "hashes": {
+        "text": "ffeb8722c878b5e3aa02bd5249f9d8a9f6d17703e77a27ce6db6cffeee4dd6a9",
+        "author": "03d4150b90e62d42708621bb24ef977f6eb69adfaca27a56bef074fdf74ff2e5",
+        "combined": "467c18d2581c3b6ace23018b94c635347cc0a15a52221de0a245181ad30b68ad",
+        "tokenSignature": "day-dr-get-is-mountain-on-seuss-so-today-waiting-way-your"
+      },
+      "lengths": {
+        "text": 64,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-13": {
+      "hashes": {
+        "text": "864eeb99b96fe19b9066fb2a993b83d1a8beec23da2795421322982dfaa4d37d",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "dcc373f60f7fe115d59892e20cd0b6c1870d1c4498343824ace8bc3859295522",
+        "tokenSignature": "be-bowlines-by-catch-did-didn-disappointed-discover-do-dream-explore-from-in-more-now-off-sails-so-t-than-the-things-throw-trade-twenty-unknown-will-winds-years-you-your"
+      },
+      "lengths": {
+        "text": 200,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-14": {
+      "hashes": {
+        "text": "7e50a60560c1d3ec3bcdb906b142ad599224c3b85f166a3c782d242bbd67cb5e",
+        "author": "064fdb11dacad342eb9f778bcd22a74d31bad1f5270ca04649d9fdcdb92e88e3",
+        "combined": "f6f7ad47873754fdf8ad601587e49f9e6e5764e8aa337d801494597afb070309",
+        "tokenSignature": "a-and-bailey-crummy-dust-feet-george-gonna-i-in-it-life-little-m-my-of-off-s-see-shaking-the-this-town-wonderful-world"
+      },
+      "lengths": {
+        "text": 88,
+        "author": 38
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-15": {
+      "hashes": {
+        "text": "a13b975d45e239b021b544c3f265c5bda96774cdb4adca32245de5c86be4c5fe",
+        "author": "1d9aaa9a9b9fff69c691bc646b15d06db2f522ae49d57e78b31667b349b59a39",
+        "combined": "e5dbf3703381cb1cb8070f6f3679f990d76a93bcc582992817a2c648f625b677",
+        "tokenSignature": "a-and-be-business-dangerous-don-door-feet-frodo-going-if-it-j-keep-knowing-might-no-off-onto-out-r-road-s-step-swept-t-the-there-to-tolkien-where-you-your"
+      },
+      "lengths": {
+        "text": 163,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-16": {
+      "hashes": {
+        "text": "878318761f391334a8234c548a7e8b07d58c61a8ce9d577d1476d7f5a141c910",
+        "author": "5d80b1236b84d77df8def17ba2cdf1f5cc6698030e758508018fc9a5e0d0015a",
+        "combined": "466c7e30eef0fcd2dba80861554055c60020423e377f1f6fec4d00522074dcd2",
+        "tokenSignature": "a-gary-home-is-it-nature-not-place-snyder-to-visit"
+      },
+      "lengths": {
+        "text": 43,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-17": {
+      "hashes": {
+        "text": "f4aa795c869a45609a6bbadd2f48dcc14833662ef38e83d03237f252a098b752",
+        "author": "e975576533a7494402684dfe70c67d3e28f05651da40e6dc2b67f89f16dbab7e",
+        "combined": "d681c83474200485d1fe437ee6d58fae3caa15f034047b13580294a71acaff23",
+        "tokenSignature": "beautiful-carry-emerson-find-it-must-not-or-over-ralph-the-though-to-travel-us-waldo-we-with-world"
+      },
+      "lengths": {
+        "text": 98,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-18": {
+      "hashes": {
+        "text": "b309d2d0c6b22a15422b1ddbe71c364e136ca1a81d4517a81023e58426ea747d",
+        "author": "c32e664c8565ae26c40eb6601bc9f3fbc051a02ce093babd81646df1c60154a9",
+        "combined": "a32bf1b2b84763fe8903301dfd2d58579f63e18cdee8d388d17ee30fc5b5f926",
+        "tokenSignature": "a-begins-journey-lao-miles-of-single-step-the-thousand-tzu-with"
+      },
+      "lengths": {
+        "text": 58,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-19": {
+      "hashes": {
+        "text": "66ccdfd6b92f19a3d3bc588a65ff5c164fdca6e85652f98dcbb5bf39667e49c1",
+        "author": "8f126c330a93dca300320095d2cf1516dc69f569b4a1adeac3fbde77e6b17350",
+        "combined": "e4102f8a119f9d6f462fac3bad96c4877b66d10205fa9e1ad26d00c620fd8a5e",
+        "tokenSignature": "every-far-he-in-john-more-muir-nature-one-receives-seeks-than-walk-with"
+      },
+      "lengths": {
+        "text": 62,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-20": {
+      "hashes": {
+        "text": "5adb21f94d015578ee852c1bb6c64f25d5b9f0d73f97a710330b1c4adc82a7f0",
+        "author": "8f126c330a93dca300320095d2cf1516dc69f569b4a1adeac3fbde77e6b17350",
+        "combined": "7b057742fe209352436f8dcffa008f2a4d759edefdb614e336297a28bbd2574a",
+        "tokenSignature": "and-are-calling-go-i-john-mountains-muir-must-the"
+      },
+      "lengths": {
+        "text": 40,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-21": {
+      "hashes": {
+        "text": "2afa2ec2cf5e87d111c271fc9fb2d47e0b22f95032acf39532ec994fcb32b7d9",
+        "author": "8f126c330a93dca300320095d2cf1516dc69f569b4a1adeac3fbde77e6b17350",
+        "combined": "fdbdf3a220c1ae1a86e695d8979958d49430b53f449e6ea16aade0733e7961e4",
+        "tokenSignature": "and-as-autumn-blow-cares-climb-drop-energy-flow-flows-freshness-get-good-into-john-leaves-like-mountains-muir-nature-off-own-peace-s-storms-sunshine-the-their-tidings-trees-while-will-winds-you"
+      },
+      "lengths": {
+        "text": 236,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-22": {
+      "hashes": {
+        "text": "64f3bd3def179b79473476dfa2b5e00cbec2cc16bf7c82b774d9142c9a602477",
+        "author": "2ca1523c79750793db46ce6aba7a137ed921bb52d4af22c2745c829f623e02cf",
+        "combined": "e56c9fc73e1eb2ea247678c37bb13da4638c71953f24eef31652a58e8427901b",
+        "tokenSignature": "a-adventure-all-at-daring-either-helen-is-keller-life-nothing-or"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-23": {
+      "hashes": {
+        "text": "68c1ded076bba6cd7ca6a11450f9a1aa8e3aec3a4997df4f59de8e62d304e848",
+        "author": "fdefa8d01ccb1cc1edf646b31324d41601351463ae98e775cac989c6fe3e89de",
+        "combined": "d8719c9ca81049b053b65686a0184ee45d30427fed4e656b5f7ba1d2a61b7513",
+        "tokenSignature": "am-anne-having-i-mary-moon-not-of-on-other-radmacher-same-seen-shine-side-the-world"
+      },
+      "lengths": {
+        "text": 77,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-24": {
+      "hashes": {
+        "text": "e587a2312194df2e73a941352e8cd336f30749dc9b68373a552ef2c8c5e4623b",
+        "author": "863498dfa3f35f634f532b3cab89b0f8b6baaf9a2a94722c52ca2ef44377efc2",
+        "combined": "752728c4162bef59ac3f766f95391c373c50f50262f79b8f506aca3eff5537f3",
+        "tokenSignature": "are-don-educated-have-how-me-mohammed-much-t-tell-travelled-you"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-25": {
+      "hashes": {
+        "text": "9c3e1bef2dff5d61c1811835b888ec1ca95250d6a4401f3be5a9f34570e0d0a3",
+        "author": "bccf7e154da9c0825bddce594eb2e1a313b8d8b1ec37584b64494abb99a3d407",
+        "combined": "9df02ff9edd8929a84af5e25f695f94a0dd22b28e5412a94f400b02755ac4bf0",
+        "tokenSignature": "and-bigotry-fatal-is-mark-mindedness-narrow-prejudice-to-travel-twain"
+      },
+      "lengths": {
+        "text": 61,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-26": {
+      "hashes": {
+        "text": "83ec423be07e5523a9afb46f763e95721193694776cc2ae15c55c0c2f9c82613",
+        "author": "f107a1305ce7222af97263965e76593a16fc27eb8f3e1e8742a76d55fffadf51",
+        "combined": "f9e6056a95313cd2e2fb8496f15e86e857b092739530561e4a0b40469cbd584e",
+        "tokenSignature": "all-freya-greatest-horizon-is-of-stark-surely-the-wonders-world"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-27": {
+      "hashes": {
+        "text": "c169cf87f26d7ccce4d2d60708c5186281cfe7d7d8e48e58c4944e2a1cec11b9",
+        "author": "f51bcd5da074ec8b4afb2985f1cb1cba536b826cbb3a2ee392080a22e4ec32eb",
+        "combined": "ec7996e6fa5fb21cab1c4a5153c7f120ba63fd72ad8e074fb2c255e7c6db218c",
+        "tokenSignature": "always-and-anthony-behind-body-bourdain-breaks-but-change-changes-comfortable-consciousness-even-good-heart-hopefully-hurts-isn-it-journey-leave-leaves-marks-memory-okay-on-pretty-s-should-something-sometimes-t-take-that-the-travel-with-you-your"
+      },
+      "lengths": {
+        "text": 328,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-28": {
+      "hashes": {
+        "text": "4a0f67339d7a2ac76df25616b39a65462f951e3eb9efea4c30dc37f1c6d23b0d",
+        "author": "c32e664c8565ae26c40eb6601bc9f3fbc051a02ce093babd81646df1c60154a9",
+        "combined": "3b9aa6f9df4dd0e38a8a67383fd8eee7d04b101b2b0ad2b5e345ee3eb78a0aa9",
+        "tokenSignature": "a-and-arriving-fixed-good-has-intent-is-lao-no-not-on-plans-traveler-tzu"
+      },
+      "lengths": {
+        "text": 66,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-29": {
+      "hashes": {
+        "text": "1ab8fd3befbd8e54b10e7b6d682b3f06bed7d01b4c33eef9fd34992351e631fa",
+        "author": "9e4afb7a4c065e73a23750df64d53f907d5bb686c85f40f988c23d1dc38985ee",
+        "combined": "24f24498d01c89a1d05bf3c3f0dce84cb4a7273db0dfa7bd46ec2e965cf5f643",
+        "tokenSignature": "are-foreign-is-it-lands-louis-no-only-robert-stevenson-the-there-traveler-who"
+      },
+      "lengths": {
+        "text": 66,
+        "author": 22
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-30": {
+      "hashes": {
+        "text": "5a232d5188f65038f16dc646f276ed56d6c4cfc582435240619b3f32781316c7",
+        "author": "7ed49fd05f369e68ccd924ee9b7f31c0e055a75746743f75aeda21f85bb5a1e4",
+        "combined": "26b7abaf1c0c508016ecfc8763f3d130d24da072976340a869a766d61463ddd6",
+        "tokenSignature": "a-and-augustine-book-do-is-not-one-only-page-read-saint-the-those-travel-who-world"
+      },
+      "lengths": {
+        "text": 68,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-31": {
+      "hashes": {
+        "text": "33b91f9c859b0fafb5dbfc01d9269988ca3428057c5efc784de51ec5a27248c8",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "7298ccd648a70030c5344460b823a56de6fb5d7a567502d886357aa14d4a37a8",
+        "tokenSignature": "adventures-and-anonymous-for-friends-good-great-is-life-meant"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-32": {
+      "hashes": {
+        "text": "073b79921980d8aba29db25bf5f9f645aaf4c9196ead2f4434fc2f3bf2ee5033",
+        "author": "920ed518a4c1be929484c9bbdd5a1af236032974ceccdae2abc218b818234efd",
+        "combined": "9c4f807754df86d881befe22a4ba4e8533526b9ff383818e83993e1f65bcffd9",
+        "tokenSignature": "been-but-everywhere-haven-i-it-list-my-on-s-sontag-susan-t"
+      },
+      "lengths": {
+        "text": 47,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-33": {
+      "hashes": {
+        "text": "b5dd33bd0146ba5cae62e25e38982c64e820a960586dba14b1fbd2fcd1286714",
+        "author": "6f84c7f1f07f72c283c1b2e1722f89b49147b82d83765dec5a8f3bbbe8a91ff7",
+        "combined": "0804d1618beb9a6460f9d3b97d048a040bf7fb832070f6663dd6b460dab1a090",
+        "tokenSignature": "a-and-by-diverged-frost-i-in-less-one-roads-robert-the-took-traveled-two-wood"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-34": {
+      "hashes": {
+        "text": "1cfe1bdb588c9c4dad225e8bb4a8c50c93559b9f2a08b2716428e8a58ec49b14",
+        "author": "f92ee0d2e3185db5930c5f76c85df774aca6ed580fe9619b0724b5798aa137af",
+        "combined": "24228a0881c37f880d42a3e3e84a11810c6941786eb3cacfb1b71d0c37833bd8",
+        "tokenSignature": "a-been-before-dalai-go-have-lama-never-once-somewhere-year-you"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-35": {
+      "hashes": {
+        "text": "3c1864a4671f4eba71195422e681c72877b1ba9a14f427ca88463b56b1b9dbcd",
+        "author": "491acdac32f85af89b7d71117e9a4cb9b9d0dac4725ff5439acc4bd9af868c2f",
+        "combined": "fe2dc9d6806d124d764f4ed65bcb7badcfd01c145bb134ed033afde59e39abdf",
+        "tokenSignature": "a-best-cahill-friends-in-is-journey-measured-miles-rather-than-tim"
+      },
+      "lengths": {
+        "text": 57,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-36": {
+      "hashes": {
+        "text": "8278899e76aeba544518f509d4706ed7fce10eb85d05acf67f1843b78cee84b3",
+        "author": "2dcf837b28278540f568c688518ff30c49cfb3955541f196ece997895a5b022d",
+        "combined": "a530344f11e90cc6ea8ddb64b81933a95e13456ea51fab27c766bdc16e1a0b2e",
+        "tokenSignature": "a-anita-becomes-desai-go-of-part-somehow-wherever-you"
+      },
+      "lengths": {
+        "text": 46,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-37": {
+      "hashes": {
+        "text": "7256df257cb1ca80f54f874bb69b9ec28063f283a5c557feffed9e0b6033aaeb",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "cb339c6a73d5a54c8a15c4964c67d8217564ee16eaaf2a1d8c6b90906de6f2c1",
+        "tokenSignature": "anonymous-don-go-listen-say-see-t-they-to-what"
+      },
+      "lengths": {
+        "text": 38,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-38": {
+      "hashes": {
+        "text": "653ed6356cf740458a52c6c5f2533715b3c54d702fadb600c84b0c176fa702c1",
+        "author": "4a14ef61e1a959fecc9414c129a719873307fcbe0d5d9175926b9ad360443b75",
+        "combined": "33cb5a66c271007dbf3e16eab8648e1431056e13d8526122a9045b790a2a5efc",
+        "tokenSignature": "chief-footprints-leave-memories-only-seattle-take"
+      },
+      "lengths": {
+        "text": 42,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-39": {
+      "hashes": {
+        "text": "d4160dfb07bc90d08096972a9ab88c56225c8cd129be869e32464b8ae2a83299",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "e4a0efcb88fca9e181388eef8b6f8818667ebce4f828061897b2492d7b2e613c",
+        "tokenSignature": "anonymous-collect-moment-not-things"
+      },
+      "lengths": {
+        "text": 27,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-40": {
+      "hashes": {
+        "text": "4064382df90d301b5f67e6e224dd91f30ed645c009f2904ca735db4fcca9a5d7",
+        "author": "e46b0ed980ac956a31702b5059e34f2e2987a471c43499cb8e1f5b3d9c89372a",
+        "combined": "cabf065ab4f0c3ed0cf623598942a05206b7e6b58cf1e6d036f017321034cbf0",
+        "tokenSignature": "adventures-are-blessed-curious-drachman-for-have-lovelle-shall-the-they"
+      },
+      "lengths": {
+        "text": 55,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-41": {
+      "hashes": {
+        "text": "26ed8cccb827207caa8e4ac4cb2ca7a426959ed30e7e213e8c3df6433a82f575",
+        "author": "158dc1f191177ec26d9904b6b4b704138ad58fcfead64b7b9324b806b454898a",
+        "combined": "018616e22087278ce12c4d33e1a5867f2ced0d1e9e6f1a919577c9a2d4c4436c",
+        "tokenSignature": "belloc-but-distraction-for-fulfilment-hilaire-travel-wander-we"
+      },
+      "lengths": {
+        "text": 56,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-42": {
+      "hashes": {
+        "text": "0175f08b4e899d8aaaeb4d6d11e04ec289d04ec395cc65cfe506455aeb54fd63",
+        "author": "9e4afb7a4c065e73a23750df64d53f907d5bb686c85f40f988c23d1dc38985ee",
+        "combined": "1fbb961620b00d6f8e01083bdc137585f55958881ad2da37207c6955462dee6f",
+        "tokenSignature": "affair-anywhere-but-for-go-great-i-is-louis-move-my-not-part-robert-s-sake-stevenson-the-to-travel"
+      },
+      "lengths": {
+        "text": 109,
+        "author": 22
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-43": {
+      "hashes": {
+        "text": "1850180c0281f4ee9177373e12cdfdb51eaa2864fda7b66747d271c206573698",
+        "author": "5f62bd9451de90c0a99589d543245cccf13fb124d57ded075c6f4fc5492559e0",
+        "combined": "c28b2372753ab017d41b1d03cc83f87162d1023da451739a72f779f5dfb082e5",
+        "tokenSignature": "and-been-cities-i-in-love-m-melody-met-never-people-to-truong-ve-with"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-44": {
+      "hashes": {
+        "text": "503ce17d6c58fe87600d83223205d82ead66811feafa2bf1ce546300be229978",
+        "author": "022e4626b2e871085490580d6c93eb21de2baf043a57dc8351accad49887bd16",
+        "combined": "2c324512b2a21784c4f5eaaf0031b36090d1b3fcfebf8cff245eb2c0362cc35b",
+        "tokenSignature": "a-coelho-it-new-one-paulo-place-strange-t-this-was-wasn"
+      },
+      "lengths": {
+        "text": 46,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-45": {
+      "hashes": {
+        "text": "75f9a1d93adcb36a99b02c38461284fdc1992c5898033c207534b8f8b1d38233",
+        "author": "ca7a7b4d4f3ae1eb0546d369c447b1dbddd980eb42fa452a8fbde9a9d44d0284",
+        "combined": "d7655c27953b0319a415df77018372ae77885bd7538b99d198ec77e7a059cb92",
+        "tokenSignature": "d-feet-have-if-in-instead-meant-of-one-place-rachel-roots-stay-to-we-were-wolchin"
+      },
+      "lengths": {
+        "text": 70,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-46": {
+      "hashes": {
+        "text": "f3860d68d884b297c4f185dd55ff7ad034845b77208f58333b6d965149cdd20a",
+        "author": "3cb24a71fb5c0ac052353e15f5865d9af12f81c58d5814e2ba2396f8df33b22a",
+        "combined": "9f731899e9d125f44c7fbec1a553fd2b4f0b48f44d64dc1d7b0617330bd7971d",
+        "tokenSignature": "and-antidote-be-bites-bug-end-happily-i-infected-is-know-known-life-michael-my-no-of-once-palin-shall-that-the-there-travel-until"
+      },
+      "lengths": {
+        "text": 123,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-47": {
+      "hashes": {
+        "text": "6765665b4437db31ce519547e42e49a50a5a505826b85798f32ac4655df7c06e",
+        "author": "4a92aca56922af6a70f92dd94804b9d441bcead38bd1863d7aebea43d56f784c",
+        "combined": "91dd4128bdab4d1eee06f9d9e72480c6e0bb291bdc1e8fd72e3100283af52cdf",
+        "tokenSignature": "and-architecture-be-bradbury-for-lost-ray-romance-to-travel-we"
+      },
+      "lengths": {
+        "text": 76,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-48": {
+      "hashes": {
+        "text": "2b1d2d14352b13ca6abde13470a210d85068079f220bc94f1d7c5e135e9c3111",
+        "author": "bccf7e154da9c0825bddce594eb2e1a313b8d8b1ec37584b64494abb99a3d407",
+        "combined": "3057ba9637355375a2fd6a07ff9baf8ce5ac5c8c49b2d4cc87f554526be4ce0a",
+        "tokenSignature": "be-by-did-didn-disappointed-do-from-mark-more-now-ones-t-than-the-things-twain-twenty-will-years-you"
+      },
+      "lengths": {
+        "text": 105,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-49": {
+      "hashes": {
+        "text": "2d32256d93a4f238634094526b5f8fff050187607f27b3572e069f083259370c",
+        "author": "662829d8160005f531f8200c6af4ed863cea46416e23c47e959a544cb83d584d",
+        "combined": "552752e6cf8428d0a709fa5571aa95519c855e4220a68412952aff85b9c11133",
+        "tokenSignature": "don-john-people-steinbeck-t-take-trips"
+      },
+      "lengths": {
+        "text": 43,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "travel-50": {
+      "hashes": {
+        "text": "ae854dcab44233563cbb84134740951212600d59b3ed88f7db9911a715af3c8f",
+        "author": "022e4626b2e871085490580d6c93eb21de2baf043a57dc8351accad49887bd16",
+        "combined": "d474dc508645008b484b4e68c865b9f4384116bf93899f236f63edb63462c8b0",
+        "tokenSignature": "a-but-coelho-courage-is-matter-money-never-of-paulo-travel"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "travel",
+        "sequence": 50
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-01": {
+      "hashes": {
+        "text": "b9132bd529646b173eea553a6021a26401b4b49d7b5943135d95d06869c39595",
+        "author": "3ef34cae2b9ec3764d5d7848f236c166623056d980b10eec3bc896ede8ec9b95",
+        "combined": "081597740b0e83393e0b434be3a82b1501649a0f9836394dd65a956ff8101592",
+        "tokenSignature": "and-ask-dreams-em-following-going-hedberg-hook-i-just-later-m-man-mitch-my-of-re-sick-they-to-up-where-with"
+      },
+      "lengths": {
+        "text": 106,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-02": {
+      "hashes": {
+        "text": "6c48b76dd70f5a8c5cb846793e01e940bb76f6940f11dae582ff4e97584ac1d4",
+        "author": "4d0109bd314519ab6f5932d8dd6b88656887b81afc2fd47b75becd4f0e51fcbf",
+        "combined": "0118862cecba3fcc4721ddb4b80ce883f556eafb39a09811074cff1f761990ac",
+        "tokenSignature": "a-don-had-has-is-listen-many-marquis-optimists-person-pessimist-to-too-who"
+      },
+      "lengths": {
+        "text": 68,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-03": {
+      "hashes": {
+        "text": "3ffa8b070ece36b3b18ffaa2ce6c24b600e27fc3ad3aab676348bee01bf095a1",
+        "author": "79845ecf0ccd655660165addce6ed466a1aa5ea6d5070787b11b054f8f919d98",
+        "combined": "2d0b668bfdacd9db1c81dbd599fc15828a6c1c1c0111a1a7032582ac071e8ee1",
+        "tokenSignature": "and-be-bullock-established-fired-high-how-it-road-sandra-should-the-whoever"
+      },
+      "lengths": {
+        "text": 76,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-04": {
+      "hashes": {
+        "text": "bf63f9112e59f2296de84a8df127c6ef1540fafdd4ecc0297cc0c760bbf8298d",
+        "author": "3d6aed0cd4e4452c5b1fbdba3c3f2d7104acb61aaa396ac3f49a1b64e9e81899",
+        "combined": "bf34fa508ef9bfc07c81b44fa7a2c4f93077788bccdcb492903bd630f7aee6a8",
+        "tokenSignature": "a-all-and-calm-carry-hocus-jantha-keep-new-pocus-sequel-the-w-wand"
+      },
+      "lengths": {
+        "text": 27,
+        "author": 47
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-05": {
+      "hashes": {
+        "text": "1d4e209d484f33514a9e45b84fa63fa8f9e767bc99b6a30a4cb5bdb011b411e8",
+        "author": "e30b2e06a7f2ec34b21c0a49a9d12695b29530ea79f827d8c05b320793bc582d",
+        "combined": "e99bd631caca409f1570e1404180117785c7caa2f8a2347b7717aa8032641372",
+        "tokenSignature": "a-an-and-anybody-anyone-carlin-driving-ever-faster-george-going-have-idiot-is-maniac-noticed-slower-than-that-you"
+      },
+      "lengths": {
+        "text": 117,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-06": {
+      "hashes": {
+        "text": "b3c9b5d92458bd44f41d01a4d0bc42210384bb07a6aeed518a80b39e7f749048",
+        "author": "2f9faf893085d6ba96baf30bb825e386792b8b42000adde43cacf6b4634720c2",
+        "combined": "1713bb27fdb85e07a7495b5b2f01720114deab3b5fa14b5cb7c3b03dbb07f02d",
+        "tokenSignature": "ace-back-detective-five-i-if-in-just-longer-m-minutes-not-pet-ventura-wait"
+      },
+      "lengths": {
+        "text": 50,
+        "author": 40
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-07": {
+      "hashes": {
+        "text": "bc60320c732c6595f24b33bd33c21b39693f7c423fe129493411293a967335c6",
+        "author": "9e79fd8069df478fc00d680a7f162bf51a8bc0e33e22af33c4a0766322c4a18d",
+        "combined": "be420b6b660bb3fb6ca63104dfec7bac526d035421b6c33794d13880a50e22f5",
+        "tokenSignature": "chocolate-factory-hope-i-is-it-last-ll-suspense-terrible-the-willy-wonka"
+      },
+      "lengths": {
+        "text": 44,
+        "author": 49
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-08": {
+      "hashes": {
+        "text": "0dee6ba4c8eb960028a1d7489909fae19da2374f7dfdf7859397988f1c2289ea",
+        "author": "7695d2f2e1c6043580cbe7b080e011f0c45ba993d685a16141000f94686d7eaa",
+        "combined": "ef7500b6039a76ee1c67cc574eec2a3ed5383291f5585294ed1dbc5259bd12bc",
+        "tokenSignature": "call-do-hour-it-moves-nothing-robin-rush-they-when-why-williams"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-09": {
+      "hashes": {
+        "text": "06039ecf97f5a78d245599814dc4731e3878d278f153b5ec6659027910ca3f04",
+        "author": "460db125f0acc823851220e0f5b896f9d39a851ffdb3a2774610e005db0c30ea",
+        "combined": "671c93a4ed34555351a3b3ed3d5f68bd0cc49c65e4dcc82a254919d830333b63",
+        "tokenSignature": "are-be-don-golda-great-humble-meir-not-so-t-that-you"
+      },
+      "lengths": {
+        "text": 44,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-10": {
+      "hashes": {
+        "text": "5f027b8ed4e36039fd439fd5bcb9acb814e5318807c528724ee618b9fae8bee2",
+        "author": "510896fff1da9839c34b22d22ea969db2ef3bdd855bc2edec82a1c4548c4c780",
+        "combined": "d81c6313b340c03fb870ac5df6d9a111ce59c1ef7a91a7342a96b2d23be81f6c",
+        "tokenSignature": "at-be-can-if-judith-kind-least-martin-t-vague-you"
+      },
+      "lengths": {
+        "text": 40,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-11": {
+      "hashes": {
+        "text": "1e3733af4e8cced0c546b99f2db02509fb49e7738adbb130ab900b6777738b63",
+        "author": "757ae1744360e4628cea0b9259e87119de0d66db72ce42dd7bf8628eab42aae0",
+        "combined": "47c05f1a484c5a0133ccfa9fa9733197292a120f6876edfeb06f5186fc6f8d16",
+        "tokenSignature": "about-and-being-dorian-gray-in-is-not-of-one-only-oscar-picture-talked-than-that-the-there-thing-wilde-world-worse"
+      },
+      "lengths": {
+        "text": 103,
+        "author": 40
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-12": {
+      "hashes": {
+        "text": "89dc65d5405cfce0c4b731596db7ff6cf7897fdde6e646a809703961c192345e",
+        "author": "bd8d218beeec48b9f2062a9bc477342ad0945fbe02d89b2faf2a3a45e209ad3b",
+        "combined": "fe1901035c62117dc5aef358cd9eaff5a26f0ec2e168b24ff4f9d05e7af18759",
+        "tokenSignature": "always-annoys-enemies-forgive-much-nothing-oscar-so-them-wilde-your"
+      },
+      "lengths": {
+        "text": 57,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-13": {
+      "hashes": {
+        "text": "cf7694c897eb59f3091cc8c5d2c40da614cd738990da2e9183e9a0fc8880049d",
+        "author": "41f97ec7fe066edf4186e88bb9d24003cc17287b693f2c84e9d188f96d258e14",
+        "combined": "163500bbcfc4f846ff4ede09457de86cc00832517023eb9dda10390712cc0e8c",
+        "tokenSignature": "algebra-as-assure-fran-i-in-is-lebowitz-life-no-real-such-there-thing-you"
+      },
+      "lengths": {
+        "text": 62,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-14": {
+      "hashes": {
+        "text": "55006d48a732499b847b39748b6ec6cbbf6b120fb65eda502177c2f2dd99b04e",
+        "author": "655a3d8c1cdfd25784a31b83ce139ab41844265e8bca357afff74db2fb25277c",
+        "combined": "2674566ff8cf16065a94b08bbcb6ba7d528bebb4922b4a290f92812a0eccd7b4",
+        "tokenSignature": "carrie-fisher-gratification-instant-long-takes-too"
+      },
+      "lengths": {
+        "text": 37,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-15": {
+      "hashes": {
+        "text": "c4e80a53240ab80f119fec87de5af1e1d2ae449811966939c0aa7ad446f52f8d",
+        "author": "b55e5f697532b136b4d59fe3a2e1f02febf226ee4b0d7faf025fa62164995d7a",
+        "combined": "917c13aef3748c8c9d933730477ab66352d89cdec7d6fd56880ad7531dc83fb5",
+        "tokenSignature": "a-accept-are-degeneres-ellen-killer-re-serial-unless-who-you"
+      },
+      "lengths": {
+        "text": 50,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-16": {
+      "hashes": {
+        "text": "607e09a62280fbc50196642de39c28a43641af377a9c03045c9017caf97910ae",
+        "author": "882644486734f56b9cf4ac501521b37db32a54719c10a5d23d2dfc18e2121bce",
+        "combined": "147ac09a1666ba4d08726736e7b1dc73cd2c013a835afc6d93b108e73aaa32bc",
+        "tokenSignature": "bo-buy-can-derek-didn-go-happiness-know-money-said-shopping-simply-t-that-to-where-whoever"
+      },
+      "lengths": {
+        "text": 85,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-17": {
+      "hashes": {
+        "text": "a8b715f080eef59ac2b75f3833f5345e3a033cb4e87a73a13461072fc82c93dc",
+        "author": "0dffd2756970db50128a5546141c730c7eb2f3a29046cb3024e1a6dcae42959c",
+        "combined": "56be81e3d178467180afcbaf6db7970901f77935caa7591c985c7c57d6a1ce4c",
+        "tokenSignature": "and-be-because-behave-cannot-gaiman-if-is-just-like-more-needs-neil-pretend-so-someone-the-then-they-to-who-wisdom-wise-world-would-you"
+      },
+      "lengths": {
+        "text": 148,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-18": {
+      "hashes": {
+        "text": "8e910abb22b3bc5bf9c981dcacb5b096acd02f5894a36793b8734c1a9a8a2e84",
+        "author": "bcbf38c6990302c12bfce513403c4aeddbcf636a6477856693c827a139c0c9be",
+        "combined": "c5d45e417bb9a81a4409fb922178b488c050cdcb30d9f539b5c0be79b17782b9",
+        "tokenSignature": "a-advice-at-bing-can-chandler-comment-friends-good-i-in-interest-m-not-sarcastic-the-you"
+      },
+      "lengths": {
+        "text": 70,
+        "author": 23
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-19": {
+      "hashes": {
+        "text": "b9132bd529646b173eea553a6021a26401b4b49d7b5943135d95d06869c39595",
+        "author": "3ef34cae2b9ec3764d5d7848f236c166623056d980b10eec3bc896ede8ec9b95",
+        "combined": "081597740b0e83393e0b434be3a82b1501649a0f9836394dd65a956ff8101592",
+        "tokenSignature": "and-ask-dreams-em-following-going-hedberg-hook-i-just-later-m-man-mitch-my-of-re-sick-they-to-up-where-with"
+      },
+      "lengths": {
+        "text": 106,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-20": {
+      "hashes": {
+        "text": "04722234626169e7181367f763e6d9bf3f2009aa69a04eb9e1e08173a5749fc5",
+        "author": "a26077a76c017eb678f0ef700da2c8d194dcb33204772d131e8af99c767ab74e",
+        "combined": "3eec6211ab444f67393c0fc45099752e6811d46f75b26fef09843797415eea67",
+        "tokenSignature": "and-but-connors-d-day-going-groundhog-here-i-love-m-not-phil-stand-talk-to-with-you"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 28
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-21": {
+      "hashes": {
+        "text": "adffc192be9f77aa4d9e3f87b5a562d57c9dc1f4ee1313bd80a734478bf398af",
+        "author": "405f79b89675e8bd16e714f730ea0c49d537094e99638bc5d6ddb02013329903",
+        "combined": "8bc2b7a63c5ea6144b586962fa32f3de58604e0f53a74306542c3e4001cd08d5",
+        "tokenSignature": "a-all-and-but-charles-chocolate-doesn-hurt-is-little-love-m-need-now-schulz-t-then-you"
+      },
+      "lengths": {
+        "text": 71,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-22": {
+      "hashes": {
+        "text": "ecf0aa15639a7082cd937dff01604061be0f09b0e49c8e133eddc4a3822aede9",
+        "author": "a8fab20f904286d43883326a48636b768236b68dd7d8d2eed32f40cf5e7e6f71",
+        "combined": "b22ccefe910134f0cb21393b15225d2937f0fa1f39773dc4a0e051e4ad497589",
+        "tokenSignature": "a-always-but-can-enough-figured-happiness-have-i-if-is-joan-key-made-money-not-people-rivers-say-that-the-to-you"
+      },
+      "lengths": {
+        "text": 122,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-23": {
+      "hashes": {
+        "text": "d4792f84b10128a876508154e4acc2b8f0ef63b22be4d0835e57e5c7356767b1",
+        "author": "cb58d4d75d62b57727accd1b2fb7dfddfa0e9442a368e61509a55338a29e09ca",
+        "combined": "60662933d5d8135fa1eab3db2de7b244b4e25154f8e1d928b549f9c749fe1dbd",
+        "tokenSignature": "also-and-because-blonde-by-dolly-dumb-i-jokes-know-m-not-offended-parton-that"
+      },
+      "lengths": {
+        "text": 97,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-24": {
+      "hashes": {
+        "text": "7802c10f2139a65c1b23bd17313d67aa04d70148ec9e30ac477f54024738102a",
+        "author": "50c412fe64cfde71147ca5e320a80eec38c7753352602e22c96ec5c7579045ca",
+        "combined": "c971c24067321ade3dbb2ad08d10e49a6beea00cf7ecbbc551d326700c066392",
+        "tokenSignature": "a-anything-drunk-for-he-hold-in-is-it-love-maclaine-madly-office-or-person-running-s-says-shirley-to-try-useless-while"
+      },
+      "lengths": {
+        "text": 113,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-25": {
+      "hashes": {
+        "text": "6571b49bbe04ea1419a659e8dce3bb23c0d1aefc6267dd08a1a047f29671f573",
+        "author": "853104bc722822e76ed2586d65d4f45904e4118bc9462030c293561e6f64810a",
+        "combined": "97f7e838a344dd0b30c92dff691e34a820966a3d968d09dc22c41ec14294040d",
+        "tokenSignature": "all-course-don-dory-finding-i-it-like-of-really-remember-t-that-was-well-yesterday"
+      },
+      "lengths": {
+        "text": 96,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-26": {
+      "hashes": {
+        "text": "c26988974b67016d359fbfea1f65c4629c62e3e64cc1c11b27dcb0b260da9f53",
+        "author": "61c71899748c922c20a9eafe0ae48bee0e8413de6c88db3a6996630b912b582c",
+        "combined": "fefee9f8574bc7ff75188f3fdc9a9d72677a391ca90491b0936f3b3993ad6321",
+        "tokenSignature": "along-an-and-coming-course-diggers-having-in-insist-is-it-mind-of-on-open-people-pratchett-put-terry-that-the-things-to-trouble-trying-will-with"
+      },
+      "lengths": {
+        "text": 123,
+        "author": 25
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-27": {
+      "hashes": {
+        "text": "762442492594d50e2c139e332dabc917bb078b861d9bb04f638b8f8f469cb70a",
+        "author": "ae8876daa9a95c37483361b6491bc79892f3928256466c6cbeb97ecdc8ef3ca1",
+        "combined": "16d2cfa6e99ccf3208a9f5db621169f53c60a901f0bcbf4ec753bb434ff5ea0d",
+        "tokenSignature": "a-an-be-call-called-could-dresses-fish-higher-i-insult-iqs-known-outwit-people-sheep-stupid-that-to-ve-wanda-with-worn-would-you"
+      },
+      "lengths": {
+        "text": 130,
+        "author": 27
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-28": {
+      "hashes": {
+        "text": "6dfdee7d269f7b3b56d4c7d8d95237ae07d9cb8be2cf75c908e594be6b8f059b",
+        "author": "c9767504c93409cec7918196c8b14a6a4b34aa9de264d108ab86db576044e853",
+        "combined": "37b5093d05eeff3136752f7a6c3b0048ae0dc01a1546e8b93ab23371e0edfb4d",
+        "tokenSignature": "a-annoyance-are-asimov-do-everything-great-isaac-know-of-people-they-think-those-to-us-who"
+      },
+      "lengths": {
+        "text": 88,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-29": {
+      "hashes": {
+        "text": "01cfb44c53e2eef693e95460df8078b5fb4e04ea66fec898be0e9fce9ce830bc",
+        "author": "e30b2e06a7f2ec34b21c0a49a9d12695b29530ea79f827d8c05b320793bc582d",
+        "combined": "9ebc55959451e6c7b4649467ff4d7f7370aa0f36db774e51f33a28ddb1f1e055",
+        "tokenSignature": "accept-answers-because-carlin-george-i-is-m-myself-one-only-reason-talk-the-to-whose"
+      },
+      "lengths": {
+        "text": 79,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-30": {
+      "hashes": {
+        "text": "7410fe26ce1a9401a71beee708af0106f81cd07f5274cf9c610019ff75988e7c",
+        "author": "705bb987529d396a5ae0e4da73cd271505eb2834dd1870524d346fd001e9360c",
+        "combined": "ff35e0d076b72c6961c7443485ad36c40a22e625216419606c125b92db0b37a4",
+        "tokenSignature": "a-am-but-i-little-m-michael-not-office-scott-stitious-superstitious-the"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 26
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-31": {
+      "hashes": {
+        "text": "649d4a43249815911c49935ee10e7adefabbd8b88f83cb217b027315d2c7db5d",
+        "author": "59555c28f6facbb02dd89ff60745310cbd1ce29c8e20b45e5357efe049724d1e",
+        "combined": "d265c351d761a207dbcfb8082326c511cc3b6c55a84f309a381df6ed3789519a",
+        "tokenSignature": "a-about-come-headline-here-how-jay-leno-like-lottery-never-psychic-s-see-something-think-to-wins-you"
+      },
+      "lengths": {
+        "text": 95,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-32": {
+      "hashes": {
+        "text": "6b0038e3aa192d4e69e1587de00055efc8e68370f4ec0007c442705c30470660",
+        "author": "298d5b1c5395ad0a21c984cb0d714bcada27cc70673b97572b4fcbb82e856704",
+        "combined": "aa4ad2cb58fd3ca7a14e07febf99771c395135ab434a130dd4210f97565e914e",
+        "tokenSignature": "condescending-dad-dead-down-he-i-is-jack-just-looking-m-my-not-on-s-sure-us-very-wherever-whitehall"
+      },
+      "lengths": {
+        "text": 93,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-33": {
+      "hashes": {
+        "text": "82d3f76a8051a04b64f13efcfdbc533fa66a2e609539dc942c65233d60b72754",
+        "author": "5d2215137026d940fec05882f5b951a085ff7e77841ceb6d676b20f1a635ede6",
+        "combined": "a8ed6b440c8b23abbb47994e90933f76528418c523518c5cf194a353b4357505",
+        "tokenSignature": "a-are-before-computer-ferrell-first-internet-make-marry-person-really-see-should-slow-them-they-to-use-who-will-with-you"
+      },
+      "lengths": {
+        "text": 115,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-34": {
+      "hashes": {
+        "text": "f8f0ede326035cfa69e5cf9cc7af98c491f2adcfb83e979366774fcdcfd79b97",
+        "author": "958ef19721821a059fd2547bd249d2648e1b4d8495293359a95f8754393c52e3",
+        "combined": "7761eb4b143dd4f5c41f63a63f188669fd440bbb1908031a33647b5065b547b1",
+        "tokenSignature": "10-a-are-asking-but-constantly-d-damien-fahey-have-his-i-kid-life-like-m-my-not-of-ready-shoes-someone-spend-sure-to-where-years"
+      },
+      "lengths": {
+        "text": 126,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-35": {
+      "hashes": {
+        "text": "54fb7257111f74e544f4f8851c775ff1d835766284aadb39a94d401e9b77d51b",
+        "author": "2828d678bc732d42fc1aeb44916e169916d9f27cb8fa1861b28ce2f1a8cc576c",
+        "combined": "d78d5331585303f9fa6ecc4add81f601355fd5199213da3c81deb1b535ddbc15",
+        "tokenSignature": "afford-all-children-couldn-diller-have-i-in-move-my-phyllis-t-the-them-then-things-to-want-with"
+      },
+      "lengths": {
+        "text": 94,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-36": {
+      "hashes": {
+        "text": "91bfbc3b1afe58b80c9425114f38f237f8de8a683e4d5228f63e9d0fc908e2fc",
+        "author": "cbbaa79287ace0448f1a21c92034fd7a35bd4fdfbcd9cb227c5e73db819bca17",
+        "combined": "3fc7ff4aafeaeedd473c5233b741e4dce452e0c8218e01a0b77b87f3fe78ec6a",
+        "tokenSignature": "a-and-at-crimes-fell-first-halley-have-husband-i-in-look-love-maybe-misdemeanors-my-reed-second-should-sight-taken"
+      },
+      "lengths": {
+        "text": 86,
+        "author": 37
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-37": {
+      "hashes": {
+        "text": "38fe7930f320abb7f6d5be58c2d165d8cca6f2c189cdfe9bd89170c12702f4bd",
+        "author": "2ba4b884b8684b1606bdf32baace83ef0e6a817a2409fc9c8bef854cf375631c",
+        "combined": "f0b8f5ed1272068e5995200819438c3b4f79dfd31d41ad6cb73e6c3afc1e3d47",
+        "tokenSignature": "a-and-become-bombeck-climb-erma-finished-i-kids-my-nice-out-playpen-re-safe-they-unruly-use-when-wild"
+      },
+      "lengths": {
+        "text": 100,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-38": {
+      "hashes": {
+        "text": "0429de95524fbdd4d10fda0c15dc8eabc670c67ffc8b1c705bb08ad173a6e642",
+        "author": "9f65d9bec51701ea89259484f38eb3e66206d20ea49f5ec6e2a7629ec255b874",
+        "combined": "9450d76a8b74030fe6312cf3682e7052d31a8779ba80d3bf2aaadd481140596b",
+        "tokenSignature": "a-always-but-dangerfield-found-i-kid-lot-moved-my-parents-rodney-them-was-when"
+      },
+      "lengths": {
+        "text": 65,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-39": {
+      "hashes": {
+        "text": "6e3ab9fb5056e000efcbc12059efb876d8b8f379543f7272716c6e34169b0835",
+        "author": "6ff59241ab435b3a84cee6ee4130079ce36069f3a215b2a4efc27e4073fd1355",
+        "combined": "ecb0dbb05cccc768e5fbaafc9e70bd6b02edc72c86d3c05356765e6c39a7c709",
+        "tokenSignature": "as-don-from-grandmother-growing-i-learned-mess-prince-t-up-william-with-you-your"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-40": {
+      "hashes": {
+        "text": "f374e4f95a0a7544ad33d2a28f0ccee8b6e897b0845fc322295401b67d9d2194",
+        "author": "a711650ba46e9b0a6c1c963ba0a01a482b5303501f9ee42b7eadd094a278af5f",
+        "combined": "31d10199dc679774e2c014a043e8685436ab8cb857af9adf8c34f13e0404714a",
+        "tokenSignature": "bang-big-cooper-had-i-insane-m-me-mother-my-not-sheldon-tested-the-theory"
+      },
+      "lengths": {
+        "text": 40,
+        "author": 36
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-41": {
+      "hashes": {
+        "text": "2c1e16be137ba9e2d090a74d7e9784430487c421ffe7e06acb2cf8269893a26a",
+        "author": "db35a5b37b8e381aac97ce99eff52a673efa4873af6ddf7881b368645e52de03",
+        "combined": "457bec8b291b2e3a3598d009f461c3967f32fe6c80c49ed7814fc064c37302a3",
+        "tokenSignature": "annoy-being-find-for-great-i-it-life-love-married-of-one-person-rest-rita-rudner-s-so-special-that-the-to-want-you-your"
+      },
+      "lengths": {
+        "text": 112,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-42": {
+      "hashes": {
+        "text": "b4d191a3b77b72e4955af666446eaf78c8c40643c653f3af2655fc67c17d196e",
+        "author": "bc183d6045511dc584e00418ea0f7f89a79b909e5272a7370479000f899998d9",
+        "combined": "93f41e3307cb1ddbaa59d80b1483b58880da34a70961f30ec99015925129cae2",
+        "tokenSignature": "a-am-buy-child-future-good-hoverboard-i-in-investing-is-lin-manuel-means-mine-miranda-parenting-s-saving-someday-to-which-why-your"
+      },
+      "lengths": {
+        "text": 120,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-43": {
+      "hashes": {
+        "text": "a5f03fa442082a8438d79b6be9d4ff1ca8256a758943b9e4880fcac5ccfabb9f",
+        "author": "c703068ab4139d43515ce2a43ee5fcf5f8ebf944e47c8fcaa8588d41f5ec97f8",
+        "combined": "3783ff22344dae02533fde2a4b1c57e5062898b39c9917d0eaea3c78369f6af9",
+        "tokenSignature": "children-everybody-except-have-how-j-knows-o-p-people-raise-rourke-the-them-to-who"
+      },
+      "lengths": {
+        "text": 71,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-44": {
+      "hashes": {
+        "text": "10ae85debfae947b578744314d8215958e7b4a16f541c3287746216d66c77edf",
+        "author": "bf0d3028c3fe0f0ce5ccf0ba4fd9bd9d0f5f9d0b6389d3a9fa696a7b8642d547",
+        "combined": "5d612650e80a9e4230d5a106e77ab6cf8c80bd121443888aa26996d38502eb84",
+        "tokenSignature": "a-are-children-dog-ephron-happy-have-house-important-in-is-it-nora-s-see-so-someone-teenagers-that-the-to-when-you-your"
+      },
+      "lengths": {
+        "text": 112,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-45": {
+      "hashes": {
+        "text": "3b2fe11ecb1125282f31f2166cf4bcf7a788135e9c01faf422772707c2529b99",
+        "author": "62a9f4528a43282ef2178287d6709b3e5b9afd6a1cc9b7a4792842d18431418c",
+        "combined": "2924d8dd28f4ec369990fedd3f32b7e6cf87249e135c7ee13bbdfc94e4132ac0",
+        "tokenSignature": "but-can-charlotte-gray-kid-not-sister-the-world-you-your"
+      },
+      "lengths": {
+        "text": 43,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-46": {
+      "hashes": {
+        "text": "d3067ef4c3efeb39645c9b92af60b3821368843439e42c2fe2dbc9f297f8bc8e",
+        "author": "9eabf4ec8ac20de6a56511cd7095af5f03f59d436be6ce82ea566b48936c275b",
+        "combined": "d10f413a69b556330fe6d748b221039f14318be4aa91f249b721184d1d46fe01",
+        "tokenSignature": "avoid-can-generally-i-it-mae-resist-t-temptation-unless-west"
+      },
+      "lengths": {
+        "text": 54,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-47": {
+      "hashes": {
+        "text": "86ba137c12e59e4fd9bfd07ae035a002d49941153f8e2a8a6c99c12c03ea1c6e",
+        "author": "f004fda394ac012de8eec32d3bb565b05dbbf31b1f2c61049913d33fa89aa1b3",
+        "combined": "8a579abfbc7db58068aad6e4d62c93713ae9513a55b03af7ea85ff0fa333ef73",
+        "tokenSignature": "as-family-for-fun-is-jerry-no-seinfeld-such-the-there-thing-whole"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-48": {
+      "hashes": {
+        "text": "41a3d5e9b7ace0d1c401277528e51f73d08494764e440873b135cfa9629dd938",
+        "author": "4344defc3050196fa2d69dec191c167e3943fde8715eb4c91faec8fdb8f1702d",
+        "combined": "237b86871a042f17dece30d84fea839fa411e27028810c4672501a6ad9eb6f80",
+        "tokenSignature": "as-bernard-cannot-dance-family-george-get-if-immaturity-it-make-may-of-rid-shaw-skeleton-the-well-you"
+      },
+      "lengths": {
+        "text": 76,
+        "author": 32
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-49": {
+      "hashes": {
+        "text": "faed6491bb9a0a2d73070fc425ef52a743a94f06ce18491b5920b981255edbac",
+        "author": "0be17f2fa1f0dddee42f94eaf9c07fd434d1f97bab30d7eae4782e9ffffa1249",
+        "combined": "10e19a75659d7535432ab29022bfaf052ebc18b7240a8128d3a952e6a1401420",
+        "tokenSignature": "a-blind-but-eye-is-love-marriage-opener-pauline-real-thomason"
+      },
+      "lengths": {
+        "text": 48,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "humor-50": {
+      "hashes": {
+        "text": "017f9bc7829caf932c794515a375b72679e43f193b21153e81bd3fe7a883ff01",
+        "author": "9cfbe59c55b48e85628cd9f4412fea9411824e0a83ef8984d747cd4554c6b34f",
+        "combined": "308a126ca91fd83c35c4c93a05072c139ca396405e04a0f838a5c6ae37ff3054",
+        "tokenSignature": "a-another-burns-caring-city-close-family-george-happiness-having-in-is-knit-large-loving"
+      },
+      "lengths": {
+        "text": 79,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "humor",
+        "sequence": 50
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-01": {
+      "hashes": {
+        "text": "684cf8df22b5181c47405c06b06815c376135c90dcc320612d6e493c5c51d53f",
+        "author": "97356e76ba48ad44d4dfc41eb6c4abd49da35f050ace6aeae8537caa75d4ae3a",
+        "combined": "9c627d44fde61a800f574286f76e0318805910774e97515613b5a544c25bbc26",
+        "tokenSignature": "financial-gone-intelligence-is-kiyosaki-money-robert-soon-without"
+      },
+      "lengths": {
+        "text": 56,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-02": {
+      "hashes": {
+        "text": "20b1b566ba718a15819cdbf622f7736b0d74164ddb9820783e0efa40054c54f6",
+        "author": "2b3ed889bf04bb6a0d86d68e0140c8c17827df4a20a8cc6f5fc92fe28830c83c",
+        "combined": "3f5c865b205b9d7f46791b21073c7575b6e1b140df52b3e5322621349c2d3611",
+        "tokenSignature": "earl-harvest-is-money-nightingale-of-our-production-the"
+      },
+      "lengths": {
+        "text": 39,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-03": {
+      "hashes": {
+        "text": "d50d4854bab3862f3bd4a6170a9ecbd80b0eab7d702db20d15a4218378079ff1",
+        "author": "55ba41c27badca7ce1cd8075250543877fb91be63d233257d9dd0906d90554fb",
+        "combined": "e26a06d2c250065775ffeb07b3ab0179e7939a9053fa91b2d3a888c6dec95cee",
+        "tokenSignature": "attract-become-bring-but-do-dyer-it-make-money-not-people-s-success-successful-that-they-to-wayne-what-who"
+      },
+      "lengths": {
+        "text": 162,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-04": {
+      "hashes": {
+        "text": "16ecd87d71597acbaef4b400607eb9f85be449030fe2b70db113d0fa89d9e7e9",
+        "author": "5a4947dbbbb0bc87520c21945caf3a90e8f342a73815766d9d1868243331667a",
+        "combined": "afc95bcce5f1d9279cb934635d12128ac5ebc812d3f73a8cc59fa0a32be00720",
+        "tokenSignature": "buy-don-earned-impress-like-many-money-people-rogers-spend-t-they-things-to-too-want-will"
+      },
+      "lengths": {
+        "text": 105,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-05": {
+      "hashes": {
+        "text": "93c36b8ff317b62e3e9b45f641d56786898764e17befcf7e2a2a816dbdb942fa",
+        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
+        "combined": "de9b840a82c148275efb6ef700349712a78a2ec04cf26333b893483e7a909ce4",
+        "tokenSignature": "and-anonymous-money-save-will-you"
+      },
+      "lengths": {
+        "text": 36,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-06": {
+      "hashes": {
+        "text": "4f7d183eadeeb93332860f3f568a064d0762b48b951ea316b725c08850fa0ada",
+        "author": "4149b9a19ffcb2dc77852ff349ae56abded601d3b3b05a614fdbf23e2d83e187",
+        "combined": "65ffa264eb756926288cf36656afce030eaa17f555dba1bc8c062baaaf4a0d6b",
+        "tokenSignature": "before-earned-have-it-jefferson-money-never-spend-thomas-you-your"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-07": {
+      "hashes": {
+        "text": "5e36bcd5facf871167667247970e5c7e5081878ff57369df7dac49002e0f1248",
+        "author": "6be9b8ceef4545464addb44a78edc28c054ba0502bf341ba425b49c800aa2ff9",
+        "combined": "182949d40255ac1a5f549623657c7d79b0847946588fecc7aaed3353282acd90",
+        "tokenSignature": "a-buffett-day-die-don-find-if-make-money-sleep-t-the-to-until-warren-way-while-will-work-you"
+      },
+      "lengths": {
+        "text": 91,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-08": {
+      "hashes": {
+        "text": "b4f0950ffae95fe8e37203225e29f20810ceb3b8a4c97868a4d2954505a4c171",
+        "author": "d446d9d85660881a05d8c4f44e76e644e84a7ee292cc3d7754e50db0849d9acb",
+        "combined": "a94e0b479a74c383cde88aba7adc2d23e68fdcdca47d483834ea2ab260ee45f5",
+        "tokenSignature": "everything-having-is-isn-it-kanye-money-not-t-west"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-09": {
+      "hashes": {
+        "text": "36554136df4e0b3613a3adbdae58be9fdd710942dabf4131c9d8c0d20e84ee94",
+        "author": "7e69773bd45e7d8dc7a042f8ac9f66567e823fa8ad5692dab350886cf5a87730",
+        "combined": "06b2e899d7e62e359827a7a1db3d0d91fa8c4ce5bbfafa43cdaa7d439ce1c274",
+        "tokenSignature": "a-benjamin-earned-franlkin-is-penny-saved"
+      },
+      "lengths": {
+        "text": 31,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-10": {
+      "hashes": {
+        "text": "feb93c411a7f7a3c8d0437958881d90d43c0b7e8ba80655310890bd0de002d14",
+        "author": "a87a59aff37600e2a7a9dea8aeb5d1c1a0f0722803904dfe5565f2bcfbb9245f",
+        "combined": "8c7da760fc667157f09f6f1a8211d9c88145952a500f10b24390aae6181271a5",
+        "tokenSignature": "and-good-hands-idowu-in-is-it-koyenikan-money-multiply-realizes-stay-that-those-to-wants-when"
+      },
+      "lengths": {
+        "text": 91,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-11": {
+      "hashes": {
+        "text": "a562f9f3277636803e2d82a7ae60c420b2a38bd6a05d8daa50e36681914fcd8c",
+        "author": "1c9a3e027d18dc174f611cff159bb29993ebbea21c92c4dce2ec004fe86800e3",
+        "combined": "e0ab6ef28c3dfc6a2d612b57db7264997717265b64e83b43230c2ebefcd18623",
+        "tokenSignature": "a-beautiful-bradley-is-it-makes-mess-money-properly-something-tool-used-vinson-wrong"
+      },
+      "lengths": {
+        "text": 89,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-12": {
+      "hashes": {
+        "text": "63749aade545da070db35f85753e14811988176343917454574820a6fbaeb495",
+        "author": "ef288cfef63913578e8586deca6397709aadfe4f39567fe6a5a4ede15d2e4ef0",
+        "combined": "8df92c22051add8ecb959ac8fb0cb764a491da29b47546cdec9cc6c0b4553e08",
+        "tokenSignature": "be-but-can-it-money-old-t-tennessee-williams-without-you-young"
+      },
+      "lengths": {
+        "text": 64,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-13": {
+      "hashes": {
+        "text": "004b11ceb1563425ad3cd6a1461d66e55e7a56dfe909b92577b9f9e75c1c7479",
+        "author": "5260f175051ab70b5528a42161e58f112ac97a201148302c570dca1d805bf4db",
+        "combined": "0d5b049619e23f4a3fe23a31dd54f9a14fffdb415af5d78273c59550b094a607",
+        "tokenSignature": "a-bacon-bad-but-francis-great-is-master-money-servant"
+      },
+      "lengths": {
+        "text": 42,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-14": {
+      "hashes": {
+        "text": "78a33c9d9ec7f19642f9d1387d1b2e6d78a8daecaceabd35677c8392e7e6358b",
+        "author": "863905527029c2685d2079a1fc2f7529aad7fc338f566a3986a83970674bd83c",
+        "combined": "76991b44e46209b085c558b934bca732c04cec9aedfb32af7e04dd5d1477bf14",
+        "tokenSignature": "be-does-for-he-hill-is-man-more-napoleon-paid-soon-than-the-who-will"
+      },
+      "lengths": {
+        "text": 82,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-15": {
+      "hashes": {
+        "text": "d195e912173a86c0bc3ff7589d464ae09e82f4e3ed4fae6c202b08543fd3bc8f",
+        "author": "fbbfd02a13de9a7bc4ed03188992a4607fe9a815eb1d2bc4112711409ab80a9f",
+        "combined": "a9441bfc9e5cd3bc221d270b3bf1b4b81a7a3c2a5a6dd772dd8746394a7c6739",
+        "tokenSignature": "a-albert-be-camus-can-happy-is-it-kind-makes-money-of-people-snobbery-spiritual-that-they-think-without"
+      },
+      "lengths": {
+        "text": 91,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-16": {
+      "hashes": {
+        "text": "dbd42f61100cc827e41a1e718be781435ba93f581cc1671b348afa925b439460",
+        "author": "0e5dc62c75bfad6864a7d7cd054fcc7cc64df4285236e16fce5054534af47e89",
+        "combined": "e5026334c514db0b717b1be73ed41af32a62fd91fd0f3c2f8b4b7a3cbf6d39e6",
+        "tokenSignature": "cardone-grant-hustling-in-is-money-no-of-shortage-start-there-this-world"
+      },
+      "lengths": {
+        "text": 60,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-17": {
+      "hashes": {
+        "text": "7e9baf4d896a5b783bb3c9b1d79f8ef8bc46c0bf4b6401f655e02a827fc802a4",
+        "author": "14aa211e49d00f207b0591f83fdd61d1ee6100cfc3d1126e85e3df936c36cea0",
+        "combined": "afe2b6da98b2c3c16508e14869d5ec681b5f45c4330b765a9662b265f7a75c2d",
+        "tokenSignature": "but-davenport-everything-isn-it-money-oxygen-ranks-right-rita-t-there-up-with"
+      },
+      "lengths": {
+        "text": 63,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-18": {
+      "hashes": {
+        "text": "83e591634847db7a600a83baeb9124782b77278d8c44b547b68cb5dcbb3af78f",
+        "author": "036dc0881371d8c1cbe44042b4c333baece123bd17a17e88dcd378092f9ffbfa",
+        "combined": "74ec1a0c1199edb466da6a20ed42254cdb9081a3a97ac1241bb1c7f98065846b",
+        "tokenSignature": "ayn-damns-dishonorably-earned-has-it-man-money-obtained-rand-respects-the-who"
+      },
+      "lengths": {
+        "text": 92,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-19": {
+      "hashes": {
+        "text": "403215d25d57d4ea2f9372551c5761bb1466dbc0b04f990309e316de96309369",
+        "author": "bccf7e154da9c0825bddce594eb2e1a313b8d8b1ec37584b64494abb99a3d407",
+        "combined": "2ecc6bad9e183278a9b311e31ae7297a3009e4d327b94fd6b618306272b1e9c4",
+        "tokenSignature": "and-been-dance-don-hurt-is-like-love-mark-money-need-never-no-one-t-the-twain-ve-watching-work-you"
+      },
+      "lengths": {
+        "text": 104,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-20": {
+      "hashes": {
+        "text": "aa20163a57db0910ae4b72fcf20697b71211f5ff4b64d5562c8575860f793993",
+        "author": "6be9b8ceef4545464addb44a78edc28c054ba0502bf341ba425b49c800aa2ff9",
+        "combined": "0419b7892efb0075f560bd9b0e2c8014647eca4673e20aa1fa1691ea7c49dc70",
+        "tokenSignature": "buffett-first-forget-is-lose-money-not-rule-second-the-to-warren"
+      },
+      "lengths": {
+        "text": 85,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-21": {
+      "hashes": {
+        "text": "ee6d9976396a759d56f0c9ae26e91653d5ae338dffbb6a114bcae604185a58e1",
+        "author": "7792d42b6d92b67460e6b9c64eb7bf93ce2016b5be2bc562b3c6bb6a31bccfbb",
+        "combined": "3334c28aa11a06b916494aa218c43ef4fa45279da37e5f5e1ab9e5274fd339c2",
+        "tokenSignature": "amorus-bank-better-feet-in-looks-money-on-sophia-than-the-your"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-22": {
+      "hashes": {
+        "text": "d88429026282957d163c147bef8b9767c104102f541b395aea1ff99f7b19f308",
+        "author": "87bcf73a0d41b2aebf2810f9c0ac178e807d3a63ceca6b41833485a8257255ae",
+        "combined": "3b1061c17466e5c0b06ad0ea700916563f56f60789b37201bdd19ba363867cd1",
+        "tokenSignature": "but-erich-fromm-gives-has-he-is-much-not-rich-who"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-23": {
+      "hashes": {
+        "text": "e134b137b8a5a7f128236424e5175ae4d984a48e06acbaee8086ee638d3fc9ba",
+        "author": "228f7ac3990c25a3ebc924644400b3ce9ac938abd389e8f9436d0cc30a5a698c",
+        "combined": "202d51d46a2f91f693fdc4538c5a09b09ec2e949514cebc2a4ba3ff87d981165",
+        "tokenSignature": "are-cheapest-david-henry-is-man-pleasures-richest-that-thoreau-whose"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-24": {
+      "hashes": {
+        "text": "9e0f4747c16c3d7edb000e2a09c2126bc8c20f45614fa21f7355c0b6c4b15ed5",
+        "author": "0adf647bf1dd96ad7cb5852bfc05046b856bcefe8ddf08f749d5070af36ce1b7",
+        "combined": "673a464ba350be6b1c51475e5a05d5d89ae378e235be8abac137cbd3ae787826",
+        "tokenSignature": "enslaves-freedom-gives-have-jacques-jean-money-pursue-rousseau-the-you"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 21
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-25": {
+      "hashes": {
+        "text": "6202493fff17d8cafed5f0c112fa3733d1491f2f0fb38c9da3cee087ab65160a",
+        "author": "228f7ac3990c25a3ebc924644400b3ce9ac938abd389e8f9436d0cc30a5a698c",
+        "combined": "5202a9ad1b085fc0a93caaa2ffa27e0d9265e4b42ece7c0b20bc1b213f0760d6",
+        "tokenSignature": "ability-david-experience-fully-henry-is-life-the-thoreau-to-wealth"
+      },
+      "lengths": {
+        "text": 47,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-26": {
+      "hashes": {
+        "text": "46249c1828337c873de368817d34b0696c01b3bb56bae3a44d13216998a91fff",
+        "author": "6be9b8ceef4545464addb44a78edc28c054ba0502bf341ba425b49c800aa2ff9",
+        "combined": "25351145c99f25f825e9964051be8e9abc946b64c7e75629f63f26f2b548fd9f",
+        "tokenSignature": "are-be-become-buffett-close-doors-fearful-greedy-how-i-others-rich-tell-the-to-warren-when-will-you"
+      },
+      "lengths": {
+        "text": 122,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-27": {
+      "hashes": {
+        "text": "bbd08097f9a37767785a80e9742c3ec4497b5023e5a1004063210d53b3cb242c",
+        "author": "bcc9a49175aabb77ab4cdc10801e528779493e4dd0dd4725525900ea1385ec7d",
+        "combined": "e8caa8be715cdd5fa4dbd2c7e7efb898551ec0442547a180a9f5919bf053d783",
+        "tokenSignature": "invested-is-key-making-money-orman-stay-suze-the-to"
+      },
+      "lengths": {
+        "text": 44,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-28": {
+      "hashes": {
+        "text": "97a93a0e4c5e34081c5ee403c7bf007bbee8fa4ad067ff5fd03d50cf4083a584",
+        "author": "6be9b8ceef4545464addb44a78edc28c054ba0502bf341ba425b49c800aa2ff9",
+        "combined": "ecec43a86b9266c98768da904fab897a8b3fc83a1a7b99e56bd69d242b90c82b",
+        "tokenSignature": "buffett-cannot-control-emotions-if-money-warren-you-your"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-29": {
+      "hashes": {
+        "text": "094e853c9825f55e7044eb65d34a3264c77dbb543bc88c4aaaf28220fdcaaddc",
+        "author": "92ed5705f47b9243863698d9cd6573aeec74b9e15f85550bcac561be5c2c16f6",
+        "combined": "fc1204746abd5034b01792abd2430b30dfcada1ae4245f0bd65cb573f1ba26e8",
+        "tokenSignature": "barnum-by-experience-for-good-is-it-know-money-nothing-of-p-t-the-unless-value-you"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-30": {
+      "hashes": {
+        "text": "d7dd99f54b081f7c110c35e2073b7713b3a6d58fcf899039e9c35560562ffb24",
+        "author": "c1d36deaee271e258f498770771ed1848ad7b001a27d73fc6b15e5bf41f7f832",
+        "combined": "7274845a1f03945e700dafe713daa2b48bbb434b8f78f1feb78c304efd808768",
+        "tokenSignature": "allen-and-be-can-companions-james-never-prosperity-sloth"
+      },
+      "lengths": {
+        "text": 45,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-31": {
+      "hashes": {
+        "text": "c9dc5cbeab445239bf0daee26d02c78680c5703e15c8e1be78baa433558e5b28",
+        "author": "4f3b963cf180b7a663b2bccb961287f6d45ba030d20a1e14d928584128eecf2f",
+        "combined": "36ee6203f14e0be577fafa2f311933fb2ab5775199bb13ef718f7be2cc010b2c",
+        "tokenSignature": "a-and-benjamin-borrow-borrowing-for-franklin-go-goes-he-if-know-money-of-some-sorrowing-that-the-to-try-value-would-you"
+      },
+      "lengths": {
+        "text": 112,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-32": {
+      "hashes": {
+        "text": "33cac09ba06e3dbf1e933384df3d52362ac59023048e60550e63b6a4ae68eee2",
+        "author": "863905527029c2685d2079a1fc2f7529aad7fc338f566a3986a83970674bd83c",
+        "combined": "7a55c396e28cb499f210011863449d624cac8ff3b765bc748696fb1d7a79781f",
+        "tokenSignature": "and-be-from-hill-how-i-in-me-money-napoleon-now-spare-spend-tell-ten-time-use-what-where-will-years-you-your"
+      },
+      "lengths": {
+        "text": 136,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-33": {
+      "hashes": {
+        "text": "91f09b717c89ba6b09e1ba96a186bb8439ce1085b1d7dd1d7226df9c4430f21b",
+        "author": "7bed2df25e2cc0caa7e4a6371dca1b3086c61f0a2e5c757ce554512056693a63",
+        "combined": "367e755f9af34d0c6a31b6f70bce68c7563c6a1603a33ba10189c0c203214968",
+        "tokenSignature": "appreciative-attitudes-be-becoming-by-can-catherine-enslaved-instead-it-its-make-master-money-of-ponder-positive-rather-servant-should-slave-than-through-toward-you-your"
+      },
+      "lengths": {
+        "text": 173,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-34": {
+      "hashes": {
+        "text": "64b8979187f4c3ae22ebfd7d38fb9f2e0d0dfa0934fe59f061db810a4e83d8eb",
+        "author": "faf98ba4087c2d433f8d16975ec0ccb5fc972a17684f33567752931853ab87db",
+        "combined": "981503ea40fb946585aac6c31496b8683ae32f2dc53f14310f03d70eed6fddde",
+        "tokenSignature": "eker-for-hard-harv-have-money-people-poor-rich-t-their-them-work"
+      },
+      "lengths": {
+        "text": 87,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-35": {
+      "hashes": {
+        "text": "62ac44283dd0abce3bd4ce475c296afc58fbbbb5c7400bec1754084560f92724",
+        "author": "0e5dc62c75bfad6864a7d7cd054fcc7cc64df4285236e16fce5054534af47e89",
+        "combined": "6e630f1ea791fa023b34b385f75d2c7c33539ccff8633bc0f330a32c0a96446e",
+        "tokenSignature": "a-big-biggest-cardone-encourage-enough-financial-for-go-grant-i-is-made-million-mistake-money-more-no-not-of-on-only-people-planet-shortage-single-than-the-there-thinking-this-to-ve-was-you"
+      },
+      "lengths": {
+        "text": 215,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-36": {
+      "hashes": {
+        "text": "747ae8b14480b85dd080107272d148274f1d0e14bd04c2f1dff98c8562541278",
+        "author": "43cf894058901f3f3794d6784735a5cdc6cbbe7fe57f7140c39cda21c2748f4b",
+        "combined": "36b4c768628d68c7a459a2e1dc7b08705d4151a32fce318a7567200bd0aedd7c",
+        "tokenSignature": "achievement-creative-d-effort-franklin-happiness-in-is-it-joy-lies-mere-money-not-of-possession-roosevelt-the-thrill"
+      },
+      "lengths": {
+        "text": 118,
+        "author": 21
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-37": {
+      "hashes": {
+        "text": "715a6b77545466283ced3ed0750ff77107aaf3a29b5d32f005d146d9bc7f55d1",
+        "author": "4d95cbe6855881cea187c0304b3712c3ec416513e241faf0f4fb1aeb2e0c8ab0",
+        "combined": "d025ea90fef56d1bb3d40d108fe97fd01c2992293e7050aa100234d8618a769b",
+        "tokenSignature": "a-achieve-an-and-are-bach-conflicts-david-end-fulfilled-goal-going-handle-happy-help-if-in-is-it-itself-lives-living-merely-money-not-our-particular-personal-some-the-to-tool-up-us-values-way-we-wind-with"
+      },
+      "lengths": {
+        "text": 220,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-38": {
+      "hashes": {
+        "text": "b8bb24046f5011aa78d2523956725407efda9351830e56aa81de5e4479f7b210",
+        "author": "0e5dc62c75bfad6864a7d7cd054fcc7cc64df4285236e16fce5054534af47e89",
+        "combined": "a5eeec316d4c7b7a0b907093499e44d01382e8b56697a644930583fdbdb37342",
+        "tokenSignature": "an-and-because-cardone-don-grant-have-invest-money-t-time-you"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-39": {
+      "hashes": {
+        "text": "53c9aceac9702d370b4ae54b0d8ccc7541df782d6eb198db64eef80e6d3c72ae",
+        "author": "97356e76ba48ad44d4dfc41eb6c4abd49da35f050ace6aeae8537caa75d4ae3a",
+        "combined": "07917639f963bd606a67822e83bf85b6d3478a59c04fa2b83a26fb66b80eb61b",
+        "tokenSignature": "fail-how-in-it-keep-kiyosaki-life-make-money-most-much-not-people-realize-robert-s-that-to-you"
+      },
+      "lengths": {
+        "text": 105,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-40": {
+      "hashes": {
+        "text": "fe41810988c63dec668a28a8a195d113387390b64734412d69eed27f83b4e124",
+        "author": "aa2cd025c15f9053ab3e04ecb1112204b7ffec156cac3905741e4024e0292ce7",
+        "combined": "ca02ac6614de100d3bdf9866587c5b76a4a268e7c9a911f2310e441a6fccbe53",
+        "tokenSignature": "all-at-barnum-difficult-for-good-have-health-in-is-it-land-make-money-more-not-p-people-persons-states-t-than-the-to-united-we-where"
+      },
+      "lengths": {
+        "text": 127,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-41": {
+      "hashes": {
+        "text": "80e4ec3516511ae34367118df22abc3f8d6ee4399081883630351c2d03778bfe",
+        "author": "97356e76ba48ad44d4dfc41eb6c4abd49da35f050ace6aeae8537caa75d4ae3a",
+        "combined": "060d591e4ef7c21d7d553c86b9021980deb80ae0096cfc41b1ddc9ae90e0336e",
+        "tokenSignature": "and-invest-is-kiyosaki-left-money-of-philosophy-poor-rich-robert-spend-the-their-this-what"
+      },
+      "lengths": {
+        "text": 152,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-42": {
+      "hashes": {
+        "text": "4e991b7108607a062cd799f1574b6e54c6f76acfecc3db5af76327f62d4deab3",
+        "author": "59d1b1b99ffa9411f4a012e8e2fd8a2878f3a742b118a69eeb6c7b7554ac490d",
+        "combined": "8eb09034840bd492cd42f756c5e0ec7ca8a03fee5c5d2312b7878f4cb0b9d98f",
+        "tokenSignature": "acquisitions-clason-for-george-govern-is-it-laws-money-plentiful-s-simple-the-those-understand-which-who"
+      },
+      "lengths": {
+        "text": 91,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-43": {
+      "hashes": {
+        "text": "faa00513d7379d164ae4089660693af37579e60a4bc225c57dc47b4d6f583980",
+        "author": "385324e8284410c6041461df260ab6c20330d4bbc078d0c2ef445a4e84a59399",
+        "combined": "b0c5943539d3425045cad55646fb5958ecb3af6a1872e035000f666360299eb5",
+        "tokenSignature": "buy-can-certainly-choose-form-groucho-happiness-it-lets-marx-misery-money-of-own-t-while-you-your"
+      },
+      "lengths": {
+        "text": 86,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-44": {
+      "hashes": {
+        "text": "4952a071bcaab598e31471469905acc1211f28276fb274961b8962ede55d1c53",
+        "author": "cf68a0c539b51e3a46e472cd147079dafb0b99b4591ebe28ef5abe1b98befbc4",
+        "combined": "c31be3380e3664944cee23f9ccf3f1d2e72f90bb1f903e44ebb247e4262ef4cb",
+        "tokenSignature": "any-don-ford-harrison-have-if-important-is-money-only-really-t-you"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-45": {
+      "hashes": {
+        "text": "a04fe7d01c51b941a812a2ac829d446b9dfb1de2c2399a8eb0a3fc9d95b77360",
+        "author": "f942e56d6a49a989829fc322fbd143dc35d218e3222b65b27ca0c47d192bd6fd",
+        "combined": "57ca4317c6998d09edac9c5c9d42546ed0a7b1a519ba4258c70fc36024fd0609",
+        "tokenSignature": "a-but-fortunes-from-insignificant-is-it-marden-may-one-orison-penny-seed-seem-small-spring-swett-the-thing-to-very-which-you"
+      },
+      "lengths": {
+        "text": 106,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-46": {
+      "hashes": {
+        "text": "dac07ae58454727a66f0b08f8163e4299d2b989b06c9473ef6324c4ef8e21bc0",
+        "author": "c9a944185dae233811155abe1cf5928d1c287b00e81b02f9a8c62dcf68ceb594",
+        "combined": "7c9a09fbfa42413957e8cc17611608c91aeafec4f22eab39cff5ae6e38ee24f0",
+        "tokenSignature": "about-better-byrne-feel-magnetize-money-more-rhonda-the-to-you-yourself"
+      },
+      "lengths": {
+        "text": 74,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-47": {
+      "hashes": {
+        "text": "9bab979d109f09817ebea0d598e97c6b3bd0b83e35a53a4f16f0fe0981b0fad3",
+        "author": "65787a2008e494d8b17d3e8830e762c8e776bece1ea373c54a4b297df6863253",
+        "combined": "1a96a4c96610fe6df130acfb73a1a2298b0c30c38e539f8777d38d34f6d4e07f",
+        "tokenSignature": "and-andrew-carnegie-double-fastest-fold-half-in-is-money-pocket-put-the-them-to-way-your"
+      },
+      "lengths": {
+        "text": 89,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-48": {
+      "hashes": {
+        "text": "fafbefc547dad63fe37254d7c9151bb1968ae4d4ae31441e3f6c65458bb74b79",
+        "author": "e234866d973d7c753d9c2b51c6f5d503397fa04d7b1fdffc59664c17729da3b5",
+        "combined": "f31c254067768c41f6d0511615e155228952d4121d714e3846a359f42626d065",
+        "tokenSignature": "attracted-is-jim-money-no-pursued-rohn-usually"
+      },
+      "lengths": {
+        "text": 39,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "money-49": {
+      "hashes": {
+        "text": "58b730f3772256a10901f68248e69f0918869bc6347de032346702ceeed6d6ea",
+        "author": "c2733cd98532f41f9c664c1512df16973959346b22a51e123bd79fd6ec22cf6f",
+        "combined": "fee707bd4006d53891799023de7dffa6b3a0485cb875b87d6bb41f3e41c77050",
+        "tokenSignature": "a-bus-but-buy-cry-d-fran-happiness-i-in-jaguar-may-money-not-oise-on-rather-sagan-than"
+      },
+      "lengths": {
+        "text": 74,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "money",
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-01": {
+      "hashes": {
+        "text": "c41f04fa8b9b1c6beba03a13dab71efa2f138a274c2fc4875282305d5b6e8f12",
+        "author": "86f8a32822e91f4336557a3b2cbef0ee1536613b222b9f04d2674b14f2197f76",
+        "combined": "4a2f9d037a598c19fb43e3e8404a64dc070c3104661fcedfa43972df5d08faa3",
+        "tokenSignature": "big-buffett-didn-house-how-in-it-love-matter-mattered-our-peter-t-that-there-was"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-02": {
+      "hashes": {
+        "text": "74e3f146e9a6170f400d44569de10d3cde03d15344b97c24cf8384497c9b8c14",
+        "author": "0e9780f97da77bb6d495f662932a72a40327e21d2206e9e9bed8bc086971db31",
+        "combined": "2c414fe2fd15ecab8b1c63c04dd04b18c57c12e016a82d337d70c917d09f9331",
+        "tokenSignature": "a-are-call-clan-family-howard-it-jane-need-network-one-tribe-whatever-whoever-you"
+      },
+      "lengths": {
+        "text": 122,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-03": {
+      "hashes": {
+        "text": "d87e74e0f3bc12b62f3611589696b8426d1cd0d42305a5fe2084eae27bf76c8c",
+        "author": "95e7f7195a53c4c1d37df4176861982aad6eae7fa2b33c6e67ed81a5548fcfae",
+        "combined": "4fccb102a1d7c6853fceaa3a3a9f31adbcddd5ba4905c4b8a011684352e55d4e",
+        "tokenSignature": "behind-david-family-forgotten-gets-left-means-nobody-ogden-or-stiers"
+      },
+      "lengths": {
+        "text": 50,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-04": {
+      "hashes": {
+        "text": "9dac97e70c135d5adb68030b4cb52e4a7231d5aa7b6c1e96b426e2d898410626",
+        "author": "4f682b71153ffa91e608445d7ea1257e2076d0d95eab6336cd1aa94b49680f11",
+        "combined": "8450224f4540ded15930ee8fed90cfaa86095ea2a39d64f1c1b00a55f9756a03",
+        "tokenSignature": "but-coco-differences-family-have-important-may-more-nothing-our-s-than-we"
+      },
+      "lengths": {
+        "text": 70,
+        "author": 4
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-05": {
+      "hashes": {
+        "text": "32b5213ef7bdb223fe9ac1f90827d930229987706bca7e6704b180aef2e4d690",
+        "author": "0f3ee73ea916ff97f63bd21e50b61221c62fb41b75c2fd80e4eb470b01315780",
+        "combined": "d11bccad0e99ce0211842cc833212f62cd931e4efa28b33b5436ed8358f04ab1",
+        "tokenSignature": "and-bach-blood-bond-but-each-family-in-is-joy-life-links-not-of-one-other-respect-richard-s-that-the-true-your"
+      },
+      "lengths": {
+        "text": 102,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-06": {
+      "hashes": {
+        "text": "9cfe7a64f18f1390ffb68e15b425769361dfa84acf8ac7451e66a7e4c3019912",
+        "author": "741b26b14784b3c2f61684f75acb73bb074f78ddd1ef1f76d7b007a195b8418a",
+        "combined": "cbf7e9182b22ae6607e8735c2d2c4b64aca225170d119a0bee065cb62f18a1f0",
+        "tokenSignature": "a-an-bernard-but-earlier-family-george-happy-heaven-is-shaw"
+      },
+      "lengths": {
+        "text": 40,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-07": {
+      "hashes": {
+        "text": "1a8c9b9b6531d52d8c1891d69eb9e737b01f9853c12ca78ebce4c105f8a01f13",
+        "author": "559ebbb6130b04bad91f8d59c7c3324f3afedc48a0bb5797a64e1c25dd316bb5",
+        "combined": "eb08173c94a141de9e26eddf83403c69d7a3bcdcc76b3cf4f9596813a716e6fb",
+        "tokenSignature": "a-and-are-be-being-family-for-it-life-lisa-love-loved-means-of-part-rest-something-the-very-weed-will-wonderful-you-your"
+      },
+      "lengths": {
+        "text": 127,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-08": {
+      "hashes": {
+        "text": "017f9bc7829caf932c794515a375b72679e43f193b21153e81bd3fe7a883ff01",
+        "author": "9cfbe59c55b48e85628cd9f4412fea9411824e0a83ef8984d747cd4554c6b34f",
+        "combined": "308a126ca91fd83c35c4c93a05072c139ca396405e04a0f838a5c6ae37ff3054",
+        "tokenSignature": "a-another-burns-caring-city-close-family-george-happiness-having-in-is-knit-large-loving"
+      },
+      "lengths": {
+        "text": 79,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-09": {
+      "hashes": {
+        "text": "d2d18842539f0e7f29d191b7eccbb1f7186682d9bb661510120d18e8eb5a566b",
+        "author": "71c5c3b7f459f2af90ac9e124f3621044ba8f550939678e08f3b1ec4b6fceb80",
+        "combined": "e91cfed4d25c99dc8b2e3059174b9c697932fe37cf3c8d2a33eda621be3d5d55",
+        "tokenSignature": "a-an-army-each-family-in-its-lies-like-loyalty-mario-of-other-puzo-strength-the-to"
+      },
+      "lengths": {
+        "text": 90,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-10": {
+      "hashes": {
+        "text": "f33fad752077478b7ce917056cdbe50a36028e1f49e9e9474410b2da52cc1ebe",
+        "author": "fa60d36b3071d5898d78c49804681a680398c4e2e9c23e2f254517d744fcbc86",
+        "combined": "ad5ea80eb77412bacc387d1799b6796b04b8d1b1342533718cd28242b97488bf",
+        "tokenSignature": "and-family-important-in-is-john-love-most-the-thing-wooden-world"
+      },
+      "lengths": {
+        "text": 57,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-11": {
+      "hashes": {
+        "text": "e0b59add4ce8a8c917cf5d79632a96ac574e65f8e82a17d41277cbe5bec57979",
+        "author": "7288a2ec2754cd00ef8c8e2476d4efc51b690c895f69e7c499d9f56ac2aa7011",
+        "combined": "ac19af844654a09ffa99754f3c1d21f8b3171619509e8d0d13acffe74b369af3",
+        "tokenSignature": "are-butcher-by-everything-family-flinching-goes-hell-jim-people-stand-the-they-to-when-who-without-you-your"
+      },
+      "lengths": {
+        "text": 97,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-12": {
+      "hashes": {
+        "text": "1add70a2c87b07982134c779d637c95e5d33276e4a5e970d9003add183b18b2e",
+        "author": "3c28b2d0b12fe6415f03b3f8f8a5cba43d8ad7da472c368bd4773064f106976c",
+        "combined": "d35ade7eca574708eaab397fcc690243704479ac2af280a48042f19812a227f2",
+        "tokenSignature": "and-arms-around-barbara-being-bush-each-family-means-other-putting-there-to-us-your"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-13": {
+      "hashes": {
+        "text": "86d444628a97bbe6e6f1af7b31e1ce8dae9b1b0ac11cc80942d9c37ce7039c61",
+        "author": "6a0968f84b8833e9c3b24c580ac98823d5c33e0431de2bdae6bc90c57115d19b",
+        "combined": "492739985893613bfd0b94794c27720b71d9487fe7421caf6533164dedb2fe62",
+        "tokenSignature": "and-binds-brings-cement-closer-eases-family-friction-friedrich-harmony-in-is-life-love-music-nietzsche-oil-that-the-together"
+      },
+      "lengths": {
+        "text": 126,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-14": {
+      "hashes": {
+        "text": "847f0daefbea8b69a4315e277eb15c8e234afd3f9bc69b91f066fe1d75d164a6",
+        "author": "e30b2e06a7f2ec34b21c0a49a9d12695b29530ea79f827d8c05b320793bc582d",
+        "combined": "f6e0a44dc543b18829f8bc0cfdeb303c65501a1a35f8a5a3560c52ca4ed27054",
+        "tokenSignature": "a-an-argument-at-ate-carlin-every-family-george-going-had-i-nice-night-other-real-restaurant-table-the"
+      },
+      "lengths": {
+        "text": 90,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-15": {
+      "hashes": {
+        "text": "aafc7bfcb483f72c8daac2080bbf24caae03d8c9018b2e6420452a82e29e8336",
+        "author": "0da4ed4008d6a1dba373dd02dc4bad7317ca1e0851f617caedc37505e450a206",
+        "combined": "a57f2ce74db44bf478e490d798c500abe3f817361741d65f03acb2e8d71d87a4",
+        "tokenSignature": "an-everything-family-fox-important-is-it-j-michael-not-s-thing"
+      },
+      "lengths": {
+        "text": 50,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-16": {
+      "hashes": {
+        "text": "0f3b855308f8c84f3ff37a5c1522d48792cf5c2440130b1dfdfc3b63d85433a8",
+        "author": "0714d94aefd10f51aa82ad80157b89c93eada4403546dfce82e2ee52a68a070f",
+        "combined": "5963cfeef5c522c71ea1ecfea0ce5a40160f8e110fe79fc2c909d047c52eb2eb",
+        "tokenSignature": "and-are-at-belong-buckley-faces-family-future-gail-looking-lumet-magic-mirrors-past-people-present-see-the-to-us-we-who"
+      },
+      "lengths": {
+        "text": 105,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-17": {
+      "hashes": {
+        "text": "a5d6551afb244698b738be045ba3a929487a7ed71cde0807013c1d7aa38160bf",
+        "author": "319b73d0c066f03be6f12b7e3187b8b0bdff4ae071ac3138b025586bb63e4ef7",
+        "combined": "c9f192aed6472d26d213eaf2b1775c21672a9cbf07be22f270e405b9f278fe40",
+        "tokenSignature": "family-george-is-masterpieces-nature-of-one-s-santayana-the"
+      },
+      "lengths": {
+        "text": 43,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-18": {
+      "hashes": {
+        "text": "c620fede4c92ff40f2935e8d33bd8fddbf191dc9dbcd869adff5e3cf33edc125",
+        "author": "8649c31cf2f31509e43249b774e571296a75a81009036fae7a799c3c5d080eef",
+        "combined": "43a80ba22a2d78ab500e2653850128fe3f185597b67e01ca49b28e84e8faf2db",
+        "tokenSignature": "and-are-brad-comfort-compass-falter-families-great-guides-heights-henry-inspiration-occasionally-our-reach-that-the-they-to-us-we-when"
+      },
+      "lengths": {
+        "text": 134,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-19": {
+      "hashes": {
+        "text": "5c3abb5ba1c284d5fc0be370255dd34404d33576e278f0172a2a654274805818",
+        "author": "5ffdf57998abf9ab0199ee446a99851c4fe0b8c17899eb28065491bad4f09f1b",
+        "combined": "9197c397af15a636088beb7ffbdeef7a41cddb3898f374501c0e048a9997a3ca",
+        "tokenSignature": "are-arrows-as-bows-children-forth-from-gibran-khalil-living-sent-the-which-you-your"
+      },
+      "lengths": {
+        "text": 74,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-20": {
+      "hashes": {
+        "text": "ab8119346c2beac3c939f2a10054e90c178c681caff0ceef8ca088321c6b5693",
+        "author": "4e2c427ef792013ea0f91c2b7517bee0b051c377fadd8f79ab02fca10bbb0845",
+        "combined": "763a7a50ee90bc4ce0221cd8c3f95bdf0d5cde73ea801f2763f8d0374be2c995",
+        "tokenSignature": "because-best-bound-family-haniel-in-is-it-long-love-loyalty-measure-measures-much-of-our-remains-sense-so-stability-that-the-up-us-what"
+      },
+      "lengths": {
+        "text": 151,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-21": {
+      "hashes": {
+        "text": "143d32546297ef83a9f34f29d3d76be91061589501d42e69c59034b916feecd3",
+        "author": "3110961930121b12174f6f82876b0164749cf408b2457762a600179aaf965622",
+        "combined": "82152b14679b7a56325386d3599008f9e4e7670732eb0d3c5beb6e8550c70fcc",
+        "tokenSignature": "a-business-disney-family-for-his-man-neglect-never-should-walt"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-22": {
+      "hashes": {
+        "text": "a61174b8ef0e82100afadb9bde52f28b4963b5938b7a89caf39c6332490dd83d",
+        "author": "848f2611f93ebfb4786326ff7d501554394306d45220d48b9577ac24c9450b50",
+        "combined": "70bebe881991281822fca84537302f63943014e3758109cf1a94b506cec6538a",
+        "tokenSignature": "all-and-c-career-careers-exist-for-has-homemaker-is-lewis-one-only-other-purpose-s-support-that-the-to-ultimate"
+      },
+      "lengths": {
+        "text": 129,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-23": {
+      "hashes": {
+        "text": "ef8d7e874e726dfdea7a15e92573f7694283e35a21e09cbf9aba15a0e6a0e442",
+        "author": "0861fd7067acc87b336426e4ca892b854282c164b6c73ecb2e1380dac0ae9764",
+        "combined": "56ab26771500d3df4375a48566fb9751fe1358ad3c9cbb3ae933301eea9f77b3",
+        "tokenSignature": "are-becomes-but-competitive-family-grown-is-it-margaret-mead-most-once-probably-relationship-sister-sisters-strongest-the-within"
+      },
+      "lengths": {
+        "text": 142,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-24": {
+      "hashes": {
+        "text": "fa2d0b2d543e967b8c7d179778b7b505fabd46668ff547a0b688eed214362863",
+        "author": "3bd6082f80e33dc7258d48889f48697c84c0912d6cbfd011bd8b170c26fc8eed",
+        "combined": "54f391395e977d58eb54687eb4745f134219ed0eba2c5e109767e8286c7a6dec",
+        "tokenSignature": "a-anthony-builds-but-everyone-family-home-house-in-is-liccione-live-needs-supportive-to-what"
+      },
+      "lengths": {
+        "text": 81,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-25": {
+      "hashes": {
+        "text": "86ba137c12e59e4fd9bfd07ae035a002d49941153f8e2a8a6c99c12c03ea1c6e",
+        "author": "f004fda394ac012de8eec32d3bb565b05dbbf31b1f2c61049913d33fa89aa1b3",
+        "combined": "8a579abfbc7db58068aad6e4d62c93713ae9513a55b03af7ea85ff0fa333ef73",
+        "tokenSignature": "as-family-for-fun-is-jerry-no-seinfeld-such-the-there-thing-whole"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-26": {
+      "hashes": {
+        "text": "621127f27183b7d0f43b9e1182240f2d82d2c125387ae21e5b4f3fb758daecd1",
+        "author": "85fe844ec3671e90182114731dc8a72eddef07ef149bb507757d6eb39327f283",
+        "combined": "8232a2825066e18b2bdcbece904624a6ea8ce93c72f62249a6f23458cd2ac73f",
+        "tokenSignature": "a-all-allows-become-best-blessed-condition-family-informality-is-kennedy-life-looking-marge-of-our-that-the-to-us-while-worst"
+      },
+      "lengths": {
+        "text": 116,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-27": {
+      "hashes": {
+        "text": "9d387417e20a78611ea1cbf95a7a1224799e1a4b2a273846dae3db1bce0ff2dc",
+        "author": "65db0c67455d32ffbfbd454e9815303bfb9048dd10c9d7d7d5ec0b62d1baad0f",
+        "combined": "a72470b6125bde32281ef7f50e077488d15aa120e0f6e35645682a78675bef5c",
+        "tokenSignature": "acquainted-be-done-even-family-for-gift-greatest-had-hailey-intimately-introduce-is-it-kendall-life-might-never-not-of-people-the-to-with-you-yourself"
+      },
+      "lengths": {
+        "text": 149,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-28": {
+      "hashes": {
+        "text": "6efc0bcfba64e650e949caf098519b76a5b82e5b5ee0b6cea822b0d0fd1d1521",
+        "author": "6e493e9d454ac5dbcf7db5fcb63412cc91a6f83413aabad0e86c8c4dd4f85411",
+        "combined": "643ef4b7940b94c79edd8324a68502a7a393364417abca28f42f152fd71e344a",
+        "tokenSignature": "all-but-groening-i-know-makes-matt-me-no-sense-sentence-that-those-to-words"
+      },
+      "lengths": {
+        "text": 63,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-29": {
+      "hashes": {
+        "text": "c75ecaf0e36279217cdaf3d27f6a16e24673db855aabd9ed5c46c77592168135",
+        "author": "48d01dc455fbb1b6140fe79d7e49898a596315292b7756890dc413f4222f6657",
+        "combined": "2e375cc3be00aa1a7dedbe5fb163b78b3db2ee3cb58f98bcdc81c247ecfb0a92",
+        "tokenSignature": "a-blessing-both-donna-family-go-having-hedges-home-is-love-place-someone-to"
+      },
+      "lengths": {
+        "text": 94,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-30": {
+      "hashes": {
+        "text": "c38676e9ebd703a75920513e54af6bbee0c9f18c38f2b5632bf8c3465d5d1254",
+        "author": "8f2891c30f31464455f00fa10d9705ad5d0acd5c9ff7393c228a57e02898c16f",
+        "combined": "3435c49466832e4e7fbfdbc0819f706eae3683b7042213f6d3773301bdd63e62",
+        "tokenSignature": "a-being-family-for-harry-means-morgan-of-part-photos-smiling"
+      },
+      "lengths": {
+        "text": 48,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-31": {
+      "hashes": {
+        "text": "8e817434b433563188cc6acc8d881c3d76393e96066cca2676e71d11acb1916c",
+        "author": "7288a2ec2754cd00ef8c8e2476d4efc51b690c895f69e7c499d9f56ac2aa7011",
+        "combined": "d29e115a1bcfc014ee2511c072245abbaeec77e74e54ad383cc58495811bbb2d",
+        "tokenSignature": "butcher-exasperated-family-happy-insane-jim-makes-more-nothing-or-s-secure-than-that-there-you"
+      },
+      "lengths": {
+        "text": 107,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-32": {
+      "hashes": {
+        "text": "20b82599a5235ac108b9fb6523f7de133e6d77776e5498a4bea26673083295f8",
+        "author": "511160ac4dac5c5f885d9d147d300ce262dd33b7b06cb2959e2a07a32f030779",
+        "combined": "89913f2a18aad686e6d663c44eacdbe9a37061a6300218d970d1913bd908d509",
+        "tokenSignature": "family-is-linda-linney"
+      },
+      "lengths": {
+        "text": 17,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-33": {
+      "hashes": {
+        "text": "6023a7ac1a2d4a785debd56fcc2200cc2512bb9f1b0ccd36974395e5af3eb6a5",
+        "author": "f7934759c8637e94327c5db138e237622266afe8510d2b3e1cd8f8710a08c2a7",
+        "combined": "51f51fb54dcb4d248065471d6d6ad8cb14000d6463e0b2ccd5b0e56ef39007a6",
+        "tokenSignature": "best-burmese-family-in-is-of-proverb-test-time"
+      },
+      "lengths": {
+        "text": 32,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-34": {
+      "hashes": {
+        "text": "6c3e0ff569159ea59086c501713b255aace7094ca7c131dab029116889246b81",
+        "author": "6aaaf1d6d3910d4e9c5ec3d043de40fbe14dee511326497df93eb06e62fe3a25",
+        "combined": "56adc7b31ed1ec5e49d65984be4e2215fa43f29bdecc3bb7ac701dd49bfbe30d",
+        "tokenSignature": "a-be-boat-canoe-cottin-everyone-family-if-it-letty-makes-no-paddles-pogrebin-progress-that-the-unless-were-would"
+      },
+      "lengths": {
+        "text": 94,
+        "author": 21
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-35": {
+      "hashes": {
+        "text": "08fda0b54f63a89b4fb13e3ebde1fa941f7dabce1bc56cce37405f632340fe61",
+        "author": "99fa0147a45d23e30bdf36386ab85e6099d749de6b8826b2558b86ad2f2fbcef",
+        "combined": "38390ced757b7406c7601603500591166cf7b110ab596ad5907a1a6216810cc7",
+        "tokenSignature": "be-day-do-family-foer-for-hate-is-it-jonathan-me-means-one-safran-that-things-to-what-will-you"
+      },
+      "lengths": {
+        "text": 84,
+        "author": 20
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-36": {
+      "hashes": {
+        "text": "67e927ce19fb233505b8f39b56d73d9b3892e906144127676f3500cac04f6098",
+        "author": "3196a1c133436c54e6d0d216cd945cd5af7a4895249c75386d351b11a317d245",
+        "combined": "e5cf6976c2c6e9126ac7df3e9ad145eca0ef4aae64a16a21ac1441130945a4e3",
+        "tokenSignature": "all-am-and-be-blessed-daily-family-friends-god-great-have-i-in-kim-life-lil-many-my-so-things-thoughts-to-will"
+      },
+      "lengths": {
+        "text": 114,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-37": {
+      "hashes": {
+        "text": "fddeb57d350d2ae3289fc62340044b48454bf76959cf885190265322c8e6005d",
+        "author": "67486ece93d9b8222f5a8d17cc4bb0513083d69ad5618d4dcaf0cef7744fc2f1",
+        "combined": "c496baf345fdc55fe649b43fa4b7168f7f8a093a3d5b1ccae1eb3c59f948152e",
+        "tokenSignature": "be-enough-have-i-is-learned-like-that-those-to-walt-whitman-with"
+      },
+      "lengths": {
+        "text": 54,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-38": {
+      "hashes": {
+        "text": "9abfca2a1bac1d3a8c0a8521bcca30986fa424e2a45333847ddafa0efcfcf91e",
+        "author": "5e465bb1a9f09f0a7a1659d7e5054ab03708674d114de3a525bd1a527cee9de2",
+        "combined": "8d6738ac55f49283866a1f29bbe5b56833a40f8dfbfdca18d18368ece3524368",
+        "tokenSignature": "dear-dodie-escape-ever-family-from-hearts-in-inmost-never-nor-octopus-our-quite-smith-tentacles-that-the-to-we-whose-wish"
+      },
+      "lengths": {
+        "text": 119,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-39": {
+      "hashes": {
+        "text": "ca125ec6ae83c32f32f06298bf3ab2fb2c0e1c4e0ffcf9c04ab571a9486ed407",
+        "author": "68514bbebe8938d63a3b61d4dfd22cb5193aa432a050538b0405b9e2449e3ebe",
+        "combined": "ee00cc50aeeb7e2a802e7c463e1049aaaa4b4c95fa333fc073bc248dbe7d51cb",
+        "tokenSignature": "cell-essential-family-first-human-is-john-of-pope-society-the-xxiii"
+      },
+      "lengths": {
+        "text": 56,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-40": {
+      "hashes": {
+        "text": "985d75eb2f15cb72c2ece18d5ad5fa0cea1cc8b4fcb2e4420919ce8d2812a3c4",
+        "author": "b3de298fc1dd3007b7c95be8bec4386b0bd0a44091f3657124240515cdd8c017",
+        "combined": "eeed5d226fb6bd522fca26803c8d12559866cd82b1dbfa3eec033d883d25442d",
+        "tokenSignature": "albert-beautiful-einstein-family-in-land-life-of-rejoice-the-with-your"
+      },
+      "lengths": {
+        "text": 55,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-41": {
+      "hashes": {
+        "text": "44c2ba1d651c771fc499fd44912b0b702264b6265d961d82bafd77474915e57d",
+        "author": "82e35f7cbd4ed32af0e48155480482a6816f2e8c1885d2c46a6e1909ec844fed",
+        "combined": "2e698316d4c0f876fe25f0114c0cf6cc009f30d661b09eb88aea2147e98913ac",
+        "tokenSignature": "12-9-abhor-be-evil-fast-genuine-good-hold-is-let-love-romans-to-what"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-42": {
+      "hashes": {
+        "text": "ae8628a1fca68107ce0e246ea5826d1f74b39d0016328989e65c1c60ed257b05",
+        "author": "e90fa07213862ef2eb19981acb6baa862077dca77710d0cc29d7d6b479339b75",
+        "combined": "1b6fd39cb2fe14ab64672f7f1d2383cb64472e1a6fa231bd9060039ae7804acc",
+        "tokenSignature": "a-albom-family-is-it-makes-mitch-sticking-what-with-your"
+      },
+      "lengths": {
+        "text": 52,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-43": {
+      "hashes": {
+        "text": "a7e6da793fd1b35c351bea680df73410a78be8c33fb120ffb7e810d4d5db49d0",
+        "author": "65523bf2f333083d286aba3c5000c47968dc63b6d8f4dbf9a6717d461f7e9990",
+        "combined": "a7759fb5b4cc0f4eee82b1b441ee02098971678189e4992d41325dea0d1322b0",
+        "tokenSignature": "a-about-all-and-balance-between-family-finding-friends-green-happy-it-life-of-philip-quality-s-the-work"
+      },
+      "lengths": {
+        "text": 99,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-44": {
+      "hashes": {
+        "text": "41a3d5e9b7ace0d1c401277528e51f73d08494764e440873b135cfa9629dd938",
+        "author": "741b26b14784b3c2f61684f75acb73bb074f78ddd1ef1f76d7b007a195b8418a",
+        "combined": "8c4a17c6f356cec3a358a7227f25b4d1cfc3d2399ffcdd20794f9d8b123f6cd5",
+        "tokenSignature": "as-bernard-cannot-dance-family-george-get-if-it-make-may-of-rid-shaw-skeleton-the-well-you"
+      },
+      "lengths": {
+        "text": 76,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-45": {
+      "hashes": {
+        "text": "3b3219a6254a5e99f2410c9b551d961cfc952af9721f56b6f91a2fa672aae944",
+        "author": "5f90cf35f00533d6bf5d44868a6a4651abc6b0173eca2474bbfea774d34e10b3",
+        "combined": "c6466fe5a0c194d92f94e9e6c78d4b547263e313964a3d94cea69687957ab977",
+        "tokenSignature": "a-and-bonaparte-family-i-me-move-napoleon-of-people-readers-show-the-who-will-world-you"
+      },
+      "lengths": {
+        "text": 79,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-46": {
+      "hashes": {
+        "text": "6093e43d7af2811ce586d2f9bb8b1a832c9d6b7bafafc4b722614dfa93bd2237",
+        "author": "0dfcd789ac50f789d3b4f7a2f40ec74867cecdde305596d535e9b20153a59a7b",
+        "combined": "ddbc0a2d65eb3bc99b4899a03eed5030afa133ec3125a37ea3950a2468710aaf",
+        "tokenSignature": "and-are-c-facilitators-family-friendships-greatest-happiness-john-maxwell-of-the-two"
+      },
+      "lengths": {
+        "text": 73,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-47": {
+      "hashes": {
+        "text": "aeffb039c4fb421807cf835424236185cdf14578cf5b84967546dd471849149c",
+        "author": "3bc8de66e0e4abab393aa3151b5aef0c7097edc07525f1124ee8ea8b02e2a0fc",
+        "combined": "a70bc4faeda3297f343ee6ebe29dfe79e2d12a171c29bd7ef5e48e3484d63a84",
+        "tokenSignature": "ann-brashares-earn-from-had-it-love-obligated-of-ones-only-parents-rest-the-to-were-world-you"
+      },
+      "lengths": {
+        "text": 96,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-48": {
+      "hashes": {
+        "text": "0d5d656a57aaf23e036a6d5808e42c24c3a8dc5414f1997e5a6013e184f75e4e",
+        "author": "2de2bc72d3fd48c1463f295a551580301e1697a8594f7309f1e6573c0520b464",
+        "combined": "249273a889d4e175584f3767c15c71897f6234f71443f7fa278af3810fc9b08b",
+        "tokenSignature": "and-better-eating-family-food-going-good-home-irina-is-nothing-relaxing-shayk-than-to"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-49": {
+      "hashes": {
+        "text": "1cc29ef78a7154c2b7e070cd1bcd281ed96859338de51e75adc52b1e9bb4d540",
+        "author": "fee7b40a706ad5f579467da9a6cd09849612fefe2974cb908da2997301046296",
+        "combined": "bc12e12259c9b1b6c4941ed0b6a39d9e3682f624a82fd7f11008c5a7643fc511",
+        "tokenSignature": "and-are-carter-enjoy-family-friends-hidden-hope-riches-seek-their-them-treasures-wanda"
+      },
+      "lengths": {
+        "text": 74,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "family-50": {
+      "hashes": {
+        "text": "0d5777796b6c09c7e90af43d78ef787d572c9de1897768ac2b57d7e7dc1f6bb8",
+        "author": "b071c137a60890847b727873d4d027857639e6d493c3778669a989ca7b9741c7",
+        "combined": "c2d9c1d05523e68e7d0f2742ac1eeaeecae70b5e4e18eb4d00255bf211bff0be",
+        "tokenSignature": "are-c-choose-family-friends-jess-scott-the-you"
+      },
+      "lengths": {
+        "text": 34,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "family",
+        "sequence": 50
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-01": {
+      "hashes": {
+        "text": "33212cb13863dd3d3ac6d3eb6406997cf381a4e2979aa02f443f014448526afe",
+        "author": "10ac4a2d57725101b7e2d4063398bb7dbf59d9557232c6f4a366c61641dce8d7",
+        "combined": "fca569cad5d99284432ecc662aa5f9c3188fa3fd251de05f566f70e24f68431c",
+        "tokenSignature": "and-angelita-even-i-lim-loved-more-not-perfect-saw-so-that-then-were-you"
+      },
+      "lengths": {
+        "text": 112,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-02": {
+      "hashes": {
+        "text": "3dc6710d2ad2fdb78b51fa95994c7d3f0cf3bf86e0b8c47ef6d2fe0a5b306c8f",
+        "author": "4d963a89b1d8a62d895bdab0e9525510c9743758e4fdd26092b631676f5e1caa",
+        "combined": "20cede1b899781a0469421fdf4a2fa04e4880f99cf09ce87df3389f629e8377a",
+        "tokenSignature": "asleep-because-better-can-dr-dreams-fall-finally-in-is-know-love-re-reality-seuss-t-than-when-you-your"
+      },
+      "lengths": {
+        "text": 102,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-03": {
+      "hashes": {
+        "text": "89c1195141c4db90b6d8e59228c166304b58d64d93d66d117a987a894d4aac60",
+        "author": "0dafc6a8ac84f59e9158aa8b68a8186a0938523667099ae0505e2d272b8f8bd3",
+        "combined": "118d1202cf496f36ec5c33d5fd5e743be2a751874d85d3d972847d3b44aae67a",
+        "tokenSignature": "a-another-condition-essential-happiness-heinlein-in-is-love-of-own-person-robert-that-the-to-which-your"
+      },
+      "lengths": {
+        "text": 89,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-04": {
+      "hashes": {
+        "text": "3533182c3decb904946ac7006a93476e5513c7e81d06e0dd69f09db769f57ecf",
+        "author": "44212602db9c86f956dd613ff1bbfb31bb6921a6dfb435267eebbfc9b8e551cf",
+        "combined": "74c6fb6cf1c1605c5f48327f9fcb5221234b1a57543014795624e67e71ffa8cd",
+        "tokenSignature": "audrey-best-each-hepburn-hold-in-is-life-onto-other-the-thing-to"
+      },
+      "lengths": {
+        "text": 50,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-05": {
+      "hashes": {
+        "text": "09f12559f04c6a8d16af6fb461a11ea1d57a6f1f1d933af6d15c24bbcc82512e",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "0b5081488de51813eb5bdb9ebfd6fc09c78e9250cd51ca66343cd2f511b9f78c",
+        "tokenSignature": "a-beat-heart-i-like-need-needs-unknown-you"
+      },
+      "lengths": {
+        "text": 37,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-06": {
+      "hashes": {
+        "text": "dc880c847ba9411a184f8490a69d0b78d1aad60050f915a9a7d30a5c4a2baec0",
+        "author": "b55633ad83fb7892057c46dc8f3dd8c31a40764d5c4f1661bd7095dcb5448ed2",
+        "combined": "3dec00c0f9b08edf808d1bef1ff49e23e1dfa3fd09aafa9f85c5f8ada4fbd044",
+        "tokenSignature": "am-and-are-because-dream-ever-every-had-hope-i-notebook-of-reason-the-ve-who-you"
+      },
+      "lengths": {
+        "text": 94,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-07": {
+      "hashes": {
+        "text": "e3c86cf7c2a0c55713bbe95b8b4c409ee41f186e604297ecd508473d2872ddae",
+        "author": "ce984127c80745f1c08165ac471df4ae7880fc4243a27a21d8f49f6c38c6db45",
+        "combined": "7a2355688d5dc6b61292ad7bedb5f8d3540eafb47566763deb2e3398fdafe985",
+        "tokenSignature": "a-alfred-could-every-flower-for-forever-garden-had-i-if-my-of-tennyson-thought-through-time-walk-you"
+      },
+      "lengths": {
+        "text": 94,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-08": {
+      "hashes": {
+        "text": "f1cd02de55fceb4831c62b1ffa89539cfe8a31b247ad8ec2e327ed5805402b3d",
+        "author": "eea18b14a58cd589020b0fde98ae4d243aee5d4ae4849a058451526a2edb327e",
+        "combined": "e1fdf479dbc8182fa729d6ab77efb3bbe8b309e2a1d983e8b93e45188d0f3bba",
+        "tokenSignature": "can-elvis-falling-for-hand-help-i-in-life-love-my-presley-t-take-too-whole-with-you"
+      },
+      "lengths": {
+        "text": 80,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-09": {
+      "hashes": {
+        "text": "11560ca7428b76453e83a0162811470b6a669a9e9cd426c3a50599cbfc521f6f",
+        "author": "5f9fe02d04beb083f81c88a6b564274389bd5189cd07db4d9d34e9bcf0d8c70b",
+        "combined": "e7fcd5235941a286455f64eada29ad805b6555b23aea4168c9d6c3f6f595bc7e",
+        "tokenSignature": "a-be-day-have-hundred-i-if-live-milne-minus-never-one-so-to-want-without-you"
+      },
+      "lengths": {
+        "text": 110,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-10": {
+      "hashes": {
+        "text": "5418a9bf029244840b4cba22062f90156588f58e6cda1e4febef206c4d88b6d2",
+        "author": "ee14cb033bfa1ec72ddb53defa081a9d75df3c4e621652c944673fb5486717ba",
+        "combined": "e48684bcaeba76ca11f7fb9fc71c9e44d73c216f6f3e0f74d6294412fd902763",
+        "tokenSignature": "be-closest-dolls-ever-goo-heaven-i-ll-re-that-the-to-you"
+      },
+      "lengths": {
+        "text": 48,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-11": {
+      "hashes": {
+        "text": "89b05cab92af0cfa8fde8545328ba078d2e5dbc0ae8b917f4d0669044bcac608",
+        "author": "1279b48587308a478f76a79b2b899c4bcc8f93cda37ed2f31351723b1034a0fe",
+        "combined": "4c929b445f2543c2831bad150ca14a602efaff18c24370dda2bb15cdf3385789",
+        "tokenSignature": "an-and-are-beautiful-even-ever-f-finest-fitzgerald-have-i-is-known-loveliest-most-person-scott-tenderest-that-the-understatement-you"
+      },
+      "lengths": {
+        "text": 121,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-12": {
+      "hashes": {
+        "text": "812b351e00e4d806f76c26115b9d5ef1b9856083f3169dda880abded52f0deb7",
+        "author": "a37858c8c087387ea07bcae61c7da76b56f8426d7d07bd8f0c4da578614b8f77",
+        "combined": "2040fff90d34e721ef571850d6ef63eb8ce70fbb260b0fb57aedd38f1b6923ed",
+        "tokenSignature": "because-crazy-find-give-i-love-never-one-stop-stupid-the-trying-up-when-will-you"
+      },
+      "lengths": {
+        "text": 79,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-13": {
+      "hashes": {
+        "text": "e8b9c9e9306cefabf75694f76ec6699216b0404c4442949ccbe953f9931b4bd6",
+        "author": "c23d6f724b6e9b33f972149fb231457e8e2575829df8effa35a7df3fc94ac412",
+        "combined": "27edce5db63055131fadac828191a51c4668f68902a71de6455bd772dfbedc60",
+        "tokenSignature": "always-better-it-jack-johnson-re-s-together-we-when"
+      },
+      "lengths": {
+        "text": 39,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-14": {
+      "hashes": {
+        "text": "95688af4c20777953dce5ef52258e9803479658bc65d37e5c0b1046dece5ba65",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "916a772bf415188a8bd18e1278861e943a012fcb3b000516ead7311444ea6ddd",
+        "tokenSignature": "all-and-are-be-been-for-have-i-love-that-unknown-will-you"
+      },
+      "lengths": {
+        "text": 81,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-15": {
+      "hashes": {
+        "text": "cee81f0d12d6176e816a7815c6c1998a9d0c3cbf741e327812b12ebf4f630d21",
+        "author": "545cbc09207ee4c137faa87bee4b89b2331e64be2a34d526cfc8abbb4a50e4ce",
+        "combined": "ad984970ef4b2f74e881e6ae252da2d6405ad7f033bae8cedfbd07df0c86afd9",
+        "tokenSignature": "and-been-completely-didn-done-end-ever-expecting-extraordinary-fall-fiercely-i-in-is-life-love-loved-most-my-never-passionately-protected-seen-single-so-t-that-the-thing-think-this-together-up-us-ve-wasn-we-with-would-you"
+      },
+      "lengths": {
+        "text": 244,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-16": {
+      "hashes": {
+        "text": "442e87a4866961b0792dcc1dc3ae83639ad377dc62109b6d78d74526b3786e52",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "2e61f27557bbc6dc84c4c9fe99f64ef2e3fc678c88eb461ae40879bd50f0f9d3",
+        "tokenSignature": "are-be-but-may-one-person-the-to-unknown-world-you"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-17": {
+      "hashes": {
+        "text": "2419d14fdab93e3c819d1bbd550ce69df0ed9cbd7ef570898d0e872516f5bbb6",
+        "author": "cd2cc306a79cefc18f21e236bffef2a979fba99b54749269f1653f0f89234398",
+        "combined": "bed29feaf2aa64b70924dd23d71b173f9b9455ed3fe8bf96bf5c2eb4650e50ca",
+        "tokenSignature": "4-9-are-better-ecclesiastes-one-than-two"
+      },
+      "lengths": {
+        "text": 24,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-18": {
+      "hashes": {
+        "text": "77aa2694ecfa8ddc9d96f9fda6f7b30ba01eda62706e7463dd951f3a8da69482",
+        "author": "a1ed6500a3eff61a0b66259adff3f263664c4f651be3e8dc6e6327bd67d958a5",
+        "combined": "6aecb12d2b6ddb6c300901a7bdf01df72ec4b431cb35593b015a75d6022c9618",
+        "tokenSignature": "a-and-fitzgerald-i-it-love-many-new-of-s-say-so-still-think-times-to-tried-ve-way-you-zelda"
+      },
+      "lengths": {
+        "text": 84,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-19": {
+      "hashes": {
+        "text": "c5fe4abebe7b1d5901ca18d01e92819a07336efe9f5891cd6763f4af0033ece2",
+        "author": "287325ab70d8164000273d4c7e40a7335f60d5e9e592208b29ed75bf04de4025",
+        "combined": "711593ee99d67a74687136a108124e3170511806dd27aef8ff7bebc16eed49c6",
+        "tokenSignature": "as-harry-life-met-of-possible-realize-rest-sally-somebody-soon-spend-start-the-to-want-when-with-you-your"
+      },
+      "lengths": {
+        "text": 132,
+        "author": 20
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-20": {
+      "hashes": {
+        "text": "dd3076b9be29121573cbd3d23ab3feabea28d8874099e056eb561b55b0e53b67",
+        "author": "1279b48587308a478f76a79b2b899c4bcc8f93cda37ed2f31351723b1034a0fe",
+        "combined": "7ea7eaa227b430e3c16e65d1a8882bb783cca083064bd1264cef7260a93bf75f",
+        "tokenSignature": "and-beginning-end-everything-f-fitzgerald-i-love-of-s-scott-that-the-you"
+      },
+      "lengths": {
+        "text": 58,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-21": {
+      "hashes": {
+        "text": "556566fb0866b6be4d9675bb633b0dcc6d6ccfbbc4e2ca92e419bf95159c2701",
+        "author": "366e5e4f643d297a0358877529fa998aabc999c04ce24a3cc2ab01b90def6736",
+        "combined": "67b430aa1125da7a3e14cffcd7f708a5996c4c93b272fa6da0ea91bbc1878488",
+        "tokenSignature": "because-hermann-hesse-i-if-is-it-know-love-of-what-you"
+      },
+      "lengths": {
+        "text": 45,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-22": {
+      "hashes": {
+        "text": "bc190918dedd573ddb5db5af6859bb532ab3db8d0241cb9cd2475bf0cc5c63ed",
+        "author": "0a90cfb043e0811f20aff01e267bf843dc3167252a6b1a3bf1c5f932cf169fc4",
+        "combined": "532b466af2476c7b56309a66e451c56bb3b4ebf1b246bd1be5ba03deb1c18c7c",
+        "tokenSignature": "and-are-forever-hart-my-n-r-soul-tangled-your"
+      },
+      "lengths": {
+        "text": 42,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-23": {
+      "hashes": {
+        "text": "0cc427d250c9547e708244605912f33de6ee28b95b495f9e29cac10f02484177",
+        "author": "33ac4ed25f98936e51c26a3b278c0903800feb38f80c3c2f4bded083c80829a6",
+        "combined": "c2a27fecbd556bd1ad3fa3ee875a0e5a0429ab3908ff87da5dc186e6d4e3e89b",
+        "tokenSignature": "a-ben-ever-folds-found-have-i-love-more-say-than-to-way-you"
+      },
+      "lengths": {
+        "text": 59,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-24": {
+      "hashes": {
+        "text": "676fb946abbe254a381449c59fbfbaadcaec0d03bf0279022496f34f71f2af36",
+        "author": "32ea2e060eed40a4fbd6141749adac11e077f3e909eb90f1a1e5f52190f1b0bb",
+        "combined": "4d07d6c815a575d5d968c267a389e8ac7d403cb269bd240cc814a6912897aaf0",
+        "tokenSignature": "3-4-found-have-i-loves-my-of-one-solomon-song-soul-the-whom"
+      },
+      "lengths": {
+        "text": 40,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-25": {
+      "hashes": {
+        "text": "e6c25f94d0476699dedba0922600c3579f073b215e06e2714ad3d1074fc1021e",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "92d62c50598783b51e2fd1f17846343a4dac8e81217783c79a404aa536477ae9",
+        "tokenSignature": "a-all-and-away-from-hug-is-melt-need-person-right-sometimes-stress-the-unknown-will-you-your"
+      },
+      "lengths": {
+        "text": 89,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-26": {
+      "hashes": {
+        "text": "1ec1272606428fb7aeafeca60b74a4e322ef09df79534d6a987319e4b6904f60",
+        "author": "8efb46e0d0e614f2f850d1024984f5d9619cf9155d6918e704dbbbd624696844",
+        "combined": "63d859f8be77467a617866abeee0c8670124a25286fe800db8adb221778bdb5b",
+        "tokenSignature": "all-angelou-for-heart-in-is-like-love-maya-me-mine-no-the-there-world-you-yours"
+      },
+      "lengths": {
+        "text": 108,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-27": {
+      "hashes": {
+        "text": "27dc80ff323145df3bba5a77dffeba8e5d00de762de5121a05d3e456516c4a7e",
+        "author": "273951c0454e6a6a764af566d5da95975d79a346ade0145f2d4cd6017c6bf57f",
+        "combined": "5f116a3193a5e9d5ba670f8b2d4f9c113e290b2039a3104957119000fc883bd5",
+        "tokenSignature": "care-don-else-everyone-forgets-haruki-i-if-me-murakami-remember-t-then-you"
+      },
+      "lengths": {
+        "text": 63,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-28": {
+      "hashes": {
+        "text": "d48dccdc416905e78acf6c75829bc5b77015ae01f4e6fdf25315a2689e0debe1",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "90efa86dd829b10ef075a62fe2f86b08e9e3212cccf3bed5378795f343aea840",
+        "tokenSignature": "beside-doing-feel-happy-is-love-nothing-perfectly-sit-someone-unknown-when-yet-you"
+      },
+      "lengths": {
+        "text": 80,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-29": {
+      "hashes": {
+        "text": "9bd5f06b43352a07eb7ce2b1f8d1c0cbbf26ff216c2f40b49426d828d500731d",
+        "author": "0a5adc8eab5b86004392147eed71b089e983e740973a2212a8744d7c69a30810",
+        "combined": "0cbec6d0f640a41066502fabac3f004ea4f63873b03d87f50e30671254d0bd24",
+        "tokenSignature": "always-and-are-been-dream-have-my-nicholas-sparks-you"
+      },
+      "lengths": {
+        "text": 40,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-30": {
+      "hashes": {
+        "text": "39150d96c8024e899224d712a977c8ddc659a36c033c822e228e475c460920d0",
+        "author": "287325ab70d8164000273d4c7e40a7335f60d5e9e592208b29ed75bf04de4025",
+        "combined": "b940aa1a3d74e01a98eb74ba3d4681932b11d91d781abfe40c3c124118fb56ac",
+        "tokenSignature": "are-at-before-go-harry-i-last-love-met-night-person-sally-sleep-talk-that-the-to-want-when-you"
+      },
+      "lengths": {
+        "text": 84,
+        "author": 20
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-31": {
+      "hashes": {
+        "text": "8ebaab1925764e1af8ee84b3185ce5875ceee3622543807553d089e6c8e5c2ec",
+        "author": "9280c8db01b05444ff6a26c52efbe639b4879a1c49bfe0e2afdc686e93d01bcb",
+        "combined": "e0b56f94c2117fb6895eb062c20b63290509fbedb1474d0023b2c2417f867557",
+        "tokenSignature": "a-aristotle-bodies-composed-inhabiting-is-love-of-single-soul-two"
+      },
+      "lengths": {
+        "text": 56,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-32": {
+      "hashes": {
+        "text": "154ee6c6d8e380c9800158813a1424e898c88700ffda2c23888af54b82e20338",
+        "author": "08580e27d2a5c33bcc1487a2751cee97a1a4be9b62bd85889d63a8f4973e5587",
+        "combined": "64e419982207f6b2d3d70c974a949dd0eebdb1ca8c2e0aaded45b62936230400",
+        "tokenSignature": "and-evening-is-it-lewis-love-morning-sinclair-star-the-what"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-33": {
+      "hashes": {
+        "text": "b000b5dfbae1a0761c0c1bd56648798f7da4b7ded70c9e79a56c78d3aac74e5a",
+        "author": "b57295ecf08e949b643536a8d40eeb5bd782a09a50a1d260590a74596d5ed901",
+        "combined": "51fcb14b933effba43413e144deb8854f600b9c6ac449b5ed959b96fe49215db",
+        "tokenSignature": "diana-find-hang-if-in-life-love-on-princess-someone-that-then-to-you-your"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-34": {
+      "hashes": {
+        "text": "ed53e89b4923a0edcd089850d665030f2a8a1cd5504ffc3d3087f2c446f013f7",
+        "author": "98614684eaebf8e755337e9442bd460b4acd595667e52e84b7c525f9c2ac0ea1",
+        "combined": "d0b4a6048150ece1da8fc19b1d35d541f6394be78310f18817bb0b521c38ea77",
+        "tokenSignature": "26-27-and-come-genesis-kiss-me-near-now"
+      },
+      "lengths": {
+        "text": 27,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-35": {
+      "hashes": {
+        "text": "09f12559f04c6a8d16af6fb461a11ea1d57a6f1f1d933af6d15c24bbcc82512e",
+        "author": "72cc62617e2b8bffd5199ba8fedfa59d46780f680147f181d76813860a911a3e",
+        "combined": "9be4bc9974010721e0604304df2da7e712aec33dd1a1fb4dead9c6d5fb121ebb",
+        "tokenSignature": "a-beat-heart-i-like-need-needs-one-republic-you"
+      },
+      "lengths": {
+        "text": 37,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-36": {
+      "hashes": {
+        "text": "d828eff62b2c2fbaa0bb5993d9681bddc9808a4ae6efc1591eeac82c068b4a3f",
+        "author": "c55d6bcf06c430e97ecf38a5acf6b50588d52770bc5134b3e115c60f382467ff",
+        "combined": "9405002dd0878049284b15ad555743cd5141f31a908f96e7b11ca195059d67c2",
+        "tokenSignature": "a-but-can-feel-i-is-it-like-love-our-remember-see-t-the-to-walk-wind"
+      },
+      "lengths": {
+        "text": 61,
+        "author": 18
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-37": {
+      "hashes": {
+        "text": "b8bc98f211d34ef01d424bb3324172f4341952315f8522299059ec73961239e3",
+        "author": "1af9d3468fd07f0ebc6949ee2ce48757fa922dcb8e83dc50208a27b6b83b5006",
+        "combined": "d62229fd643b29e6f98d0f2835dffa22871a9d6f13014a2ff2cd2ced7696f229",
+        "tokenSignature": "a-an-devour-it-loving-necessity-never-option-truth-was-you"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-38": {
+      "hashes": {
+        "text": "e8b9c9e9306cefabf75694f76ec6699216b0404c4442949ccbe953f9931b4bd6",
+        "author": "c23d6f724b6e9b33f972149fb231457e8e2575829df8effa35a7df3fc94ac412",
+        "combined": "27edce5db63055131fadac828191a51c4668f68902a71de6455bd772dfbedc60",
+        "tokenSignature": "always-better-it-jack-johnson-re-s-together-we-when"
+      },
+      "lengths": {
+        "text": 39,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-39": {
+      "hashes": {
+        "text": "ac5bf6324674959980607c4edfc3359ccbacd686179fe3bd19bddcef8f31c2e0",
+        "author": "40c367b80f761841cef62b64ed09847cfcb93ddee606a10441bd6f2714dd182f",
+        "combined": "d1a9e6212aab4f8189cba81dbcae6081bac5b4e87a549b206c121039b54c3037",
+        "tokenSignature": "ages-all-alone-face-i-j-k-lifetime-of-one-rather-spend-than-the-this-tolken-with-world-would-you"
+      },
+      "lengths": {
+        "text": 87,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 39
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-40": {
+      "hashes": {
+        "text": "d90bea46897244bfad8b54a7a088f455f903899b4db55f54711c5f486a8b5303",
+        "author": "a4a7f7f0310d9eec60e1ab033a5b24cfa56b9aa8dd8fcd2a890a351dd9b483b5",
+        "combined": "68fb5bf2dd7f457a0edb0324bda8d981ce619dd1daea3657373fa52dfbd1bea0",
+        "tokenSignature": "are-boundaries-christina-depth-ever-expanding-for-has-its-love-my-no-white-you"
+      },
+      "lengths": {
+        "text": 64,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 40
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-41": {
+      "hashes": {
+        "text": "806c348a66a51a27762446d513e4f2f7d6f833f8449973b497eb9e46367b86ea",
+        "author": "93874766e6ba3f9831e3cda2db90ba730d88d5adf125c3302a2d26033a9ae0f7",
+        "combined": "f5dac599adbca56c4a5fd14f15caa9c2e9244ed04418ebf9ed1197b997fe6841",
+        "tokenSignature": "a-amazing-are-bruno-cause-change-face-i-just-mars-not-re-s-see-that-the-there-thing-way-when-would-you-your"
+      },
+      "lengths": {
+        "text": 107,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 41
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-42": {
+      "hashes": {
+        "text": "7a784895f777cfff5a6f88b30b24e7dc456e5d380a747d4da29c557dcc058560",
+        "author": "e523adac98a11d3d6005b1c1f9b16c81be0f60b75e32c4529509a66fc1fc6ce3",
+        "combined": "9bead3019ca8b38948ae84baa216dc1a1af3b83a82f28db3913b3ab36a19aec9",
+        "tokenSignature": "always-because-becoming-being-but-can-dreamed-feel-gregson-have-i-knott-me-myself-of-slowly-surely-the-tyler-you"
+      },
+      "lengths": {
+        "text": 101,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 42
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-43": {
+      "hashes": {
+        "text": "5f172ba5efd6db9604b7d1ade0d021d289e9a59be3b42bf20cb2ad79707f1f5d",
+        "author": "be595e8bf3a7d54be687531dcb42adcc8eb39412d284871daffeca2b39174474",
+        "combined": "c9e763e88a3b173087fc7bfd92deaefabd7e768659fe383c2a30e89744a7029d",
+        "tokenSignature": "a-allen-edgar-love-loved-more-poe-than-that-was-we-with"
+      },
+      "lengths": {
+        "text": 45,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 43
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-44": {
+      "hashes": {
+        "text": "33212cb13863dd3d3ac6d3eb6406997cf381a4e2979aa02f443f014448526afe",
+        "author": "10ac4a2d57725101b7e2d4063398bb7dbf59d9557232c6f4a366c61641dce8d7",
+        "combined": "fca569cad5d99284432ecc662aa5f9c3188fa3fd251de05f566f70e24f68431c",
+        "tokenSignature": "and-angelita-even-i-lim-loved-more-not-perfect-saw-so-that-then-were-you"
+      },
+      "lengths": {
+        "text": 112,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 44
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-45": {
+      "hashes": {
+        "text": "abb46b3e6f2c702076159a5d4a525da67ac028a07d5e3b7d3fd89bce49d57fd0",
+        "author": "210bf05e24fcda8e83229d7ec84819f89b0d1790643d3c17eb06d000c788ce6f",
+        "combined": "e1d2e36d9832a88f157c72428d61e60dbfb3ad31f5764547685fcae58c0e0192",
+        "tokenSignature": "3-6-am-and-beloved-i-is-mine-my-of-s-solomon-song"
+      },
+      "lengths": {
+        "text": 41,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 45
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-46": {
+      "hashes": {
+        "text": "55bec65c70b0d7b4912b447fe20503a256b70ffabbb1c7952d2904beab9931c4",
+        "author": "0b993abf2bba6aedce60b84b0f26f0a10c0d8828f275e98fd0806fb4e8196f60",
+        "combined": "26a13d3fde2f5c09ed54d6196e831b50a0f7031ec7ea114bb0c3ec8dbce4c8b9",
+        "tokenSignature": "across-and-beautiful-her-i-in-more-see-smile-something-stars-than-the-universe"
+      },
+      "lengths": {
+        "text": 63,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 46
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-47": {
+      "hashes": {
+        "text": "c07ba67b7d01fbe259acdd0c696e1f8379b31629cf915cc1b8129439d822b519",
+        "author": "949e803e54f46762f6cb6178ce520bda43b1d7e432ab57d6131e99dadde3a853",
+        "combined": "3f38e4d297a5573178fbe3a8ca5522c855807cac6242f5672a149f2637db4e41",
+        "tokenSignature": "and-at-ever-first-it-last-love-nabokov-sight-vladimir-was"
+      },
+      "lengths": {
+        "text": 66,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 47
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-48": {
+      "hashes": {
+        "text": "6a75df73085da3d077efbe411e2bba8c1d55e05457f6093c9bdba5cf0d64f3a0",
+        "author": "2731ee11566f5e7e1fcc435b1cf92f16a7fbd1a0d7187b255e654babd3b3e743",
+        "combined": "dfc1be04d59948c40cc94f4c32cd77c99498f875f15675b13a26abb7f3b1bc81",
+        "tokenSignature": "antoine-at-but-consist-de-direction-does-each-exupery-gazing-in-looking-love-not-other-outward-saint-same-the-together"
+      },
+      "lengths": {
+        "text": 101,
+        "author": 24
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 48
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-49": {
+      "hashes": {
+        "text": "2630c28625863ea251439ce628d1f1846f574a124906edfeccc9dff970311240",
+        "author": "f2238add51b34e956ba886e19a4dde7c1ac32850a45a4283431cda48a1f6eb99",
+        "combined": "540238f7c01ac6cef03084c6b527ed6b950bc0f3aab7e01b777a24731b4f102e",
+        "tokenSignature": "always-and-bentley-dierks-do-first-go-heart-i-last-m-matter-mine-no-of-on-or-re-the-thing-thinking-this-what-where-you"
+      },
+      "lengths": {
+        "text": 122,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 49
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-50": {
+      "hashes": {
+        "text": "d48225251c14a700dd4ed4e02cbaa07baa410dd70d116fd889a0120756b4103e",
+        "author": "2ec26314ef521a5288c6d491a31e81306a43bc2b89bb0c5b867bcab63052c207",
+        "combined": "a9c1bbb1611905bb1caf49edd829c29f995e5a3e2fdd8a675930fa211460af06",
+        "tokenSignature": "and-arrigo-because-boito-fell-i-in-knew-love-saw-smiled-when-you"
+      },
+      "lengths": {
+        "text": 63,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 50
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-51": {
+      "hashes": {
+        "text": "459753797dc94682781e491b63a5425fcbce2a436f85d8055fc0d930ffd0be24",
+        "author": "bea501c40ca7eeaf73a18339bf0b48922900c57f5086cdf1abc1eea053d896c9",
+        "combined": "9d5c9575716ca1fa59fcab624a1129a807062ae52ebd06c9334f7c1119d8af63",
+        "tokenSignature": "by-can-iris-learn-love-loving-murdoch-only-to-we"
+      },
+      "lengths": {
+        "text": 36,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 51
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-52": {
+      "hashes": {
+        "text": "3200a510ffea09362c58a3ab84186819db468d83a7a168e8df072c5f99edf646",
+        "author": "49bde1fc12cf5024d1ac249ec66e86a4f98cb1c27c2d6854bc6ba89de5e0022c",
+        "combined": "c97960aa9205f15dc0fdc64a6f92aeb89c8a235782f43258dfa7caa4d31472ff",
+        "tokenSignature": "flower-got-grow-is-john-lennon-let-love-the-to-ve-you"
+      },
+      "lengths": {
+        "text": 42,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 52
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "love-53": {
+      "hashes": {
+        "text": "004f8bdc69e50c1ebb3712aa0fab5d2ca9b65410f9ad108bb08f1fdaa6e4adb5",
+        "author": "b57295ecf08e949b643536a8d40eeb5bd782a09a50a1d260590a74596d5ed901",
+        "combined": "76637d14ad82a2f4c359828dc9cc7cb9559c2ca688d3f599859d3b76761ded08",
+        "tokenSignature": "diana-do-heart-only-princess-tells-what-you-your"
+      },
+      "lengths": {
+        "text": 34,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "love",
+        "sequence": 53
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-01": {
+      "hashes": {
+        "text": "69fc50cc6acb57002d4d9dfb6d5254f4b0f614eb7e96171e448f5252e360028e",
+        "author": "e975576533a7494402684dfe70c67d3e28f05651da40e6dc2b67f89f16dbab7e",
+        "combined": "c5707e6757482420faf654c88c8be16336a0df80b0a35bf33f65cc9fb0b9000c",
+        "tokenSignature": "are-be-become-decide-destined-emerson-is-only-person-ralph-the-to-waldo-you"
+      },
+      "lengths": {
+        "text": 74,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-02": {
+      "hashes": {
+        "text": "341e7119994f097c66d70d14ba2644a94b8ee0c52b2459cdb83f9a00c60d78ad",
+        "author": "fdefa8d01ccb1cc1edf646b31324d41601351463ae98e775cac989c6fe3e89de",
+        "combined": "2b6f4b88e09688a4674dd217cf0e8388853559a04ff3dfbc694c8e0d51096891",
+        "tokenSignature": "anne-as-create-for-light-mary-naturally-others-our-own-radmacher-to-way-we-work"
+      },
+      "lengths": {
+        "text": 70,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-03": {
+      "hashes": {
+        "text": "916601da96b0431bffacbdac13074fd28fd2f69444df6966f24c1e2982eb771f",
+        "author": "bd8d218beeec48b9f2062a9bc477342ad0945fbe02d89b2faf2a3a45e209ad3b",
+        "combined": "b73fd72c4e42674853840619211a5a50c2d69db973d9832a2bb6897d5ee3e40c",
+        "tokenSignature": "all-exist-in-is-live-most-oscar-people-rarest-that-the-thing-to-wilde-world"
+      },
+      "lengths": {
+        "text": 73,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-04": {
+      "hashes": {
+        "text": "adc236ca04df69a7467c3f9f7cedc6fc537f25256c3900f135fa54c7f3c9b838",
+        "author": "2ca1523c79750793db46ce6aba7a137ed921bb52d4af22c2745c829f623e02cf",
+        "combined": "dd023ee3f413e228dc2c96831e1d8e11faa0188803a4c148b0dc66abcf598369",
+        "tokenSignature": "a-and-cannot-face-helen-keep-keller-see-shadow-sunshine-the-to-you-your"
+      },
+      "lengths": {
+        "text": 59,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-05": {
+      "hashes": {
+        "text": "68b59991f083454fd3342dae9026bf748c51f544f68b51cc29ea81abbb0a3bf5",
+        "author": "da1efb48fc34bea9a20f1ccaad8cb0c317a739b6b1882233538053d4ee71257e",
+        "combined": "eaf4a9c695c5ef19eeb452bb7ec0b38a7ef71d9f021e61ceed8c0386473c59f4",
+        "tokenSignature": "anything-can-difficult-do-high-i-is-mountain-no-overcome-rudolph-shining-sun-the-to-too-trouble-when-wilma"
+      },
+      "lengths": {
+        "text": 105,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-06": {
+      "hashes": {
+        "text": "4d65efbe04815dc066a2675abb78ebe5d47866bee12f64ac0ef700b0771bbc36",
+        "author": "140e1b7b47a7256853bdbf951d5e2c493072476917cc6b4b0068ef3236d3a7bb",
+        "combined": "41cd1580d01c6a758ca72d65300f44001935718b45ed80211222fc68d5d5afd0",
+        "tokenSignature": "and-be-change-fanatically-if-is-liking-militantly-not-optimistic-positive-rick-something-steves-to-your"
+      },
+      "lengths": {
+        "text": 106,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-07": {
+      "hashes": {
+        "text": "9805880ac12913a38412a391a144121a11b8659ba36ea5608fce6fd64b7a4589",
+        "author": "e975576533a7494402684dfe70c67d3e28f05651da40e6dc2b67f89f16dbab7e",
+        "combined": "7079b16a39b16790a4f5a43719bce9fec4b8a373e3a4ae7ea9ee609c4d6cfe8e",
+        "tokenSignature": "a-accomplishment-be-constantly-else-emerson-greatest-in-is-make-ralph-something-that-the-to-trying-waldo-world-you-yourself"
+      },
+      "lengths": {
+        "text": 110,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-08": {
+      "hashes": {
+        "text": "f35c9e95e298d503325f66ffbb3207c6de27378446275c437742349c870da19e",
+        "author": "e8c2cac0c75f0edabf87e74977f846a114b87256b69eea7e35504f3342901054",
+        "combined": "a286f05e3f5ba178e51e68c4ae3dccdbae3621ddfd4915ee6519589fee6496db",
+        "tokenSignature": "all-confucius-have-lives-one-only-realize-second-starts-the-two-we-when"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-09": {
+      "hashes": {
+        "text": "31f245d0029ffce07e5f6ff404206036d5c4194e1012ec467246fa871074e283",
+        "author": "9280c8db01b05444ff6a26c52efbe639b4879a1c49bfe0e2afdc686e93d01bcb",
+        "combined": "0fea6cd6f6a2a20853005180684c65cf39664dfa5e71481d03682c5b10234c28",
+        "tokenSignature": "aristotle-darkest-during-focus-is-it-light-moments-must-our-see-that-the-to-we"
+      },
+      "lengths": {
+        "text": 69,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-10": {
+      "hashes": {
+        "text": "a1b0f59d712c432a764261e4ebc8d62162d37090de0dfec7b6de33f773850e52",
+        "author": "e975576533a7494402684dfe70c67d3e28f05651da40e6dc2b67f89f16dbab7e",
+        "combined": "eee8dbf01651e5f21d81610fa3f6828c66223b0c85195444a84672d403c97b3b",
+        "tokenSignature": "angry-are-emerson-every-for-happiness-lose-minute-of-ralph-seconds-sixty-waldo-you"
+      },
+      "lengths": {
+        "text": 68,
+        "author": 19
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-11": {
+      "hashes": {
+        "text": "4af00ff8420020e4971b4dd046f1fe31d0acd10499537f89bddeeec24f789a6b",
+        "author": "3110961930121b12174f6f82876b0164749cf408b2457762a600179aaf965622",
+        "combined": "4203efa1697cccf074f6a03869fffd9281b42dc09cde0089b5a79441a8dcb043",
+        "tokenSignature": "all-can-come-courage-disney-dreams-have-if-pursue-the-them-to-true-walt-we-your"
+      },
+      "lengths": {
+        "text": 68,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-12": {
+      "hashes": {
+        "text": "bb186a10c12636166b6c555dd320810b11c06c1a10042334f60a153981f7d194",
+        "author": "bd8d218beeec48b9f2062a9bc477342ad0945fbe02d89b2faf2a3a45e209ad3b",
+        "combined": "43cdeb2c2303f4cb82ee1523b4c1586a8f37ff0dbda16969f85e10d17fc1bacc",
+        "tokenSignature": "a-and-fair-for-good-is-it-life-most-never-not-of-oscar-perhaps-that-thing-us-wilde"
+      },
+      "lengths": {
+        "text": 81,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-13": {
+      "hashes": {
+        "text": "04ac93b7f5ab35f206d3232d7f54ac0bedb9714460dc8bd5fb76563dffec0440",
+        "author": "bd8d218beeec48b9f2062a9bc477342ad0945fbe02d89b2faf2a3a45e209ad3b",
+        "combined": "64d2a3d6238b03dc8e89ca4f3b91cdcb25ad223f3ad6260ac7116930aec241b6",
+        "tokenSignature": "already-be-else-everyone-is-oscar-taken-wilde-yourself"
+      },
+      "lengths": {
+        "text": 44,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-14": {
+      "hashes": {
+        "text": "09ab315eedbf645d37a053fba48f7eeffa9edf8dea2cdcb3b6c65d5754863eaf",
+        "author": "bdf405d0b4d7c4defc29f3277ec27413d0859f59f1d59d30ecd1ab287899a5d1",
+        "combined": "f623afedae42c69a43cb406539349ad88ce926a652407e47e41436213c6fee64",
+        "tokenSignature": "are-cannot-change-do-only-philip-pullman-what-you"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 14
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-15": {
+      "hashes": {
+        "text": "6eb3e25997fe8a4fecb4ccd5401f0b563fb6a07266c242bd4b8e1bb489c38fa7",
+        "author": "710482eaa280e6b7e9ed98958197686ea52772371d2374089e677ff77eae18eb",
+        "combined": "94afb470ee97bc37db16861a5823d6fe68258e2e296c3d3099a25f69ee6a083e",
+        "tokenSignature": "an-is-life-living-not-socrates-unexamined-worth"
+      },
+      "lengths": {
+        "text": 39,
+        "author": 8
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 15
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-16": {
+      "hashes": {
+        "text": "6ac095603aea77862a5b2cd1f450c58994cd2877f2ceeb940089e15d0d67ffb8",
+        "author": "e85ff2980337df6eb885bdb71fbc014e83deee9e993a2234216dff5dcf50f928",
+        "combined": "b8a58ead5c483e72cc472bd3a2746ee94ea50cf55c6498602d4a97efd9bd5c12",
+        "tokenSignature": "babe-brings-closer-every-home-me-next-run-ruth-strike-the-to"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 16
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-17": {
+      "hashes": {
+        "text": "a481e52e9ce8c6d6cdc72c6719c07d3fb5fbacc3931ab180eef0979c73a946bf",
+        "author": "93cba9354eb51e1528dcd68330039c53620a2251fe38cc47979a8d67cbe30bab",
+        "combined": "f2183f2225d07465fe83119b2f935ac42e64a57c40a858f1042cf1d553ce2de6",
+        "tokenSignature": "aurelius-depends-happiness-life-marcus-of-on-quality-the-thoughts-your"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 17
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-18": {
+      "hashes": {
+        "text": "52ce2e23221a88778f159e3839a3613e3c7c5382700a236b6560d04d8148d27f",
+        "author": "ec86680e2526cdd6e8ab336ddfec398fa958632ed0729deec23412052f963e7a",
+        "combined": "2add213378b845cb3ec18f941d113a495f757fae851f48497aac9f3403baf5c2",
+        "tokenSignature": "alexander-anything-before-bell-else-graham-is-key-preparation-success-the-to"
+      },
+      "lengths": {
+        "text": 56,
+        "author": 21
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 18
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-19": {
+      "hashes": {
+        "text": "da82f036fd66ed6fe4765829f5ea845d2bf26e25f18eb25161b2b082bfa57857",
+        "author": "d25edc57bfd0628212efe43b37dd1c028a5c57a5557e09146695ec04e99921fd",
+        "combined": "45225cfb1600fa96fb552d516a44ce29bf257d2a18f94e1e975e37509a2d901e",
+        "tokenSignature": "dickinson-dwell-emily-i-in-possibility"
+      },
+      "lengths": {
+        "text": 23,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 19
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-20": {
+      "hashes": {
+        "text": "66c71b8856686a1453145d85a36d74e7ab426aee24c48954c698d038bdb2adde",
+        "author": "c19bad27559485f12db018e5fc30185bb1d310451b1e9653c46563d1c8d6c100",
+        "combined": "6e32fbf9e94c3e9bdf2c382c2199875bd48419ff9d6a34e47b08a465353d0c43",
+        "tokenSignature": "be-for-happy-is-khayyam-life-moment-omar-this-your"
+      },
+      "lengths": {
+        "text": 51,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 20
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-21": {
+      "hashes": {
+        "text": "e2b77f53b6760d0dbbf585c0279f8296f3420d7689560c840a2a54a69c7696cf",
+        "author": "8f126c330a93dca300320095d2cf1516dc69f569b4a1adeac3fbde77e6b17350",
+        "combined": "819e2f02477901d26c2f236b37397aa5cad96cf84ac5fac449ecc365c4fda17f",
+        "tokenSignature": "imagination-infinite-john-makes-muir-of-power-the-us"
+      },
+      "lengths": {
+        "text": 43,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 21
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-22": {
+      "hashes": {
+        "text": "d4a0016a51d53b8d81bcb5181941b013e2dba4beed09cceb85323651a27944c4",
+        "author": "878abe99fc3feeb3477372921ac272fa5b7994b71b8579a97f9b364ca4f24554",
+        "combined": "95abadaf11160ccb01ececa0cfbd013d34c9c859bf83f258b758b08fe91da225",
+        "tokenSignature": "choice-george-important-is-most-next-the-wells"
+      },
+      "lengths": {
+        "text": 45,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 22
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-23": {
+      "hashes": {
+        "text": "d6915e204ba33be4e2162a84e4c5473be470378f0abd2b4b0bc67336207f03d9",
+        "author": "9a1320a7bd0ad0a3f6d2e07f51268609ff7ae11b66a5206a13abddd4a9ab7652",
+        "combined": "1f4f396cc12668cbe7296782a5ce21683f9c7b3904661d98e24c9e73b7481da7",
+        "tokenSignature": "aaron-and-doing-fun-have-hurst-it-life-make-matter-your"
+      },
+      "lengths": {
+        "text": 44,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 23
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-24": {
+      "hashes": {
+        "text": "191205003b8c3cdbe7fb90893c121a5a65618728c2d9280398f6284961955ff3",
+        "author": "1f2fecaf94f8c623a673b3c4409655cd4f4f4b4bb6c214aae3fde8a1ab55acce",
+        "combined": "e400f9cdeb64a45f901d8bb2b0339677abbfb7cf8956da16f4d9198037427bb7",
+        "tokenSignature": "a-and-anything-is-lilly-little-pink-possible-pulitzer-sunshine-with"
+      },
+      "lengths": {
+        "text": 53,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 24
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-25": {
+      "hashes": {
+        "text": "fb3f3e4be0535065eb54caca6538aacf1eda05e8e82445431ffc0271c105e689",
+        "author": "a6bc541bef0b15163d2813ad62bfe63ed20d21ffc0c38c89e37b75b23ced2897",
+        "combined": "2e02b66c89744642b7ed6fdc1713dd0d14d0b0413cc67aa342de349000bcb8d8",
+        "tokenSignature": "adam-and-come-do-good-lowy-to-will-you"
+      },
+      "lengths": {
+        "text": 34,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 25
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-26": {
+      "hashes": {
+        "text": "1d1cdf154de17c01719a557360dbc8998f833da500153615366042ea275c0886",
+        "author": "56348ccb52067f15875509f2fdad99899a7f5b4055730e8629d7f54059110e8d",
+        "combined": "e5e93cf676fd7134c8d16f2b214f7b19581f7ef0bb9799ceff0e0859dfa6f701",
+        "tokenSignature": "do-find-happy-it-life-make-monson-not-s-the-thomas-you"
+      },
+      "lengths": {
+        "text": 44,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 26
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-27": {
+      "hashes": {
+        "text": "65c14714409bece4c9dda63c10172e9de7b453ddf0a609ed2d4ee407b1e3bc0d",
+        "author": "d4da2549af9ad037ba0a5642e2ae50b15be62dc29b3dd0c5b3798adba897380e",
+        "combined": "e7be8ea2cbb60d3080dd3746300abb96620d1c7124a70b16110b25ef816b7e85",
+        "tokenSignature": "cummings-days-e-is-laughter-most-of-one-the-wasted-without"
+      },
+      "lengths": {
+        "text": 48,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 27
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-28": {
+      "hashes": {
+        "text": "a0b4a8019ab78edd762a1ce46ce9f001e13f6b0fad95a18cd527195898d2c40c",
+        "author": "8efb46e0d0e614f2f850d1024984f5d9619cf9155d6918e704dbbbd624696844",
+        "combined": "f75ef8e9b4c3e91faa2f32416bf324ee6f15b9e4193e5c19bc5d0c74f3c28f68",
+        "tokenSignature": "angelou-be-but-defeated-defeats-face-in-let-life-many-maya-never-will-you-yourself"
+      },
+      "lengths": {
+        "text": 71,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 28
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-29": {
+      "hashes": {
+        "text": "42ffe63995f455fe8c3a72927ed632af5cc9ca2b0a1ac5e3f299db41a3ce610d",
+        "author": "c1a8d593e2e41bbbd473562eeabe1a90320b2bd07b557f3d9150f1396522a20f",
+        "combined": "b34f8bc32cfe02361a61cf7a63e7f03900349ca489817a7c6e2edd92799dab19",
+        "tokenSignature": "exciting-hope-in-is-life-mandy-moore-most-the-there-thing"
+      },
+      "lengths": {
+        "text": 49,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 29
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-30": {
+      "hashes": {
+        "text": "ecfc46836a63b6272ed35a4eb74fae6926ed37eadddf56b5226e507d322a4b1a",
+        "author": "bf61abd9c8c94e02103733c96be27852844483acbf580158f224257e620356a8",
+        "combined": "39e078fdb7529e43b0aeb490949423842864f5f605946f39cbaf2237ed2b8beb",
+        "tokenSignature": "act-aesop-ever-how-is-kindness-matter-no-of-small-wasted"
+      },
+      "lengths": {
+        "text": 56,
+        "author": 5
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 30
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-31": {
+      "hashes": {
+        "text": "67680a63a197c7e4e9f09cf8f8b6536136d3a77f8ec8c59b4a469952222e3936",
+        "author": "b57295ecf08e949b643536a8d40eeb5bd782a09a50a1d260590a74596d5ed901",
+        "combined": "25daa863525ea5f20b7853d1bfe7eaa42ebae981a0f6c149f512be3ee368e2e5",
+        "tokenSignature": "diana-from-head-heart-lead-not-princess-the"
+      },
+      "lengths": {
+        "text": 34,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 31
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-32": {
+      "hashes": {
+        "text": "446b061041d4bb98c81ec4810bf724c576b2926a247440fbfdf347a9c7ac4f90",
+        "author": "5a9ebdfbedb636f501ca01309e184b69319f0db158b344e906ddd7d6de6b705d",
+        "combined": "d7b1232acbf935078691fb3570ff4efc5ebffcffeb7c87c8dd4911e14d76b941",
+        "tokenSignature": "before-comes-dictionary-in-is-only-place-sassoon-success-the-vidal-where-work"
+      },
+      "lengths": {
+        "text": 68,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 32
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-33": {
+      "hashes": {
+        "text": "0666f2fff367c8a71e345348a52403f9e95b574aa1ab9e47a407eaa1b2764860",
+        "author": "4772150b2bfeef03edc13691bb588e8d979acec7aacc6b3534bb5c0bb90e3640",
+        "combined": "a17b306e3efe26989b0cb97cb7e84da27dc6439cc80a57c92d8d37499ec96ae0",
+        "tokenSignature": "act-amelia-decision-difficult-earhart-is-merely-most-rest-tenacity-the-thing-to"
+      },
+      "lengths": {
+        "text": 77,
+        "author": 14
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 33
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-34": {
+      "hashes": {
+        "text": "50727b5510251f266a9a0d7f8c155fa46525b8b644750bb769fe17b282da940f",
+        "author": "8254cfcf9ef604b43e139d93e31619a0ea37c4298a447935c863be078def1314",
+        "combined": "ce17ba965e500467a12d9c93c6aa0d90ded9e47c9aa3409d10fbd74f8e94e1b9",
+        "tokenSignature": "and-be-bryant-can-do-great-important-in-inspire-is-kobe-most-people-so-that-the-they-thing-to-try-want-whatever"
+      },
+      "lengths": {
+        "text": 108,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 34
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-35": {
+      "hashes": {
+        "text": "2e48f142ad8cb68fe0117ca620616f97f19e4d24401a9d748e12d30d53f7f636",
+        "author": "7c0ec53eff0ad7658cb33c8644d8497af62763919d181d92f1aaf5aea5e59402",
+        "combined": "310731fff2194700c51f17e700faf2ded121611f10599fca0d88153ccb86db76",
+        "tokenSignature": "enjoy-for-if-life-ll-morris-never-spend-storm-sunshine-the-waiting-west-whole-you-your"
+      },
+      "lengths": {
+        "text": 84,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 35
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-36": {
+      "hashes": {
+        "text": "a268558a1a4f680133f9ed2987b38a0a889733189a85027b05020d29f31b2e6d",
+        "author": "45993a12c75f80b9c842b9592474077e5122c41e084003ed7d80f84935b8ca60",
+        "combined": "5e5a0ad2d7e2d6d95726fb59148811fd8344f86b11c0ca0728b12f58ff891f8e",
+        "tokenSignature": "and-breathe-go-hanh-nhat-slowly-smile-thich"
+      },
+      "lengths": {
+        "text": 30,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 36
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-37": {
+      "hashes": {
+        "text": "fa128731bd944f65dd673341e81e27974da976f1ecc478468945482d270bde1a",
+        "author": "404e99af22014db108daa322697e551022016f4014fc757489cf0989dad456ea",
+        "combined": "0db0f10bd672e1d3f7ddb74fa2fe967feae8c7b9e92d72185476963a4df50f7c",
+        "tokenSignature": "a-absolutely-are-available-before-beggs-frown-jim-make-no-on-put-smiles-sure-there-you"
+      },
+      "lengths": {
+        "text": 78,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 37
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "positive-38": {
+      "hashes": {
+        "text": "c1d717d55d25c2a6e7b8572c908a2fbae494586542ec52549b34184b29ae63bf",
+        "author": "b3bdb63c995e85a64b977ead92e5b6aa2bf2068230b42b3958ccd058bb5a2206",
+        "combined": "a1e1621864afff42fb17e841b6a1d53e8c1217e38f6c29ef1513e3df6ee8d344",
+        "tokenSignature": "a-action-an-at-beautiful-every-gift-is-it-love-mother-of-person-smile-someone-teresa-that-thing-time-to-you"
+      },
+      "lengths": {
+        "text": 99,
+        "author": 13
+      },
+      "source": {
+        "categoryId": "positive",
+        "sequence": 38
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-01": {
+      "hashes": {
+        "text": "b1a66d5e5c0b80a6d799259730909c169c3c31bfbe520cbc33ada197be0ff722",
+        "author": "9280c8db01b05444ff6a26c52efbe639b4879a1c49bfe0e2afdc686e93d01bcb",
+        "combined": "e0950750772c227d76e39e04f5c64d0f0a7cb342ee7fdb5b37a107897fe937ea",
+        "tokenSignature": "aristotle-depends-happiness-ourselves-upon"
+      },
+      "lengths": {
+        "text": 33,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 1
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-02": {
+      "hashes": {
+        "text": "8e48b844bc9139fbfc46368cd57bdc48b568c17d083fb008a1d7cd0c02b04618",
+        "author": "97c7716ab1668ee2b5eaf3427ccc27ea083aa6ac2ec96c9909a6e7b763929d70",
+        "combined": "55084f54dd802ff4df62339be48501df4bb180143fb9132af1a8413c9961c7ce",
+        "tokenSignature": "a-all-and-be-by-can-certainly-come-few-happiness-is-kind-like-love-many-mary-nearest-needed-stuart-the-those-to-wanted-we"
+      },
+      "lengths": {
+        "text": 140,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 2
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-03": {
+      "hashes": {
+        "text": "d50e4ba44936bb2a838652714dab5d41df44ed71da343164d81a17dea2cd6da3",
+        "author": "f92ee0d2e3185db5930c5f76c85df774aca6ed580fe9619b0724b5798aa137af",
+        "combined": "4f6e5785c3cf6dd954ff0c2e1c65cfd60166fcfd429403b98789db72f4640f7e",
+        "tokenSignature": "actions-comes-dalai-from-happiness-is-it-lama-made-not-own-ready-something-your"
+      },
+      "lengths": {
+        "text": 72,
+        "author": 10
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 3
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-04": {
+      "hashes": {
+        "text": "293669822062bae67cf60504b4017a99ab1601a7708d729741d4002146d2da66",
+        "author": "c536567a7e5ee0eb131877b5af42d7d5eed5d1cffd1da95905b543790534c43c",
+        "combined": "ad967a8fb0bd9a235df0eaa5814ffe77276cf11c5076de64751dda5119221ba3",
+        "tokenSignature": "a-an-chinese-day-else-fishing-for-fortune-go-happiness-help-hour-if-inherit-lifetime-nap-proverb-someone-take-want-year-you"
+      },
+      "lengths": {
+        "text": 201,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 4
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-05": {
+      "hashes": {
+        "text": "a425696f65dd00d2f6a2213205908016e5dd2bf092f1721147bbdd5b8a0e16fd",
+        "author": "9a53795a8afd9f636d71aee2bb750cca29596453a27f3d9e64ee2b9b362fa525",
+        "combined": "50510c0e46c2839df135322a78b3bc18c3781d68564fa57653c2f0ea102e55f7",
+        "tokenSignature": "a-able-ball-being-happy-helluva-it-lucille-makes-recognize-s-start-to-what-you"
+      },
+      "lengths": {
+        "text": 67,
+        "author": 12
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 5
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-06": {
+      "hashes": {
+        "text": "e6d01bff54cb1f51e5205a6a10ce73edb4f32766a01d0e569abb22a65f35258d",
+        "author": "0806956e047b68cd0c5acf0cc47ae74bff868c02bab24934703e22adc589bc71",
+        "combined": "0e15913c5e3f631ebffac57a17dd623dec82bcccf6cbe9415e00e08b263f8511",
+        "tokenSignature": "all-along-and-bothering-can-doing-don-going-hear-just-listening-not-nothing-of-pooh-t-the-things-to-underestimate-value-winnie-you"
+      },
+      "lengths": {
+        "text": 131,
+        "author": 15
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 6
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-07": {
+      "hashes": {
+        "text": "9548a97e3142c72a8b298088d76d2d5ccb1f71d4680cfedc856dc27d245d2496",
+        "author": "bd8d218beeec48b9f2062a9bc477342ad0945fbe02d89b2faf2a3a45e209ad3b",
+        "combined": "2c488ea31e82be179f4e2627fba3f497a671fb026e2fdc44bcaaa56c8c27ec51",
+        "tokenSignature": "cause-go-happiness-oscar-others-some-they-whenever-wherever-wilde"
+      },
+      "lengths": {
+        "text": 63,
+        "author": 11
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 7
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-08": {
+      "hashes": {
+        "text": "747ae8b14480b85dd080107272d148274f1d0e14bd04c2f1dff98c8562541278",
+        "author": "43cf894058901f3f3794d6784735a5cdc6cbbe7fe57f7140c39cda21c2748f4b",
+        "combined": "36b4c768628d68c7a459a2e1dc7b08705d4151a32fce318a7567200bd0aedd7c",
+        "tokenSignature": "achievement-creative-d-effort-franklin-happiness-in-is-it-joy-lies-mere-money-not-of-possession-roosevelt-the-thrill"
+      },
+      "lengths": {
+        "text": 118,
+        "author": 21
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 8
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-09": {
+      "hashes": {
+        "text": "0e84cad9cefd147e66efcd45c083ce05f64a110b75e95e033327eaad32efcd1f",
+        "author": "1909d576d87cabeea353470ba334b95d80fcb790806b082dc5c293719f82df1c",
+        "combined": "7e7b8200077c9c91131375886c4389569cca7a5dc310f34213a5782cf5d5b48a",
+        "tokenSignature": "always-been-can-enjoy-experience-firmly-if-it-l-m-make-mind-montgomery-my-nearly-s-that-things-up-will-you-your"
+      },
+      "lengths": {
+        "text": 110,
+        "author": 16
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 9
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-10": {
+      "hashes": {
+        "text": "a90dc4378b33e96b5e6f291339ff18ddc08c47470232853d7eac85cead4a7bc8",
+        "author": "0c798605789434dd31e95ff5a3e531c2e72d8eca656eff5fd465ecd6de22edfd",
+        "combined": "8cc487633d8a74c00c761aeb6f8878653bf3273fa42799ec47bc439e8e1f4991",
+        "tokenSignature": "a-able-are-deal-eleanor-get-give-giving-good-happiness-into-joy-more-of-others-out-put-roosevelt-should-since-that-the-thought-to-you"
+      },
+      "lengths": {
+        "text": 135,
+        "author": 17
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 10
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-11": {
+      "hashes": {
+        "text": "b83cf0fe5ee384137a4f030ca4ccc7b4c28e0d4a758d0c878f28207148ab9791",
+        "author": "4d963a89b1d8a62d895bdab0e9525510c9743758e4fdd26092b631676f5e1caa",
+        "combined": "d2863f15caa71edb6be5672587939e67fb10925ca1a800c7f6d9de4363ec5897",
+        "tokenSignature": "because-cry-don-dr-happened-it-over-s-seuss-smile-t"
+      },
+      "lengths": {
+        "text": 55,
+        "author": 9
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 11
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-12": {
+      "hashes": {
+        "text": "309b09d8d977590255914d028d93016df235559bbbf7b2bcc4d17a66af8bdb1f",
+        "author": "8a202463a79b857f6b1e3f7f4b6cab33b8ebbbd150d43c7f7b90ac238271fdb9",
+        "combined": "56f04fb91e36762d45f1fc6af2a8312080b7f89f04b0f49420291127d5f782c3",
+        "tokenSignature": "execution-finds-goethe-great-happiness-in-johann-talent-von-wolfgang"
+      },
+      "lengths": {
+        "text": 42,
+        "author": 26
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 12
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "happiness-13": {
+      "hashes": {
+        "text": "4823bf4ce004929a87f17fa77fd44ff51eaeb2e966da491e17c249340674a653",
+        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+        "combined": "102e42dd24db20b8599117650633348853a0c2ece57806b9d9a7208ff0fedfc4",
+        "tokenSignature": "create-happiness-it-others-pursue-some-unknown"
+      },
+      "lengths": {
+        "text": 40,
+        "author": 7
+      },
+      "source": {
+        "categoryId": "happiness",
+        "sequence": 13
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    }
+  }
+}

--- a/tools/build-jokes-from-icanhaz.js
+++ b/tools/build-jokes-from-icanhaz.js
@@ -2,6 +2,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const jokesPreamble = '// Maintenance: run the commands in apps/jokes/AGENTS.md after editing this dataset to keep the syntax valid.';
+
 function clean(text) {
   return text
     .replace(/\r?\n+/g, ' ')
@@ -11,11 +13,12 @@ function clean(text) {
 }
 
 function format(entries) {
-  const lines = ['window.jokes = ['];
+  const lines = [jokesPreamble, '', 'window.jokes = ['];
   entries.forEach((entry, index) => {
     if (index === 0) {
       lines.push('        {');
     }
+    lines.push(`            "id": ${JSON.stringify(entry.id)},`);
     lines.push(`            "joke": ${JSON.stringify(entry.joke)},`);
     lines.push(`            "punchline": ${JSON.stringify(entry.punchline)}`);
     if (index === entries.length - 1) {
@@ -41,8 +44,15 @@ function build() {
     }))
     .filter((item) => item.joke && item.punchline);
 
-  fs.writeFileSync(outputPath, format(entries));
-  console.log(`Wrote ${entries.length} jokes to ${path.relative(process.cwd(), outputPath)}`);
+  const width = Math.max(4, String(entries.length).length);
+  const prepared = entries.map((entry, index) => ({
+    id: `j-${String(index + 1).padStart(width, '0')}`,
+    joke: entry.joke,
+    punchline: entry.punchline,
+  }));
+
+  fs.writeFileSync(outputPath, format(prepared));
+  console.log(`Wrote ${prepared.length} jokes to ${path.relative(process.cwd(), outputPath)}`);
 }
 
 if (require.main === module) {

--- a/tools/build-quotes-from-data.js
+++ b/tools/build-quotes-from-data.js
@@ -15,6 +15,7 @@ function format(entries) {
     lines.push('    "quotes": [');
     category.quotes.forEach((quote, quoteIndex) => {
       lines.push('      {');
+      lines.push(`        "id": ${JSON.stringify(quote.id)},`);
       lines.push(`        "text": ${JSON.stringify(clean(quote.text))},`);
       lines.push(`        "author": ${JSON.stringify(clean(quote.author))}`);
       if (quoteIndex === category.quotes.length - 1) {
@@ -43,10 +44,18 @@ function build() {
   const prepared = data.map((category) => ({
     id: category.id,
     label: category.label,
-    quotes: category.quotes.map((quote) => ({
-      text: clean(quote.text),
-      author: clean(quote.author),
-    })),
+    quotes: (() => {
+      const cleanedQuotes = category.quotes.map((quote) => ({
+        text: clean(quote.text),
+        author: clean(quote.author),
+      }));
+      const width = Math.max(2, String(cleanedQuotes.length).length);
+      return cleanedQuotes.map((quote, index) => ({
+        id: `${category.id}-${String(index + 1).padStart(width, '0')}`,
+        text: quote.text,
+        author: quote.author,
+      }));
+    })(),
   }));
   fs.writeFileSync(outputPath, format(prepared));
   console.log(`Wrote ${prepared.reduce((total, category) => total + category.quotes.length, 0)} quotes across ${prepared.length} categories.`);

--- a/tools/update-content-metadata.js
+++ b/tools/update-content-metadata.js
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const vm = require('vm');
+
+const rootDir = path.join(__dirname, '..');
+const jokesPreamble = '// Maintenance: run the commands in apps/jokes/AGENTS.md after editing this dataset to keep the syntax valid.';
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function writeFile(filePath, contents) {
+  fs.writeFileSync(filePath, `${contents}\n`);
+}
+
+function loadDataset(relativePath, globalKey) {
+  const absolutePath = path.join(rootDir, relativePath);
+  const code = readFile(absolutePath);
+  const context = vm.createContext({ window: {} });
+  const script = new vm.Script(code, { filename: absolutePath });
+  script.runInContext(context);
+  const data = context.window[globalKey];
+  if (!Array.isArray(data)) {
+    throw new Error(`Expected window.${globalKey} to be an array in ${relativePath}`);
+  }
+  return { absolutePath, data };
+}
+
+function padNumber(value, width) {
+  return String(value).padStart(width, '0');
+}
+
+function ensureJokeIds(entries) {
+  const width = Math.max(4, String(entries.length).length);
+  const seen = new Set();
+  return entries.map((entry, index) => {
+    const base = entry && typeof entry.id === 'string' ? entry.id.trim() : '';
+    const fallback = `j-${padNumber(index + 1, width)}`;
+    const id = base && !seen.has(base) ? base : fallback;
+    seen.add(id);
+    return {
+      id,
+      joke: entry.joke,
+      punchline: entry.punchline,
+    };
+  });
+}
+
+function ensureQuoteIds(categories) {
+  return categories.map((category) => {
+    const quotes = Array.isArray(category.quotes) ? category.quotes : [];
+    const width = Math.max(2, String(quotes.length).length);
+    const seen = new Set();
+    const preparedQuotes = quotes.map((quote, index) => {
+      const base = quote && typeof quote.id === 'string' ? quote.id.trim() : '';
+      const fallback = `${category.id}-${padNumber(index + 1, width)}`;
+      const id = base && !seen.has(base) ? base : fallback;
+      seen.add(id);
+      return {
+        id,
+        text: quote.text,
+        author: quote.author,
+      };
+    });
+    return {
+      id: category.id,
+      label: category.label,
+      quotes: preparedQuotes,
+    };
+  });
+}
+
+function formatJokes(entries) {
+  const lines = [jokesPreamble, '', 'window.jokes = ['];
+  entries.forEach((entry, index) => {
+    if (index === 0) {
+      lines.push('        {');
+    }
+    lines.push(`            "id": ${JSON.stringify(entry.id)},`);
+    lines.push(`            "joke": ${JSON.stringify(entry.joke)},`);
+    lines.push(`            "punchline": ${JSON.stringify(entry.punchline)}`);
+    if (index === entries.length - 1) {
+      lines.push('        }');
+    } else {
+      lines.push('        }, {');
+    }
+  });
+  lines.push('    ];');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function formatQuotes(categories) {
+  const lines = ['window.quotesData = ['];
+  categories.forEach((category, categoryIndex) => {
+    lines.push('  {');
+    lines.push(`    "id": ${JSON.stringify(category.id)},`);
+    lines.push(`    "label": ${JSON.stringify(category.label)},`);
+    lines.push('    "quotes": [');
+    category.quotes.forEach((quote, quoteIndex) => {
+      lines.push('      {');
+      lines.push(`        "id": ${JSON.stringify(quote.id)},`);
+      lines.push(`        "text": ${JSON.stringify(quote.text)},`);
+      lines.push(`        "author": ${JSON.stringify(quote.author)}`);
+      if (quoteIndex === category.quotes.length - 1) {
+        lines.push('      }');
+      } else {
+        lines.push('      },');
+      }
+    });
+    lines.push('    ]');
+    if (categoryIndex === categories.length - 1) {
+      lines.push('  }');
+    } else {
+      lines.push('  },');
+    }
+  });
+  lines.push('];');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function normalizeQuotes(text) {
+  return (text || '')
+    .normalize('NFKC')
+    .replace(/[“”«»„]/g, '"')
+    .replace(/[‘’‚‛‹›]/g, "'")
+    .toLowerCase();
+}
+
+function normalizeText(text) {
+  return normalizeQuotes(text)
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([?!.,;:])/g, '$1')
+    .trim();
+}
+
+function tokenSignature(...parts) {
+  const tokens = new Set();
+  parts.forEach((part) => {
+    const normalized = normalizeQuotes(part)
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim();
+    if (!normalized) {
+      return;
+    }
+    normalized.split(' ').forEach((token) => {
+      if (token) {
+        tokens.add(token);
+      }
+    });
+  });
+  return Array.from(tokens).sort().join('-');
+}
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function buildJokesManifest(jokes) {
+  const records = {};
+  jokes.forEach((entry, index) => {
+    const setupNormalized = normalizeText(entry.joke || '');
+    const punchlineNormalized = normalizeText(entry.punchline || '');
+    const combinedParts = [];
+    if (setupNormalized) {
+      combinedParts.push(setupNormalized);
+    }
+    if (punchlineNormalized) {
+      combinedParts.push(punchlineNormalized);
+    }
+    const combinedNormalized = combinedParts.join('|');
+    records[entry.id] = {
+      hashes: {
+        setup: sha256(setupNormalized),
+        punchline: sha256(punchlineNormalized),
+        combined: sha256(combinedNormalized),
+        tokenSignature: tokenSignature(entry.joke, entry.punchline),
+      },
+      lengths: {
+        joke: typeof entry.joke === 'string' ? entry.joke.length : 0,
+        punchline: typeof entry.punchline === 'string' ? entry.punchline.length : 0,
+      },
+      source: {
+        sequence: index + 1,
+      },
+      embedding: {
+        status: 'pending',
+        model: null,
+        vectorSha256: null,
+        updatedAt: null,
+      },
+    };
+  });
+  return {
+    meta: {
+      generatedAt: new Date().toISOString(),
+      total: jokes.length,
+      hashAlgorithm: 'sha256',
+      tokenSignature: 'unique-words-v1',
+      fields: ['joke', 'punchline'],
+    },
+    records,
+  };
+}
+
+function buildQuotesManifest(categories) {
+  const records = {};
+  categories.forEach((category) => {
+    category.quotes.forEach((quote, index) => {
+      const textNormalized = normalizeText(quote.text || '');
+      const authorNormalized = normalizeText(quote.author || '');
+      const combinedParts = [];
+      if (textNormalized) {
+        combinedParts.push(textNormalized);
+      }
+      if (authorNormalized) {
+        combinedParts.push(authorNormalized);
+      }
+      const combinedNormalized = combinedParts.join('|');
+      records[quote.id] = {
+        hashes: {
+          text: sha256(textNormalized),
+          author: sha256(authorNormalized),
+          combined: sha256(combinedNormalized),
+          tokenSignature: tokenSignature(quote.text, quote.author),
+        },
+        lengths: {
+          text: typeof quote.text === 'string' ? quote.text.length : 0,
+          author: typeof quote.author === 'string' ? quote.author.length : 0,
+        },
+        source: {
+          categoryId: category.id,
+          sequence: index + 1,
+        },
+        embedding: {
+          status: 'pending',
+          model: null,
+          vectorSha256: null,
+          updatedAt: null,
+        },
+      };
+    });
+  });
+  const totalQuotes = Object.keys(records).length;
+  return {
+    meta: {
+      generatedAt: new Date().toISOString(),
+      total: totalQuotes,
+      categories: categories.length,
+      hashAlgorithm: 'sha256',
+      tokenSignature: 'unique-words-v1',
+      fields: ['text', 'author'],
+    },
+    records,
+  };
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function main() {
+  const jokesData = loadDataset(path.join('apps', 'jokes', 'jokes.js'), 'jokes');
+  const quotesData = loadDataset(path.join('apps', 'quotes', 'quotes-data.js'), 'quotesData');
+
+  const jokesWithIds = ensureJokeIds(jokesData.data);
+  const quotesWithIds = ensureQuoteIds(quotesData.data);
+
+  writeFile(jokesData.absolutePath, formatJokes(jokesWithIds));
+  writeFile(quotesData.absolutePath, formatQuotes(quotesWithIds));
+
+  const jokesManifestPath = path.join(rootDir, 'data', 'jokes-manifest.json');
+  const quotesManifestPath = path.join(rootDir, 'data', 'quotes-manifest.json');
+
+  writeJson(jokesManifestPath, buildJokesManifest(jokesWithIds));
+  writeJson(quotesManifestPath, buildQuotesManifest(quotesWithIds));
+
+  console.log(`Updated ${jokesWithIds.length} jokes and wrote ${path.relative(rootDir, jokesManifestPath)}`);
+  console.log(`Updated ${quotesWithIds.reduce((total, category) => total + category.quotes.length, 0)} quotes and wrote ${path.relative(rootDir, quotesManifestPath)}`);
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add sequential IDs to the jokes and quotes decks and update the generators/documentation to preserve the new fields
- add a maintenance script that rewrites the datasets with IDs and emits hash/token manifests for downstream dedupe work
- check in the generated jokes and quotes manifests seeded with normalized hashes and embedding placeholders

## Testing
- node --check apps/jokes/jokes.js
- node -e "global.window = {}; require('./apps/jokes/jokes.js'); console.log(Array.isArray(window.jokes), window.jokes.length);"
- node -e "global.window = {}; require('./apps/quotes/quotes-data.js'); console.log(Array.isArray(window.quotesData), window.quotesData.length);"

------
https://chatgpt.com/codex/tasks/task_e_68cefc23439c8328bc0bc6264ba05303