### PR TITLE
Prune duplicate entries and add onboarding similarity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,9 @@ This starts a server on <http://localhost:3000> (or the next available port).
   `--provider=hfspace --model=bienkieu/sentence-embedding`, which pipes batches through the BienKieu Hugging Face Space
   (`sentence-transformers/all-MiniLM-L6-v2`) using `curl`—no API key required. Keep `--batch-size` at 8 or lower to avoid the
   shared queue timing out.
+  - When onboarding new material, add `--candidates=jokes:path/to/new-jokes.json` (or `quotes:...`) to embed the prospective
+    entries and compare them against the existing decks at the current cosine threshold. Candidate files accept arrays of
+    objects that mirror the dataset fields (`joke`/`punchline` for jokes, `text`/`author` for quotes) and reuse the active
+    `--provider`/`--model` combination so duplicates are flagged before committing new content.
 - Apply the curated duplicate removals with `node tools/prune-duplicate-records.js`. Use `--dry-run` to preview how many
   jokes, quotes, and embedding vectors would be pruned before writing the updated datasets, manifests, and stores back to disk.

--- a/apps/jokes/jokes.js
+++ b/apps/jokes/jokes.js
@@ -1858,10 +1858,6 @@ window.jokes = [
             "joke": "Where did Captain Hook get his hook?",
             "punchline": "From a second hand store."
         }, {
-            "id": "j-0465",
-            "joke": "I got fired from a florist",
-            "punchline": "apparently I took too many leaves."
-        }, {
             "id": "j-0466",
             "joke": "Two silk worms had a race.",
             "punchline": "They ended up in a tie."
@@ -2678,10 +2674,6 @@ window.jokes = [
             "joke": "Have you heard about corduroy pillows?",
             "punchline": "They're making headlines!"
         }, {
-            "id": "j-0670",
-            "joke": "What did the fish say when it hit the wall?",
-            "punchline": "Dam."
-        }, {
             "id": "j-0671",
             "joke": "How do you make a tissue dance?",
             "punchline": "You put a little boogie on it."
@@ -2693,10 +2685,6 @@ window.jokes = [
             "id": "j-0673",
             "joke": "What do you call a belt made out of watches?",
             "punchline": "A waist of time."
-        }, {
-            "id": "j-0674",
-            "joke": "Why can't bicycles stand on their own?",
-            "punchline": "They are two tired"
         }, {
             "id": "j-0675",
             "joke": "How does a train eat?",
@@ -2794,10 +2782,6 @@ window.jokes = [
             "joke": "What did the duck say when he bought lipstick?",
             "punchline": "Put it on my bill"
         }, {
-            "id": "j-0699",
-            "joke": "What happens to a frog's car when it breaks down?",
-            "punchline": "It gets toad away"
-        }, {
             "id": "j-0700",
             "joke": "did you know the first French fries weren't cooked in France?",
             "punchline": "they were cooked in Greece"
@@ -2857,14 +2841,6 @@ window.jokes = [
             "id": "j-0714",
             "joke": "Don't look at the eclipse through a colander.",
             "punchline": "You'll strain your eyes."
-        }, {
-            "id": "j-0715",
-            "joke": "I bought some shoes from a drug dealer.",
-            "punchline": "I don't know what he laced them with, but I was tripping all day!"
-        }, {
-            "id": "j-0716",
-            "joke": "Why do chicken coops only have two doors?",
-            "punchline": "Because if they had four, they would be chicken sedans"
         }, {
             "id": "j-0717",
             "joke": "What do you call a factory that sells passable products?",
@@ -2950,14 +2926,6 @@ window.jokes = [
             "joke": "Why do C# and Java developers keep breaking their keyboards?",
             "punchline": "Because they use a strongly typed language."
         }, {
-            "id": "j-0738",
-            "joke": "What do you give to a lemon in need?",
-            "punchline": "Lemonaid."
-        }, {
-            "id": "j-0739",
-            "joke": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before. What can I get for you?\"",
-            "punchline": "Pop,goes the weasel."
-        }, {
             "id": "j-0740",
             "joke": "Can I watch the TV?",
             "punchline": "Yes, but don’t turn it on."
@@ -2970,17 +2938,9 @@ window.jokes = [
             "joke": "How good are you at Power Point?",
             "punchline": "I Excel at it."
         }, {
-            "id": "j-0743",
-            "joke": "How many seconds are in a year?",
-            "punchline": "12. January 2nd, February 2nd, March 2nd, April 2nd.... etc"
-        }, {
             "id": "j-0744",
             "joke": "What’s 50 Cent’s name in Zimbabwe?",
             "punchline": "200 Dollars."
-        }, {
-            "id": "j-0745",
-            "joke": "Where’s the bin?",
-            "punchline": "I haven’t been anywhere!"
         }, {
             "id": "j-0746",
             "joke": "Knock-knock.",
@@ -3158,10 +3118,6 @@ window.jokes = [
             "joke": "Why did the private classes break up?",
             "punchline": "Because they never saw each other."
         }, {
-            "id": "j-0790",
-            "joke": "Why did the developer quit his job?",
-            "punchline": "Because he didn't get arrays."
-        }, {
             "id": "j-0791",
             "joke": "How many React developers does it take to change a lightbulb?",
             "punchline": "None, they prefer dark mode."
@@ -3194,10 +3150,6 @@ window.jokes = [
             "joke": "Why did the programmer go broke?",
             "punchline": "He used up all his cache"
         }, {
-            "id": "j-0799",
-            "joke": "Why did the programmer always mix up Halloween and Christmas?",
-            "punchline": "Because Oct 31 equals Dec 25."
-        }, {
             "id": "j-0800",
             "joke": "Why don't programmers like nature?",
             "punchline": "There's too many bugs."
@@ -3222,10 +3174,6 @@ window.jokes = [
             "joke": "What did the janitor say when he jumped out of the closet?",
             "punchline": "Supplies!"
         }, {
-            "id": "j-0806",
-            "joke": "What did one ocean say to the other ocean?",
-            "punchline": "Nothing, they just waved."
-        }, {
             "id": "j-0807",
             "joke": "What's the best thing about Switzerland?",
             "punchline": "I don't know, but their flag is a big plus."
@@ -3234,17 +3182,9 @@ window.jokes = [
             "joke": "Why did the golfer bring two pairs of pants?",
             "punchline": "In case he got a hole in one."
         }, {
-            "id": "j-0809",
-            "joke": "Why did the chicken cross the playground?",
-            "punchline": "To get to the other slide."
-        }, {
             "id": "j-0810",
             "joke": "Why don't scientists trust atoms?",
             "punchline": "Because they make up everything."
-        }, {
-            "id": "j-0811",
-            "joke": "Why don't oysters give to charity?",
-            "punchline": "Because they're shellfish."
         }, {
             "id": "j-0812",
             "joke": "Why did the cookie go to the doctor?",
@@ -3257,10 +3197,6 @@ window.jokes = [
             "id": "j-0814",
             "joke": "Why did the designer break up with their font?",
             "punchline": "Because it wasn't their type."
-        }, {
-            "id": "j-0815",
-            "joke": "Why did the programmer quit their job?",
-            "punchline": "They didn't get arrays."
         }, {
             "id": "j-0816",
             "joke": "Why did the developer go broke?",

--- a/apps/quotes/quotes-data.js
+++ b/apps/quotes/quotes-data.js
@@ -29,11 +29,6 @@ window.quotesData = [
         "author": "Ralph Waldo Emerson"
       },
       {
-        "id": "adventure-06",
-        "text": "Travel makes one modest. You see what a tiny place you occupy in the world.",
-        "author": "Gustav Flaubert"
-      },
-      {
         "id": "adventure-07",
         "text": "A ship in harbor is safe, but that is not what ships are built for.",
         "author": "John A. Shedd"
@@ -182,11 +177,6 @@ window.quotesData = [
         "id": "adventure-36",
         "text": "If you think adventure is dangerous, try routine, it is lethal.",
         "author": "Paulo Coelho"
-      },
-      {
-        "id": "adventure-37",
-        "text": "Travel makes one modest, you see what a tiny place you occupy in the world.",
-        "author": "Gustave Flaubert"
       },
       {
         "id": "adventure-38",
@@ -1279,11 +1269,6 @@ window.quotesData = [
     "label": "Travel",
     "quotes": [
       {
-        "id": "travel-01",
-        "text": "The world is a book, and those who do not travel read only a page.",
-        "author": "Unknown"
-      },
-      {
         "id": "travel-02",
         "text": "Take only memories, leave only footprints.",
         "author": "Unknown"
@@ -1429,11 +1414,6 @@ window.quotesData = [
         "author": "Anonymous"
       },
       {
-        "id": "travel-39",
-        "text": "Collect Moment, Not Things.",
-        "author": "Anonymous"
-      },
-      {
         "id": "travel-40",
         "text": "Blessed are the curious for they shall have adventures.",
         "author": "Lovelle Drachman"
@@ -1452,11 +1432,6 @@ window.quotesData = [
         "id": "travel-44",
         "text": "This wasn’t a strange place; it was a new one.",
         "author": "Paulo Coelho"
-      },
-      {
-        "id": "travel-45",
-        "text": "If we were meant to stay in one place, we’d have roots instead of feet",
-        "author": "Rachel Wolchin"
       },
       {
         "id": "travel-46",
@@ -1713,11 +1688,6 @@ window.quotesData = [
         "id": "humor-46",
         "text": "I generally avoid temptation unless I can’t resist it.",
         "author": "Mae West"
-      },
-      {
-        "id": "humor-48",
-        "text": "If you cannot get rid of the family skeleton, you may as well make it dance.",
-        "author": "George Bernard Shaw, “Immaturity"
       },
       {
         "id": "humor-49",

--- a/data/jokes-embeddings.json
+++ b/data/jokes-embeddings.json
@@ -1,2 +1,7319 @@
-    "generatedAt": "2025-09-20T20:02:25.996Z",
-    "recordCount": 828
+{
+  "meta": {
+    "provider": "fake",
+    "model": "fake-64",
+    "dimensions": 64,
+    "generatedAt": "2025-09-20T22:27:41.543Z",
+    "recordCount": 812
+  },
+  "records": {
+    "j-0001": {
+      "vector": "mJcXv9bVVT/r6uo+trU1P769PT+VlBQ+5eRkPuXkZL6HhoY+np0dv6yrKz/+/X2/8vFxP42MDL6cmxs/09LSPsfGxr7j4uI+kZAQvZWUFD6FhAQ+qqkpP/38fD7My0s/srExv4KBAb+SkRG/trU1P4aFBT/a2Vk/xcREPr++vj6Ylxe/1tVVP+vq6j62tTU/vr09P5WUFD7l5GQ+5eRkvoeGhj6enR2/rKsrP/79fb/y8XE/jYwMvpybGz/T0tI+x8bGvuPi4j6RkBC9lZQUPoWEBD6qqSk//fx8PszLSz+ysTG/goEBv5KREb+2tTU/hoUFP9rZWT/FxEQ+v76+Pg==",
+      "vectorSha256": "25b86de4c565923a74dad51665c058978d64569fc9756382cc64afe996a9145f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "34eabadade929c63a131d501f86ecdb44eb87b9290d49fe5273f37dac2ec98af",
+      "updatedAt": "2025-09-20T22:27:41.489Z"
+    },
+    "j-0002": {
+      "vector": "0dBQvYmIiL2koyO/+fj4PZOSkr7Y11e/3dxcPtTTUz/f3t6+wcBAPPn4+L2pqKi9wcBAPJuamr7Lysq+lZQUPoOCgj6sqys/29raPsXERD6cmxs//Pt7P5STEz+zsrI+ycjIPdXUVD7FxES+nJsbv/X0dL6WlRW///7+voKBAb/R0FC9iYiIvaSjI7/5+Pg9k5KSvtjXV7/d3Fw+1NNTP9/e3r7BwEA8+fj4vamoqL3BwEA8m5qavsvKyr6VlBQ+g4KCPqyrKz/b2to+xcREPpybGz/8+3s/lJMTP7Oysj7JyMg91dRUPsXERL6cmxu/9fR0vpaVFb///v6+goEBvw==",
+      "vectorSha256": "f9c3aaf90bda00a0ae4a59aa2c43a27be08bb8449dbd166db08076cb95f8f228",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "79772e8f5b149be94881707581594d92a0d5b698cdfdc9ac8c9a67326135403f",
+      "updatedAt": "2025-09-20T22:27:41.490Z"
+    },
+    "j-0003": {
+      "vector": "jo0Nv7CvL7/j4uI+2tlZP9bVVb+Pjo6+2NdXv/r5eb+vrq4+wcBAPO3sbL6Ihwc/wcBAvOXkZD6HhoY+7u1tP4uKij6Pjo4+5ONjv4qJCT+GhQU/8O9vv9jXVz/Y11c/+Pd3v9jXV7/083M/4eDgvMnIyL3KyUk/iIcHP+fm5j6OjQ2/sK8vv+Pi4j7a2Vk/1tVVv4+Ojr7Y11e/+vl5v6+urj7BwEA87exsvoiHBz/BwEC85eRkPoeGhj7u7W0/i4qKPo+Ojj7k42O/iokJP4aFBT/w72+/2NdXP9jXVz/493e/2NdXv/Tzcz/h4OC8ycjIvcrJST+Ihwc/5+bmPg==",
+      "vectorSha256": "7f3b64634f4ec96d01bbbe924821a8bebbb3a11488788254ed95c732b8117ac5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3928b8ec155c1403ab8162c37e9ca1f6a2a30ec4c208ebeb0414f97c73e4c3b9",
+      "updatedAt": "2025-09-20T22:27:41.490Z"
+    },
+    "j-0004": {
+      "vector": "+vl5P6CfHz/Lysq+l5aWvpaVFT+8uzu/5ONjP/38fL6amRk/ycjIPYGAgDsAAIA/srExv769PT/HxsY+wL8/v/Lxcb/Avz8/8vFxv8nIyL2EgwO/iYiIvaSjI7/Ew0O/zcxMPoWEBL7R0FC9AACAP7Oysj7q6Wm/rq0tv+XkZL76+Xk/oJ8fP8vKyr6Xlpa+lpUVP7y7O7/k42M//fx8vpqZGT/JyMg9gYCAOwAAgD+ysTG/vr09P8fGxj7Avz+/8vFxv8C/Pz/y8XG/ycjIvYSDA7+JiIi9pKMjv8TDQ7/NzEw+hYQEvtHQUL0AAIA/s7KyPurpab+urS2/5eRkvg==",
+      "vectorSha256": "cd4fe6d19b8e33e13821833a98624ba8d4cb0092237c044fa39ff0380dcef2ab",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fccf4d5aca22f160cc8c80ff27deb12007df07733e772e1e996f79ffac0b2963",
+      "updatedAt": "2025-09-20T22:27:41.490Z"
+    },
+    "j-0005": {
+      "vector": "yMdHP/HwcD3v7u6+lZQUPomIiD2BgIA7nJsbP/Tzcz/CwUG/jYwMvs/Ozj6vrq6+w8LCPqqpKT/s62s/3NtbP5aVFT/m5WW/vbw8vsC/P7/Hxsa+u7q6vqyrKz/OzU2/x8bGvvDvbz+VlBQ+hoUFP4uKij7Z2Ng9k5KSvsHAQDzIx0c/8fBwPe/u7r6VlBQ+iYiIPYGAgDucmxs/9PNzP8LBQb+NjAy+z87OPq+urr7DwsI+qqkpP+zraz/c21s/lpUVP+blZb+9vDy+wL8/v8fGxr67urq+rKsrP87NTb/Hxsa+8O9vP5WUFD6GhQU/i4qKPtnY2D2TkpK+wcBAPA==",
+      "vectorSha256": "6e8db44805f0b978a4f10547988ead1ff28cfe70fd8452ef17caf041d52d4748",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e38744928880cdf91f6eb354b0d4f5edca0d68204e51d5194ef792c2a28d5b81",
+      "updatedAt": "2025-09-20T22:27:41.490Z"
+    },
+    "j-0006": {
+      "vector": "6OdnP9nY2L2opye/t7a2PrOysj6NjAw+wsFBv7u6ur7Qz08/7+7uvv79fb/z8vI+iokJP56dHb/JyMi9q6qqvgAAgL/l5GQ+09LSvo6NDb/f3t6+//7+vp6dHT+gnx+/goEBP8/Ozj6FhAQ+7u1tv7q5Ob+trCy+oaCgvNDPTz/o52c/2djYvainJ7+3trY+s7KyPo2MDD7CwUG/u7q6vtDPTz/v7u6+/v19v/Py8j6KiQk/np0dv8nIyL2rqqq+AACAv+XkZD7T0tK+jo0Nv9/e3r7//v6+np0dP6CfH7+CgQE/z87OPoWEBD7u7W2/urk5v62sLL6hoKC80M9PPw==",
+      "vectorSha256": "bafcaadbb32c7dea8f5fe49fac318bac2a5802cadf566b1a1052b034c4a7f719",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f3722cadac911f51e74401bcc4317355009c4b394840ce30c0b39009236a7de7",
+      "updatedAt": "2025-09-20T22:27:41.493Z"
+    },
+    "j-0007": {
+      "vector": "sK8vP8LBQb+vrq6+7+7uPvHwcL3j4uK+m5qavri3Nz+rqqq+h4aGPpWUFL7FxEQ+AACAv6KhIT/29XU/2djYPcfGxj7FxES+yMdHP4yLC7/T0tI+7OtrP5STEz/DwsI+3NtbP5GQEL2Lioo+srExv83MTD7k42O/vr09v83MTL6wry8/wsFBv6+urr7v7u4+8fBwvePi4r6bmpq+uLc3P6uqqr6HhoY+lZQUvsXERD4AAIC/oqEhP/b1dT/Z2Ng9x8bGPsXERL7Ix0c/jIsLv9PS0j7s62s/lJMTP8PCwj7c21s/kZAQvYuKij6ysTG/zcxMPuTjY7++vT2/zcxMvg==",
+      "vectorSha256": "eea9312a5b2d80911c5d3d75d86dbe8d1dee0a551e560da6afbc4667e609c8cc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d71f54bb784759db55a16d9800d0fa8db167e33ab4f5c9b0ed7ba227990e2166",
+      "updatedAt": "2025-09-20T22:27:41.493Z"
+    },
+    "j-0008": {
+      "vector": "wsFBv/79fb+3trY+nJsbv8jHRz/29XU/j46OPurpab/s62u/oaCgvNjXV7+VlBQ+oaCgPLm4uD2wry8/5ONjP728PD7n5ua+nZwcvrSzMz+ZmJi9z87OvsHAQDz083M/19bWPvr5eb/h4OA8wcBAPL69Pb/KyUm/qaiovfz7e7/CwUG//v19v7e2tj6cmxu/yMdHP/b1dT+Pjo4+6ulpv+zra7+hoKC82NdXv5WUFD6hoKA8ubi4PbCvLz/k42M/vbw8Pufm5r6dnBy+tLMzP5mYmL3Pzs6+wcBAPPTzcz/X1tY++vl5v+Hg4DzBwEA8vr09v8rJSb+pqKi9/Pt7vw==",
+      "vectorSha256": "a1b967b8a5fbe6b3e01203969edaf8480a22dbb2f921a2e42f4ceba36f9afca0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1f01ad32e3faa30b0a7d1492828bd7f197466cd9764c81f9b5038381211b7502",
+      "updatedAt": "2025-09-20T22:27:41.493Z"
+    },
+    "j-0009": {
+      "vector": "zs1NP769PT+WlRU/7OtrP/HwcL2/vr4++/r6vurpab+9vDy+8vFxv6inJ7/Hxsa+wL8/P7m4uL2dnBy+gYCAu8PCwr6hoKA8+vl5P6inJz/Avz8/vLs7v8bFRb+EgwM/y8rKvp6dHT+pqKg9mZiYvb28PL6wry8/t7a2vsLBQb/OzU0/vr09P5aVFT/s62s/8fBwvb++vj77+vq+6ulpv728PL7y8XG/qKcnv8fGxr7Avz8/ubi4vZ2cHL6BgIC7w8LCvqGgoDz6+Xk/qKcnP8C/Pz+8uzu/xsVFv4SDAz/Lysq+np0dP6moqD2ZmJi9vbw8vrCvLz+3tra+wsFBvw==",
+      "vectorSha256": "5532e4d3bf3901aa9142ca81bf0f752b0777f9684e50cc5a34033dc9be1a220d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e6decaf578af410b68072c4edf746c7f4f82fcd3df221dc14dce8a7668d7521f",
+      "updatedAt": "2025-09-20T22:27:41.494Z"
+    },
+    "j-0010": {
+      "vector": "tbQ0vu3sbL61tDS+0M9PP+zra7/6+Xk/xMNDv9rZWT/r6uq+j46OvtDPTz+TkpK+9fR0PtrZWT+enR2/j46OPoOCgj7My0s/+Pd3v//+/j6VlBQ+2djYPZKREb+4tzc/4N9fP7u6uj6koyM/nJsbP83MTD6KiQm/qqkpP5iXFz+1tDS+7exsvrW0NL7Qz08/7Otrv/r5eT/Ew0O/2tlZP+vq6r6Pjo6+0M9PP5OSkr719HQ+2tlZP56dHb+Pjo4+g4KCPszLSz/493e///7+PpWUFD7Z2Ng9kpERv7i3Nz/g318/u7q6PqSjIz+cmxs/zcxMPoqJCb+qqSk/mJcXPw==",
+      "vectorSha256": "72394f7f2264a0c00ce5467d0bbf725ee60b520f353ba2953537b6b0eca98d4f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "696269e70afc1eec455ce75b9eec31a3a0e504bf928d37dbefaed1cd993bd4cb",
+      "updatedAt": "2025-09-20T22:27:41.494Z"
+    },
+    "j-0011": {
+      "vector": "u7q6PoKBAT+1tDS+7+7uvrW0ND6ysTE/hoUFv8zLS7+Pjo6+1dRUvsjHR7+/vr4+lpUVv6GgoDympSU/9/b2vuno6L3d3Fw+qKcnP/Lxcb+zsrI+tLMzv6qpKb+OjQ0/jIsLP6inJz/Z2Ni9/fx8vpSTEz+trCy+qqkpv4GAgDu7uro+goEBP7W0NL7v7u6+tbQ0PrKxMT+GhQW/zMtLv4+Ojr7V1FS+yMdHv7++vj6WlRW/oaCgPKalJT/39va+6ejovd3cXD6opyc/8vFxv7Oysj60szO/qqkpv46NDT+Miws/qKcnP9nY2L39/Hy+lJMTP62sLL6qqSm/gYCAOw==",
+      "vectorSha256": "328b69e0e2499f45ac6355895b299f77ef15044e8e31d48334e6615b6cfbde37",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "aec0694496d83d1a5c651caf3582d242719bd307ac262bc6c5d37260c96a2b80",
+      "updatedAt": "2025-09-20T22:27:41.494Z"
+    },
+    "j-0012": {
+      "vector": "7u1tP5iXFz+joqI+1tVVv6yrK7+Qjw8/mpkZP5ybGz+urS0/pKMjP7i3N7+RkBC9iokJv5ybG7+7uro+sK8vP4+Ojj6npqY+ubi4vdDPT7/d3Fy+5uVlP+/u7r66uTk/2NdXv5uamr7NzEy+6Odnv5qZGT+3trY+zcxMPszLS7/u7W0/mJcXP6Oioj7W1VW/rKsrv5CPDz+amRk/nJsbP66tLT+koyM/uLc3v5GQEL2KiQm/nJsbv7u6uj6wry8/j46OPqempj65uLi90M9Pv93cXL7m5WU/7+7uvrq5OT/Y11e/m5qavs3MTL7o52e/mpkZP7e2tj7NzEw+zMtLvw==",
+      "vectorSha256": "83e2bb316bac6ee6509aa367d74049fd3697a0222e961c648690fcd224542e60",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f6cba8152ac7cccdd6d1247b3b32aed7a3a9741864f244dc1459660cccad991a",
+      "updatedAt": "2025-09-20T22:27:41.495Z"
+    },
+    "j-0013": {
+      "vector": "+fj4vczLS7+DgoI+o6KiPpWUFD6mpSU/g4KCPvDvbz+ioSG/6ulpv/r5eb/p6Oi9paQkPtjXV7+Lioq+8vFxv9fW1r64tzc/o6KiPpWUFL7w72+/j46OvtLRUb/z8vK+0tFRv56dHT+EgwM/r66uPsLBQb+dnBw+6OdnP8rJST/5+Pi9zMtLv4OCgj6joqI+lZQUPqalJT+DgoI+8O9vP6KhIb/q6Wm/+vl5v+no6L2lpCQ+2NdXv4uKir7y8XG/19bWvri3Nz+joqI+lZQUvvDvb7+Pjo6+0tFRv/Py8r7S0VG/np0dP4SDAz+vrq4+wsFBv52cHD7o52c/yslJPw==",
+      "vectorSha256": "1e5f9cb43801a8f26454b402a02780d5b1ec029a0b2b2878b7491ac1afa6720e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "701aa0a892d2a0f72f0b037194145d074adba86d085c174317cec1ab1f93f3e4",
+      "updatedAt": "2025-09-20T22:27:41.495Z"
+    },
+    "j-0014": {
+      "vector": "2NdXP7W0ND7q6Wm/uLc3P+vq6r6Qjw8/6ulpv/n4+L3X1ta+4N9fP9XUVL7n5ua+4N9fv93cXL6Ylxc/8O9vP5WUFL6zsrK+9PNzP+7tbb/7+vq+qKcnP8C/P7/g31+/4N9fv6KhIT/w72+/tbQ0vu/u7r719HS+qqkpP9TTUz/Y11c/tbQ0Purpab+4tzc/6+rqvpCPDz/q6Wm/+fj4vdfW1r7g318/1dRUvufm5r7g31+/3dxcvpiXFz/w728/lZQUvrOysr7083M/7u1tv/v6+r6opyc/wL8/v+DfX7/g31+/oqEhP/Dvb7+1tDS+7+7uvvX0dL6qqSk/1NNTPw==",
+      "vectorSha256": "f1874e031b502bd23dca64a09df15b68a75b6de8ce07e31a22b3182ccc019d28",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "eb960bdb45c70b704aef65461064cbf76d53f90941d3201010d008694461d4e9",
+      "updatedAt": "2025-09-20T22:27:41.495Z"
+    },
+    "j-0015": {
+      "vector": "4+LiPrq5Ob+6uTk/wL8/v5uamr7Pzs6+oqEhP5OSkj7q6Wk//v19v5eWlj7v7u6+xcREvs/Ozr7Pzs6+9/b2Purpab/19HQ+lZQUvrKxMb/R0FA91dRUPs/Ozr6CgQG/2tlZv4yLC7+OjQ0//v19v4KBAT+opyc/5+bmPvDvbz/j4uI+urk5v7q5OT/Avz+/m5qavs/Ozr6ioSE/k5KSPurpaT/+/X2/l5aWPu/u7r7FxES+z87Ovs/Ozr739vY+6ulpv/X0dD6VlBS+srExv9HQUD3V1FQ+z87OvoKBAb/a2Vm/jIsLv46NDT/+/X2/goEBP6inJz/n5uY+8O9vPw==",
+      "vectorSha256": "77f7b4a9a3a7f02d5456250fa0be4c868114193b4592af90a8f2909b9ac24f29",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b823dc20594cd0a4f401a544674c4cbd0b9e6d27869a4c3f133ac601c0d3b9f7",
+      "updatedAt": "2025-09-20T22:27:41.496Z"
+    },
+    "j-0016": {
+      "vector": "2tlZv7CvL7/Lyso+1NNTv+XkZD7CwUG/8vFxP7y7Oz/7+vq+srExv6+urj7x8HC9jIsLP8/Ozj6opyc/mZiYvamoqD2ioSE/r66uvrq5Ob+amRk/29ravsXERL6ysTG/pqUlv97dXT+BgIC76ejovfr5eT/w72+/+/r6Pv79fb/a2Vm/sK8vv8vKyj7U01O/5eRkPsLBQb/y8XE/vLs7P/v6+r6ysTG/r66uPvHwcL2Miws/z87OPqinJz+ZmJi9qaioPaKhIT+vrq6+urk5v5qZGT/b2tq+xcREvrKxMb+mpSW/3t1dP4GAgLvp6Oi9+vl5P/Dvb7/7+vo+/v19vw==",
+      "vectorSha256": "33ba9c2c30bb60eefd519ccab01cdd1d3d00fec21c72e2026a4165634e1a1d59",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1328b2169c1ff8dd4127ab78c5b3d3768ad05423cc4967272dee7f71fc08be01",
+      "updatedAt": "2025-09-20T22:27:41.496Z"
+    },
+    "j-0017": {
+      "vector": "1NNTv83MTD4AAIC/nJsbP4KBAT+/vr6+/Pt7v4+Ojj7NzEy+wL8/P4uKij6UkxO/5uVlP+rpaT+FhAQ+nJsbP4WEBD6EgwO/rKsrP9DPT7/5+Pi9zcxMPr28PL7s62u/y8rKPo6NDT+dnBw+sK8vv5uamr7p6Og9t7a2vquqqj7U01O/zcxMPgAAgL+cmxs/goEBP7++vr78+3u/j46OPs3MTL7Avz8/i4qKPpSTE7/m5WU/6ulpP4WEBD6cmxs/hYQEPoSDA7+sqys/0M9Pv/n4+L3NzEw+vbw8vuzra7/Lyso+jo0NP52cHD6wry+/m5qavuno6D23tra+q6qqPg==",
+      "vectorSha256": "d03339ea030c8973824102b563a3aa7f5b0663c4a2e0a7492b62c847de752523",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "169900cdc05002a366dfa236f2f490cd903ed5187099680ab2c69328598e52aa",
+      "updatedAt": "2025-09-20T22:27:41.497Z"
+    },
+    "j-0018": {
+      "vector": "ycjIvcjHRz/R0FA9xsVFv+LhYb+fnp4+3Ntbv4KBAb+npqY+vLs7v+jnZ7/BwEA8zcxMvu7tbb+VlBS+ubi4Pdva2j76+Xk/sK8vP+/u7r7Pzs6+3t1dP8nIyD3g31+/l5aWPoGAgDvIx0c/oJ8fP5CPD7/6+Xk/v76+PpeWlr7JyMi9yMdHP9HQUD3GxUW/4uFhv5+enj7c21u/goEBv6empj68uzu/6Odnv8HAQDzNzEy+7u1tv5WUFL65uLg929raPvr5eT+wry8/7+7uvs/Ozr7e3V0/ycjIPeDfX7+XlpY+gYCAO8jHRz+gnx8/kI8Pv/r5eT+/vr4+l5aWvg==",
+      "vectorSha256": "db4adc12e700bd2baedc029b5fa5a5ea2f6f4cdee72100226ee45e65640a2c99",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "73e3861d0fa7123fa9220c8166096d8bb6fcd7444cee8c10a580e3cf38fcaf5a",
+      "updatedAt": "2025-09-20T22:27:41.497Z"
+    },
+    "j-0019": {
+      "vector": "09LSPpWUFL67urq++vl5P8bFRT+WlRU/3dxcvpiXF7/Y11c/hIMDP6empj6NjAw+y8rKvt7dXb/Ew0M/jYwMvsjHR7+WlRW/v76+vpaVFT+gnx+/oJ8fP8XERD6Ihwe/7exsvtbVVb+RkBC9gYCAu/X0dD7r6uq+p6amvvLxcT/T0tI+lZQUvru6ur76+Xk/xsVFP5aVFT/d3Fy+mJcXv9jXVz+EgwM/p6amPo2MDD7Lysq+3t1dv8TDQz+NjAy+yMdHv5aVFb+/vr6+lpUVP6CfH7+gnx8/xcREPoiHB7/t7Gy+1tVVv5GQEL2BgIC79fR0Puvq6r6npqa+8vFxPw==",
+      "vectorSha256": "57f3255d209d39254da6626c4be04bc318d947f4b4ede6a9ea52edd8970c2993",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b46d51fce2ca6434ebc1a9914d11e16e1c3550ca30cf983c62157b7f9e4556f8",
+      "updatedAt": "2025-09-20T22:27:41.497Z"
+    },
+    "j-0020": {
+      "vector": "paQkvquqqj6TkpK+qKcnv9jXVz+TkpK+g4KCvs3MTL7V1FS+j46OPpCPDz++vT2/+fj4vcfGxj6opye/8/LyPoKBAT+ioSG/vLs7v8XERD7493c/4+LiPoSDAz/u7W2/5eRkvqmoqL2ysTG/oaCgvOPi4r7493c/i4qKvs7NTT+lpCS+q6qqPpOSkr6opye/2NdXP5OSkr6DgoK+zcxMvtXUVL6Pjo4+kI8PP769Pb/5+Pi9x8bGPqinJ7/z8vI+goEBP6KhIb+8uzu/xcREPvj3dz/j4uI+hIMDP+7tbb/l5GS+qaiovbKxMb+hoKC84+Livvj3dz+Lioq+zs1NPw==",
+      "vectorSha256": "78199a06c9407eb98a56e13a1d37408ef45300916854034d58069ba0a6dd11a6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6baa5b2ceb5b5f6665a3c72170b12cbcc02f2298fbb8c1096375277d47fb5de6",
+      "updatedAt": "2025-09-20T22:27:41.497Z"
+    },
+    "j-0021": {
+      "vector": "/fx8PujnZz/p6Oi9+/r6PujnZz/6+Xk/3dxcPtLRUb+fnp4+jo0Nv+Hg4LylpCS+w8LCvpybG7/h4OA8sbAwPf79fb/V1FS+iIcHv9bVVT/s62u/5+bmPrW0NL7Ew0M/qaioPcXERD7l5GS+hYQEvpKREb+dnBy+y8rKvsXERD79/Hw+6OdnP+no6L37+vo+6OdnP/r5eT/d3Fw+0tFRv5+enj6OjQ2/4eDgvKWkJL7DwsK+nJsbv+Hg4DyxsDA9/v19v9XUVL6Ihwe/1tVVP+zra7/n5uY+tbQ0vsTDQz+pqKg9xcREPuXkZL6FhAS+kpERv52cHL7Lysq+xcREPg==",
+      "vectorSha256": "dcecebb6afb12ccd251fc6efbd40fff2621a83c4c701bc2b4567637a563b6225",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9ff371bef3fc9b17a7397c6b4f32838501653cea0ab969e18a98636f376c4d98",
+      "updatedAt": "2025-09-20T22:27:41.497Z"
+    },
+    "j-0022": {
+      "vector": "jYwMPuXkZL6ysTE/09LSvtva2j7//v6+4+Livs7NTT+UkxO/n56evqGgoDy1tDQ+ycjIPaWkJL7+/X0/gYCAu5STEz/m5WW/qqkpP4qJCb+Qjw8/wsFBP66tLb/19HS+7u1tv5OSkj6wry8/2tlZP8bFRT+8uzu/oJ8fP5CPD7+NjAw+5eRkvrKxMT/T0tK+29raPv/+/r7j4uK+zs1NP5STE7+fnp6+oaCgPLW0ND7JyMg9paQkvv79fT+BgIC7lJMTP+blZb+qqSk/iokJv5CPDz/CwUE/rq0tv/X0dL7u7W2/k5KSPrCvLz/a2Vk/xsVFP7y7O7+gnx8/kI8Pvw==",
+      "vectorSha256": "cc29949b6702904605b95c56277282ab8feb98b9cf938ac6c36c002f14b14a73",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9163d84bb64047e6365882968c6bfe7fc90dd43bc7e0296109a4d7ece222cf38",
+      "updatedAt": "2025-09-20T22:27:41.497Z"
+    },
+    "j-0023": {
+      "vector": "n56ePqGgoLyUkxO/paQkPrCvL7/d3Fw+1dRUPsrJSb+7urq+zs1NP/38fD6EgwO/0tFRv8LBQb///v4+0dBQveTjY7/n5ua+xsVFP6alJT+4tzc/wL8/v5aVFb/+/X2/6Odnv9rZWT/5+Pg9lJMTP62sLL7y8XG/mZiYPcXERD6fnp4+oaCgvJSTE7+lpCQ+sK8vv93cXD7V1FQ+yslJv7u6ur7OzU0//fx8PoSDA7/S0VG/wsFBv//+/j7R0FC95ONjv+fm5r7GxUU/pqUlP7i3Nz/Avz+/lpUVv/79fb/o52e/2tlZP/n4+D2UkxM/rawsvvLxcb+ZmJg9xcREPg==",
+      "vectorSha256": "604b8a7c6f3a7ecc70e28aa544566edf57d1ab0fd0b8c2f698327f2cd9dc3fa8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a77d3694289b9a1b51e69f3e171fbf790e46e2d2db2035010cec8fc96a078998",
+      "updatedAt": "2025-09-20T22:27:41.498Z"
+    },
+    "j-0024": {
+      "vector": "7u1tP5WUFD6wry+/z87OPvHwcD3i4WE/mZiYvdTTUz+TkpK+oaCgPKyrKz/s62s/lJMTP/f29j7GxUU/hYQEvs/Ozj719HS+paQkPqOioj6opyc/p6amvublZb/BwEA8s7KyPrGwMD3j4uI+tbQ0vvTzcz+9vDy+goEBP/b1dT/u7W0/lZQUPrCvL7/Pzs4+8fBwPeLhYT+ZmJi91NNTP5OSkr6hoKA8rKsrP+zraz+UkxM/9/b2PsbFRT+FhAS+z87OPvX0dL6lpCQ+o6KiPqinJz+npqa+5uVlv8HAQDyzsrI+sbAwPePi4j61tDS+9PNzP728PL6CgQE/9vV1Pw==",
+      "vectorSha256": "8d3e180a373278bbb02c7f7988f159dc1d84e89247eed21e725d2e1e6a76c756",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f69228b387f076e95b82d5f5c9bde26fb36194a8d3560d81ac85b869f968c0fa",
+      "updatedAt": "2025-09-20T22:27:41.498Z"
+    },
+    "j-0025": {
+      "vector": "i4qKPuXkZL6CgQE/jIsLP/b1db/KyUk/9vV1P7W0NL77+vo+09LSvsLBQT/7+vq+4eDgPLCvL7/a2Vk/9PNzv9XUVL7Qz0+/5+bmvpKREb+pqKg9pKMjv8LBQT/CwUG/mpkZv6CfHz++vT0/paQkvpCPD7+amRm/oqEhP7SzMz+Lioo+5eRkvoKBAT+Miws/9vV1v8rJST/29XU/tbQ0vvv6+j7T0tK+wsFBP/v6+r7h4OA8sK8vv9rZWT/083O/1dRUvtDPT7/n5ua+kpERv6moqD2koyO/wsFBP8LBQb+amRm/oJ8fP769PT+lpCS+kI8Pv5qZGb+ioSE/tLMzPw==",
+      "vectorSha256": "a02d87ac60d2d2430ee8a01cbb6309caf401ee34d247d0a59be61135f051e77e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a263c0c505e4fa69be4be0418328ec06651846378a2ee01f33cfde6b3833d0d9",
+      "updatedAt": "2025-09-20T22:27:41.498Z"
+    },
+    "j-0026": {
+      "vector": "8vFxP87NTb+EgwO/q6qqvre2tr6Pjo4+zcxMvrCvLz+mpSU//fx8vs3MTD6koyM/3dxcPp+enj67uro+qaioPa6tLT/j4uK+//7+PqqpKb/p6Og9trU1P8C/Pz/Avz+/pKMjv8nIyL2joqI+kZAQvcfGxr6/vr4+wL8/v5eWlr7y8XE/zs1Nv4SDA7+rqqq+t7a2vo+Ojj7NzEy+sK8vP6alJT/9/Hy+zcxMPqSjIz/d3Fw+n56ePru6uj6pqKg9rq0tP+Pi4r7//v4+qqkpv+no6D22tTU/wL8/P8C/P7+koyO/ycjIvaOioj6RkBC9x8bGvr++vj7Avz+/l5aWvg==",
+      "vectorSha256": "8de9da55ff9b1b8210ec09d7f136a96a5f17c2ee116b114835fa5bb6bd564907",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f8193e5552a366d7d26099d19ba7ae8ad647bf2b8edadf202e73a87b4eaf205a",
+      "updatedAt": "2025-09-20T22:27:41.498Z"
+    },
+    "j-0027": {
+      "vector": "hoUFP8C/P7/+/X2/2NdXP6KhIT/Avz8/397ePt/e3r7//v4+0dBQPbq5Ob+JiIi9hoUFv5eWlj719HS+np0dP8XERL67urq+wsFBv+Pi4j6rqqo+zcxMvsLBQT+CgQG/t7a2Pv38fD6Ihwc/kI8Pv7u6ur7My0u/lJMTv4uKij6GhQU/wL8/v/79fb/Y11c/oqEhP8C/Pz/f3t4+397evv/+/j7R0FA9urk5v4mIiL2GhQW/l5aWPvX0dL6enR0/xcREvru6ur7CwUG/4+LiPquqqj7NzEy+wsFBP4KBAb+3trY+/fx8PoiHBz+Qjw+/u7q6vszLS7+UkxO/i4qKPg==",
+      "vectorSha256": "2f89efe3479b2d1b0a174c5d21fe0110b0917e70c11554a55a6c9e9aa4bafc0f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c22001ebd0dfb748bf8623773da561ce67511fb8aa66e03fad9fc338511a36a2",
+      "updatedAt": "2025-09-20T22:27:41.498Z"
+    },
+    "j-0028": {
+      "vector": "0dBQPcjHRz/a2Vk/hoUFv7q5Ob/o52e/hIMDP5GQEL3493c/z87OvvHwcD25uLg9+Pd3v+Pi4r7x8HA9ycjIPfj3dz+opyc/9fR0Pq+urj6UkxM/4uFhv+blZT/n5uY+1NNTP+zra7/R0FA9tbQ0vs/Ozj6koyO/3dxcPp6dHb/R0FA9yMdHP9rZWT+GhQW/urk5v+jnZ7+EgwM/kZAQvfj3dz/Pzs6+8fBwPbm4uD3493e/4+LivvHwcD3JyMg9+Pd3P6inJz/19HQ+r66uPpSTEz/i4WG/5uVlP+fm5j7U01M/7Otrv9HQUD21tDS+z87OPqSjI7/d3Fw+np0dvw==",
+      "vectorSha256": "87c7495f55b2b4de4d94a7957b2f7f080cd6e39d4f2a070e9e0a5c8a2553e9ee",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "86e3ec3d230cc17bfb4c878b0447878cfbd39eabc90ff2b9e90a8669b32e9b31",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0029": {
+      "vector": "4eDgPNTTU7+CgQG/+/r6vuLhYT/g318/wcBAPIqJCb/V1FS+4uFhv+zra7/7+vo+mpkZP87NTT/o52c/jo0NP87NTT/Ix0e/8O9vv+no6L3u7W2/0dBQPdjXV7+joqK+8O9vv9fW1r7Z2Ng9oaCgPIqJCb/9/Hy+v76+vqWkJL7h4OA81NNTv4KBAb/7+vq+4uFhP+DfXz/BwEA8iokJv9XUVL7i4WG/7Otrv/v6+j6amRk/zs1NP+jnZz+OjQ0/zs1NP8jHR7/w72+/6ejove7tbb/R0FA92NdXv6Oior7w72+/19bWvtnY2D2hoKA8iokJv/38fL6/vr6+paQkvg==",
+      "vectorSha256": "5486edaf47edeada0c32b1c7fa477db40d3ad46d793e7ed5cb25330596cb20fb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "83163f41f0ef813b650f0abecce6f3c6e61c087109861457084a8d823b60506b",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0030": {
+      "vector": "2NdXP56dHb++vT0/ycjIvcvKyr7083M/5eRkPoyLC7/z8vK+iIcHv/n4+L2pqKi9vr09v7Oysj6GhQU/t7a2vuvq6r6ysTE/jIsLv/v6+r78+3u/p6amPtva2r7w72+/j46OvvDvbz+SkRG/rq0tv6alJT/Z2Ni9n56evvPy8r7Y11c/np0dv769PT/JyMi9y8rKvvTzcz/l5GQ+jIsLv/Py8r6Ihwe/+fj4vamoqL2+vT2/s7KyPoaFBT+3tra+6+rqvrKxMT+Miwu/+/r6vvz7e7+npqY+29ravvDvb7+Pjo6+8O9vP5KREb+urS2/pqUlP9nY2L2fnp6+8/Lyvg==",
+      "vectorSha256": "8bf2b9f1ab8d26cfad3d03ddc3eb253036fe8d092ec0935be6aedb1a717f5264",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "eb31de734df99c3a433c707521acc25245d83a4102a949085cf73729d2725843",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0031": {
+      "vector": "+vl5v7e2tj7+/X2/19bWvqqpKT/BwEA8trU1v46NDb/9/Hy+iokJP/r5eb/CwUE/jIsLP6GgoLyXlpY+iIcHv4mIiL0AAIC/7exsvvz7e7/CwUE/oqEhv5aVFb/t7Gw+lJMTP6moqL3Y11e/qqkpP5GQED2npqY+6OdnP66tLb/6+Xm/t7a2Pv79fb/X1ta+qqkpP8HAQDy2tTW/jo0Nv/38fL6KiQk/+vl5v8LBQT+Miws/oaCgvJeWlj6Ihwe/iYiIvQAAgL/t7Gy+/Pt7v8LBQT+ioSG/lpUVv+3sbD6UkxM/qaiovdjXV7+qqSk/kZAQPaempj7o52c/rq0tvw==",
+      "vectorSha256": "8cb2dcb442ceb1df29a7ce0651a0dc24142c671c1e33ea7a722d6970dd8ccf19",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "03ad014ad481253960c403e0c57da53c77006202e02f359dc97514d484a9f329",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0032": {
+      "vector": "09LSvvX0dD75+Pg9/v19P/v6+j6ioSG/0M9PP6inJz/6+Xm/m5qaPufm5r7BwEC8wsFBv5WUFD739va+397ePsXERL7BwEA85eRkPtzbWz+ysTE/z87Ovvj3dz+3tra+wL8/P5GQED37+vq+5+bmPoaFBb8AAIC/lpUVv7q5OT/T0tK+9fR0Pvn4+D3+/X0/+/r6PqKhIb/Qz08/qKcnP/r5eb+bmpo+5+bmvsHAQLzCwUG/lZQUPvf29r7f3t4+xcREvsHAQDzl5GQ+3NtbP7KxMT/Pzs6++Pd3P7e2tr7Avz8/kZAQPfv6+r7n5uY+hoUFvwAAgL+WlRW/urk5Pw==",
+      "vectorSha256": "ab6b630a2e174685c28fe9fa5fdcc5eba99020e4cb07ca27c0e38521f632562e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4b9e8ffebe2fe7d303a6467e1f9242b767819cedd84cfb52df8441b93d0035dc",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0033": {
+      "vector": "trU1v/z7ez/29XW/hYQEPtjXVz/6+Xk/ubi4Pauqqr7Ix0c/kI8PP4qJCT/z8vI+n56ePpCPD7/Ix0e/lpUVv/n4+L3S0VE/09LSvp+enr6xsDC9pqUlP6empj6NjAw+1dRUvqalJT+8uzs/urk5v5WUFL60szO/ubi4vdjXV7+2tTW//Pt7P/b1db+FhAQ+2NdXP/r5eT+5uLg9q6qqvsjHRz+Qjw8/iokJP/Py8j6fnp4+kI8Pv8jHR7+WlRW/+fj4vdLRUT/T0tK+n56evrGwML2mpSU/p6amPo2MDD7V1FS+pqUlP7y7Oz+6uTm/lZQUvrSzM7+5uLi92NdXvw==",
+      "vectorSha256": "b477ebb1af6e0bfd929f8af2bac397e5e3ee163c905a3805af1388b247d010f2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "25fd0590ebfc8b55e3c7c4bca7381c3570e84b587ad2a99165d2dd236d267414",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0034": {
+      "vector": "5uVlP6KhIb+WlRW/8fBwvYyLCz+FhAQ+0dBQvY+Ojj63trY+0tFRP7Oysr6SkRG/+Pd3v6qpKb+qqSm/n56ePsnIyD3s62s/9PNzPwAAgL+mpSW/yslJP6CfHz+GhQU/5+bmvrSzM7+Hhoa++/r6Pqempr63tra+6+rqvufm5r7m5WU/oqEhv5aVFb/x8HC9jIsLP4WEBD7R0FC9j46OPre2tj7S0VE/s7KyvpKREb/493e/qqkpv6qpKb+fnp4+ycjIPezraz/083M/AACAv6alJb/KyUk/oJ8fP4aFBT/n5ua+tLMzv4eGhr77+vo+p6amvre2tr7r6uq+5+bmvg==",
+      "vectorSha256": "1c75a59e9f7c9137cf59e2d6b27c47a18e7ca24ad42b06328c5d17a9e38e9435",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f22f3578c59079a3ade85337042b2ba78cf5f9002de4cfc246265ebe56524546",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0035": {
+      "vector": "kpERP62sLD6rqqo+zMtLv5mYmL3493c/+Pd3P+blZT/8+3s/x8bGPrm4uL2ZmJi9hoUFP5uamj6zsrI+oJ8fv4SDAz+Ihwe/7OtrP5KREb+3trY+rawsPvDvb7/493c/k5KSvrW0NL7q6Wk/iIcHP7GwMD2Qjw+/s7Kyvvz7ez+SkRE/rawsPquqqj7My0u/mZiYvfj3dz/493c/5uVlP/z7ez/HxsY+ubi4vZmYmL2GhQU/m5qaPrOysj6gnx+/hIMDP4iHB7/s62s/kpERv7e2tj6trCw+8O9vv/j3dz+TkpK+tbQ0vurpaT+Ihwc/sbAwPZCPD7+zsrK+/Pt7Pw==",
+      "vectorSha256": "2fb858b518802a3ef6f4f7727bc77e06506f3641692004f62a9f8f5e077a09f9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c895aa1a76fbfbf2fdb17476c2a6ac30c13cf537ad9508fb5b69f4c3853853fd",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0036": {
+      "vector": "iYiIPYWEBL7Z2Ni95ONjP7u6uj7BwEC89/b2vtfW1j78+3u/hIMDP7e2tj66uTk/8O9vv/f29j76+Xk/2tlZP7KxMb+Ihwc/rq0tv8zLSz/U01M/hoUFv4OCgj7i4WE/3t1dvwAAgD/Avz+/wsFBv4+Ojr76+Xk/5uVlv/38fD6JiIg9hYQEvtnY2L3k42M/u7q6PsHAQLz39va+19bWPvz7e7+EgwM/t7a2Prq5OT/w72+/9/b2Pvr5eT/a2Vk/srExv4iHBz+urS2/zMtLP9TTUz+GhQW/g4KCPuLhYT/e3V2/AACAP8C/P7/CwUG/j46Ovvr5eT/m5WW//fx8Pg==",
+      "vectorSha256": "f8305ba0cfd05cdff565cdc9c94550d17fc2311161cdad16166428b766357412",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "886f72f1ae7e42b502c1addc08bdfcec27c329e5e93da0f011ff201f5cfc0d9f",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0037": {
+      "vector": "+fj4vd/e3j7Qz08/19bWPtrZWb/493e/n56ePrCvLz///v6+8fBwve3sbL6fnp4+0M9Pv6qpKT/h4OA8x8bGvtTTU7/i4WG/9/b2vomIiL0AAIA/qKcnv66tLT/NzEw+8O9vP7++vj6GhQW/kZAQvYaFBT+HhoY+wcBAPKGgoDz5+Pi9397ePtDPTz/X1tY+2tlZv/j3d7+fnp4+sK8vP//+/r7x8HC97exsvp+enj7Qz0+/qqkpP+Hg4DzHxsa+1NNTv+LhYb/39va+iYiIvQAAgD+opye/rq0tP83MTD7w728/v76+PoaFBb+RkBC9hoUFP4eGhj7BwEA8oaCgPA==",
+      "vectorSha256": "d89d120b7208d377a322e7e04b8a5f4affebb78c53015f4cd4c3b936187fd03c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "70b7e7b51304a7d7407862a718d4834e160f4277ff2cd699f7af3d7bc2a18182",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0038": {
+      "vector": "8/LyvpKREb+VlBS+jo0Nv8HAQLynpqY+qqkpP7m4uD28uzs/vr09P/r5eT+RkBC9v76+vuLhYb/a2Vm/uLc3P+Pi4j7083M/t7a2Pq+urr6gnx8/pKMjv5uamj7NzEy+zcxMvpeWlj7Lysq+lpUVP8zLS7/r6uo+4N9fv4GAgDvz8vK+kpERv5WUFL6OjQ2/wcBAvKempj6qqSk/ubi4Pby7Oz++vT0/+vl5P5GQEL2/vr6+4uFhv9rZWb+4tzc/4+LiPvTzcz+3trY+r66uvqCfHz+koyO/m5qaPs3MTL7NzEy+l5aWPsvKyr6WlRU/zMtLv+vq6j7g31+/gYCAOw==",
+      "vectorSha256": "79b94998ecf727786c1182b3ad0bc06bcd455f31f78d1fe48b4e8d5f7031991e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "43376d397ea9d48bdddefc7b500f13dbb8f9ad54cf2ea66666a54dca1aba1080",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0039": {
+      "vector": "x8bGvo+Ojj6cmxs/5uVlP4OCgj6WlRW/4N9fv5uamj6EgwM/gYCAO+LhYT/BwEA8vbw8vquqqj6Hhoa+p6amPpmYmL2SkRE/r66uvszLS7+npqY+397evuvq6j7T0tI+u7q6PpiXFz/NzEy+397evqempj7X1tY+7+7uvpiXF7/Hxsa+j46OPpybGz/m5WU/g4KCPpaVFb/g31+/m5qaPoSDAz+BgIA74uFhP8HAQDy9vDy+q6qqPoeGhr6npqY+mZiYvZKRET+vrq6+zMtLv6empj7f3t6+6+rqPtPS0j67uro+mJcXP83MTL7f3t6+p6amPtfW1j7v7u6+mJcXvw==",
+      "vectorSha256": "ee857bfd51b1abd54028408898dca3c54d1f93b07242cee3b790117a12905663",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4ea3cdf2a03510a6c180f08168aa5ea976c8541aa948bab4aecb6648a9b54434",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0040": {
+      "vector": "tbQ0vsbFRT/f3t4+zMtLv4SDA7/KyUm/lpUVv7CvLz+joqI+jYwMvpGQED3Ix0e/m5qaPp2cHL6UkxM/2tlZv/LxcT+1tDS+vLs7v9va2j66uTm/7Otrv6WkJD7c21s/z87OvpGQEL2npqa+4+LivsvKyr6UkxM/zcxMPpGQEL21tDS+xsVFP9/e3j7My0u/hIMDv8rJSb+WlRW/sK8vP6Oioj6NjAy+kZAQPcjHR7+bmpo+nZwcvpSTEz/a2Vm/8vFxP7W0NL68uzu/29raPrq5Ob/s62u/paQkPtzbWz/Pzs6+kZAQvaempr7j4uK+y8rKvpSTEz/NzEw+kZAQvQ==",
+      "vectorSha256": "4b6fdfa9e6742943fdc46d4adfc0ae1fec9d415e835d291cc59b22b9167fd85b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "69e2b71a3e1b35d7a86e841ca66cc913f86922b6230a94ed4c7b56474dc9997b",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0041": {
+      "vector": "6ulpP7u6uj6Qjw+/hIMDP8bFRb/Lyso+8/LyvtDPTz+Pjo4+19bWPtDPTz/n5ua+u7q6vquqqj7W1VU/yMdHP+fm5r6vrq4+n56ePrCvLz/X1ta+tLMzv/b1dT/493c/zcxMPgAAgD/v7u4+k5KSPvr5eb/My0s/5ONjP+jnZ7/q6Wk/u7q6PpCPD7+EgwM/xsVFv8vKyj7z8vK+0M9PP4+Ojj7X1tY+0M9PP+fm5r67urq+q6qqPtbVVT/Ix0c/5+bmvq+urj6fnp4+sK8vP9fW1r60szO/9vV1P/j3dz/NzEw+AACAP+/u7j6TkpI++vl5v8zLSz/k42M/6Odnvw==",
+      "vectorSha256": "987fc45997e28cde266e7e7b74d4022636497193ddcf424029766091dbbe2a79",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f4ae38c11db243e7a3b5e74651aaeae346aba7d74a26fafb99ffbba403e5f10c",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0042": {
+      "vector": "hoUFP/Py8r719HQ+29raPsvKyj6JiIi9tLMzP9zbW7/T0tI+rKsrv9fW1r62tTW/AACAv/79fb+Ylxe/mJcXP6uqqj7w72+/lJMTP+DfX7/g31+/ubi4vevq6j7Avz+/+fj4vbe2tj65uLg9pKMjvwAAgL+5uLg9pqUlP/HwcD2GhQU/8/LyvvX0dD7b2to+y8rKPomIiL20szM/3Ntbv9PS0j6sqyu/19bWvra1Nb8AAIC//v19v5iXF7+Ylxc/q6qqPvDvb7+UkxM/4N9fv+DfX7+5uLi96+rqPsC/P7/5+Pi9t7a2Prm4uD2koyO/AACAv7m4uD2mpSU/8fBwPQ==",
+      "vectorSha256": "a43cc37deebb7e4340b308e811721a8e99e1946964acd9177758a44053994aeb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c2439eb6b277d912b42a4a25000134cbaa08c9101074ba2070ad8b2e008bd287",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0043": {
+      "vector": "qqkpv/Py8j7Qz08/+Pd3v8nIyD2hoKC8v76+PqmoqD3W1VW/0dBQvff29j7083M/7exsvry7Oz/+/X0/kpERP6KhIb+FhAQ+t7a2PoiHB7+ioSE/mpkZv5ybG7+ysTG/2djYvY+Ojj6npqY+iokJv4uKir6TkpK+srExP5STEz+qqSm/8/LyPtDPTz/493e/ycjIPaGgoLy/vr4+qaioPdbVVb/R0FC99/b2PvTzcz/t7Gy+vLs7P/79fT+SkRE/oqEhv4WEBD63trY+iIcHv6KhIT+amRm/nJsbv7KxMb/Z2Ni9j46OPqempj6KiQm/i4qKvpOSkr6ysTE/lJMTPw==",
+      "vectorSha256": "4ed1ee698a217b3244fcb5f3dff153c82ebecc76a5170d717b39bb817c55ab3d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2bbce7048c7daf8a1579bdf962ddfec82f90ad3cd033322772a3a93b5d5bd8c9",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0044": {
+      "vector": "goEBv8vKyj6xsDC9lZQUvpaVFb+9vDw+2djYPeTjY78AAIA/kI8Pv728PL4AAIC/lJMTP5+enj7s62u/vLs7P+vq6r7083M/jo0NP/38fL6rqqq+9vV1P9LRUT+sqys/2tlZP/HwcD2npqa+p6amPuLhYb+1tDQ+09LSPpeWlj6CgQG/y8rKPrGwML2VlBS+lpUVv728PD7Z2Ng95ONjvwAAgD+Qjw+/vbw8vgAAgL+UkxM/n56ePuzra7+8uzs/6+rqvvTzcz+OjQ0//fx8vquqqr729XU/0tFRP6yrKz/a2Vk/8fBwPaempr6npqY+4uFhv7W0ND7T0tI+l5aWPg==",
+      "vectorSha256": "a529dbe58783005b575b6c567a1776ab2342124a9c26c34e3494e8379a8b8c5e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3fb27a6d35978d0eff386800c9a70add45f9c66055fae8d5ec8756a90f96b4a5",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0045": {
+      "vector": "lJMTv4KBAT+ysTG/q6qqvvTzc7+OjQ0/xsVFv4OCgj7Ew0O/lJMTP/HwcD2Hhoa+q6qqPoWEBD6mpSU/rawsvsLBQb/Z2Ni9vLs7P7SzMz+lpCS+hYQEvtzbW7/T0tI+rKsrP9/e3r7BwEC89fR0Pqempr7p6Oi96ulpP/X0dL6UkxO/goEBP7KxMb+rqqq+9PNzv46NDT/GxUW/g4KCPsTDQ7+UkxM/8fBwPYeGhr6rqqo+hYQEPqalJT+trCy+wsFBv9nY2L28uzs/tLMzP6WkJL6FhAS+3Ntbv9PS0j6sqys/397evsHAQLz19HQ+p6amvuno6L3q6Wk/9fR0vg==",
+      "vectorSha256": "efb0846b3aaff20a546e8822194ef569294dce407210da5eda8d43b5853818e8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "36c0275506c61da01ec9875eaa90d26a1f72ddd96b6f12b4d5487e9e5671f461",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0046": {
+      "vector": "mZiYPdHQUL38+3u/n56evpWUFL6xsDA97Otrv6alJT/W1VU/goEBv6moqL3T0tK+h4aGPra1NT/k42O/7Otrv/r5eb/T0tI+mJcXv5iXF7+urS0/6Odnv7e2tr6hoKC8tLMzP6WkJD6fnp4+wcBAPP38fD6sqyu/8O9vP9fW1j6ZmJg90dBQvfz7e7+fnp6+lZQUvrGwMD3s62u/pqUlP9bVVT+CgQG/qaiovdPS0r6HhoY+trU1P+TjY7/s62u/+vl5v9PS0j6Ylxe/mJcXv66tLT/o52e/t7a2vqGgoLy0szM/paQkPp+enj7BwEA8/fx8PqyrK7/w728/19bWPg==",
+      "vectorSha256": "9120ce1d1ee284e487c9e4e25717767749c26e6a3e45e27cf71abf19febadda2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "897902586d850ad2ea3f754ba1da0e0a03b43434d60c527dd994a7819f2af7b5",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0047": {
+      "vector": "nJsbv+fm5j6Lioo+5+bmPoeGhj7g318/qaiovdPS0r6RkBC9iokJP5aVFb+0szM/uLc3P87NTT+Ihwc/sK8vv4GAgDugnx+/pqUlP9LRUT/+/X0/jIsLv9va2j7CwUG/jYwMPuLhYT/OzU2/+fj4PeTjY7+CgQG/2djYPYqJCb+cmxu/5+bmPouKij7n5uY+h4aGPuDfXz+pqKi909LSvpGQEL2KiQk/lpUVv7SzMz+4tzc/zs1NP4iHBz+wry+/gYCAO6CfH7+mpSU/0tFRP/79fT+Miwu/29raPsLBQb+NjAw+4uFhP87NTb/5+Pg95ONjv4KBAb/Z2Ng9iokJvw==",
+      "vectorSha256": "0d6e0f34d507116e7fa8be6e4a5b8ab8d1c6ec9d6e47c5fd3a3c40bf74cbdffd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "32b9a2b9a1ef754b7bc435d9dbe6c3288030d2e8fe3ab61f91f0198f0e3f8d3b",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0048": {
+      "vector": "/Pt7P4KBAT+UkxO//fx8vrSzM7+fnp6+qKcnv/38fD6sqys/9/b2Pru6ur76+Xk/wL8/v8TDQz/z8vK+wcBAPPv6+r6ioSG/t7a2vre2tj7w72+/h4aGvoqJCT/n5ua+xMNDv6SjIz/V1FS+9/b2vq6tLb/Pzs6+mJcXP7i3Nz/8+3s/goEBP5STE7/9/Hy+tLMzv5+enr6opye//fx8PqyrKz/39vY+u7q6vvr5eT/Avz+/xMNDP/Py8r7BwEA8+/r6vqKhIb+3tra+t7a2PvDvb7+Hhoa+iokJP+fm5r7Ew0O/pKMjP9XUVL739va+rq0tv8/Ozr6Ylxc/uLc3Pw==",
+      "vectorSha256": "3d1c290f214f2ba98728df04296e5c11fe66fff0bd7f6d4e23b3d0b879c6a5e8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fdc0366026582c9fd5bd51fc20e14381412f52ad085ec4461ed16542294ccbdb",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0049": {
+      "vector": "uLc3P+blZb/JyMg9iYiIPbW0ND7m5WW/gYCAO7q5OT/6+Xm/trU1v7y7Oz+8uzu/7exsvpybG7+RkBA9pKMjv5uamr7n5ua+j46Ovs7NTb+JiIg9oaCgvI+Ojj65uLi93Ntbv6SjI7+lpCS+u7q6vpOSkj7Avz8/0tFRv4eGhr64tzc/5uVlv8nIyD2JiIg9tbQ0PublZb+BgIA7urk5P/r5eb+2tTW/vLs7P7y7O7/t7Gy+nJsbv5GQED2koyO/m5qavufm5r6Pjo6+zs1Nv4mIiD2hoKC8j46OPrm4uL3c21u/pKMjv6WkJL67urq+k5KSPsC/Pz/S0VG/h4aGvg==",
+      "vectorSha256": "5e27f04ebe5f331e861ccf684e731d762f0a8d9038498a1928711a3192093e16",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "db0d8c88960d80dc0325dd226232842e59465c19887da374122e6b51a4df175e",
+      "updatedAt": "2025-09-20T22:27:41.501Z"
+    },
+    "j-0050": {
+      "vector": "ycjIvaSjI7+7uro+m5qaPqalJT+Qjw+/6ulpP8LBQT/v7u6+5eRkPpCPDz/v7u6+2djYPY2MDL7f3t6+1NNTP4uKir6qqSm/l5aWvvHwcL3U01M/4uFhP8PCwj7Lysq+2djYvczLSz/z8vK+4eDgPKuqqj6bmpq+3dxcPsbFRb/JyMi9pKMjv7u6uj6bmpo+pqUlP5CPD7/q6Wk/wsFBP+/u7r7l5GQ+kI8PP+/u7r7Z2Ng9jYwMvt/e3r7U01M/i4qKvqqpKb+Xlpa+8fBwvdTTUz/i4WE/w8LCPsvKyr7Z2Ni9zMtLP/Py8r7h4OA8q6qqPpuamr7d3Fw+xsVFvw==",
+      "vectorSha256": "392521a85568e6979a29b10b06394dd65f25f9b1c4848bc7fec2b1d3ecf3a301",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "732eaea6d238f4e0449cc7448d6e48e95d2b5a78e9f0b04d72e54383aa599b1d",
+      "updatedAt": "2025-09-20T22:27:41.501Z"
+    },
+    "j-0051": {
+      "vector": "9PNzv6SjIz+7uro+ycjIPc7NTb/n5uY+g4KCPo+Ojj7u7W2/+fj4vdbVVb/q6Wm/oaCgPJGQED3Ew0M/+/r6PtfW1j6NjAy+v76+PsnIyL36+Xk/vr09PwAAgD+Hhoa+yMdHv4WEBL4AAIA/goEBP5STE7/f3t4+/Pt7v7u6uj7083O/pKMjP7u6uj7JyMg9zs1Nv+fm5j6DgoI+j46OPu7tbb/5+Pi91tVVv+rpab+hoKA8kZAQPcTDQz/7+vo+19bWPo2MDL6/vr4+ycjIvfr5eT++vT0/AACAP4eGhr7Ix0e/hYQEvgAAgD+CgQE/lJMTv9/e3j78+3u/u7q6Pg==",
+      "vectorSha256": "c1df035b526b8f19c0fdf628e80377345f404881e0142f11ff1e0599b3bec6f1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "06d1ae8c19b9a0a30970150b8284e1beb56eaf73fcdeff5e1c6fffc036b702ae",
+      "updatedAt": "2025-09-20T22:27:41.501Z"
+    },
+    "j-0052": {
+      "vector": "1NNTP4qJCT/v7u4+j46OPvz7e7+8uzs/yMdHv5STEz/k42O/6+rqvoWEBL6pqKi9s7Kyvuno6D3x8HA9rKsrv9TTUz+BgIC72tlZv7y7O7+opyc/zcxMvqempj6urS2/v76+vsPCwj7m5WU/p6amvrGwMD39/Hw+oaCgPKuqqj7U01M/iokJP+/u7j6Pjo4+/Pt7v7y7Oz/Ix0e/lJMTP+TjY7/r6uq+hYQEvqmoqL2zsrK+6ejoPfHwcD2sqyu/1NNTP4GAgLva2Vm/vLs7v6inJz/NzEy+p6amPq6tLb+/vr6+w8LCPublZT+npqa+sbAwPf38fD6hoKA8q6qqPg==",
+      "vectorSha256": "567d7f6e0e2dd89e056caa837019e7e2d0a35b0bbc5db62ef878c171f241041d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e9c4bba302dd1cc90e456f75538e872ae97f1322d366a92950b0f256859f82aa",
+      "updatedAt": "2025-09-20T22:27:41.501Z"
+    },
+    "j-0053": {
+      "vector": "kZAQPZaVFb+joqI+hoUFP/Tzcz/083M/xMNDP6uqqj7T0tI++/r6PoWEBL6hoKA87u1tv/n4+L26uTm/xsVFP+Hg4LyZmJg9np0dv+/u7j7o52c/k5KSvtfW1r4AAIA/iYiIva6tLb/k42O/8vFxv4SDAz/19HQ+srExv5CPDz+RkBA9lpUVv6Oioj6GhQU/9PNzP/Tzcz/Ew0M/q6qqPtPS0j77+vo+hYQEvqGgoDzu7W2/+fj4vbq5Ob/GxUU/4eDgvJmYmD2enR2/7+7uPujnZz+TkpK+19bWvgAAgD+JiIi9rq0tv+TjY7/y8XG/hIMDP/X0dD6ysTG/kI8PPw==",
+      "vectorSha256": "268dac40eca24aaf06a03ab2c8f8e96a301669c06bcdd911613d64a6fbb1c132",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8435a8c2f9f9e1aab4be6f82097023e27c8931bbf35b4aff77290e07c19e27c7",
+      "updatedAt": "2025-09-20T22:27:41.501Z"
+    },
+    "j-0054": {
+      "vector": "kpERv8C/Pz+7uro+i4qKPvLxcT/q6Wk/7OtrP769Pb+ZmJi99vV1P+blZT+NjAw+vbw8Pp+enr6amRm/zcxMPpaVFT/w728//fx8vq6tLT/X1tY+qqkpv4eGhr7w728/paQkvv38fL7x8HC9vr09P4SDA7+Hhoa+oqEhP6CfH7+SkRG/wL8/P7u6uj6Lioo+8vFxP+rpaT/s62s/vr09v5mYmL329XU/5uVlP42MDD69vDw+n56evpqZGb/NzEw+lpUVP/Dvbz/9/Hy+rq0tP9fW1j6qqSm/h4aGvvDvbz+lpCS+/fx8vvHwcL2+vT0/hIMDv4eGhr6ioSE/oJ8fvw==",
+      "vectorSha256": "4f17d4f905d5b8bd6da85f9c2315ad6dafaaf43787d6a9f374380a49d495a04f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "37dfaea2f8f4f52176faf29197583399caf760d6b52b5ef76b6078de3e5ed030",
+      "updatedAt": "2025-09-20T22:27:41.501Z"
+    },
+    "j-0055": {
+      "vector": "/Pt7P/HwcD2Lioq+wcBAPI6NDb+dnBy+9vV1P4qJCb/083M/xMNDP8C/Pz+ioSE/wsFBP9nY2L3FxEQ+4uFhP4qJCT/w728/pKMjv4GAgDvHxsa+i4qKPr++vr60szM/7exsvpKRET+qqSm/3dxcPu3sbD7083M/qKcnP+TjYz/8+3s/8fBwPYuKir7BwEA8jo0Nv52cHL729XU/iokJv/Tzcz/Ew0M/wL8/P6KhIT/CwUE/2djYvcXERD7i4WE/iokJP/Dvbz+koyO/gYCAO8fGxr6Lioo+v76+vrSzMz/t7Gy+kpERP6qpKb/d3Fw+7exsPvTzcz+opyc/5ONjPw==",
+      "vectorSha256": "dcf4ceef2984a5bc22825596fea39c96a12f6a8b5a01fcd80e259841156f4512",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fd875d81396cfa3bf9e1dfd0e07298f0c4f72e804ea250d962c82b9b9df9d3f1",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0056": {
+      "vector": "xcREvp2cHL7W1VW/0dBQPcHAQDwAAIC/zMtLv5uamr6+vT2/v76+vuDfXz/Hxsa+zcxMvoaFBT/Avz8//v19P4qJCT+trCy+j46OPr++vj7Avz+/xcREPv38fL6ioSE/nZwcPr69PT+WlRW/kZAQPY+Ojr6pqKg9nZwcvqWkJL7FxES+nZwcvtbVVb/R0FA9wcBAPAAAgL/My0u/m5qavr69Pb+/vr6+4N9fP8fGxr7NzEy+hoUFP8C/Pz/+/X0/iokJP62sLL6Pjo4+v76+PsC/P7/FxEQ+/fx8vqKhIT+dnBw+vr09P5aVFb+RkBA9j46OvqmoqD2dnBy+paQkvg==",
+      "vectorSha256": "91aa1cab7507aae72ec32a004d42aa4bb15cbd69890fa71807007a9da16add4b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "676c158681001a592150ef4e66c2dffec46aa3af209860d093de35845c8a6c6b",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0057": {
+      "vector": "vLs7P/r5eb+enR2/19bWvsHAQLzm5WW/tLMzP/Tzc7/KyUk/29ravoKBAT+amRm/i4qKvri3N7+GhQW/4eDgPOrpab+JiIg9z87OvqGgoDyioSG/9PNzP/X0dD7Qz08/xsVFv/Dvb7/Y11e/397evo2MDD7V1FS++fj4Pe7tbb+8uzs/+vl5v56dHb/X1ta+wcBAvOblZb+0szM/9PNzv8rJST/b2tq+goEBP5qZGb+Lioq+uLc3v4aFBb/h4OA86ulpv4mIiD3Pzs6+oaCgPKKhIb/083M/9fR0PtDPTz/GxUW/8O9vv9jXV7/f3t6+jYwMPtXUVL75+Pg97u1tvw==",
+      "vectorSha256": "cd6d2c454197192f7d31ba481861da8c26108d70983fdd248e8e30027e7630ad",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dd03314a7e0dd906e449c0335d243d830b884c822ff99ee71d08144891658f09",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0058": {
+      "vector": "zMtLv7u6uj6ioSE/mZiYvfn4+D3n5ua+rKsrP62sLD7p6Oi9xcREvuTjYz+urS0/9vV1v7m4uD35+Pi9/Pt7P+rpaT/U01M/7exsvt/e3r7Qz08/z87OPtfW1r7My0s/rq0tv6SjI7+FhAS+pqUlP7m4uL3FxES+goEBP9XUVD7My0u/u7q6PqKhIT+ZmJi9+fj4Pefm5r6sqys/rawsPuno6L3FxES+5ONjP66tLT/29XW/ubi4Pfn4+L38+3s/6ulpP9TTUz/t7Gy+397evtDPTz/Pzs4+19bWvszLSz+urS2/pKMjv4WEBL6mpSU/ubi4vcXERL6CgQE/1dRUPg==",
+      "vectorSha256": "4116e31caab79ff5014ce09c9af5d7a5a68281ddc0d729055a785da823137cf9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1aaed0768f46d5957167f1d6058b70fdf4e96248e7b34ae5292e6fd27467c09a",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0059": {
+      "vector": "8fBwvZqZGT+cmxs/goEBP+no6D3HxsY+nJsbv4uKij6opye/3t1dP5mYmD3S0VE/v76+Pru6uj7OzU0/7exsvqyrK7/q6Wm/s7KyPq+urr6Ihwc/jo0Nv/Dvb7/w728/wcBAPOno6L2SkRE/9vV1v6empr7083M/+Pd3P5iXFz/x8HC9mpkZP5ybGz+CgQE/6ejoPcfGxj6cmxu/i4qKPqinJ7/e3V0/mZiYPdLRUT+/vr4+u7q6Ps7NTT/t7Gy+rKsrv+rpab+zsrI+r66uvoiHBz+OjQ2/8O9vv/Dvbz/BwEA86ejovZKRET/29XW/p6amvvTzcz/493c/mJcXPw==",
+      "vectorSha256": "4ccd6fb2b611054aab8ea4ffa7ec38707ff30a8532f47cb57a4b826a1a45c38f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "78cccdc08eb132a22cee89e8afaee6622a0bac54c33908f78171c80556f9fbcb",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0060": {
+      "vector": "1tVVP7SzM7/u7W0/rq0tv5WUFL6amRm/l5aWPo+Ojj7V1FQ+rq0tv66tLb/KyUk/wcBAPJSTEz/s62u/gYCAO/n4+L3+/X0/kpERv4WEBL65uLi9oqEhv66tLb/19HQ+ubi4vZKRET+bmpq+tLMzv6empj60szO/pqUlP8TDQ7/W1VU/tLMzv+7tbT+urS2/lZQUvpqZGb+XlpY+j46OPtXUVD6urS2/rq0tv8rJST/BwEA8lJMTP+zra7+BgIA7+fj4vf79fT+SkRG/hYQEvrm4uL2ioSG/rq0tv/X0dD65uLi9kpERP5uamr60szO/p6amPrSzM7+mpSU/xMNDvw==",
+      "vectorSha256": "7fd334733fd963c87ecc24803f1484daf786356c3f0b2d44df5745c8464b25cf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ea26f6296d33a5a39a2929e481c90a8070fe376f742f299e74c85926a926d21e",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0061": {
+      "vector": "qqkpv9bVVT+5uLi90tFRv4mIiD2/vr6+1tVVP+blZT/j4uK+oqEhP+rpaT+enR2/29ravoSDA7/x8HA93t1dP7y7O7+hoKC84N9fv5ybG7+FhAS+j46OPgAAgL+qqSk/qaiovaGgoDy+vT0/397ePvb1dT+OjQ2/3Ntbv+vq6r6qqSm/1tVVP7m4uL3S0VG/iYiIPb++vr7W1VU/5uVlP+Pi4r6ioSE/6ulpP56dHb/b2tq+hIMDv/HwcD3e3V0/vLs7v6GgoLzg31+/nJsbv4WEBL6Pjo4+AACAv6qpKT+pqKi9oaCgPL69PT/f3t4+9vV1P46NDb/c21u/6+rqvg==",
+      "vectorSha256": "e72d9264f4cff287b0e41feb891eb1571a8182769b52ff432da80f6814d2deae",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2bea74178850eaf247d0f431493e87ee227d10326fa300d47582deb7fa391245",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0062": {
+      "vector": "3Ntbv7a1Nb/BwEA8397evquqqj6enR2/6+rqPtzbWz+Ihwc/wsFBv9TTU7+FhAQ+jIsLv9jXV7+8uzs/hYQEvuPi4r68uzs/pKMjP42MDD7//v4++fj4PdXUVD6pqKg96Odnv9HQUL3Qz0+/o6KivqOioj7b2tq+2tlZv8/Ozr7c21u/trU1v8HAQDzf3t6+q6qqPp6dHb/r6uo+3NtbP4iHBz/CwUG/1NNTv4WEBD6Miwu/2NdXv7y7Oz+FhAS+4+Livry7Oz+koyM/jYwMPv/+/j75+Pg91dRUPqmoqD3o52e/0dBQvdDPT7+joqK+o6KiPtva2r7a2Vm/z87Ovg==",
+      "vectorSha256": "94554a7484518d84094c9761036d3c78b4e4faf81595872f789ade42b0233eb7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "12258148aa31baedc31f16903a14dd6f47ddd191bf8f9a8a0c791857a849134c",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0063": {
+      "vector": "xsVFP+LhYT+5uLg929ravtTTU7/Z2Ni9xMNDv5qZGT+WlRU/ycjIPf79fb+vrq6+//7+vvHwcL3e3V0/qKcnP6GgoLzg31+/4uFhv6inJz+Lioq+mpkZP/Lxcb+JiIi9m5qaPqOioj7T0tK+yMdHP7++vr6amRm//fx8Pu3sbL7GxUU/4uFhP7m4uD3b2tq+1NNTv9nY2L3Ew0O/mpkZP5aVFT/JyMg9/v19v6+urr7//v6+8fBwvd7dXT+opyc/oaCgvODfX7/i4WG/qKcnP4uKir6amRk/8vFxv4mIiL2bmpo+o6KiPtPS0r7Ix0c/v76+vpqZGb/9/Hw+7exsvg==",
+      "vectorSha256": "98953d64b91fb392abfe50288e22a4ede664a8b703469f9fc997a21303e9a40a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e2f08b4916721eccca8c01544078eed37d100fd35dcc0777a6a84be350339f62",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0064": {
+      "vector": "/Pt7v9fW1j67urq+iYiIvaCfHz+HhoY+2tlZv/f29j7+/X0/mZiYPYmIiD3My0s/oaCgPJSTEz/d3Fy+0dBQPaWkJL7Avz8/tbQ0PtbVVT/R0FC9v76+vt3cXD63trY+397evqalJb/U01O/tLMzv7W0NL6Xlpa+1dRUPrCvLz/8+3u/19bWPru6ur6JiIi9oJ8fP4eGhj7a2Vm/9/b2Pv79fT+ZmJg9iYiIPczLSz+hoKA8lJMTP93cXL7R0FA9paQkvsC/Pz+1tDQ+1tVVP9HQUL2/vr6+3dxcPre2tj7f3t6+pqUlv9TTU7+0szO/tbQ0vpeWlr7V1FQ+sK8vPw==",
+      "vectorSha256": "8fa5beb887b23d44310271cc3e358a6e06a5c5a93205753f76b570077d66de68",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "02b55177cfa113bdfe8988e582c964866bdf96ea79509bad482d1626695a9ad7",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0065": {
+      "vector": "6ejoPamoqD2Qjw+/wcBAvKalJb/p6Og90dBQvezra7/Y11c/qqkpP6GgoDzR0FA9ubi4vefm5r7Pzs4+n56evoSDA7/493e/8/Lyvvb1dT/CwUE/x8bGPq6tLT/f3t6+8fBwPQAAgL+EgwM/sbAwvaqpKb+koyM/hYQEvsrJSb/p6Og9qaioPZCPD7/BwEC8pqUlv+no6D3R0FC97Otrv9jXVz+qqSk/oaCgPNHQUD25uLi95+bmvs/Ozj6fnp6+hIMDv/j3d7/z8vK+9vV1P8LBQT/HxsY+rq0tP9/e3r7x8HA9AACAv4SDAz+xsDC9qqkpv6SjIz+FhAS+yslJvw==",
+      "vectorSha256": "b12d378928f5972740dd29e9c753325281db532e22a984f1c705d6810de76718",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8e8a387e2d8e790aebd482867446b3583e0443fae0b1d6488700c17a2bd16f1b",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0066": {
+      "vector": "+fj4vcrJST++vT2/3NtbP6uqqj7OzU0/kpERP+LhYT+GhQW/x8bGvoOCgr7o52c/q6qqvsjHRz/9/Hw+mJcXv9DPT7+EgwM/4eDgvKuqqr6Hhoa+qaiovZGQEL3e3V0/6ejoPbi3N7+Miwu/m5qavuvq6r7Ew0O/5+bmPr++vr75+Pi9yslJP769Pb/c21s/q6qqPs7NTT+SkRE/4uFhP4aFBb/Hxsa+g4KCvujnZz+rqqq+yMdHP/38fD6Ylxe/0M9Pv4SDAz/h4OC8q6qqvoeGhr6pqKi9kZAQvd7dXT/p6Og9uLc3v4yLC7+bmpq+6+rqvsTDQ7/n5uY+v76+vg==",
+      "vectorSha256": "a6e647b2bce12e2fcad9b80fe2ddd73ec65fdc87b40204f30f175b03bd946b0d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "70e421edaae6c8f03d4e5ff355e39f3418c17c555e757bee8e243a59451eb950",
+      "updatedAt": "2025-09-20T22:27:41.505Z"
+    },
+    "j-0067": {
+      "vector": "hoUFP9XUVD7KyUm/v76+PvDvb7+/vr4+sK8vP+7tbb+hoKC8hYQEvpqZGb/8+3u/jIsLP6qpKT+OjQ2/+/r6voeGhj7//v6+mZiYPdnY2D3Avz8/yslJv/Lxcb/My0s/paQkPqalJT+3tra+//7+vpeWlj6enR2/uLc3v9XUVD6GhQU/1dRUPsrJSb+/vr4+8O9vv7++vj6wry8/7u1tv6GgoLyFhAS+mpkZv/z7e7+Miws/qqkpP46NDb/7+vq+h4aGPv/+/r6ZmJg92djYPcC/Pz/KyUm/8vFxv8zLSz+lpCQ+pqUlP7e2tr7//v6+l5aWPp6dHb+4tze/1dRUPg==",
+      "vectorSha256": "8ce368b4ab02fe5c00598c3968ddbcb82f5e9401251f98e28acc44c043875739",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c29a1baf08afd7097d6f3302c5d43941a140898ddf1b07e594d25240a531249a",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0068": {
+      "vector": "397evqalJT+sqys/9/b2voyLC7/w72+/1dRUPqmoqD2ioSE/gYCAu5CPDz/CwUE/y8rKPvj3dz/f3t4+5uVlv8LBQT/Z2Ng9i4qKPoeGhj6Miws/pqUlP8LBQb/y8XG/rq0tv5GQEL23tra+4uFhv7CvLz/n5ua+5uVlP5KRET/f3t6+pqUlP6yrKz/39va+jIsLv/Dvb7/V1FQ+qaioPaKhIT+BgIC7kI8PP8LBQT/Lyso++Pd3P9/e3j7m5WW/wsFBP9nY2D2Lioo+h4aGPoyLCz+mpSU/wsFBv/Lxcb+urS2/kZAQvbe2tr7i4WG/sK8vP+fm5r7m5WU/kpERPw==",
+      "vectorSha256": "60bc2fd0a609ef1d789244266d82f4015d69248f5e743a2cb2b0ddc946bdf3a1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "48d2d5423a089a8ad07fc7e0b2fbb70de08da2a1c5d21f07297b520fd746f2c8",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0069": {
+      "vector": "w8LCvpaVFb/S0VE/8vFxv+rpaT+1tDQ+nZwcvuno6L3V1FS+urk5v5CPDz/r6uo+4N9fP+/u7r6pqKi9/Pt7P6GgoLy/vr4+09LSPsPCwj6gnx+/np0dv52cHL7u7W0/x8bGvuTjY7/5+Pg9//7+PqKhIb+2tTW/o6Kivvz7e7/DwsK+lpUVv9LRUT/y8XG/6ulpP7W0ND6dnBy+6ejovdXUVL66uTm/kI8PP+vq6j7g318/7+7uvqmoqL38+3s/oaCgvL++vj7T0tI+w8LCPqCfH7+enR2/nZwcvu7tbT/Hxsa+5ONjv/n4+D3//v4+oqEhv7a1Nb+joqK+/Pt7vw==",
+      "vectorSha256": "3676a6c330b5c23db66ab67490143fbe55d5f3a53d105dfde26fe897f41014b8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4f35e807f4966c716523c7baef4475fd7dafb4b030316cf64e0e8fbf2f255702",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0070": {
+      "vector": "jIsLv4iHBz/6+Xk/l5aWvrKxMT/29XU/j46Ovvf29r7Z2Ni9/Pt7P8LBQb8AAIC/8vFxP7GwML2dnBw+l5aWPgAAgD/Pzs4+i4qKPpybG7/FxES+rq0tP5KRET+opyc/r66uPvr5eb+OjQ0/+fj4vYOCgj6wry8/kZAQPfr5eb+Miwu/iIcHP/r5eT+Xlpa+srExP/b1dT+Pjo6+9/b2vtnY2L38+3s/wsFBvwAAgL/y8XE/sbAwvZ2cHD6XlpY+AACAP8/Ozj6Lioo+nJsbv8XERL6urS0/kpERP6inJz+vrq4++vl5v46NDT/5+Pi9g4KCPrCvLz+RkBA9+vl5vw==",
+      "vectorSha256": "ad9f1cc967c5def3df57569f0812c28fa3f03b13014408d3ece32ee5bab54761",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3ac3fc5ad8fa5c4272fd1f00f87a93a5ffb3a23267d6c8d3ab03c670a0d78403",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0071": {
+      "vector": "+Pd3P6moqD3u7W2/oJ8fv//+/j6rqqo+kI8Pv8fGxj7My0s/iIcHP5qZGb/d3Fw+1tVVv4OCgj729XU/uLc3v93cXD6DgoI+hoUFP+XkZL7083O/s7KyPq6tLT/5+Pg9kZAQvb69PT+/vr4+qqkpP4KBAb+5uLi9tbQ0PtzbW7/493c/qaioPe7tbb+gnx+///7+Pquqqj6Qjw+/x8bGPszLSz+Ihwc/mpkZv93cXD7W1VW/g4KCPvb1dT+4tze/3dxcPoOCgj6GhQU/5eRkvvTzc7+zsrI+rq0tP/n4+D2RkBC9vr09P7++vj6qqSk/goEBv7m4uL21tDQ+3Ntbvw==",
+      "vectorSha256": "2f30752ddf0839c10d5e998968a8175dd354010aec1dc875413b049d85d6caf7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fb8a0930bfaa38b1e5c3339b15a0fa249ba0c26306acd68f7bdeafd43f749612",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0072": {
+      "vector": "1tVVv728PL7V1FQ+4uFhP4KBAT+Xlpa+4N9fP7++vr65uLi9/fx8PujnZ7+fnp6++Pd3v66tLb+Hhoa+0tFRP8zLS7+NjAw+vbw8PqCfH7+HhoY+xsVFP6empr69vDw+np0dP5+enj6ysTE/qaiovdDPT7/FxEQ+q6qqPr28PD7W1VW/vbw8vtXUVD7i4WE/goEBP5eWlr7g318/v76+vrm4uL39/Hw+6Odnv5+enr7493e/rq0tv4eGhr7S0VE/zMtLv42MDD69vDw+oJ8fv4eGhj7GxUU/p6amvr28PD6enR0/n56ePrKxMT+pqKi90M9Pv8XERD6rqqo+vbw8Pg==",
+      "vectorSha256": "fc8db06713846ca6e56854ec53b220a8ee7b4f016492a2db230dd7a8bdf1bf78",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "15689af0c05aef50749f0c5804295ee81a919730a1e25697cea7d8751898aa97",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0073": {
+      "vector": "paQkPp2cHL6sqyu/3NtbP8PCwr6koyM/09LSvv38fL7+/X0/goEBP/79fT/083O/u7q6PsHAQDzu7W0/mZiYPf/+/r68uzs/o6KivsHAQLzOzU2/s7KyvoaFBT+EgwO//Pt7v7a1NT+opye/j46OvsC/Pz/v7u4+9PNzv83MTD6lpCQ+nZwcvqyrK7/c21s/w8LCvqSjIz/T0tK+/fx8vv79fT+CgQE//v19P/Tzc7+7uro+wcBAPO7tbT+ZmJg9//7+vry7Oz+joqK+wcBAvM7NTb+zsrK+hoUFP4SDA7/8+3u/trU1P6inJ7+Pjo6+wL8/P+/u7j7083O/zcxMPg==",
+      "vectorSha256": "f5ac33a50154fbfb0fe774727c3d02ded46d0e13d2469715cc2a21324042cbb9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "946c2aed4fd14b60fec0fe06ae81f68940dd577e1953c23e02da2c5cdfbb0699",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0074": {
+      "vector": "iIcHP769Pb/S0VG/mpkZP+jnZz+zsrI+o6KivtjXVz/083M/hYQEPtDPTz8AAIC/paQkvpqZGT/GxUW/hIMDP93cXD6KiQm/np0dv4uKij6Xlpa+urk5P4+Ojr7V1FS+4uFhv9/e3j6JiIg92djYPaGgoDzHxsY+9/b2PtHQUD2Ihwc/vr09v9LRUb+amRk/6OdnP7Oysj6joqK+2NdXP/Tzcz+FhAQ+0M9PPwAAgL+lpCS+mpkZP8bFRb+EgwM/3dxcPoqJCb+enR2/i4qKPpeWlr66uTk/j46OvtXUVL7i4WG/397ePomIiD3Z2Ng9oaCgPMfGxj739vY+0dBQPQ==",
+      "vectorSha256": "a4c95f70c90231f6ea783704048455fa78503fc2b1efc80363f20d95fd1f5817",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c32117ccf3ac57ebf990e7006bcc1dc19b3b31a25adc5c650fb7888d82b1bd86",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0075": {
+      "vector": "xMNDv/n4+L2fnp4+1tVVP97dXb/d3Fw+pKMjv+rpaT/i4WG/lJMTP6WkJL7u7W2/oJ8fv+no6D37+vq+hIMDP8C/P7/r6uq+iIcHv4yLC7+9vDw+u7q6vrOysj7m5WW/5uVlv6CfHz/+/X0/29raPquqqr6opye/v76+vtnY2L3Ew0O/+fj4vZ+enj7W1VU/3t1dv93cXD6koyO/6ulpP+LhYb+UkxM/paQkvu7tbb+gnx+/6ejoPfv6+r6EgwM/wL8/v+vq6r6Ihwe/jIsLv728PD67urq+s7KyPublZb/m5WW/oJ8fP/79fT/b2to+q6qqvqinJ7+/vr6+2djYvQ==",
+      "vectorSha256": "3aeb71a62d2d36eaf6856e773eb824f836ee4401be0e5293980822892405dadb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1e70a7ea119b2ef40fc96b09308e41c120453c3a9751ac0d0dcffeb6552c5072",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0076": {
+      "vector": "3t1dv+no6L2cmxs/rawsvurpab/19HS+xsVFP/Dvbz/x8HC9goEBv/38fL6SkRG/+fj4PYGAgLukoyO/paQkvvDvb7/g318/vbw8vu/u7r729XU/w8LCPu/u7j6NjAw+oaCgvAAAgL+UkxO/wsFBP/v6+j7u7W2/397ePrKxMT/e3V2/6ejovZybGz+trCy+6ulpv/X0dL7GxUU/8O9vP/HwcL2CgQG//fx8vpKREb/5+Pg9gYCAu6SjI7+lpCS+8O9vv+DfXz+9vDy+7+7uvvb1dT/DwsI+7+7uPo2MDD6hoKC8AACAv5STE7/CwUE/+/r6Pu7tbb/f3t4+srExPw==",
+      "vectorSha256": "a13d450a1f9a01c52c5bd5b9c22de570207fe0e7f0257e6069e1b2c6ec86b39d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1171cd6a0b61e2f7783f60378f7f2e6b08ef6844fab0bb917d0036e0be09b7d8",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0077": {
+      "vector": "paQkvq6tLb+3trY+tLMzv/Tzcz+sqyu/n56ePsXERL7d3Fy+5uVlv/n4+D329XU/n56evvX0dL739vY+wsFBv5OSkj7U01M/q6qqPuDfXz/JyMg9qKcnP6CfHz/Z2Ni9tbQ0vu3sbL7s62s/uLc3v97dXb+KiQk/7Otrv5GQEL2lpCS+rq0tv7e2tj60szO/9PNzP6yrK7+fnp4+xcREvt3cXL7m5WW/+fj4Pfb1dT+fnp6+9fR0vvf29j7CwUG/k5KSPtTTUz+rqqo+4N9fP8nIyD2opyc/oJ8fP9nY2L21tDS+7exsvuzraz+4tze/3t1dv4qJCT/s62u/kZAQvQ==",
+      "vectorSha256": "4fa72edaffbd31421ece1a5dcd3f49302b0304683a9ece753d7c5df717160c61",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6b29ad26f92aa767640d8ffa5861bd1fa4e9aaef8cd3cf726962f52411c40a7b",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0078": {
+      "vector": "j46OvtHQUD3Y11c/sK8vP//+/j7Pzs4+6ejoPY2MDL7X1ta+/v19P5aVFb+hoKA8vr09v//+/j6Hhoa+3NtbP/Dvb7/BwEA87OtrP+no6D35+Pg9+vl5v6Oioj75+Pi9rawsvuzraz/e3V0/0dBQveDfX7/DwsK+jIsLv9/e3r6Pjo6+0dBQPdjXVz+wry8///7+Ps/Ozj7p6Og9jYwMvtfW1r7+/X0/lpUVv6GgoDy+vT2///7+PoeGhr7c21s/8O9vv8HAQDzs62s/6ejoPfn4+D36+Xm/o6KiPvn4+L2trCy+7OtrP97dXT/R0FC94N9fv8PCwr6Miwu/397evg==",
+      "vectorSha256": "d98d02da93896fd4404c2fe860329de198c9e62fdc6939cf2ebee69f97a77d5f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5c86ebd7bfb38e6e4afe358221bf5eed0881f58e8f03a8706af5ee79104f3a48",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0079": {
+      "vector": "9/b2Pvv6+r6gnx+/urk5v9nY2L3Y11c/wcBAvL69PT/d3Fw+p6amvo2MDD61tDQ+lJMTP+blZb/h4OA83t1dP6WkJD6Qjw8/5eRkPu/u7j7e3V2/pqUlP/f29j6xsDA91NNTv9PS0j6urS2/m5qaPq2sLL6Ylxc/kI8Pv/LxcT/39vY++/r6vqCfH7+6uTm/2djYvdjXVz/BwEC8vr09P93cXD6npqa+jYwMPrW0ND6UkxM/5uVlv+Hg4Dze3V0/paQkPpCPDz/l5GQ+7+7uPt7dXb+mpSU/9/b2PrGwMD3U01O/09LSPq6tLb+bmpo+rawsvpiXFz+Qjw+/8vFxPw==",
+      "vectorSha256": "8bceb9acd92a9a8bf3dfa5bc20900513dbc57dfb4accf63c667f0f191cb15231",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bd41302372eb7ede9b569196c90d83ee94c79cbb11d2bd8516b429a66acb38f8",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0080": {
+      "vector": "wcBAvKOioj7e3V2/xcREvuDfXz/KyUm/9PNzv5OSkj64tze/09LSvsvKyj6Hhoa+zMtLP//+/j7x8HA9ycjIvfr5eb/083O/qqkpP4SDAz///v6+rKsrv6Oior729XU/8O9vP8C/P7/l5GS+xsVFv7i3N7+ZmJg98fBwPezra7/BwEC8o6KiPt7dXb/FxES+4N9fP8rJSb/083O/k5KSPri3N7/T0tK+y8rKPoeGhr7My0s///7+PvHwcD3JyMi9+vl5v/Tzc7+qqSk/hIMDP//+/r6sqyu/o6Kivvb1dT/w728/wL8/v+XkZL7GxUW/uLc3v5mYmD3x8HA97Otrvw==",
+      "vectorSha256": "13cdef955c1af5fefc54400ca013061cb7ebf3dc84c5033ea6fef89aae3f3a4a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7ea81167ef1b06a4244bb25ee5bf87730306d4c1402a57faf720631d2489870a",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0081": {
+      "vector": "mZiYPZeWlr7X1ta+hIMDv7i3Nz+NjAy+/Pt7P+jnZ7/29XU/8/LyvrGwML3w728/l5aWvu7tbb+8uzs/h4aGPrGwMD3k42O//v19v//+/j7U01M/3t1dv+DfX7+HhoY++vl5v9jXVz+amRk/+fj4Pf79fT/g31+/u7q6PuHg4DyZmJg9l5aWvtfW1r6EgwO/uLc3P42MDL78+3s/6Odnv/b1dT/z8vK+sbAwvfDvbz+Xlpa+7u1tv7y7Oz+HhoY+sbAwPeTjY7/+/X2///7+PtTTUz/e3V2/4N9fv4eGhj76+Xm/2NdXP5qZGT/5+Pg9/v19P+DfX7+7uro+4eDgPA==",
+      "vectorSha256": "ab90bbf2714e2fd502d2860793486acb6c574e246976102e197fe633ca1e79d4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "895a4a3edb6efd0cfa437af75a09dda1850e01bfe91110a103ebcc8ffe10ae83",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0082": {
+      "vector": "0dBQPbW0NL6CgQE/0tFRP/f29j7f3t6+1tVVP7GwMD3My0s/5eRkPp2cHD7g318/jo0Nv6Oioj6Xlpa+6+rqvoiHB7+amRm/xMNDP8HAQDyWlRU/5+bmPtXUVL7+/X2/+Pd3P87NTb/FxES+oaCgPNbVVb+/vr4+nZwcvvr5eb/R0FA9tbQ0voKBAT/S0VE/9/b2Pt/e3r7W1VU/sbAwPczLSz/l5GQ+nZwcPuDfXz+OjQ2/o6KiPpeWlr7r6uq+iIcHv5qZGb/Ew0M/wcBAPJaVFT/n5uY+1dRUvv79fb/493c/zs1Nv8XERL6hoKA81tVVv7++vj6dnBy++vl5vw==",
+      "vectorSha256": "0e7b8b2f7580dfa47cbf176116068b70f3b30ab6633c52fa0528c88ca42307f7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8669c0e8bd48ea85e59c93ef39a85a453c33e181cab96501fb19678215af6c03",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0083": {
+      "vector": "8vFxv7Oysj6JiIg9j46OPu3sbD6CgQG/np0dP4+Ojj6qqSk/oaCgvPHwcL29vDy+oqEhv+XkZL719HQ++/r6vszLSz/b2to+goEBv6+urr6HhoY+rKsrv87NTT/39va+goEBv62sLL6ZmJi9//7+Pvb1db/GxUW/8O9vv5OSkr7y8XG/s7KyPomIiD2Pjo4+7exsPoKBAb+enR0/j46OPqqpKT+hoKC88fBwvb28PL6ioSG/5eRkvvX0dD77+vq+zMtLP9va2j6CgQG/r66uvoeGhj6sqyu/zs1NP/f29r6CgQG/rawsvpmYmL3//v4+9vV1v8bFRb/w72+/k5KSvg==",
+      "vectorSha256": "d123347d16191b3d4671a04eef84d20bf39124353ff7762c66b9b963890af75c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "07ac88a39d3fcea3d47d78682f639e41e5b63f54a12ae6423f6a76bf051d085b",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0084": {
+      "vector": "r66uPt7dXT/DwsI+paQkvqWkJL7h4OA8xMNDv7u6uj6Xlpa+trU1v+Hg4DyZmJi9rKsrv6inJ7+Miwu/wcBAPKSjIz/29XW/6OdnP//+/r7Ix0e/hYQEPoWEBD6vrq4+gYCAO+XkZL7Qz0+/kZAQvaOior6sqyu/uLc3v+fm5r6vrq4+3t1dP8PCwj6lpCS+paQkvuHg4DzEw0O/u7q6PpeWlr62tTW/4eDgPJmYmL2sqyu/qKcnv4yLC7/BwEA8pKMjP/b1db/o52c///7+vsjHR7+FhAQ+hYQEPq+urj6BgIA75eRkvtDPT7+RkBC9o6KivqyrK7+4tze/5+bmvg==",
+      "vectorSha256": "4d212e902a7030b32cbf560daf6c3de848fac1ccd71beffe8cefc8642500b75b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "abeeb06b6b831eae5a2583762a2c3a81d105f3401c9090ab8063187b572a2446",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0085": {
+      "vector": "3dxcvomIiL22tTW/tLMzP/f29r7+/X0/6+rqPoSDA7+RkBC9wL8/P8XERD75+Pg9hIMDv9bVVb/W1VU/5eRkvsTDQ7/29XU/9/b2vuTjYz/5+Pi9t7a2PvHwcL3V1FS+29raPuzraz+Ihwe/+/r6Prq5Ob+6uTk/jYwMvu7tbb/d3Fy+iYiIvba1Nb+0szM/9/b2vv79fT/r6uo+hIMDv5GQEL3Avz8/xcREPvn4+D2EgwO/1tVVv9bVVT/l5GS+xMNDv/b1dT/39va+5ONjP/n4+L23trY+8fBwvdXUVL7b2to+7OtrP4iHB7/7+vo+urk5v7q5OT+NjAy+7u1tvw==",
+      "vectorSha256": "d6008d5ca25846e94bed479dd8a18ce7275f7f6f49e289eb1ee1b66309b0c5a1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "647725d942feba3e7bdf988f3e15ea631efa42f170ad7865b6f53cbe23dc6e09",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0086": {
+      "vector": "5+bmPuno6D2BgIA7jo0Nv4mIiL2mpSU/9fR0PouKir7j4uK+lZQUvo6NDT/i4WG/vr09v9XUVD6cmxs/w8LCvo+Ojj6dnBw+sK8vP/z7ez/t7Gy+8O9vP9va2j7083O//v19P7W0NL6lpCQ+yMdHP//+/j6lpCQ+pKMjv42MDL7n5uY+6ejoPYGAgDuOjQ2/iYiIvaalJT/19HQ+i4qKvuPi4r6VlBS+jo0NP+LhYb++vT2/1dRUPpybGz/DwsK+j46OPp2cHD6wry8//Pt7P+3sbL7w728/29raPvTzc7/+/X0/tbQ0vqWkJD7Ix0c///7+PqWkJD6koyO/jYwMvg==",
+      "vectorSha256": "30fa0075ff602a349611cca07105ccba985db566ccdc8dd71bef815947f4d978",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b98e803977d29e5d476dc60f219acd4fa393d7fd62f7b606fe6994e3bf942e6e",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0087": {
+      "vector": "mZiYvaalJT/n5ua+oJ8fP83MTD7083O/7+7uPtrZWT+1tDS+19bWPvb1dT+pqKg92tlZP4KBAT+JiIi9oaCgvP38fL6WlRU/kpERv+LhYb/My0u/+Pd3v42MDL77+vq+jYwMPsLBQT/083M/+fj4PZuamr7NzEw+gYCAu769PT+ZmJi9pqUlP+fm5r6gnx8/zcxMPvTzc7/v7u4+2tlZP7W0NL7X1tY+9vV1P6moqD3a2Vk/goEBP4mIiL2hoKC8/fx8vpaVFT+SkRG/4uFhv8zLS7/493e/jYwMvvv6+r6NjAw+wsFBP/Tzcz/5+Pg9m5qavs3MTD6BgIC7vr09Pw==",
+      "vectorSha256": "04d854d135b398a657fccd631472cb4391c006dd51a4cbf4da70859bb524d678",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "76d246cf9906bbec69b5fa8aecc0777d60ca370f1a046e4191e0f98f59997fde",
+      "updatedAt": "2025-09-20T22:27:41.507Z"
+    },
+    "j-0088": {
+      "vector": "2tlZv8vKyr7T0tI+g4KCvpaVFb/X1ta+8/LyvrSzMz+9vDw+6+rqPre2tj7g318/qqkpv5aVFb+RkBC9//7+vsnIyD2hoKA84eDgvNrZWb/KyUk/2djYPefm5j6mpSU/xMNDP9/e3j64tze/1NNTP5mYmD3j4uI+lJMTP6inJ7/a2Vm/y8rKvtPS0j6DgoK+lpUVv9fW1r7z8vK+tLMzP728PD7r6uo+t7a2PuDfXz+qqSm/lpUVv5GQEL3//v6+ycjIPaGgoDzh4OC82tlZv8rJST/Z2Ng95+bmPqalJT/Ew0M/397ePri3N7/U01M/mZiYPePi4j6UkxM/qKcnvw==",
+      "vectorSha256": "2cd32aa6c746ea26ec4083b43547372b78a3aef35643d1fe2775e7e0aeb41318",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "134db45f354a43d997baadef2b357b408c827c13e48db9d2e1b724e989b8c92c",
+      "updatedAt": "2025-09-20T22:27:41.507Z"
+    },
+    "j-0089": {
+      "vector": "9/b2PoOCgr7t7Gy+iYiIvfj3dz+koyM/qqkpP9PS0j6npqY+4+Livp2cHL6Pjo4+wcBAvIyLC7/c21s/8vFxv4OCgj6Lioo+wL8/v/Dvbz/Pzs6+iokJP7i3Nz/6+Xk/xsVFP5+enr67urq+wL8/v9TTU7+7uro+0tFRv/n4+L339vY+g4KCvu3sbL6JiIi9+Pd3P6SjIz+qqSk/09LSPqempj7j4uK+nZwcvo+Ojj7BwEC8jIsLv9zbWz/y8XG/g4KCPouKij7Avz+/8O9vP8/Ozr6KiQk/uLc3P/r5eT/GxUU/n56evru6ur7Avz+/1NNTv7u6uj7S0VG/+fj4vQ==",
+      "vectorSha256": "e1da52d19ee7423d3b3cfb6d9cd9794a96c83cd1eb8a149d06d2988284f60977",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bd5f6277fbd1d4b4a9476ca37e3aed07a0a220f74cc4dbfce258512016ae1770",
+      "updatedAt": "2025-09-20T22:27:41.507Z"
+    },
+    "j-0090": {
+      "vector": "8fBwPdPS0j7Avz+/1dRUvsPCwj6bmpq+jIsLv93cXD7t7Gy+29ravu3sbD7493c/j46OPvj3dz+JiIg9kI8Pv4iHBz/o52e/4+Livvf29j7u7W2/hYQEvuPi4j729XU/wL8/P/Py8j7Qz0+/7Otrv4aFBb+npqa+x8bGPsHAQDzx8HA909LSPsC/P7/V1FS+w8LCPpuamr6Miwu/3dxcPu3sbL7b2tq+7exsPvj3dz+Pjo4++Pd3P4mIiD2Qjw+/iIcHP+jnZ7/j4uK+9/b2Pu7tbb+FhAS+4+LiPvb1dT/Avz8/8/LyPtDPT7/s62u/hoUFv6empr7HxsY+wcBAPA==",
+      "vectorSha256": "a4a4768c94c06847f95067fb516b0bb428c095e4b747ed0b986ab832b48f54ab",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "87b42065b0593a9b62499dfba3fb8838c30c47bd096fb8fadfbc180a3d56b181",
+      "updatedAt": "2025-09-20T22:27:41.507Z"
+    },
+    "j-0091": {
+      "vector": "tbQ0vqKhIT/u7W0/3t1dv97dXb+Ylxe/i4qKvs/Ozj7n5ua+8fBwvfPy8r7j4uI+1dRUvru6ur7z8vI+ycjIPc/Ozr6JiIg9//7+PpqZGT+6uTk/19bWvvTzc7+SkRE/1dRUvsnIyL2lpCQ+0dBQPc3MTD7+/X2/pKMjv9va2j61tDS+oqEhP+7tbT/e3V2/3t1dv5iXF7+Lioq+z87OPufm5r7x8HC98/LyvuPi4j7V1FS+u7q6vvPy8j7JyMg9z87OvomIiD3//v4+mpkZP7q5OT/X1ta+9PNzv5KRET/V1FS+ycjIvaWkJD7R0FA9zcxMPv79fb+koyO/29raPg==",
+      "vectorSha256": "2fb80b7be94d2c6fa9da5931e65c84681f18dfbc0807232c2bc1b588dae5bb3d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "69d0f61111345db3467843b86551bc8c4c88bfccdc4a06c86573948699012eb6",
+      "updatedAt": "2025-09-20T22:27:41.507Z"
+    },
+    "j-0092": {
+      "vector": "4eDgvLKxMT+7uro+goEBP6uqqj6RkBC9oqEhv6qpKT+CgQG/4eDgPPr5eT/9/Hw+iYiIvYiHBz+UkxM/hoUFP4iHB7/DwsI+mpkZv+XkZD6GhQU/vbw8PtDPT7/k42M/zcxMPvLxcT/Lyso+lJMTP4GAgLvl5GS+h4aGvra1NT/h4OC8srExP7u6uj6CgQE/q6qqPpGQEL2ioSG/qqkpP4KBAb/h4OA8+vl5P/38fD6JiIi9iIcHP5STEz+GhQU/iIcHv8PCwj6amRm/5eRkPoaFBT+9vDw+0M9Pv+TjYz/NzEw+8vFxP8vKyj6UkxM/gYCAu+XkZL6Hhoa+trU1Pw==",
+      "vectorSha256": "206bde4edfbf2b37419f6b71fdaf2541fc0d60ebb2e8d6ab757c2018711493da",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7cd8aec0aa7b2fd43f83fc9f77c3c9c23cb0339cc29718f199f8b2c97f635eda",
+      "updatedAt": "2025-09-20T22:27:41.507Z"
+    },
+    "j-0093": {
+      "vector": "zs1Nv+TjY7/CwUG/+fj4vcLBQb/7+vo+nJsbv9LRUT+urS2/srExP5OSkj7g318/29ravrSzM7+joqK+wsFBv/z7e7/CwUG/iYiIPe3sbD66uTk/rawsPo6NDb/FxES+1tVVP/z7ez+7uro+nJsbv6+urj7V1FQ+rKsrP9HQUL3OzU2/5ONjv8LBQb/5+Pi9wsFBv/v6+j6cmxu/0tFRP66tLb+ysTE/k5KSPuDfXz/b2tq+tLMzv6Oior7CwUG//Pt7v8LBQb+JiIg97exsPrq5OT+trCw+jo0Nv8XERL7W1VU//Pt7P7u6uj6cmxu/r66uPtXUVD6sqys/0dBQvQ==",
+      "vectorSha256": "85addfa4f9561b8fd6b85103f36f1842fb47da8b06575d20b5900362b8fb35eb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "190e1f701fbe32e829d8a4ef4926571f021f889ddc953967eafdae32ab9ad579",
+      "updatedAt": "2025-09-20T22:27:41.507Z"
+    },
+    "j-0094": {
+      "vector": "ubi4vd/e3j6JiIi95eRkvtrZWb/FxES+k5KSPo2MDL7Ew0O/goEBv/b1db+Lioq+nZwcvqKhIT/NzEy+kI8Pv7GwMD3My0s/nZwcPpKREb/s62u//v19P769Pb/My0u/y8rKvt3cXD7Ew0M/5uVlv5CPD7/m5WW/h4aGvrm4uL25uLi9397ePomIiL3l5GS+2tlZv8XERL6TkpI+jYwMvsTDQ7+CgQG/9vV1v4uKir6dnBy+oqEhP83MTL6Qjw+/sbAwPczLSz+dnBw+kpERv+zra7/+/X0/vr09v8zLS7/Lysq+3dxcPsTDQz/m5WW/kI8Pv+blZb+Hhoa+ubi4vQ==",
+      "vectorSha256": "c785bb970e215e868863d363fb64df6e06fa7817e649c55f957a32b2b9176ba4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "74b777631367a46e1e3f055d6cd0663885e593370afe211a4d9be10d380d5e74",
+      "updatedAt": "2025-09-20T22:27:41.507Z"
+    },
+    "j-0095": {
+      "vector": "lZQUPpqZGb+JiIi98fBwvamoqL2Ylxe/oJ8fP52cHD7i4WE/paQkPra1Nb/e3V0/vbw8PuLhYb/k42O/k5KSPsHAQDzk42O/5ONjP5eWlr6amRk/hoUFv6Oioj68uzs/oqEhv+LhYb/Y11e/09LSPru6ur7y8XG/mJcXv5+enr6VlBQ+mpkZv4mIiL3x8HC9qaiovZiXF7+gnx8/nZwcPuLhYT+lpCQ+trU1v97dXT+9vDw+4uFhv+TjY7+TkpI+wcBAPOTjY7/k42M/l5aWvpqZGT+GhQW/o6KiPry7Oz+ioSG/4uFhv9jXV7/T0tI+u7q6vvLxcb+Ylxe/n56evg==",
+      "vectorSha256": "a02e04935743c147b5d5e867c63b1126c15708d4bcb2f1a180c245c25b4d342b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "923377787534cf93f09425ee970f0ea4810ef15acc3da8dd2f0f14b451073458",
+      "updatedAt": "2025-09-20T22:27:41.507Z"
+    },
+    "j-0096": {
+      "vector": "/fx8PpaVFT+UkxM/4+LiPoyLCz+lpCQ+zcxMPrm4uD3s62s/nJsbv6qpKb+amRm/7exsPu/u7r60szO/n56evvr5eT/t7Gw+rKsrv/n4+L2+vT0/4eDgvPv6+j7CwUG/6OdnP/b1db/b2tq+pKMjP9PS0r6Miwu/9/b2vra1NT/9/Hw+lpUVP5STEz/j4uI+jIsLP6WkJD7NzEw+ubi4Pezraz+cmxu/qqkpv5qZGb/t7Gw+7+7uvrSzM7+fnp6++vl5P+3sbD6sqyu/+fj4vb69PT/h4OC8+/r6PsLBQb/o52c/9vV1v9va2r6koyM/09LSvoyLC7/39va+trU1Pw==",
+      "vectorSha256": "450cc6b287b0c2ad3640abefcaedab112f43dfd73d524c6d46b5cf06f1b0f634",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9fcac9b8c594998bf5322b339d442658fc9d2a70de7cbe1ff30549d14b3a42da",
+      "updatedAt": "2025-09-20T22:27:41.508Z"
+    },
+    "j-0097": {
+      "vector": "trU1P83MTD6rqqo+2djYvfLxcb/s62u/np0dv5GQED2amRk/sK8vv6alJT/d3Fw+jIsLv4yLCz/7+vq+hYQEPsTDQz+qqSm/zMtLv4KBAT/CwUG/paQkvtHQUL3h4OA86+rqvp2cHD7R0FA9oqEhv5iXFz+/vr4+tLMzv62sLD62tTU/zcxMPquqqj7Z2Ni98vFxv+zra7+enR2/kZAQPZqZGT+wry+/pqUlP93cXD6Miwu/jIsLP/v6+r6FhAQ+xMNDP6qpKb/My0u/goEBP8LBQb+lpCS+0dBQveHg4Dzr6uq+nZwcPtHQUD2ioSG/mJcXP7++vj60szO/rawsPg==",
+      "vectorSha256": "72b4aaae731ce8257b19cb80aa3f9ca8e3111029e60e7b1f9d1af9350491ac05",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "da99aa72070a3184cc28d29b3ac54190e12b1ac01f6b79834593862fcbaf2695",
+      "updatedAt": "2025-09-20T22:27:41.508Z"
+    },
+    "j-0098": {
+      "vector": "zMtLP6Oior6Lioo+wL8/P/Tzc7+2tTW/qKcnP+DfX7/HxsY+qKcnP8C/Pz/19HS+4+LiPoOCgj6Hhoa+k5KSvpCPDz+Qjw8/5uVlv+LhYT+NjAy+2djYPfj3dz+Hhoa+6+rqPoiHB7/W1VW/6ejoPZ+enr6KiQm/k5KSPqalJb/My0s/o6KivouKij7Avz8/9PNzv7a1Nb+opyc/4N9fv8fGxj6opyc/wL8/P/X0dL7j4uI+g4KCPoeGhr6TkpK+kI8PP5CPDz/m5WW/4uFhP42MDL7Z2Ng9+Pd3P4eGhr7r6uo+iIcHv9bVVb/p6Og9n56evoqJCb+TkpI+pqUlvw==",
+      "vectorSha256": "07e466f6acf01319fa49242ff1331a8c28c8c1d78746c86ad6d646d83a54086d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e557a2df0625d310b1d3df61b8a05e5bc7c70df06e8dfb5eba3c158e583ba42d",
+      "updatedAt": "2025-09-20T22:27:41.508Z"
+    },
+    "j-0099": {
+      "vector": "+vl5P+Hg4DyFhAS+6+rqvgAAgL/JyMg9l5aWPqinJz+koyM/s7KyvvHwcL339vY+qKcnP9nY2D24tzc/5eRkvr69PT/7+vo+hIMDv5STEz+EgwO/u7q6vv/+/j7o52c/k5KSvr69Pb/n5ua+3dxcPs3MTD77+vq+xsVFP6moqD36+Xk/4eDgPIWEBL7r6uq+AACAv8nIyD2XlpY+qKcnP6SjIz+zsrK+8fBwvff29j6opyc/2djYPbi3Nz/l5GS+vr09P/v6+j6EgwO/lJMTP4SDA7+7urq+//7+PujnZz+TkpK+vr09v+fm5r7d3Fw+zcxMPvv6+r7GxUU/qaioPQ==",
+      "vectorSha256": "4b81d605a0af6395a0de792ce873196b6d28304937c18edf17851b6ad377feac",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fc836f45008ca5d3d15378bdd38ddb63debe3ec93e51bff35b21469b9941e28a",
+      "updatedAt": "2025-09-20T22:27:41.508Z"
+    },
+    "j-0100": {
+      "vector": "qqkpv4uKir75+Pi92tlZv4yLC7/c21u/hoUFv4qJCb+ysTG//v19v9zbWz/NzEw+29raPvTzcz/Avz+/mJcXv7i3Nz+/vr4+hYQEvujnZz+amRm/yslJv4yLCz/CwUE/pKMjv4KBAT+koyO//Pt7v4mIiD3NzEw+1dRUvtrZWb+qqSm/i4qKvvn4+L3a2Vm/jIsLv9zbW7+GhQW/iokJv7KxMb/+/X2/3NtbP83MTD7b2to+9PNzP8C/P7+Ylxe/uLc3P7++vj6FhAS+6OdnP5qZGb/KyUm/jIsLP8LBQT+koyO/goEBP6SjI7/8+3u/iYiIPc3MTD7V1FS+2tlZvw==",
+      "vectorSha256": "47719b926e61007f0cbcdef3323fa003ffbc410b496adf51a02b8362f390b0dd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2b5d70133a123d3b2701ed99b6f92034dbaf6ff3331bc5e02ec02e0288996513",
+      "updatedAt": "2025-09-20T22:27:41.508Z"
+    },
+    "j-0101": {
+      "vector": "wL8/v9DPT7/i4WE/0tFRv7u6uj7Qz08/hYQEvpiXFz+WlRW/y8rKvq+urr6Ylxe/kpERv6Oior6DgoI+nZwcvp2cHD7+/X0/vr09P7e2tj6/vr6+xcREPpCPD7/493c/5ONjP8vKyj739va+lZQUvoyLCz/x8HA9iokJv5CPDz/Avz+/0M9Pv+LhYT/S0VG/u7q6PtDPTz+FhAS+mJcXP5aVFb/Lysq+r66uvpiXF7+SkRG/o6KivoOCgj6dnBy+nZwcPv79fT++vT0/t7a2Pr++vr7FxEQ+kI8Pv/j3dz/k42M/y8rKPvf29r6VlBS+jIsLP/HwcD2KiQm/kI8PPw==",
+      "vectorSha256": "b5528e59e784f7f5ce79d8e285cb4b0eb02d2ec379d048ab0cdc91110a75c58b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2018f017aee76fcb354d54343757a06c93fedead509838fbf1b2426dc5873bc7",
+      "updatedAt": "2025-09-20T22:27:41.508Z"
+    },
+    "j-0102": {
+      "vector": "1dRUPoiHBz+XlpY+u7q6vvz7e7++vT2/pqUlv6SjIz+bmpq+0dBQPbCvL7/HxsY+l5aWvrKxMT+Lioq+6+rqPq6tLb+ioSE/tbQ0Pvj3dz/Hxsa+9PNzv4yLC7/b2tq+/Pt7P9jXV7+NjAy+yMdHP+rpaT+VlBS+k5KSvre2tr7V1FQ+iIcHP5eWlj67urq+/Pt7v769Pb+mpSW/pKMjP5uamr7R0FA9sK8vv8fGxj6Xlpa+srExP4uKir7r6uo+rq0tv6KhIT+1tDQ++Pd3P8fGxr7083O/jIsLv9va2r78+3s/2NdXv42MDL7Ix0c/6ulpP5WUFL6TkpK+t7a2vg==",
+      "vectorSha256": "1d9a7e9487b5631bb0ee88c1506e8329d6a958d82564f4710f997bdc7a506e7d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9ac3a55102212dd1598628b15ad85dba29d096fb4e063a49fd146ee3f46d5b52",
+      "updatedAt": "2025-09-20T22:27:41.508Z"
+    },
+    "j-0103": {
+      "vector": "zs1Nv/Dvbz+Ylxe/wsFBv+3sbD7s62u/xcREvqempr6dnBw+z87OPgAAgL+XlpY+6Odnv4OCgr7l5GQ+ycjIPfv6+r7V1FQ+rawsPtXUVL7i4WE/5uVlP+/u7r75+Pi9/v19v9TTUz+npqa+u7q6Pq+urr6pqKg91NNTv+Pi4j7OzU2/8O9vP5iXF7/CwUG/7exsPuzra7/FxES+p6amvp2cHD7Pzs4+AACAv5eWlj7o52e/g4KCvuXkZD7JyMg9+/r6vtXUVD6trCw+1dRUvuLhYT/m5WU/7+7uvvn4+L3+/X2/1NNTP6empr67uro+r66uvqmoqD3U01O/4+LiPg==",
+      "vectorSha256": "e75e8caad6a07e320486b581b7fba5f3d83dfe8e449788be3e3a36f493cedb46",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "19f7341f9d0a675693b300a50c5f9c8c419a9565f0f2447001e956ae548a16b8",
+      "updatedAt": "2025-09-20T22:27:41.508Z"
+    },
+    "j-0104": {
+      "vector": "mpkZv7KxMT/29XW/6ulpv9jXVz+Lioq+lZQUPr++vj61tDS+3Ntbv4qJCT/b2to+9vV1v6empj6zsrI++Pd3v7q5OT/Z2Ni96OdnP769PT/W1VW/tLMzv+XkZL7z8vK+/v19P6GgoDz9/Hy+k5KSPvPy8j7a2Vk/8/LyPpeWlr6amRm/srExP/b1db/q6Wm/2NdXP4uKir6VlBQ+v76+PrW0NL7c21u/iokJP9va2j729XW/p6amPrOysj7493e/urk5P9nY2L3o52c/vr09P9bVVb+0szO/5eRkvvPy8r7+/X0/oaCgPP38fL6TkpI+8/LyPtrZWT/z8vI+l5aWvg==",
+      "vectorSha256": "64b1bf031a5af11c0e1adcaa6a5c9c13855215b105176694d31f4364b8d5e3cf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "33d8050beb5d92af6912c4b605a9ac04dc72f3de15266343fe8260a4bcecbc5a",
+      "updatedAt": "2025-09-20T22:27:41.508Z"
+    },
+    "j-0105": {
+      "vector": "2NdXv9HQUD3q6Wk/qKcnv//+/j729XU/rKsrP5ybGz+dnBy+o6KiPsC/P7+lpCS+8vFxP4aFBb+EgwM/5+bmvuDfX7+sqys/9PNzv/Tzc7+trCw+hoUFP+fm5r76+Xm/hoUFP93cXL7GxUW/oaCgPAAAgD/o52e/hoUFv5qZGT/Y11e/0dBQPerpaT+opye///7+Pvb1dT+sqys/nJsbP52cHL6joqI+wL8/v6WkJL7y8XE/hoUFv4SDAz/n5ua+4N9fv6yrKz/083O/9PNzv62sLD6GhQU/5+bmvvr5eb+GhQU/3dxcvsbFRb+hoKA8AACAP+jnZ7+GhQW/mpkZPw==",
+      "vectorSha256": "d7cd59842677f0b8d18e36626baee0249341033462d0baa0581fcf405a447ff2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1486f42cbffad5cd6ca8206bf83dc14610d5060695c24603c2641d82ff0c3dcc",
+      "updatedAt": "2025-09-20T22:27:41.509Z"
+    },
+    "j-0106": {
+      "vector": "x8bGvsbFRT/e3V2/h4aGPu/u7r6Qjw+/+Pd3P/j3d7+trCw+yslJP9bVVb/8+3s/4uFhv7a1Nb+ysTE/s7KyvsHAQLzDwsI+lZQUPoaFBb+enR0/9fR0voiHBz+npqY+p6amvuDfXz+Lioo+kpERP7e2tj6RkBC9mZiYPfn4+L3Hxsa+xsVFP97dXb+HhoY+7+7uvpCPD7/493c/+Pd3v62sLD7KyUk/1tVVv/z7ez/i4WG/trU1v7KxMT+zsrK+wcBAvMPCwj6VlBQ+hoUFv56dHT/19HS+iIcHP6empj6npqa+4N9fP4uKij6SkRE/t7a2PpGQEL2ZmJg9+fj4vQ==",
+      "vectorSha256": "129d0f0101731b671067e7aed575fba66fd194c3e6adb873d593fa6c8bf5adb7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4ee211a14438fb0495e415fd0f25d8537eb0923dce61c3a956efa2c8ad7b8970",
+      "updatedAt": "2025-09-20T22:27:41.509Z"
+    },
+    "j-0107": {
+      "vector": "np0dP769PT/NzEy+jYwMvqmoqL3Z2Ni98O9vP87NTb+ioSE/qKcnP5iXFz/r6uo+oaCgPPr5eb/39va+paQkvpWUFL6UkxO/lpUVv9nY2D3Lyso+5uVlP9TTUz+lpCS+jYwMvuTjY7/My0s/i4qKPt3cXD65uLg9v76+PsbFRT+enR0/vr09P83MTL6NjAy+qaiovdnY2L3w728/zs1Nv6KhIT+opyc/mJcXP+vq6j6hoKA8+vl5v/f29r6lpCS+lZQUvpSTE7+WlRW/2djYPcvKyj7m5WU/1NNTP6WkJL6NjAy+5ONjv8zLSz+Lioo+3dxcPrm4uD2/vr4+xsVFPw==",
+      "vectorSha256": "02e2cf317a751a093298311a7178e6e1b1c96351cfd01044bccc4a37d08132bb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cede666e7572f719d0d3cbba8203426b6d36358db2f2e96b6e0ee5a29b8bafe2",
+      "updatedAt": "2025-09-20T22:27:41.509Z"
+    },
+    "j-0108": {
+      "vector": "0dBQPcnIyD3o52c/xcREvoiHBz/a2Vm/tLMzP9fW1j6XlpY+3NtbP769Pb/U01M/q6qqvv38fL76+Xm/sK8vP6yrK7/v7u6+9vV1v4mIiL24tze/v76+vr++vj7q6Wm/wsFBP8HAQLzDwsI+5uVlP62sLD7DwsI+i4qKvvPy8r7R0FA9ycjIPejnZz/FxES+iIcHP9rZWb+0szM/19bWPpeWlj7c21s/vr09v9TTUz+rqqq+/fx8vvr5eb+wry8/rKsrv+/u7r729XW/iYiIvbi3N7+/vr6+v76+Purpab/CwUE/wcBAvMPCwj7m5WU/rawsPsPCwj6Lioq+8/Lyvg==",
+      "vectorSha256": "978b95b70bc4a3c67ffd27a9b99d3fda56250e6ecdabbd8e9e51ef12e8b0e985",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "868cf367c313d9b5a5ed21e9556003d72a4405772450af0be07eb0f295b05d43",
+      "updatedAt": "2025-09-20T22:27:41.509Z"
+    },
+    "j-0109": {
+      "vector": "u7q6Pu7tbT+Lioq+q6qqvry7O7/i4WE/iIcHP8HAQDz6+Xk/n56ePoqJCb/GxUW/397evuzra7/a2Vk/lZQUvqyrK7/c21s/y8rKPqGgoLzY11c/vbw8vvPy8r7Lysq+rq0tv+fm5j6dnBw+t7a2vv38fD7OzU2/xMNDv5ybGz+7uro+7u1tP4uKir6rqqq+vLs7v+LhYT+Ihwc/wcBAPPr5eT+fnp4+iokJv8bFRb/f3t6+7Otrv9rZWT+VlBS+rKsrv9zbWz/Lyso+oaCgvNjXVz+9vDy+8/LyvsvKyr6urS2/5+bmPp2cHD63tra+/fx8Ps7NTb/Ew0O/nJsbPw==",
+      "vectorSha256": "00b8295f99658088db5ec0f3308352809f8f7a5c81086ad1dd00b5c6ae586786",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "aef65d5522f0c381fca73b1d480aec6d2aedb27deb68434d29b993529f191ecd",
+      "updatedAt": "2025-09-20T22:27:41.509Z"
+    },
+    "j-0110": {
+      "vector": "pKMjP8bFRT/k42M/4uFhv/79fb/n5uY+6+rqPtva2r729XW/8O9vv5OSkr6bmpq+xcREvvj3d7+trCy+vbw8PurpaT+Xlpa+9PNzv7y7O7/T0tK+rKsrv+TjYz/W1VU/3dxcPqSjI7/g318/oqEhP5uamj7DwsK+7exsvsHAQDykoyM/xsVFP+TjYz/i4WG//v19v+fm5j7r6uo+29ravvb1db/w72+/k5KSvpuamr7FxES++Pd3v62sLL69vDw+6ulpP5eWlr7083O/vLs7v9PS0r6sqyu/5ONjP9bVVT/d3Fw+pKMjv+DfXz+ioSE/m5qaPsPCwr7t7Gy+wcBAPA==",
+      "vectorSha256": "eab65d0a2509d8e92453860a3fb27e92745ede3ec90b55c18e43c50a546a2a07",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d1e2f10f01b9ba4905085b5967046a97f45a06224b2af1ea9b2eefd0a64f6281",
+      "updatedAt": "2025-09-20T22:27:41.509Z"
+    },
+    "j-0111": {
+      "vector": "7+7uPpqZGb/a2Vm/8/LyPqinJz+6uTm/iokJv4qJCb+vrq6+1NNTP/HwcD2enR2/vbw8PsrJSb/9/Hy+np0dP4aFBT+wry8/hYQEPtzbWz+dnBw+0dBQvaOior75+Pg9jo0Nv6qpKT+/vr6+9/b2PqyrK7+fnp4+qqkpv8PCwr7v7u4+mpkZv9rZWb/z8vI+qKcnP7q5Ob+KiQm/iokJv6+urr7U01M/8fBwPZ6dHb+9vDw+yslJv/38fL6enR0/hoUFP7CvLz+FhAQ+3NtbP52cHD7R0FC9o6Kivvn4+D2OjQ2/qqkpP7++vr739vY+rKsrv5+enj6qqSm/w8LCvg==",
+      "vectorSha256": "cbe4d9489824f7df6e7bedb575d36017601cbf01ed8c99884d7da34b698f0c7c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bb3313bcd3233b3b54e98731971b60cec2d790ed9379578f39d450bd2aa72b4f",
+      "updatedAt": "2025-09-20T22:27:41.509Z"
+    },
+    "j-0112": {
+      "vector": "kI8PP+Pi4r7m5WW/7exsvra1NT/9/Hw+rKsrv5iXF7/X1tY+tbQ0PuXkZL6pqKg90tFRP5GQEL3Lysq+qKcnv7Oysj7083M/p6amPuzraz+opye/x8bGPq2sLD7p6Og97u1tv62sLL6Ihwe/+fj4vQAAgL+koyO/x8bGPtbVVT+Qjw8/4+LivublZb/t7Gy+trU1P/38fD6sqyu/mJcXv9fW1j61tDQ+5eRkvqmoqD3S0VE/kZAQvcvKyr6opye/s7KyPvTzcz+npqY+7OtrP6inJ7/HxsY+rawsPuno6D3u7W2/rawsvoiHB7/5+Pi9AACAv6SjI7/HxsY+1tVVPw==",
+      "vectorSha256": "498df164102e3d47b6c370726d92f3cec2bad4e9441f2fbb0c0f901fa2071045",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c7470d62da9f2a34b596638ae87b4d2cacf9a9f52cb1958e096a3c70002eb1ea",
+      "updatedAt": "2025-09-20T22:27:41.509Z"
+    },
+    "j-0113": {
+      "vector": "qqkpP9fW1r6hoKA8iYiIvY6NDb/o52c/paQkvrSzM7/FxES+xcREPpOSkj7R0FA9i4qKvsvKyj6Qjw8/qaiovdva2j7k42M/oaCgvISDAz+dnBy+iIcHv9/e3j6bmpq+4N9fv+/u7j6Hhoa+s7Kyvv79fT+0szM/kZAQvb69Pb+qqSk/19bWvqGgoDyJiIi9jo0Nv+jnZz+lpCS+tLMzv8XERL7FxEQ+k5KSPtHQUD2Lioq+y8rKPpCPDz+pqKi929raPuTjYz+hoKC8hIMDP52cHL6Ihwe/397ePpuamr7g31+/7+7uPoeGhr6zsrK+/v19P7SzMz+RkBC9vr09vw==",
+      "vectorSha256": "4adba64bf1e423f80948cf51b172f5b22255c3943bd8a2868e895009fe10b3c1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d44a827739f36b266798a4865db2c775b6f17dc16c3cb75910bb5e53fed97b21",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0114": {
+      "vector": "+fj4vaCfHz+DgoK+sK8vP56dHb+fnp4+2tlZv6empj7//v4+xcREvuvq6j7Pzs4+z87Ovv/+/j6rqqq+8vFxP7GwML27urq+6Odnv5CPD7+fnp4+6+rqPuzraz/GxUW/1dRUvvv6+r7c21s/o6KivsC/P7/X1tY+397ePq6tLb/5+Pi9oJ8fP4OCgr6wry8/np0dv5+enj7a2Vm/p6amPv/+/j7FxES+6+rqPs/Ozj7Pzs6+//7+Pquqqr7y8XE/sbAwvbu6ur7o52e/kI8Pv5+enj7r6uo+7OtrP8bFRb/V1FS++/r6vtzbWz+joqK+wL8/v9fW1j7f3t4+rq0tvw==",
+      "vectorSha256": "5a5dd3b22ecd925c99dd84a891c01c3e8b91444a6212eb37cf24607d9e8c9807",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "70cf5fd731a713a9bf67bab34cbf55f87a510c38a7baf51d6541ed5720b5b729",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0115": {
+      "vector": "qqkpv7SzM7/v7u4+7+7uvvHwcD2TkpK+paQkPuno6D2WlRW/rawsPoqJCb+XlpY+o6KiPvn4+L2OjQ2/gYCAO9zbW7/Y11c/ycjIPbm4uL2BgIA7mpkZv//+/j7Ix0e/goEBv4yLC7+dnBy+i4qKPtjXV7+Miwu/mZiYvf79fT+qqSm/tLMzv+/u7j7v7u6+8fBwPZOSkr6lpCQ+6ejoPZaVFb+trCw+iokJv5eWlj6joqI++fj4vY6NDb+BgIA73Ntbv9jXVz/JyMg9ubi4vYGAgDuamRm///7+PsjHR7+CgQG/jIsLv52cHL6Lioo+2NdXv4yLC7+ZmJi9/v19Pw==",
+      "vectorSha256": "07986ba64ebf6dbdff37ac710abd5ee2b1598319a774e96f7162704a988d8acf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2b26bb44875b948e35953ba5a870398012eb8c748033bf1c3f3a6ca2143a76fe",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0116": {
+      "vector": "nJsbP7KxMT+ysTE/xMNDP+fm5j7R0FA9kI8PP9XUVL6vrq4+zMtLv8jHRz+KiQk/srExv7u6uj79/Hy+9vV1P/X0dL6urS2/AACAP+/u7r60szO/kpERP+no6D21tDQ+xMNDP+DfXz+0szO/rawsPomIiL2pqKg9iokJP9PS0j6cmxs/srExP7KxMT/Ew0M/5+bmPtHQUD2Qjw8/1dRUvq+urj7My0u/yMdHP4qJCT+ysTG/u7q6Pv38fL729XU/9fR0vq6tLb8AAIA/7+7uvrSzM7+SkRE/6ejoPbW0ND7Ew0M/4N9fP7SzM7+trCw+iYiIvamoqD2KiQk/09LSPg==",
+      "vectorSha256": "d607f235c0b277a9a60f328b297aa0a459dbb05c9b9c96a4ecab715954d95780",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cdd8d8e1b986c765ab1ae3c427ae60fa6129ff4426c88e96e1ef2695778ac4b4",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0117": {
+      "vector": "vLs7v5iXFz+sqyu/kpERv4aFBb/CwUE/19bWvu3sbL6ioSG/srExv5aVFb/493c/lZQUvpybG7+9vDy+paQkPuTjYz+ZmJg94eDgPMvKyr66uTk/iIcHv46NDT+opyc/i4qKPublZb+OjQ2/np0dP4SDA7+JiIg9jo0NP4eGhj68uzu/mJcXP6yrK7+SkRG/hoUFv8LBQT/X1ta+7exsvqKhIb+ysTG/lpUVv/j3dz+VlBS+nJsbv728PL6lpCQ+5ONjP5mYmD3h4OA8y8rKvrq5OT+Ihwe/jo0NP6inJz+Lioo+5uVlv46NDb+enR0/hIMDv4mIiD2OjQ0/h4aGPg==",
+      "vectorSha256": "1406617e7b5e87212d0274427d3cdbced62315a2bc0ca97832946588a6f6138c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "22cb2a373de04a622f2735fb6d326894f189834ddc3cc6d3a20d39ce3e88c6a1",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0118": {
+      "vector": "4eDgvMvKyr7FxEQ+trU1v6WkJL7q6Wm/rawsvrm4uL2EgwO/s7KyvsLBQT/h4OC8qKcnP97dXb/6+Xm/3t1dP7GwML2hoKA8+fj4PfX0dL77+vq+tLMzP7GwMD2OjQ2/hIMDP9PS0r6CgQE/5ONjv8PCwj7KyUk/kZAQvYWEBD7h4OC8y8rKvsXERD62tTW/paQkvurpab+trCy+ubi4vYSDA7+zsrK+wsFBP+Hg4Lyopyc/3t1dv/r5eb/e3V0/sbAwvaGgoDz5+Pg99fR0vvv6+r60szM/sbAwPY6NDb+EgwM/09LSvoKBAT/k42O/w8LCPsrJST+RkBC9hYQEPg==",
+      "vectorSha256": "896e62352bb3d3366587b1bfcd338726766bb7f18b1113cc75c7dc2e1cd64f45",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7c4d98256b0b6a743e53e07cd31103ee7a828f6141d98539c14bc00eb0e47b90",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0119": {
+      "vector": "oqEhP/n4+D3Lysq+xsVFv5mYmD2vrq4+4eDgPI+Ojj7//v4+1NNTv7a1Nb/CwUG/oJ8fv+vq6r6koyM/y8rKPqWkJL7v7u6+0tFRP/38fD7l5GS+j46OvsHAQDympSU/+fj4Pba1Nb+amRk/5+bmvsC/Pz/q6Wk/hoUFP6CfH7+ioSE/+fj4PcvKyr7GxUW/mZiYPa+urj7h4OA8j46OPv/+/j7U01O/trU1v8LBQb+gnx+/6+rqvqSjIz/Lyso+paQkvu/u7r7S0VE//fx8PuXkZL6Pjo6+wcBAPKalJT/5+Pg9trU1v5qZGT/n5ua+wL8/P+rpaT+GhQU/oJ8fvw==",
+      "vectorSha256": "6d9fa590fc7e73dbf2f0130857159ee6c167a13802970a7eb06dd654f6d22b94",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d08f4d1d89ab83a3bf16251f3045d1b26b44e89f635c81d28f25cc46dff4c230",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0120": {
+      "vector": "vLs7P9fW1j7c21u/qKcnv5eWlr6RkBA9o6KivvDvb7+Lioo+oaCgvNnY2L2XlpY+2djYPcXERD7HxsY+kZAQPaKhIT/c21u/1tVVv56dHb/R0FC9h4aGvsnIyL3Ix0e/29ravr28PD7Qz0+/6ejoPa6tLT/x8HC9mJcXP+/u7r68uzs/19bWPtzbW7+opye/l5aWvpGQED2joqK+8O9vv4uKij6hoKC82djYvZeWlj7Z2Ng9xcREPsfGxj6RkBA9oqEhP9zbW7/W1VW/np0dv9HQUL2Hhoa+ycjIvcjHR7/b2tq+vbw8PtDPT7/p6Og9rq0tP/HwcL2Ylxc/7+7uvg==",
+      "vectorSha256": "4bdbaa493fed411608b05fc73143cb1d16c17f81e8a0c4461af88c41a554b3aa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ddb5122c5a845708a27d72a58d98b184d0121531795e731c4997188ed678cb44",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0121": {
+      "vector": "qaioPYyLCz/U01O/7exsPpGQED3Qz0+/29raPoiHBz+trCw+yslJP8rJSb+Pjo4++fj4Pd7dXb/x8HC99/b2vtjXV7/p6Og97Otrv4mIiD2sqys//Pt7P//+/j6ysTE/xMNDv8zLS7+ysTG/2NdXv6CfH7+fnp4+h4aGvri3N7+pqKg9jIsLP9TTU7/t7Gw+kZAQPdDPT7/b2to+iIcHP62sLD7KyUk/yslJv4+Ojj75+Pg93t1dv/HwcL339va+2NdXv+no6D3s62u/iYiIPayrKz/8+3s///7+PrKxMT/Ew0O/zMtLv7KxMb/Y11e/oJ8fv5+enj6Hhoa+uLc3vw==",
+      "vectorSha256": "fad623b119c4ba37ac34255b4fedc6628a2c88c7969d90e18d800c058bd4a158",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8ac5169d8418b6c395e41ba38f117842148e0a88d5fdbfd81e1a271430a75e24",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0122": {
+      "vector": "vbw8vuLhYT+SkRE/0dBQPcbFRb+qqSk/rawsPoWEBD6WlRW/rq0tP42MDD7NzEw+trU1P+3sbD7Z2Ni9sK8vP/Py8j6Miwu//fx8vtHQUD2dnBy+p6amPpGQED2xsDA9qaiovdHQUD2qqSk/8vFxv+LhYT+RkBA9+vl5v/HwcL29vDy+4uFhP5KRET/R0FA9xsVFv6qpKT+trCw+hYQEPpaVFb+urS0/jYwMPs3MTD62tTU/7exsPtnY2L2wry8/8/LyPoyLC7/9/Hy+0dBQPZ2cHL6npqY+kZAQPbGwMD2pqKi90dBQPaqpKT/y8XG/4uFhP5GQED36+Xm/8fBwvQ==",
+      "vectorSha256": "29cbcfd54c24035c94d31b7c1e480fd60ccfc6109cdf5d5ac23c809302236b0f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "68f0c8861dd4959035d69199da9d72d7bc3a60866ca984857586d407f0840378",
+      "updatedAt": "2025-09-20T22:27:41.510Z"
+    },
+    "j-0123": {
+      "vector": "8/LyPs/Ozr7S0VG/qqkpP7W0ND7W1VU/0dBQPejnZ7/U01O///7+vqWkJD6ZmJi9s7KyPsnIyD2fnp6+sK8vP9nY2D2mpSU/iIcHP4uKir6NjAw+vbw8vpGQEL3//v4+6ejoveXkZL7Ew0O/gYCAu5iXFz/s62s/4N9fv6moqL3z8vI+z87OvtLRUb+qqSk/tbQ0PtbVVT/R0FA96Odnv9TTU7///v6+paQkPpmYmL2zsrI+ycjIPZ+enr6wry8/2djYPaalJT+Ihwc/i4qKvo2MDD69vDy+kZAQvf/+/j7p6Oi95eRkvsTDQ7+BgIC7mJcXP+zraz/g31+/qaiovQ==",
+      "vectorSha256": "500fc9c9c9e7fc9a0037308abc2ea4aaa7996c8a613c33c21819725077ef82a8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bc4c17d496ea860c16409476ac8c58d78dd2c35d91687bbf71631e7fcbf51075",
+      "updatedAt": "2025-09-20T22:27:41.511Z"
+    },
+    "j-0124": {
+      "vector": "nZwcPoSDAz+lpCQ+iYiIPbOysr7FxEQ+4+LiPoqJCT+HhoY+6ulpPwAAgD+koyM/v76+Po6NDT+opye/n56evurpab/FxES+srExv9va2j6wry+/9/b2vs/Ozr7d3Fy+hoUFv7W0NL6Ihwe/4eDgvOno6D2TkpK+9vV1P/n4+L2dnBw+hIMDP6WkJD6JiIg9s7KyvsXERD7j4uI+iokJP4eGhj7q6Wk/AACAP6SjIz+/vr4+jo0NP6inJ7+fnp6+6ulpv8XERL6ysTG/29raPrCvL7/39va+z87Ovt3cXL6GhQW/tbQ0voiHB7/h4OC86ejoPZOSkr729XU/+fj4vQ==",
+      "vectorSha256": "aef6a4487cc107d4437b0672749cbae090329ae9b6c6cda94adae40f442cf59c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "93c194885398b8c4a1f4ffd1afc62c580b6727b628424c643d693c7c8e5bfa70",
+      "updatedAt": "2025-09-20T22:27:41.511Z"
+    },
+    "j-0125": {
+      "vector": "6ulpv/n4+L2GhQU/2djYvbu6uj6bmpo+tLMzv5uamj6Ylxc/kZAQvcfGxj7//v4+lZQUvvLxcT+zsrI+7Otrv6CfH7/l5GQ+0dBQvdXUVD7Y11e/vr09v56dHb+RkBC9/Pt7P/LxcT/HxsY+iIcHv6GgoLyQjw+/zMtLP97dXb/q6Wm/+fj4vYaFBT/Z2Ni9u7q6Ppuamj60szO/m5qaPpiXFz+RkBC9x8bGPv/+/j6VlBS+8vFxP7Oysj7s62u/oJ8fv+XkZD7R0FC91dRUPtjXV7++vT2/np0dv5GQEL38+3s/8vFxP8fGxj6Ihwe/oaCgvJCPD7/My0s/3t1dvw==",
+      "vectorSha256": "c87400e17957076b05defd9e2154122c4218971bdcdd535e220e5d027b3e2c5c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0b70c272aea626a6cb7bb1bf6df8ac0a309c799a1421317bfdf8b13c7d38e511",
+      "updatedAt": "2025-09-20T22:27:41.511Z"
+    },
+    "j-0126": {
+      "vector": "wcBAPMrJST/Z2Ng9xsVFv62sLD79/Hw+6ejoPfz7e7+8uzu/iIcHP5iXFz/x8HA9xcREPsfGxr7U01M/j46OvsPCwj6JiIi9iokJP9jXVz/Avz+/1NNTv6Oior61tDQ+mJcXP4WEBL7z8vI+0tFRv+7tbb/GxUU/4eDgvOfm5j7BwEA8yslJP9nY2D3GxUW/rawsPv38fD7p6Og9/Pt7v7y7O7+Ihwc/mJcXP/HwcD3FxEQ+x8bGvtTTUz+Pjo6+w8LCPomIiL2KiQk/2NdXP8C/P7/U01O/o6KivrW0ND6Ylxc/hYQEvvPy8j7S0VG/7u1tv8bFRT/h4OC85+bmPg==",
+      "vectorSha256": "6104503f919ac6d741a6f41e18386c62efebef022bba2a9f24ec6369fbfbd2d9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "81e48d1d959f8e0222c3cb87984ee95cb077c4eb20165796cb6fbc1709e27cb9",
+      "updatedAt": "2025-09-20T22:27:41.511Z"
+    },
+    "j-0127": {
+      "vector": "nJsbP4WEBL7493e/m5qaPp+enj7h4OC8mpkZP8LBQT+lpCQ+5uVlP9zbW7/+/X0/rawsPuzra7/T0tI+g4KCvq2sLD7y8XG/s7KyPrSzM7+fnp4++vl5v7KxMT/u7W0/rKsrP5iXFz/n5uY+iYiIPeDfXz/39va+3Ntbv97dXT+cmxs/hYQEvvj3d7+bmpo+n56ePuHg4LyamRk/wsFBP6WkJD7m5WU/3Ntbv/79fT+trCw+7Otrv9PS0j6DgoK+rawsPvLxcb+zsrI+tLMzv5+enj76+Xm/srExP+7tbT+sqys/mJcXP+fm5j6JiIg94N9fP/f29r7c21u/3t1dPw==",
+      "vectorSha256": "c640d094e1e9fdda299b60a868e9ae9dfa95afcd711a4a9530cc74e4c6f89cae",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cd6f04a6a77ccce094f212fe950ab45f9507ac26a703d8f6d5cbb988ef4212ee",
+      "updatedAt": "2025-09-20T22:27:41.511Z"
+    },
+    "j-0128": {
+      "vector": "/v19v6Oior7Hxsa+wsFBv8HAQDylpCQ+9fR0PtjXVz+mpSW/kZAQva2sLD6ioSE/z87Ovry7O7/Z2Ni9mJcXP728PD6pqKg9r66uPtjXVz/NzEy+xcREPr28PD6sqys/4eDgPJOSkj7c21s/8O9vP+/u7j6gnx+/p6amPvPy8r7+/X2/o6KivsfGxr7CwUG/wcBAPKWkJD719HQ+2NdXP6alJb+RkBC9rawsPqKhIT/Pzs6+vLs7v9nY2L2Ylxc/vbw8PqmoqD2vrq4+2NdXP83MTL7FxEQ+vbw8PqyrKz/h4OA8k5KSPtzbWz/w728/7+7uPqCfH7+npqY+8/Lyvg==",
+      "vectorSha256": "69fbc30843d82f028c063c4d4ba247e188ff15f1cebacf2d0c14f2a800045994",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "01574e1f81949eeb2d7b95d04c2272cb978aabeb669897d583a4edf7bb30a943",
+      "updatedAt": "2025-09-20T22:27:41.511Z"
+    },
+    "j-0129": {
+      "vector": "pqUlP8TDQz/Qz0+/6ulpP9DPTz/q6Wk/hIMDP+LhYT/r6uq+3t1dP9TTUz/U01O/m5qaPsjHR7+VlBS+xcREPr69Pb/Ew0M/r66uvtLRUT+zsrK+trU1v87NTb/+/X2///7+vuXkZL7k42O/kpERP6GgoLzx8HA9mZiYvamoqL2mpSU/xMNDP9DPT7/q6Wk/0M9PP+rpaT+EgwM/4uFhP+vq6r7e3V0/1NNTP9TTU7+bmpo+yMdHv5WUFL7FxEQ+vr09v8TDQz+vrq6+0tFRP7Oysr62tTW/zs1Nv/79fb///v6+5eRkvuTjY7+SkRE/oaCgvPHwcD2ZmJi9qaiovQ==",
+      "vectorSha256": "9d038ae4aaee02051de03bd614b0b38e3e53aa4052d7636d1611d8e5d9e581f3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d2e118f4e7f4c1f045eee916a61c6d9821e154e85325190140630ec87d877675",
+      "updatedAt": "2025-09-20T22:27:41.511Z"
+    },
+    "j-0130": {
+      "vector": "8/LyPra1Nb+0szM/09LSvsTDQ7/Ew0O/hoUFP8jHRz/HxsY+trU1P4yLC7/Y11c/kZAQvcLBQb/KyUk/tbQ0vvLxcT/a2Vk/6+rqvv79fb/Ix0e/l5aWPuHg4LyJiIi9rawsPtrZWT+DgoI+lJMTP62sLD63tra+3t1dP+TjY7/z8vI+trU1v7SzMz/T0tK+xMNDv8TDQ7+GhQU/yMdHP8fGxj62tTU/jIsLv9jXVz+RkBC9wsFBv8rJST+1tDS+8vFxP9rZWT/r6uq+/v19v8jHR7+XlpY+4eDgvImIiL2trCw+2tlZP4OCgj6UkxM/rawsPre2tr7e3V0/5ONjvw==",
+      "vectorSha256": "18beefc2537fd926dd912912573871c55cadeeb86ebc0604cb889b34c459d0ec",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bc25d94b1e1ec2e3b1da3aeb7b1fe469f8ec45011ca57c7795eca0c99552ee0e",
+      "updatedAt": "2025-09-20T22:27:41.511Z"
+    },
+    "j-0131": {
+      "vector": "iokJv4SDAz/Ix0c/urk5P+TjYz+NjAy+5ONjP9LRUb+GhQW/xcREPpaVFb/DwsK+9/b2PszLSz+BgIA7kpERv/r5eT/g318/6ulpP/Py8j7V1FS+kpERP/j3dz/b2to+jo0NP4GAgDsAAIA/5uVlP+jnZ78AAIC/9/b2vuzra7+KiQm/hIMDP8jHRz+6uTk/5ONjP42MDL7k42M/0tFRv4aFBb/FxEQ+lpUVv8PCwr739vY+zMtLP4GAgDuSkRG/+vl5P+DfXz/q6Wk/8/LyPtXUVL6SkRE/+Pd3P9va2j6OjQ0/gYCAOwAAgD/m5WU/6OdnvwAAgL/39va+7Otrvw==",
+      "vectorSha256": "b93977b8f571b663b8e0179a709bfa16113a38d0fdd74c9224acc13ae511f7b2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3bc1e3dcf16ef1173d98354fbde58037fceff4bc65c8fbb6c680fff20c00420a",
+      "updatedAt": "2025-09-20T22:27:41.511Z"
+    },
+    "j-0132": {
+      "vector": "0dBQvcbFRT+ZmJg9nJsbv83MTL7JyMg9sbAwPfDvb7+enR0/0dBQPfLxcT/R0FC92tlZP7y7Oz+ysTE/qKcnP5aVFb/n5uY+xMNDv/n4+D26uTk/1dRUPvn4+L2wry8/3t1dP66tLb/a2Vm/lJMTv7a1Nb+cmxu/+Pd3P6SjIz/R0FC9xsVFP5mYmD2cmxu/zcxMvsnIyD2xsDA98O9vv56dHT/R0FA98vFxP9HQUL3a2Vk/vLs7P7KxMT+opyc/lpUVv+fm5j7Ew0O/+fj4Pbq5OT/V1FQ++fj4vbCvLz/e3V0/rq0tv9rZWb+UkxO/trU1v5ybG7/493c/pKMjPw==",
+      "vectorSha256": "bb4ed5de24e451736046e0ea5bf6f61bb57a62ed8fa3070b64c2f78e1e2b8bec",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "79e28932668c8508ce86f879ecddd8d335b91e8fdc9a70d7ee2913362532fbd1",
+      "updatedAt": "2025-09-20T22:27:41.512Z"
+    },
+    "j-0133": {
+      "vector": "3dxcvvz7ez+TkpI+3dxcPtDPTz+4tzc/zMtLv5uamr7d3Fy+j46OvqCfHz+2tTU/mZiYPeDfX7+Qjw+/sbAwvf79fb+UkxM/zs1NP97dXT+ioSE/2NdXvwAAgL/5+Pg93NtbP+TjY7/v7u4+srExv+LhYb/y8XE/l5aWPsLBQb/d3Fy+/Pt7P5OSkj7d3Fw+0M9PP7i3Nz/My0u/m5qavt3cXL6Pjo6+oJ8fP7a1NT+ZmJg94N9fv5CPD7+xsDC9/v19v5STEz/OzU0/3t1dP6KhIT/Y11e/AACAv/n4+D3c21s/5ONjv+/u7j6ysTG/4uFhv/LxcT+XlpY+wsFBvw==",
+      "vectorSha256": "ed8f23f9df2c00d8d0a9bc191028fa96c567c8c3f9539991ce7ce189d3c3d636",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "64fda49be7db1a59645ccfda8910387a01c9e6eed014008fed0ebb270ff8a51f",
+      "updatedAt": "2025-09-20T22:27:41.512Z"
+    },
+    "j-0134": {
+      "vector": "l5aWPtXUVD7c21u/6Odnv6+urr7e3V0/ycjIPdDPTz+vrq4+k5KSPuDfX7+SkRE/vr09v+XkZL7Y11c///7+vvv6+j7083M/wcBAvM/Ozj4AAIC/zs1NP9va2r7Ix0e/sbAwPf38fL6bmpq+y8rKvvPy8j6amRk/lZQUvpOSkr6XlpY+1dRUPtzbW7/o52e/r66uvt7dXT/JyMg90M9PP6+urj6TkpI+4N9fv5KRET++vT2/5eRkvtjXVz///v6++/r6PvTzcz/BwEC8z87OPgAAgL/OzU0/29ravsjHR7+xsDA9/fx8vpuamr7Lysq+8/LyPpqZGT+VlBS+k5KSvg==",
+      "vectorSha256": "6e024bbeed0efb05fa3cfe524b311ac94872d565d779c7e76852f7406f382ca0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a59a120c54ee8ce7aba410c82163eb40bef97eb300e6491c8560594dbccc6d5b",
+      "updatedAt": "2025-09-20T22:27:41.512Z"
+    },
+    "j-0135": {
+      "vector": "/Pt7v/Py8j6sqys/yslJv62sLD6vrq4+sbAwvf79fb+8uzu/1NNTv5WUFL7My0u//fx8vgAAgD/T0tI+jIsLv9HQUD20szM/1NNTv/n4+L2gnx+/hIMDP6qpKT/R0FC9/v19P6empj6vrq4+7+7uPpiXFz/n5uY+8vFxP7i3Nz/8+3u/8/LyPqyrKz/KyUm/rawsPq+urj6xsDC9/v19v7y7O7/U01O/lZQUvszLS7/9/Hy+AACAP9PS0j6Miwu/0dBQPbSzMz/U01O/+fj4vaCfH7+EgwM/qqkpP9HQUL3+/X0/p6amPq+urj7v7u4+mJcXP+fm5j7y8XE/uLc3Pw==",
+      "vectorSha256": "6594a2d4df224aadc21f8780c6ebb20f47bdf8fa11187909a8dfa89ab525589a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "02bcd51b95ab7a0122166d1a60ffb43a86d9167030c1d479fea9abbbcbb9f8db",
+      "updatedAt": "2025-09-20T22:27:41.512Z"
+    },
+    "j-0136": {
+      "vector": "u7q6vpybGz/a2Vm//Pt7P+LhYb/6+Xm/sK8vv7SzMz+EgwM/6ejoPczLSz+3tra+vbw8vrSzM7+XlpY+6ejovdjXVz/29XU/5eRkPtrZWb+hoKA8z87OPp6dHb/5+Pi93NtbP+rpaT+FhAQ+8fBwvff29j6cmxu/srExv5iXF7+7urq+nJsbP9rZWb/8+3s/4uFhv/r5eb+wry+/tLMzP4SDAz/p6Og9zMtLP7e2tr69vDy+tLMzv5eWlj7p6Oi92NdXP/b1dT/l5GQ+2tlZv6GgoDzPzs4+np0dv/n4+L3c21s/6ulpP4WEBD7x8HC99/b2PpybG7+ysTG/mJcXvw==",
+      "vectorSha256": "82280c0dab48cf62dee2f9b37da679b7d1651485a659ceb0f09f81ceaabc190e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "51cd13fd0f0328d9c18ee5526826a571ebfa9c1382b33170edf49078bd322734",
+      "updatedAt": "2025-09-20T22:27:41.512Z"
+    },
+    "j-0137": {
+      "vector": "g4KCvvLxcb+RkBA9srExv5OSkj7Lysq+n56evoiHB7+WlRU/p6amPt3cXD7S0VE/jIsLP4+Ojj6KiQm/rq0tP5ybGz/Ew0M/n56evsjHRz+koyM/l5aWvrOysr6Ylxc/+vl5v7GwMD2FhAS+zMtLP/r5eT+vrq4+7exsPqyrK7+DgoK+8vFxv5GQED2ysTG/k5KSPsvKyr6fnp6+iIcHv5aVFT+npqY+3dxcPtLRUT+Miws/j46OPoqJCb+urS0/nJsbP8TDQz+fnp6+yMdHP6SjIz+Xlpa+s7KyvpiXFz/6+Xm/sbAwPYWEBL7My0s/+vl5P6+urj7t7Gw+rKsrvw==",
+      "vectorSha256": "32990bccda2eba7ca98f318a322c090865a47cd840962a456d4a1290459008f0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5f078427a44d583ccaa99be8c5a33bd6cde158e3d15a53cb03856fe5fcab9d2a",
+      "updatedAt": "2025-09-20T22:27:41.512Z"
+    },
+    "j-0138": {
+      "vector": "6+rqvr++vr6JiIg9tLMzv5eWlj6EgwO/zs1NP+TjYz+/vr4+gYCAu9TTU7+SkRG/ubi4va+urr62tTW/z87OPs7NTT/W1VU/qaioPbe2tr6HhoY+gYCAu+blZT+Hhoa+0M9Pv6Oior78+3u/hIMDP+TjY7+DgoI+v76+vsjHRz/r6uq+v76+vomIiD20szO/l5aWPoSDA7/OzU0/5ONjP7++vj6BgIC71NNTv5KREb+5uLi9r66uvra1Nb/Pzs4+zs1NP9bVVT+pqKg9t7a2voeGhj6BgIC75uVlP4eGhr7Qz0+/o6Kivvz7e7+EgwM/5ONjv4OCgj6/vr6+yMdHPw==",
+      "vectorSha256": "d15a1de51b6b3683ae5efd8902fbb497d89d35d82b4acd8bd1c8d39f7b745b17",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "45508826a53ee6f1af7f1637745425b3e6ea8a52a17ff25e185702c10ea050e3",
+      "updatedAt": "2025-09-20T22:27:41.512Z"
+    },
+    "j-0139": {
+      "vector": "5ONjv7CvLz/Avz8/29ravt/e3r6JiIg9s7KyvtbVVT/f3t6+trU1P8fGxr7493c/zcxMPsXERL6/vr4+0tFRv4aFBT/Pzs4+0dBQPb++vr7Hxsa+3Ntbv4uKir69vDy+0tFRP4SDA7/Z2Ng91NNTP5uamj7Hxsa+iIcHv4aFBT/k42O/sK8vP8C/Pz/b2tq+397evomIiD2zsrK+1tVVP9/e3r62tTU/x8bGvvj3dz/NzEw+xcREvr++vj7S0VG/hoUFP8/Ozj7R0FA9v76+vsfGxr7c21u/i4qKvr28PL7S0VE/hIMDv9nY2D3U01M/m5qaPsfGxr6Ihwe/hoUFPw==",
+      "vectorSha256": "77b1cb3bc62c4a686be26e3d88ec692bde808f309904d2906bdbbac32ef34ad4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0ed7df49488853ea48da4efb9967af17c2b386504e125d68e83e8de9a64e3cc2",
+      "updatedAt": "2025-09-20T22:27:41.512Z"
+    },
+    "j-0140": {
+      "vector": "iYiIPa6tLT/W1VU/3t1dP93cXD6rqqq+kZAQPd7dXT+Miws/yslJv6SjI7/x8HC9wcBAPOrpaT/9/Hw+3t1dP46NDT/5+Pi9x8bGvgAAgD/493e/8vFxP52cHD7Qz08/+vl5P4GAgLvw72+/19bWvp2cHD6qqSk/5uVlP6GgoLyJiIg9rq0tP9bVVT/e3V0/3dxcPquqqr6RkBA93t1dP4yLCz/KyUm/pKMjv/HwcL3BwEA86ulpP/38fD7e3V0/jo0NP/n4+L3Hxsa+AACAP/j3d7/y8XE/nZwcPtDPTz/6+Xk/gYCAu/Dvb7/X1ta+nZwcPqqpKT/m5WU/oaCgvA==",
+      "vectorSha256": "799730b7d12c7fea580b92a7067b5f55171d86a3532d0e2681c35ff0b31a3560",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "88d6eaee9b5584eec51b2e7881f49feec6704eff04f893e7fc7f084a93d4f27d",
+      "updatedAt": "2025-09-20T22:27:41.512Z"
+    },
+    "j-0141": {
+      "vector": "h4aGvqOioj6VlBQ+6ulpv7GwML2EgwO/9vV1P8LBQT/JyMg9xsVFv8PCwj7HxsY+9vV1P9PS0r7b2tq+kZAQPeLhYT/19HQ++/r6vv38fL66uTm/iIcHv+rpaT+KiQm/4N9fv7i3Nz+CgQE/lpUVP6qpKT/V1FQ+r66uvtva2r6Hhoa+o6KiPpWUFD7q6Wm/sbAwvYSDA7/29XU/wsFBP8nIyD3GxUW/w8LCPsfGxj729XU/09LSvtva2r6RkBA94uFhP/X0dD77+vq+/fx8vrq5Ob+Ihwe/6ulpP4qJCb/g31+/uLc3P4KBAT+WlRU/qqkpP9XUVD6vrq6+29ravg==",
+      "vectorSha256": "a78ea491000d834a5b9eed17ec38ebe540b6594893ac43aaa11ca63162219d35",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5ea8920b7a3efae08c1db0b1fa4b4984f09e4160233cf43b10dbc0cad49a5449",
+      "updatedAt": "2025-09-20T22:27:41.513Z"
+    },
+    "j-0142": {
+      "vector": "/Pt7v5GQED3Y11c/kI8PP7u6uj7f3t4+xMNDP4qJCT/k42O/ycjIveHg4LyGhQU/8/Lyvpuamr7U01M/qKcnP42MDL6Lioo+q6qqPuDfX7+/vr4+kZAQPfz7e7+ysTE/trU1v6CfHz+enR0/v76+vv38fL6XlpY+9vV1P5ybGz/8+3u/kZAQPdjXVz+Qjw8/u7q6Pt/e3j7Ew0M/iokJP+TjY7/JyMi94eDgvIaFBT/z8vK+m5qavtTTUz+opyc/jYwMvouKij6rqqo+4N9fv7++vj6RkBA9/Pt7v7KxMT+2tTW/oJ8fP56dHT+/vr6+/fx8vpeWlj729XU/nJsbPw==",
+      "vectorSha256": "2dc5061de9f63a555199ac32ffcb118e4449218e8d818da899b549e108dd774b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0284ebc7aeb7e1c40e737cc24359e9d36ea2aa10af8402d825cfce5060a5facd",
+      "updatedAt": "2025-09-20T22:27:41.513Z"
+    },
+    "j-0143": {
+      "vector": "g4KCvtva2j7S0VG/vr09v87NTb/k42O/srExv+no6D2KiQk/+/r6vpybGz+0szO/6ejovdXUVD6Ihwc/ubi4vbKxMb/S0VG/7Otrv4eGhr7FxEQ+4uFhP/X0dL7V1FQ+5eRkvuPi4j7My0u/1dRUvvj3d7/DwsI+ubi4vayrK7+DgoK+29raPtLRUb++vT2/zs1Nv+TjY7+ysTG/6ejoPYqJCT/7+vq+nJsbP7SzM7/p6Oi91dRUPoiHBz+5uLi9srExv9LRUb/s62u/h4aGvsXERD7i4WE/9fR0vtXUVD7l5GS+4+LiPszLS7/V1FS++Pd3v8PCwj65uLi9rKsrvw==",
+      "vectorSha256": "15992d49e557759d6567fe8731fba9260f0ff10db7d77bd0f2ca30f6537efa47",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5fb61721190e278ec441cd26719ac37427170a5e98f0619a63b81a6504b0742a",
+      "updatedAt": "2025-09-20T22:27:41.513Z"
+    },
+    "j-0144": {
+      "vector": "0M9Pv728PD67uro+oqEhP5OSkj6amRk/lZQUPpuamj68uzu/i4qKPrm4uL2vrq6+yMdHP6WkJD7Pzs6+7OtrP4aFBb/DwsI+9/b2PoqJCT+Qjw+/qKcnv+blZT+7urq+9/b2Pq6tLb/x8HA9+Pd3v+blZb+CgQG/pKMjv9rZWT/Qz0+/vbw8Pru6uj6ioSE/k5KSPpqZGT+VlBQ+m5qaPry7O7+Lioo+ubi4va+urr7Ix0c/paQkPs/Ozr7s62s/hoUFv8PCwj739vY+iokJP5CPD7+opye/5uVlP7u6ur739vY+rq0tv/HwcD3493e/5uVlv4KBAb+koyO/2tlZPw==",
+      "vectorSha256": "e53c35b1de538326faf349a446d40fac3ae8a2d58a5625d3be56fe74ac54fc54",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1897aed0a4cc92a622a27454e3944cf53db0bdc4382cf251bd2987040d3f2eec",
+      "updatedAt": "2025-09-20T22:27:41.513Z"
+    },
+    "j-0145": {
+      "vector": "+/r6voKBAb/+/X2/zs1NP/b1dT+Miwu/yMdHP8rJST/OzU0/7Otrv4SDA7/o52e/9PNzP9bVVT++vT0/8vFxP9nY2D2Ihwe/i4qKvpaVFT+Hhoa+uLc3v8nIyL2joqK+r66uPuno6L0AAIA/9vV1v9PS0r75+Pg9kI8PP9zbWz/7+vq+goEBv/79fb/OzU0/9vV1P4yLC7/Ix0c/yslJP87NTT/s62u/hIMDv+jnZ7/083M/1tVVP769PT/y8XE/2djYPYiHB7+Lioq+lpUVP4eGhr64tze/ycjIvaOior6vrq4+6ejovQAAgD/29XW/09LSvvn4+D2Qjw8/3NtbPw==",
+      "vectorSha256": "3c666f0d5712cce59342146b031a83a06ddb1c3711138c515d7fa1ba7a89ae9a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "413f01e6fa3ae3e4e60a3e0cf9eadef88d3c5dca5e247357ab71ff054b8fc7ed",
+      "updatedAt": "2025-09-20T22:27:41.513Z"
+    },
+    "j-0146": {
+      "vector": "kpERP4uKir6dnBw+m5qavurpaT+ysTE/gYCAO/n4+D3p6Oi98fBwPcbFRT+dnBw+8fBwvdva2j7r6uo+4+LiPvLxcT+2tTW/5uVlP6+urr6Qjw8/mZiYPb28PD76+Xk/6ulpv5+enr62tTW/hIMDP4OCgr7T0tI+nZwcvoaFBT+SkRE/i4qKvp2cHD6bmpq+6ulpP7KxMT+BgIA7+fj4Peno6L3x8HA9xsVFP52cHD7x8HC929raPuvq6j7j4uI+8vFxP7a1Nb/m5WU/r66uvpCPDz+ZmJg9vbw8Pvr5eT/q6Wm/n56evra1Nb+EgwM/g4KCvtPS0j6dnBy+hoUFPw==",
+      "vectorSha256": "ec9b74bdbe895f2c309adf066751b90f35f46e050ab471c8f4003070b9acc895",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c85d9359f4d8808f7187e29378b6bab8f825f254c78997fc0b5825c15fb46cc2",
+      "updatedAt": "2025-09-20T22:27:41.513Z"
+    },
+    "j-0147": {
+      "vector": "np0dv/79fb+ioSG/tLMzv728PL6VlBQ+mpkZv4OCgj7a2Vm/4uFhv6WkJD6GhQU/3NtbP7SzMz/Lyso+vLs7P9TTU7+NjAy+oaCgvMTDQz/GxUU/hoUFv+zra7/v7u6+kpERP+Hg4Dy7uro+0M9Pv5uamr7Ew0M/zMtLP6moqL2enR2//v19v6KhIb+0szO/vbw8vpWUFD6amRm/g4KCPtrZWb/i4WG/paQkPoaFBT/c21s/tLMzP8vKyj68uzs/1NNTv42MDL6hoKC8xMNDP8bFRT+GhQW/7Otrv+/u7r6SkRE/4eDgPLu6uj7Qz0+/m5qavsTDQz/My0s/qaiovQ==",
+      "vectorSha256": "b28191525220ca5ac6baa142799521a6201bae68136e09632d49955e9d5ff12a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "31012f26689233a0130f94c2edd9b2dd166e7de1e23d0a44c883ae1859e1e575",
+      "updatedAt": "2025-09-20T22:27:41.513Z"
+    },
+    "j-0148": {
+      "vector": "+fj4vb69PT+vrq6+x8bGvsC/Pz+1tDS+nJsbv66tLT/Pzs4+/v19P8nIyD3s62u/vLs7v/38fL7+/X0/srExP/LxcT/Ix0e/rKsrv+LhYT+bmpq+mJcXv6yrK7/NzEw+zMtLv7++vj6enR2/vbw8PsHAQDykoyM/iokJP6CfH7/5+Pi9vr09P6+urr7Hxsa+wL8/P7W0NL6cmxu/rq0tP8/Ozj7+/X0/ycjIPezra7+8uzu//fx8vv79fT+ysTE/8vFxP8jHR7+sqyu/4uFhP5uamr6Ylxe/rKsrv83MTD7My0u/v76+Pp6dHb+9vDw+wcBAPKSjIz+KiQk/oJ8fvw==",
+      "vectorSha256": "c82387d436b21da50cfdd1d775b1ab489795ed007e4641b1bd78beda23b91ecd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "70de544edf6932d6b3fe8c0a2260fed8f81c2af059342a991aaf319781d1c430",
+      "updatedAt": "2025-09-20T22:27:41.513Z"
+    },
+    "j-0149": {
+      "vector": "w8LCvpOSkr7KyUk/AACAv8LBQT/W1VW/y8rKPoeGhj75+Pg9s7Kyvo6NDb+0szM/qaioPeTjY7+Qjw8/paQkPoWEBD7BwEA8kZAQverpab+UkxO/sK8vP7i3Nz/NzEw++fj4PaalJb+dnBy+sK8vP769Pb+cmxu/7exsPtLRUb/DwsK+k5KSvsrJST8AAIC/wsFBP9bVVb/Lyso+h4aGPvn4+D2zsrK+jo0Nv7SzMz+pqKg95ONjv5CPDz+lpCQ+hYQEPsHAQDyRkBC96ulpv5STE7+wry8/uLc3P83MTD75+Pg9pqUlv52cHL6wry8/vr09v5ybG7/t7Gw+0tFRvw==",
+      "vectorSha256": "b5893363db4b87c1ce0fc4c37d3660c1dfb227abdb0b4c650f980ea9aca20415",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4f5be400e015b2a18f5339d98a0ec79490817b0b36d7db998f2d6cd721329d17",
+      "updatedAt": "2025-09-20T22:27:41.514Z"
+    },
+    "j-0150": {
+      "vector": "q6qqPuzraz+gnx8/o6Kivo+Ojj6CgQE/r66uPtfW1r7Y11c/sbAwPY6NDb/p6Oi90dBQPejnZ7+KiQm/s7KyPoGAgLuhoKA84+LivuLhYT/u7W2/g4KCPvb1db+VlBS+lJMTv6moqL319HS+6+rqvp+enj6bmpo+wL8/P/X0dD6rqqo+7OtrP6CfHz+joqK+j46OPoKBAT+vrq4+19bWvtjXVz+xsDA9jo0Nv+no6L3R0FA96Odnv4qJCb+zsrI+gYCAu6GgoDzj4uK+4uFhP+7tbb+DgoI+9vV1v5WUFL6UkxO/qaiovfX0dL7r6uq+n56ePpuamj7Avz8/9fR0Pg==",
+      "vectorSha256": "c1d8888f9538f8026c166d4f0a32e22fb1cecb276e4088a96abac6f4280c4715",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "aaf5cf57a3c0ab4aeb853971860c3bac7f8247f009a0056d36756145a7a6df9e",
+      "updatedAt": "2025-09-20T22:27:41.514Z"
+    },
+    "j-0151": {
+      "vector": "8O9vv4aFBb/k42O/xcREPq+urr7b2to+0dBQvezra7+mpSU/ycjIvdbVVb/9/Hw+xsVFv5qZGT/m5WW/+Pd3P7CvLz+KiQm/l5aWPvr5eb+0szM/goEBv+TjY7/Avz+/trU1v4yLC7+ioSE/iYiIPaqpKT+/vr6+3dxcPvr5eT/w72+/hoUFv+TjY7/FxEQ+r66uvtva2j7R0FC97Otrv6alJT/JyMi91tVVv/38fD7GxUW/mpkZP+blZb/493c/sK8vP4qJCb+XlpY++vl5v7SzMz+CgQG/5ONjv8C/P7+2tTW/jIsLv6KhIT+JiIg9qqkpP7++vr7d3Fw++vl5Pw==",
+      "vectorSha256": "4b2aa0920b4339c20021653c2a3af7296f68cba7ceb3c2782aa3999a06b5b57e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "083d0e9854b6790ad273159f1dcc0dfbd73ba503d93f0e20253ad088d4509bfc",
+      "updatedAt": "2025-09-20T22:27:41.514Z"
+    },
+    "j-0152": {
+      "vector": "19bWPpeWlr739va+kZAQPfn4+D3g318/xsVFv52cHD7n5uY+5+bmvuvq6r7j4uK+//7+PqSjIz+joqK+goEBP/HwcL2KiQm/vLs7v6KhIb/h4OC8vbw8vpSTE7+KiQm/3dxcvoWEBL68uzs/u7q6Pu3sbD6OjQ0/xcREvomIiD3X1tY+l5aWvvf29r6RkBA9+fj4PeDfXz/GxUW/nZwcPufm5j7n5ua+6+rqvuPi4r7//v4+pKMjP6Oior6CgQE/8fBwvYqJCb+8uzu/oqEhv+Hg4Ly9vDy+lJMTv4qJCb/d3Fy+hYQEvry7Oz+7uro+7exsPo6NDT/FxES+iYiIPQ==",
+      "vectorSha256": "d052eb5330aac4ededb629ab103ffe87eab99540b17732212deb7741abe7f41c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b55a42848fef1d93b9464547bfd157c0783b222f7c68363b646fddae9dc66788",
+      "updatedAt": "2025-09-20T22:27:41.514Z"
+    },
+    "j-0153": {
+      "vector": "p6amvuHg4Lz//v4+0dBQvYSDA7/t7Gy+6OdnP9bVVb/p6Oi9/v19P4GAgDvCwUE/09LSvs3MTD7m5WW/7exsvoOCgr7u7W2/zs1Nv+LhYT+urS2/3dxcPpOSkr7l5GQ+9/b2Pr++vj6opye/8fBwvaGgoLze3V2/kZAQPbGwMD2npqa+4eDgvP/+/j7R0FC9hIMDv+3sbL7o52c/1tVVv+no6L3+/X0/gYCAO8LBQT/T0tK+zcxMPublZb/t7Gy+g4KCvu7tbb/OzU2/4uFhP66tLb/d3Fw+k5KSvuXkZD739vY+v76+PqinJ7/x8HC9oaCgvN7dXb+RkBA9sbAwPQ==",
+      "vectorSha256": "9ddbc19fdbe1cb8cdf728a69e4ac1dacd48a2700981e74c5e938e3298c9f2d41",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "567cbf793e62f31571fe80e04b990d625f0919f0299b5b9cbdaf2c787d118485",
+      "updatedAt": "2025-09-20T22:27:41.514Z"
+    },
+    "j-0154": {
+      "vector": "goEBv+/u7r68uzu/5eRkPpiXF7+SkRG/r66uvszLSz/z8vK+lZQUvqqpKb/CwUE/9/b2vre2tr6sqys/q6qqPvHwcD2+vT2/q6qqvujnZz+BgIA79PNzv7GwML2NjAy+tLMzv9/e3r61tDQ+6+rqPuTjYz/X1tY+xMNDP6WkJL6CgQG/7+7uvry7O7/l5GQ+mJcXv5KREb+vrq6+zMtLP/Py8r6VlBS+qqkpv8LBQT/39va+t7a2vqyrKz+rqqo+8fBwPb69Pb+rqqq+6OdnP4GAgDv083O/sbAwvY2MDL60szO/397evrW0ND7r6uo+5ONjP9fW1j7Ew0M/paQkvg==",
+      "vectorSha256": "e13e27cf989bc2e67d7daf720cfc0d11ac8768d81c1cc7d4aa98b1ebe98e660a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3f44229c343754e5436d2be04252d5aa872155f380067a6e264896baf1b5e16b",
+      "updatedAt": "2025-09-20T22:27:41.514Z"
+    },
+    "j-0155": {
+      "vector": "//7+vpKREb/Avz8//Pt7v/X0dL6rqqq+5ONjPwAAgD/FxEQ+29raPo2MDD7FxES+3t1dv9XUVD7GxUW/urk5v9va2r7X1tY+6+rqvpuamr7V1FQ+u7q6vv38fL719HQ+srExv/38fL7R0FC94eDgvL28PD7W1VU/rawsvoSDAz///v6+kpERv8C/Pz/8+3u/9fR0vquqqr7k42M/AACAP8XERD7b2to+jYwMPsXERL7e3V2/1dRUPsbFRb+6uTm/29ravtfW1j7r6uq+m5qavtXUVD67urq+/fx8vvX0dD6ysTG//fx8vtHQUL3h4OC8vbw8PtbVVT+trCy+hIMDPw==",
+      "vectorSha256": "b00d65734732bb7a4c1308b83e43e36de4916bc5aa4bed703c95e9261717d576",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4037df026155f1ff98b69167119a1d2349b545599a51609e2760797c97ea6ac1",
+      "updatedAt": "2025-09-20T22:27:41.514Z"
+    },
+    "j-0156": {
+      "vector": "s7KyPtLRUT+6uTm/xcREPtnY2L2Qjw8/kI8PP4GAgDvT0tI+jo0NP/n4+L3q6Wk/y8rKPoiHB7+ioSG/tLMzP7a1NT/NzEw+2djYPZ+enj6VlBS+9/b2vvz7ez/g318/oaCgvJ6dHT+zsrK+rKsrP8nIyD2Xlpa+zs1Nv/X0dL6zsrI+0tFRP7q5Ob/FxEQ+2djYvZCPDz+Qjw8/gYCAO9PS0j6OjQ0/+fj4verpaT/Lyso+iIcHv6KhIb+0szM/trU1P83MTD7Z2Ng9n56ePpWUFL739va+/Pt7P+DfXz+hoKC8np0dP7Oysr6sqys/ycjIPZeWlr7OzU2/9fR0vg==",
+      "vectorSha256": "558c0f9f8b79927e9ae664dec52659250072f89f5f30aaa73f872467dd628889",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ace8239872c7c780b4c670f4b23c2fd9da998da76d42fdef7dce53d58c5a1961",
+      "updatedAt": "2025-09-20T22:27:41.514Z"
+    },
+    "j-0157": {
+      "vector": "qaioPcfGxr6JiIi9+/r6vpiXF7+ioSG/nJsbv6alJb/Ew0O/tLMzv7u6ur7X1tY+zs1Nv6empj76+Xk/3t1dP7q5Ob/v7u4+0M9Pv+3sbL6rqqo+29raPrSzM7/My0u/19bWvsnIyL3493e/9PNzv4OCgr6ZmJg9/fx8Pp6dHT+pqKg9x8bGvomIiL37+vq+mJcXv6KhIb+cmxu/pqUlv8TDQ7+0szO/u7q6vtfW1j7OzU2/p6amPvr5eT/e3V0/urk5v+/u7j7Qz0+/7exsvquqqj7b2to+tLMzv8zLS7/X1ta+ycjIvfj3d7/083O/g4KCvpmYmD39/Hw+np0dPw==",
+      "vectorSha256": "249a03671cab61b8cb9434f393f15d989a536356f8efb54bbbbc4da118055fd6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8a4e7741342f322d1e2651b519a9fcee23bb1862aab6261a4a7304065f899fce",
+      "updatedAt": "2025-09-20T22:27:41.515Z"
+    },
+    "j-0158": {
+      "vector": "09LSvuXkZD6mpSU/7OtrP6Oioj7GxUW/mpkZv7m4uL2npqa+pKMjP9LRUb/u7W0/qqkpP6CfH7/CwUE/6OdnP9XUVD7u7W0/j46Ovvj3d7+urS2/vr09P/b1dT++vT2/1NNTP6GgoDyxsDC9oaCgPNzbWz+7uro+sK8vv5qZGb/T0tK+5eRkPqalJT/s62s/o6KiPsbFRb+amRm/ubi4vaempr6koyM/0tFRv+7tbT+qqSk/oJ8fv8LBQT/o52c/1dRUPu7tbT+Pjo6++Pd3v66tLb++vT0/9vV1P769Pb/U01M/oaCgPLGwML2hoKA83NtbP7u6uj6wry+/mpkZvw==",
+      "vectorSha256": "10c1fe3e2038d825bd471ec90eca09be4308e531d15c7b5a12a43f9262ed9f74",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4b9cd2f5a81d337456d117f6d430e0f39af65c0429defa21e9827a82edae2833",
+      "updatedAt": "2025-09-20T22:27:41.515Z"
+    },
+    "j-0159": {
+      "vector": "mpkZP7y7Oz+Lioq+oaCgvNfW1r67uro+xcREvsC/P7+Pjo6+m5qaPoiHBz/BwEA8+Pd3v+/u7j7493e/paQkvq6tLT+DgoI+ycjIPcHAQDzT0tI+1tVVP8LBQT/j4uI+2NdXv52cHL7U01O/v76+PqmoqD2NjAw+6Odnv/Tzc7+amRk/vLs7P4uKir6hoKC819bWvru6uj7FxES+wL8/v4+Ojr6bmpo+iIcHP8HAQDz493e/7+7uPvj3d7+lpCS+rq0tP4OCgj7JyMg9wcBAPNPS0j7W1VU/wsFBP+Pi4j7Y11e/nZwcvtTTU7+/vr4+qaioPY2MDD7o52e/9PNzvw==",
+      "vectorSha256": "066a6e9b2df9ce5a43ee4154eec33991a01106de67b0ab95a4d50b5083d36ab1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ccdd5d7d4aae67205ca6c38104bb046bd6a08c81b4eae0b8146c16af8a910c06",
+      "updatedAt": "2025-09-20T22:27:41.515Z"
+    },
+    "j-0160": {
+      "vector": "8/Lyvuvq6j7//v4+4N9fP7y7O7+FhAS+s7Kyvqempr7Qz08/pqUlv/f29r66uTk/vbw8Pufm5r6mpSU/srExv9LRUb+ZmJg9oJ8fv+LhYb/5+Pi9wL8/P7KxMb+OjQ2/3NtbP+zraz/X1tY+6+rqvqinJ7+bmpq+/Pt7v83MTL7z8vK+6+rqPv/+/j7g318/vLs7v4WEBL6zsrK+p6amvtDPTz+mpSW/9/b2vrq5OT+9vDw+5+bmvqalJT+ysTG/0tFRv5mYmD2gnx+/4uFhv/n4+L3Avz8/srExv46NDb/c21s/7OtrP9fW1j7r6uq+qKcnv5uamr78+3u/zcxMvg==",
+      "vectorSha256": "00b42caaef70380acb661b5bb254a96745211fcb667b12024e92a708debd4393",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "43babfef226f5356e72d42dc9746d2271789300f70df2739edf5b5452c590266",
+      "updatedAt": "2025-09-20T22:27:41.515Z"
+    },
+    "j-0161": {
+      "vector": "6ulpP4qJCb+NjAw+g4KCvpWUFL76+Xk/qKcnv/n4+L2urS2/kZAQvbe2tr7z8vK+zs1NP7u6uj7a2Vk/nJsbv8zLSz+rqqq+hIMDv5KRET+Pjo4+m5qaPpuamr739vY+8O9vv+zraz/b2tq+6OdnP5mYmL3h4OC8v76+vpCPD7/q6Wk/iokJv42MDD6DgoK+lZQUvvr5eT+opye/+fj4va6tLb+RkBC9t7a2vvPy8r7OzU0/u7q6PtrZWT+cmxu/zMtLP6uqqr6EgwO/kpERP4+Ojj6bmpo+m5qavvf29j7w72+/7OtrP9va2r7o52c/mZiYveHg4Ly/vr6+kI8Pvw==",
+      "vectorSha256": "7f015a87c799b86208f1fb14da4c4b48f4e8566f7b45effac8f40e2162c52669",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f43b915f6dfc2c70297b5243e6aeec32e5553ec8a3a659bd08f549f3767c5038",
+      "updatedAt": "2025-09-20T22:27:41.515Z"
+    },
+    "j-0162": {
+      "vector": "3t1dP728PD7OzU2/v76+PrSzM7+DgoK+jIsLv4KBAT/R0FA9tbQ0Pt7dXT+amRm/nJsbv62sLD6amRk/+/r6vu3sbD7KyUm/09LSvqCfH7++vT0/4+LivvLxcT/e3V0/m5qaPvPy8r7My0u/0M9PP9zbW7/DwsI+8vFxv5qZGb/e3V0/vbw8Ps7NTb+/vr4+tLMzv4OCgr6Miwu/goEBP9HQUD21tDQ+3t1dP5qZGb+cmxu/rawsPpqZGT/7+vq+7exsPsrJSb/T0tK+oJ8fv769PT/j4uK+8vFxP97dXT+bmpo+8/LyvszLS7/Qz08/3Ntbv8PCwj7y8XG/mpkZvw==",
+      "vectorSha256": "c41f90452f3b7303787e450dccbe107b434dffb79886a613766b556add61b92a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ee9719af265f3ac08696ee333295cc419d1b4b30de47f8eea6431ae712b00733",
+      "updatedAt": "2025-09-20T22:27:41.515Z"
+    },
+    "j-0163": {
+      "vector": "9PNzP5OSkr6DgoI+t7a2vra1NT/DwsI+pqUlP7i3Nz/Ix0e/3Ntbv83MTL7x8HC9vbw8vsHAQLz8+3u/z87OPuPi4j7U01O/lZQUvqinJz+UkxM/0tFRv4KBAb/n5ua+3Ntbv9DPTz+VlBS++fj4PdHQUL35+Pg9/Pt7v7y7Oz/083M/k5KSvoOCgj63tra+trU1P8PCwj6mpSU/uLc3P8jHR7/c21u/zcxMvvHwcL29vDy+wcBAvPz7e7/Pzs4+4+LiPtTTU7+VlBS+qKcnP5STEz/S0VG/goEBv+fm5r7c21u/0M9PP5WUFL75+Pg90dBQvfn4+D38+3u/vLs7Pw==",
+      "vectorSha256": "774662625a6bc69884956afa4e90a281e4df54dfcbc52da23dff021d01ea65d5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f95ba052dab0d2db1c126678687e02b3b8166dd3c9173f4612e76d8f798f02dd",
+      "updatedAt": "2025-09-20T22:27:41.515Z"
+    },
+    "j-0164": {
+      "vector": "srExP97dXb/Ew0O/g4KCvvDvb7+sqyu/rawsPtfW1r7083O/6ejovZ2cHL64tzc/yslJv93cXL6Miwu/oqEhP6WkJL7o52c/vbw8vuPi4r6vrq4+4N9fP728PD6cmxs/sbAwvY6NDT+OjQ0/np0dP9fW1j6fnp6+q6qqvquqqr6ysTE/3t1dv8TDQ7+DgoK+8O9vv6yrK7+trCw+19bWvvTzc7/p6Oi9nZwcvri3Nz/KyUm/3dxcvoyLC7+ioSE/paQkvujnZz+9vDy+4+Livq+urj7g318/vbw8PpybGz+xsDC9jo0NP46NDT+enR0/19bWPp+enr6rqqq+q6qqvg==",
+      "vectorSha256": "bdf849297967fb403d00b2e37252d3059fd65770a490065528d0b47a63c5ee96",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d8111e5f082a954a06716cdb1b643ad06bf36847abef97cd7ac6c6ceb5585555",
+      "updatedAt": "2025-09-20T22:27:41.515Z"
+    },
+    "j-0165": {
+      "vector": "srExv7GwML2mpSW/rKsrv+Pi4r7v7u6+//7+vvDvb7/w72+/+vl5P6KhIT/FxEQ+sbAwveLhYb///v4+xsVFv4GAgDvw72+/19bWPsXERD7i4WG/1NNTP7a1Nb/Ew0M/lZQUvvTzc7+amRk/v76+PqOior6VlBS+397evsHAQDyysTG/sbAwvaalJb+sqyu/4+Livu/u7r7//v6+8O9vv/Dvb7/6+Xk/oqEhP8XERD6xsDC94uFhv//+/j7GxUW/gYCAO/Dvb7/X1tY+xcREPuLhYb/U01M/trU1v8TDQz+VlBS+9PNzv5qZGT+/vr4+o6KivpWUFL7f3t6+wcBAPA==",
+      "vectorSha256": "9489d105b70dad7a9ef55c578953d0efc06682f4763a85d194770c9480bb02aa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "277a2d2a4744400808fcd0987a0fbf1d8008b5980fe925e16d06ccaf576d4881",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0166": {
+      "vector": "w8LCPpGQEL2fnp6+vr09P728PL7DwsI+xsVFP6WkJD7t7Gy+vLs7P5qZGT/t7Gy+397ePp6dHT+hoKA8p6amvrq5Ob/d3Fy++vl5v8fGxr729XW/l5aWPqGgoLz29XU/vr09PwAAgL+fnp6+v76+vuPi4r6GhQW/9PNzv/Lxcb/DwsI+kZAQvZ+enr6+vT0/vbw8vsPCwj7GxUU/paQkPu3sbL68uzs/mpkZP+3sbL7f3t4+np0dP6GgoDynpqa+urk5v93cXL76+Xm/x8bGvvb1db+XlpY+oaCgvPb1dT++vT0/AACAv5+enr6/vr6+4+LivoaFBb/083O/8vFxvw==",
+      "vectorSha256": "e26d8467285c27d7db48802b40f2bdf3b30cd55f59417468bcfbd56d96cbd764",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b07b58de68b0e29462ddcc62b7ce82562364034e05a57dfade005850473d0607",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0167": {
+      "vector": "tbQ0vv38fL6RkBC9iIcHP8C/P7/v7u6+oaCgPIqJCT+hoKA89/b2PoKBAb+vrq6+lZQUPo+Ojr7t7Gw+xMNDv/z7e7/i4WG/g4KCPsbFRT+SkRG/x8bGvq2sLL7d3Fw+n56ePuXkZD6sqys/9fR0vpuamj6NjAy+y8rKvvv6+j61tDS+/fx8vpGQEL2Ihwc/wL8/v+/u7r6hoKA8iokJP6GgoDz39vY+goEBv6+urr6VlBQ+j46Ovu3sbD7Ew0O//Pt7v+LhYb+DgoI+xsVFP5KREb/Hxsa+rawsvt3cXD6fnp4+5eRkPqyrKz/19HS+m5qaPo2MDL7Lysq++/r6Pg==",
+      "vectorSha256": "019b2ca1dcfc39118fc9628222d5edc023ccb7bd9dc0cebd300ba68d56d796a2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "69607bc3204482c482bd3f54925c9d1e020fa0e2374e6a9ba79cd561a66e4dbe",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0168": {
+      "vector": "9/b2vsfGxr7i4WE/h4aGvoWEBL7BwEC8y8rKPvDvbz/HxsY+5ONjv+3sbD6koyM/p6amPublZT+rqqo+hoUFP8fGxj6Ylxc//Pt7v4GAgLuTkpK+8O9vv8C/P7+/vr6+9PNzv+rpab+gnx+/hIMDP/z7ez+4tzc/u7q6vsfGxj739va+x8bGvuLhYT+Hhoa+hYQEvsHAQLzLyso+8O9vP8fGxj7k42O/7exsPqSjIz+npqY+5uVlP6uqqj6GhQU/x8bGPpiXFz/8+3u/gYCAu5OSkr7w72+/wL8/v7++vr7083O/6ulpv6CfH7+EgwM//Pt7P7i3Nz+7urq+x8bGPg==",
+      "vectorSha256": "528f5a744bc7e9791db76b6b5ce8b82d6a71a29dd481fbfa91fb887c8e822843",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "424ef05e6f7eb2f7b10e9dd1a9f2aac2b1cb027f5b082050060b30c1fddb51b1",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0169": {
+      "vector": "1NNTv7y7Oz+1tDS+oJ8fP4GAgLupqKi95eRkvpeWlj7GxUU/4+LiPvX0dD6Lioo+yMdHP+no6L2BgIC7vbw8vvLxcT/n5ua+7OtrP7m4uD339va+zMtLP8XERL7v7u6+tbQ0PouKij7JyMg9paQkvs7NTb+cmxs/tLMzv/r5eb/U01O/vLs7P7W0NL6gnx8/gYCAu6moqL3l5GS+l5aWPsbFRT/j4uI+9fR0PouKij7Ix0c/6ejovYGAgLu9vDy+8vFxP+fm5r7s62s/ubi4Pff29r7My0s/xcREvu/u7r61tDQ+i4qKPsnIyD2lpCS+zs1Nv5ybGz+0szO/+vl5vw==",
+      "vectorSha256": "50648df09ac6bdec960b2d772cc34d6389f39abae457b0bec1bb5acd85ef95f4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "16dd69cf7f7563a5e2b89ea2e3717f68f846f58b42e5674496a28c6b19cd2603",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0170": {
+      "vector": "zs1NP8/Ozj6VlBS+m5qavvb1db+9vDy+5ONjP6uqqr6fnp6+tbQ0PtbVVT+trCy+9fR0PtrZWb+0szO/vLs7v97dXb/DwsI+hIMDP66tLT/W1VW//Pt7P+no6L3t7Gw+uLc3P5STEz/29XW/i4qKvtva2j6WlRU/gYCAu9jXVz/OzU0/z87OPpWUFL6bmpq+9vV1v728PL7k42M/q6qqvp+enr61tDQ+1tVVP62sLL719HQ+2tlZv7SzM7+8uzu/3t1dv8PCwj6EgwM/rq0tP9bVVb/8+3s/6ejove3sbD64tzc/lJMTP/b1db+Lioq+29raPpaVFT+BgIC72NdXPw==",
+      "vectorSha256": "6afb391c3496505992d2526786a963997622633265e3fdc5d75c951702c8b475",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e6b36d590568f1555896ea6a9e13262211b0c1d615fd719ddbc9055db6ca7feb",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0171": {
+      "vector": "5eRkvv79fb/n5ua+lpUVP6yrK7+mpSW/ubi4PbOysr7X1tY+s7KyPpiXFz/493e/oJ8fP+/u7j6opye/yMdHP6KhIT/t7Gw+2NdXv+zra7+Hhoa+lJMTP8TDQz+7uro+h4aGPsfGxj69vDy+ycjIvff29j6BgIA74+LiPsLBQb/l5GS+/v19v+fm5r6WlRU/rKsrv6alJb+5uLg9s7KyvtfW1j6zsrI+mJcXP/j3d7+gnx8/7+7uPqinJ7/Ix0c/oqEhP+3sbD7Y11e/7Otrv4eGhr6UkxM/xMNDP7u6uj6HhoY+x8bGPr28PL7JyMi99/b2PoGAgDvj4uI+wsFBvw==",
+      "vectorSha256": "80e6f68238e84b56b16f2e96977787e8e67b18deaaa489228bc64bf1ded94937",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "630146ca2a2d8b53b5accb04cfbb2ce3d09d140a5ec9e1aea1b16873bd80b81f",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0172": {
+      "vector": "k5KSvre2tr6sqys/19bWvquqqj7S0VE/zcxMPvPy8j7Qz08/4+LivvLxcT/Z2Ng9//7+PublZT/Avz8/lJMTP56dHT+urS2/pKMjP728PL6trCy+7+7uvuvq6r6pqKg909LSvpSTE7/x8HA9+fj4PfPy8j7o52c/8vFxv/n4+L2TkpK+t7a2vqyrKz/X1ta+q6qqPtLRUT/NzEw+8/LyPtDPTz/j4uK+8vFxP9nY2D3//v4+5uVlP8C/Pz+UkxM/np0dP66tLb+koyM/vbw8vq2sLL7v7u6+6+rqvqmoqD3T0tK+lJMTv/HwcD35+Pg98/LyPujnZz/y8XG/+fj4vQ==",
+      "vectorSha256": "6e72c9cd6aac006106ec0069318c53f904547335cc00fc93931456273615b829",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5b52d54aaae899bce747f88dbff2dfc9ce29d1686a44458a4b36878fbcf30770",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0173": {
+      "vector": "qKcnv8rJST/JyMi95uVlv5OSkj6qqSk/gYCAO+no6D3v7u4+1dRUvtDPTz/n5uY+9/b2vrW0NL7q6Wm/q6qqPvf29r7i4WG/+vl5v4mIiD3j4uI+8fBwPa+urj7Pzs4+5uVlP/HwcD3T0tK+p6amvoKBAT++vT2/ubi4PdjXV7+opye/yslJP8nIyL3m5WW/k5KSPqqpKT+BgIA76ejoPe/u7j7V1FS+0M9PP+fm5j739va+tbQ0vurpab+rqqo+9/b2vuLhYb/6+Xm/iYiIPePi4j7x8HA9r66uPs/Ozj7m5WU/8fBwPdPS0r6npqa+goEBP769Pb+5uLg92NdXvw==",
+      "vectorSha256": "737b9749589c85d061520151e85e561275f38d47927c357341a7a0220426e76c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2ce4730da4d4808ebb65e7b942690baa420f0388b887abb3f2874b56c0218b14",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0174": {
+      "vector": "iokJv97dXT/f3t4+xsVFP7a1NT+VlBQ+4+Livs3MTD6joqI+/Pt7v6SjIz+3tra+8/LyPoOCgr6amRm/09LSvoWEBL6Ylxe/4N9fv9LRUb+KiQm/wcBAPJybG7/BwEC8rq0tv8nIyL21tDS+wsFBv+DfXz+XlpY+r66uvs3MTL6KiQm/3t1dP9/e3j7GxUU/trU1P5WUFD7j4uK+zcxMPqOioj78+3u/pKMjP7e2tr7z8vI+g4KCvpqZGb/T0tK+hYQEvpiXF7/g31+/0tFRv4qJCb/BwEA8nJsbv8HAQLyurS2/ycjIvbW0NL7CwUG/4N9fP5eWlj6vrq6+zcxMvg==",
+      "vectorSha256": "c6b2ff04fe78d71716f6346cbe1d12ca75bdc2f0f153b5621d3770317320936d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3beeb7e2da924799a802d152bc5f334b6f3410173b81327e2973691fefa55466",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0175": {
+      "vector": "sK8vv5+enr62tTU/srExP6KhIT/+/X0/zMtLv93cXD7x8HA97u1tv7++vr6opyc/lZQUvp6dHT+3tra+qqkpv6KhIb/JyMi9lpUVP7q5OT+Qjw+/hYQEvo6NDb+8uzs/1tVVP7SzMz+CgQG/1NNTv+Hg4DyYlxc/zcxMvoOCgr6wry+/n56evra1NT+ysTE/oqEhP/79fT/My0u/3dxcPvHwcD3u7W2/v76+vqinJz+VlBS+np0dP7e2tr6qqSm/oqEhv8nIyL2WlRU/urk5P5CPD7+FhAS+jo0Nv7y7Oz/W1VU/tLMzP4KBAb/U01O/4eDgPJiXFz/NzEy+g4KCvg==",
+      "vectorSha256": "e737eefa575ff5e6a2ce868f4e784f0c060bcb60cd6bf245ace6025703d11349",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2858dad8d0fe1a9b870950d36dce522b2f73cadc386f39ddead93f1683cb665f",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0176": {
+      "vector": "ubi4PaCfHz/CwUE/5eRkPoeGhr6VlBS+xcREvuHg4Dz29XW/x8bGPvz7e7/X1tY+4eDgPKKhIT+KiQk/rawsvtnY2D3Pzs4+7u1tv5qZGT+7uro+xcREPoGAgDvDwsI+g4KCPoeGhr75+Pg9pqUlv9nY2D25uLi9lZQUvublZb+5uLg9oJ8fP8LBQT/l5GQ+h4aGvpWUFL7FxES+4eDgPPb1db/HxsY+/Pt7v9fW1j7h4OA8oqEhP4qJCT+trCy+2djYPc/Ozj7u7W2/mpkZP7u6uj7FxEQ+gYCAO8PCwj6DgoI+h4aGvvn4+D2mpSW/2djYPbm4uL2VlBS+5uVlvw==",
+      "vectorSha256": "842a579663af67d6bd91af534b1643f29e8afc51bde3089c64abf90569adb626",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8bcfe09c5e6d678305b102b583d0c46a8db309ccae9880b0a05e8f2d8d746d0d",
+      "updatedAt": "2025-09-20T22:27:41.516Z"
+    },
+    "j-0177": {
+      "vector": "+vl5v5mYmD2zsrK++vl5P8jHRz8AAIA/wcBAvPz7e7+HhoY+hIMDP4WEBD78+3u/m5qavuHg4DyQjw+/l5aWPsHAQDzw72+/397ePrOysr6RkBA90M9Pv5WUFD6fnp4+AACAP6moqD37+vq+9/b2Pvj3d7/39va+xcREPpGQEL36+Xm/mZiYPbOysr76+Xk/yMdHPwAAgD/BwEC8/Pt7v4eGhj6EgwM/hYQEPvz7e7+bmpq+4eDgPJCPD7+XlpY+wcBAPPDvb7/f3t4+s7KyvpGQED3Qz0+/lZQUPp+enj4AAIA/qaioPfv6+r739vY++Pd3v/f29r7FxEQ+kZAQvQ==",
+      "vectorSha256": "c7f2fc6ccfedfcb96370e482b8230c29528cbef850edb648b2fe6e98f20a7787",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "038953fce3ff7e02a1c19002598338a58108b753841892a7ff8a41bd0442987b",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0178": {
+      "vector": "g4KCvtTTUz+ysTG/+fj4PcLBQb/493e/zcxMPsHAQDzBwEC8uLc3v5KRET/R0FA9iIcHP/38fD6DgoI+6OdnP7a1NT+1tDQ+i4qKPpmYmL3Y11e/n56evt/e3j64tze/wcBAPMvKyj6Ihwc/8fBwPc/Ozj76+Xm/jIsLv83MTD6DgoK+1NNTP7KxMb/5+Pg9wsFBv/j3d7/NzEw+wcBAPMHAQLy4tze/kpERP9HQUD2Ihwc//fx8PoOCgj7o52c/trU1P7W0ND6Lioo+mZiYvdjXV7+fnp6+397ePri3N7/BwEA8y8rKPoiHBz/x8HA9z87OPvr5eb+Miwu/zcxMPg==",
+      "vectorSha256": "c4aab0a0570bc05203c81fa09581e210b4d5909f6ea44065730c097c6a886e9c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5fe9278f1f0499817e24c886c39fa0f3da96a2761458b72481b2c387b3033a99",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0179": {
+      "vector": "iYiIPb++vr6joqI+v76+vrKxMb/GxUU/q6qqvszLSz+3tra+rawsPr69PT+rqqo+4eDgvPX0dL6Pjo6+oJ8fP7y7Oz+qqSk/pKMjv+jnZz+6uTk/ycjIvdXUVL6Pjo6+j46OPsvKyj6SkRE/8/LyvtjXV7/u7W2/i4qKPuHg4LyJiIg9v76+vqOioj6/vr6+srExv8bFRT+rqqq+zMtLP7e2tr6trCw+vr09P6uqqj7h4OC89fR0vo+Ojr6gnx8/vLs7P6qpKT+koyO/6OdnP7q5OT/JyMi91dRUvo+Ojr6Pjo4+y8rKPpKRET/z8vK+2NdXv+7tbb+Lioo+4eDgvA==",
+      "vectorSha256": "330024435866cbf23a0b406167c8598dc3bed019ddce78cd34da1c47c502e9fd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8850a85027e255e55295deaa7c615ccfddd42ef3dc73655ca3b2c8431409a27c",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0180": {
+      "vector": "uLc3P+zra7+5uLg9vLs7P8vKyj6Ylxc/lJMTP5KREb+mpSU/vbw8PuTjYz+NjAy+kpERP/Tzc7/7+vq+8/LyvublZT+JiIg9sK8vP8nIyD2DgoI+5uVlv+jnZ7/g31+/m5qavpGQED2CgQG/jIsLv/38fL7e3V2/iIcHv9bVVT+4tzc/7Otrv7m4uD28uzs/y8rKPpiXFz+UkxM/kpERv6alJT+9vDw+5ONjP42MDL6SkRE/9PNzv/v6+r7z8vK+5uVlP4mIiD2wry8/ycjIPYOCgj7m5WW/6Odnv+DfX7+bmpq+kZAQPYKBAb+Miwu//fx8vt7dXb+Ihwe/1tVVPw==",
+      "vectorSha256": "9356ccea8715cbb7f59be519f785392ce3e7a9e19be4bb0dff6efaa501bc0d6d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "db0a8bddb2cbc937d297f16ec8064143f288d78ca00d0c1059843f3a60113cea",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0181": {
+      "vector": "3t1dv8nIyD3Pzs4+uLc3v9nY2D3w72+/l5aWvs3MTL6vrq4+1dRUPt7dXT+bmpq+29raPublZb/h4OC8/fx8vvr5eb+6uTm/6+rqvufm5j69vDy+AACAv+Pi4r7p6Og97u1tv7a1NT+JiIg9tbQ0Pt/e3j7X1tY+lZQUvuTjYz/e3V2/ycjIPc/Ozj64tze/2djYPfDvb7+Xlpa+zcxMvq+urj7V1FQ+3t1dP5uamr7b2to+5uVlv+Hg4Lz9/Hy++vl5v7q5Ob/r6uq+5+bmPr28PL4AAIC/4+Livuno6D3u7W2/trU1P4mIiD21tDQ+397ePtfW1j6VlBS+5ONjPw==",
+      "vectorSha256": "5d4519b596b786f7930f7037eca062059cb91fd974ee5afc6b7d9475c7464cd6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "118cb3248d085a66ab9aee59b60d7c60032345b96800478e09da8896b7b56df1",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0182": {
+      "vector": "09LSPsbFRb+BgIC76+rqvvb1db+npqa+wsFBv9nY2L2gnx8/p6amPoGAgLv5+Pg9wcBAPOno6L2xsDA9zcxMvrCvL7/h4OC80tFRv7++vr7b2tq+yslJP4aFBb/Ew0O/+vl5v4aFBb/c21u/vLs7v5mYmL3DwsK+5+bmvtHQUL3T0tI+xsVFv4GAgLvr6uq+9vV1v6empr7CwUG/2djYvaCfHz+npqY+gYCAu/n4+D3BwEA86ejovbGwMD3NzEy+sK8vv+Hg4LzS0VG/v76+vtva2r7KyUk/hoUFv8TDQ7/6+Xm/hoUFv9zbW7+8uzu/mZiYvcPCwr7n5ua+0dBQvQ==",
+      "vectorSha256": "21830244646034cceafffa747e99f7dd8ef633a7926fbb719211c3a4d9fdc293",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b41d7f4505561f72cfa97f8f81718566287c175049e43d1e033d1222764f4679",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0183": {
+      "vector": "lZQUPp+enr6rqqq+09LSvomIiD2WlRU/7+7uvpybGz+cmxs/7+7uPtzbW7+GhQW/vLs7v5GQEL3q6Wm/t7a2vrm4uL2wry+/rq0tP87NTb/p6Oi9/Pt7P/Py8r7DwsI+8vFxP728PL6HhoY+3dxcPqmoqD2Ihwc/l5aWPufm5j6VlBQ+n56evquqqr7T0tK+iYiIPZaVFT/v7u6+nJsbP5ybGz/v7u4+3Ntbv4aFBb+8uzu/kZAQverpab+3tra+ubi4vbCvL7+urS0/zs1Nv+no6L38+3s/8/LyvsPCwj7y8XE/vbw8voeGhj7d3Fw+qaioPYiHBz+XlpY+5+bmPg==",
+      "vectorSha256": "628803ea70bf885d37875a0dd3d136814c5a1ec80f4df65e4ac7a9a77eb9e022",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9258554b88ca44cdcdbb123d227b0b527428d61971fd43b0f868a19b8ac3a5b9",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0184": {
+      "vector": "kZAQvb++vj7Qz0+/gYCAu5WUFD6KiQm/3t1dP4uKir6npqa+rq0tP5GQEL3b2tq+iIcHP9XUVL7j4uI+8O9vP/z7e7/p6Og9paQkvtTTUz/q6Wk/5+bmPqqpKT/a2Vk/3t1dv728PD6/vr4+3NtbP6SjIz/t7Gw+jIsLP8nIyD2RkBC9v76+PtDPT7+BgIC7lZQUPoqJCb/e3V0/i4qKvqempr6urS0/kZAQvdva2r6Ihwc/1dRUvuPi4j7w728//Pt7v+no6D2lpCS+1NNTP+rpaT/n5uY+qqkpP9rZWT/e3V2/vbw8Pr++vj7c21s/pKMjP+3sbD6Miws/ycjIPQ==",
+      "vectorSha256": "754aef28d8e833f092d5d16bbb49de6187f9ba0601e96428c3deab017961fa12",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7baf187f923bee5d56d67b49c365b8f7028e6be9f4b9d4ec1197afedd19dc58c",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0185": {
+      "vector": "tbQ0vsC/P7+rqqq+uLc3v+XkZD65uLg9sK8vP5GQED3Y11c/iokJP7Oysj7Y11e/397evsLBQb/Ew0O/4+LiPquqqj6NjAw+lJMTv+TjYz+0szO/qqkpP8TDQz/i4WE/5uVlv87NTT/HxsY+7+7uPt/e3r7JyMg97Otrv4aFBT+1tDS+wL8/v6uqqr64tze/5eRkPrm4uD2wry8/kZAQPdjXVz+KiQk/s7KyPtjXV7/f3t6+wsFBv8TDQ7/j4uI+q6qqPo2MDD6UkxO/5ONjP7SzM7+qqSk/xMNDP+LhYT/m5WW/zs1NP8fGxj7v7u4+397evsnIyD3s62u/hoUFPw==",
+      "vectorSha256": "e75557198f414a11c5ded6bd3e288f42a20287fd1008356947170808e426bae6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "692055249c8bd784ebc4ac14481f1eb8aa9136f126d4e1f00de6b1bb488c0ac2",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0186": {
+      "vector": "rawsvr28PL66uTm/7exsPvj3dz+VlBQ+pqUlP4KBAT/BwEA8n56ePoSDA7/OzU0/q6qqPoWEBD6xsDA98O9vP8bFRT+vrq4+urk5P/HwcL2npqY+hYQEPvj3dz++vT2///7+vsC/Pz+RkBA9qaiovcjHR7/e3V0/7+7uvuDfX7+trCy+vbw8vrq5Ob/t7Gw++Pd3P5WUFD6mpSU/goEBP8HAQDyfnp4+hIMDv87NTT+rqqo+hYQEPrGwMD3w728/xsVFP6+urj66uTk/8fBwvaempj6FhAQ++Pd3P769Pb///v6+wL8/P5GQED2pqKi9yMdHv97dXT/v7u6+4N9fvw==",
+      "vectorSha256": "1999046c60aaa16eeec2bfa5acf355d65afd2e45b44c2cd4caaead4a4384e4b4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6a68239dfb92d2c081a73ee6aa9085f7e2abdc78a990fb2140df84751cee4410",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0187": {
+      "vector": "19bWPre2tr6opye/paQkPtXUVL4AAIA/397ePpiXFz+opye/jYwMvqWkJD7NzEw+6OdnP6SjI7+enR0/6ulpv4eGhj7HxsY+sK8vP+Hg4Dzb2to+9fR0PoWEBL739vY+3dxcPrKxMT/e3V0/sK8vv/Py8j4AAIC/x8bGPoeGhj7X1tY+t7a2vqinJ7+lpCQ+1dRUvgAAgD/f3t4+mJcXP6inJ7+NjAy+paQkPs3MTD7o52c/pKMjv56dHT/q6Wm/h4aGPsfGxj6wry8/4eDgPNva2j719HQ+hYQEvvf29j7d3Fw+srExP97dXT+wry+/8/LyPgAAgL/HxsY+h4aGPg==",
+      "vectorSha256": "19b9c1ddd5f583bbbec53b6a85ec46ead24875beac2f1e1cd373d049742aae03",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b5522c9465ffb7cb2c6e9499f32ece0ba1b1d783b69e6fbd9bd8ee28bc00b1a1",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0188": {
+      "vector": "0M9Pv97dXb/t7Gy+6ulpP6KhIT/s62s/hIMDv6CfHz+urS0/t7a2vurpab/r6uo+mpkZv8LBQT/w728/6+rqvsjHR7/b2tq+0tFRP8C/Pz+Qjw+/5+bmvq+urj75+Pi9i4qKvre2tj6zsrK+yslJP/Dvbz+DgoI+3NtbP9nY2D3Qz0+/3t1dv+3sbL7q6Wk/oqEhP+zraz+EgwO/oJ8fP66tLT+3tra+6ulpv+vq6j6amRm/wsFBP/Dvbz/r6uq+yMdHv9va2r7S0VE/wL8/P5CPD7/n5ua+r66uPvn4+L2Lioq+t7a2PrOysr7KyUk/8O9vP4OCgj7c21s/2djYPQ==",
+      "vectorSha256": "31923f00690c733440e43d241ddab26401abdbb95a3a2d1e22da2b1a75499f66",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "181162f4d0f53ecfd6520bba33e0f7451c49e8df3846ab705dad53e4f7a0ed8d",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0189": {
+      "vector": "g4KCvtLRUb/U01O/goEBP/Dvb7/Ix0c/1tVVP/Py8j77+vo+iIcHP5GQED3KyUk/1NNTP9zbW7+dnBw+2djYPcTDQz+sqyu/jo0Nv4SDA7/CwUE/trU1P9HQUD3DwsK+trU1P5KREb+0szM/8O9vP6Oioj7t7Gw+vbw8vuLhYb+DgoK+0tFRv9TTU7+CgQE/8O9vv8jHRz/W1VU/8/LyPvv6+j6Ihwc/kZAQPcrJST/U01M/3Ntbv52cHD7Z2Ng9xMNDP6yrK7+OjQ2/hIMDv8LBQT+2tTU/0dBQPcPCwr62tTU/kpERv7SzMz/w728/o6KiPu3sbD69vDy+4uFhvw==",
+      "vectorSha256": "5d5168929af68ac56d71496f10a7a25fdd7a25a77e58f65be2f817ff81d0d835",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5f1716c008e3eabcbec384e4e912938de12a393ee0da864fda37d9f7a89d680f",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0190": {
+      "vector": "mJcXv6alJb/d3Fw+4N9fv6WkJD6Qjw8/ycjIvezra7+KiQm/3t1dP7CvLz+VlBQ+x8bGPri3Nz/5+Pg97+7uPsXERL7OzU2/g4KCPp+enj6opye/+Pd3v9va2j6zsrI+wL8/P5OSkr7X1tY+vbw8voyLCz+GhQU/tbQ0PqSjI7+Ylxe/pqUlv93cXD7g31+/paQkPpCPDz/JyMi97Otrv4qJCb/e3V0/sK8vP5WUFD7HxsY+uLc3P/n4+D3v7u4+xcREvs7NTb+DgoI+n56ePqinJ7/493e/29raPrOysj7Avz8/k5KSvtfW1j69vDy+jIsLP4aFBT+1tDQ+pKMjvw==",
+      "vectorSha256": "f8ee9ab33c5cb9a40549dc0c6e31e1ef06f2da081fdc4e88b4474b3afd6259fb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "342d9b1094c7730a3beed792b1db8fbb6719a0a72c04b6acdf5bb568c5c2962e",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0191": {
+      "vector": "0dBQvdPS0r7Avz+/jIsLv42MDL62tTU/5ONjv7W0ND7p6Oi98O9vv5GQEL2HhoY+wsFBP4GAgDvDwsK+0dBQPdrZWT+rqqo+1dRUPtbVVT+cmxs/5uVlv8/Ozj7BwEA86ejovZuamj7s62s/3Ntbv87NTb+JiIi96ulpP8jHRz/R0FC909LSvsC/P7+Miwu/jYwMvra1NT/k42O/tbQ0Puno6L3w72+/kZAQvYeGhj7CwUE/gYCAO8PCwr7R0FA92tlZP6uqqj7V1FQ+1tVVP5ybGz/m5WW/z87OPsHAQDzp6Oi9m5qaPuzraz/c21u/zs1Nv4mIiL3q6Wk/yMdHPw==",
+      "vectorSha256": "9168315c89ff3f0be54d3eaaff64504ec7341a0b2bc2bd3e318e789b825679a1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "794b203a6eda0e9671087ba1e0804f86ecaa9aeacd0db38171a6f5121977f4e3",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0192": {
+      "vector": "oqEhP8fGxj6fnp4+wsFBP6+urr7S0VG/397evsLBQT+mpSU/qqkpP/Py8j7e3V0/v76+Prm4uL3Ew0O/t7a2Pq2sLL7t7Gw+vbw8vuTjY7/Y11c/np0dv4GAgDvl5GS+7u1tP5KREb+4tze/4N9fP52cHD7BwEC8/v19v6alJb+ioSE/x8bGPp+enj7CwUE/r66uvtLRUb/f3t6+wsFBP6alJT+qqSk/8/LyPt7dXT+/vr4+ubi4vcTDQ7+3trY+rawsvu3sbD69vDy+5ONjv9jXVz+enR2/gYCAO+XkZL7u7W0/kpERv7i3N7/g318/nZwcPsHAQLz+/X2/pqUlvw==",
+      "vectorSha256": "261a672930fffba0b8c7cfdb8adba02ce00bf7eda9b94c6baa99abba9101202c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d0b1a7e0541748e0d2d4bceeaf741ead6a9d680eeb318063f63724ef937e012d",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0193": {
+      "vector": "19bWPsnIyL2Pjo4+4N9fP4yLCz+JiIg99PNzv5aVFb/DwsK+19bWvv79fb/s62s/3dxcPoqJCb/39va+vr09P6empr6Miws//v19v6+urr69vDw+zcxMPqCfHz/NzEw+kI8PP/b1db/Qz08/jo0NP6alJT/9/Hw+oJ8fP8rJST/X1tY+ycjIvY+Ojj7g318/jIsLP4mIiD3083O/lpUVv8PCwr7X1ta+/v19v+zraz/d3Fw+iokJv/f29r6+vT0/p6amvoyLCz/+/X2/r66uvr28PD7NzEw+oJ8fP83MTD6Qjw8/9vV1v9DPTz+OjQ0/pqUlP/38fD6gnx8/yslJPw==",
+      "vectorSha256": "2b0f8cdc6d0307ade4ca8438b7adb22360742e0633eade1f26efff62e0082a25",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b573a3efc58806354f4a01f59b3b42de56c501549799cf99c705e7c6d29fcfe4",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0194": {
+      "vector": "vr09v4yLC7+dnBy+p6amPuXkZL7j4uI+zMtLP/HwcL37+vq+4N9fv5uamj7o52c/iIcHP4uKir6koyM/5eRkPtva2j7p6Oi95ONjP6+urr7u7W0/vbw8PgAAgL/a2Vm/lZQUPqKhIb+mpSU/9vV1P4qJCb+5uLg98/LyPpiXF7++vT2/jIsLv52cHL6npqY+5eRkvuPi4j7My0s/8fBwvfv6+r7g31+/m5qaPujnZz+Ihwc/i4qKvqSjIz/l5GQ+29raPuno6L3k42M/r66uvu7tbT+9vDw+AACAv9rZWb+VlBQ+oqEhv6alJT/29XU/iokJv7m4uD3z8vI+mJcXvw==",
+      "vectorSha256": "3ed777cfb4bde7cb5107e63af3bfc13b44c6e8392c57b3322bd1253695726f6e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "213a6ca963b8e5784110a6f3c35dd19cb671f154f6970013922fd2fa3b8bbc34",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0195": {
+      "vector": "iIcHP+/u7j6mpSU/kZAQPfHwcD3Qz08//v19P9jXVz++vT2/np0dv7W0NL7X1tY+srExv+rpaT+XlpY+lpUVP/Dvbz+6uTk/n56evtPS0j7i4WG/jYwMPvLxcT///v6+mZiYvd3cXD66uTm/qaioPezraz/e3V2/xMNDv9PS0j6Ihwc/7+7uPqalJT+RkBA98fBwPdDPTz/+/X0/2NdXP769Pb+enR2/tbQ0vtfW1j6ysTG/6ulpP5eWlj6WlRU/8O9vP7q5OT+fnp6+09LSPuLhYb+NjAw+8vFxP//+/r6ZmJi93dxcPrq5Ob+pqKg97OtrP97dXb/Ew0O/09LSPg==",
+      "vectorSha256": "ecefac56b628ff1b6010a36d68764e2b64e764ad4a4955771495b4f3df11f74c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c3bbd28487e7feeb213169b527f4a5caf7dc58b40f91f840769b238af5111eb4",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0196": {
+      "vector": "u7q6vvn4+L3R0FC9wcBAPPn4+L2amRk/iokJv769Pb+bmpq+uLc3P+jnZz/V1FS+vLs7v6CfH7+bmpo+AACAv769PT/19HQ+iokJv9DPTz/HxsY+j46OPo2MDL7HxsY+2NdXP5aVFb+OjQ2/zMtLv9bVVT+sqys/7OtrP5ybGz+7urq++fj4vdHQUL3BwEA8+fj4vZqZGT+KiQm/vr09v5uamr64tzc/6OdnP9XUVL68uzu/oJ8fv5uamj4AAIC/vr09P/X0dD6KiQm/0M9PP8fGxj6Pjo4+jYwMvsfGxj7Y11c/lpUVv46NDb/My0u/1tVVP6yrKz/s62s/nJsbPw==",
+      "vectorSha256": "1156cb5b3cde89c728953dbdd805eb5c0440a76f44be636bd20f560840167f95",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5170798170cc3b2159dbf3652230a600de9e3be7b1a36eb1eb35391aead5f5cd",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0197": {
+      "vector": "qKcnv4+Ojj6BgIA75uVlv6moqL3b2tq+u7q6PoGAgDvNzEy+h4aGPtfW1r719HQ+19bWPoiHB7///v4+s7KyPtrZWb/Pzs4+zMtLP6KhIT/m5WW/q6qqPgAAgL/f3t6+6ejoPc3MTL6Ihwe/9/b2Po+Ojr6trCw+0dBQvZOSkr6opye/j46OPoGAgDvm5WW/qaiovdva2r67uro+gYCAO83MTL6HhoY+19bWvvX0dD7X1tY+iIcHv//+/j6zsrI+2tlZv8/Ozj7My0s/oqEhP+blZb+rqqo+AACAv9/e3r7p6Og9zcxMvoiHB7/39vY+j46Ovq2sLD7R0FC9k5KSvg==",
+      "vectorSha256": "8283bf2c260ed1915dc6aec3fe250a85d6f6bc3e45788d4082261ec37276a4a5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2ca3800d7549ae8066a14a9eb53cbfac13b3e5d00daa00488e663cbd5c95795b",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0198": {
+      "vector": "w8LCPvv6+r7OzU0/1tVVP4WEBD7c21u/+Pd3v+XkZD6NjAw+29ravtXUVD7GxUW/7+7uvtva2j7493c/nJsbv6WkJL6SkRE/j46OPp+enj6ysTE/oaCgvPb1db/GxUW/sbAwvcTDQ7+urS0///7+vu7tbb+HhoY+rawsvtnY2D3DwsI++/r6vs7NTT/W1VU/hYQEPtzbW7/493e/5eRkPo2MDD7b2tq+1dRUPsbFRb/v7u6+29raPvj3dz+cmxu/paQkvpKRET+Pjo4+n56ePrKxMT+hoKC89vV1v8bFRb+xsDC9xMNDv66tLT///v6+7u1tv4eGhj6trCy+2djYPQ==",
+      "vectorSha256": "7179eae7b90143d0320566313532d2803913b778e81a46c0b1d1ed42f5c52196",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b041e6ea9012049c91499a1d44b6fb326bc8a3a7d87d051d7a1ed64009a16a8d",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0199": {
+      "vector": "oaCgPJaVFT/x8HC93dxcPqinJ7/DwsK+mZiYPdXUVL68uzu/yslJP9jXV7/S0VG/1tVVv56dHb/V1FS+/v19v6yrK7+bmpo+k5KSvt/e3j7Y11e/7u1tP9HQUL2Qjw+/m5qavoeGhr6npqa+y8rKvuno6D2fnp6+l5aWvvn4+D2hoKA8lpUVP/HwcL3d3Fw+qKcnv8PCwr6ZmJg91dRUvry7O7/KyUk/2NdXv9LRUb/W1VW/np0dv9XUVL7+/X2/rKsrv5uamj6TkpK+397ePtjXV7/u7W0/0dBQvZCPD7+bmpq+h4aGvqempr7Lysq+6ejoPZ+enr6Xlpa++fj4PQ==",
+      "vectorSha256": "ee046d39afa81d40a7cf650ff0933038b6f36ebfba2a46c3b5882a771ca44241",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "82ca789b2c4f896522e41417153165012aa65bb714f67938595e564d8e585a8f",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0200": {
+      "vector": "jIsLP+/u7j7+/X2/z87OPtbVVT/Ew0M/+Pd3v+vq6r7JyMi9uLc3P/38fD7FxEQ+i4qKvp2cHL6amRk/sK8vv5uamj7e3V0/jIsLv9va2r6hoKC8trU1v5+enj7y8XE/rawsPoaFBb/S0VE//fx8vomIiL3b2tq+oJ8fv8vKyr6Miws/7+7uPv79fb/Pzs4+1tVVP8TDQz/493e/6+rqvsnIyL24tzc//fx8PsXERD6Lioq+nZwcvpqZGT+wry+/m5qaPt7dXT+Miwu/29ravqGgoLy2tTW/n56ePvLxcT+trCw+hoUFv9LRUT/9/Hy+iYiIvdva2r6gnx+/y8rKvg==",
+      "vectorSha256": "42697eb341f548a77a5772f2a5f0bb0057d5a3cfe20d59d96737310e4a11ac0f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c5bb01b3eae1044573db9f985d6ccc28a6ee3a497d25a7f8953de8607749304d",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0201": {
+      "vector": "4uFhP+rpaT+1tDS+1tVVP5WUFD7e3V2/zMtLv4yLCz+UkxM/goEBP/r5eb+9vDy+9vV1P5GQEL27urq+m5qaPre2tr6JiIi93t1dv83MTD7j4uI+tLMzP9jXV7/q6Wk/hoUFv/b1dT+0szO/2NdXv83MTL69vDw+kI8PP9PS0j7i4WE/6ulpP7W0NL7W1VU/lZQUPt7dXb/My0u/jIsLP5STEz+CgQE/+vl5v728PL729XU/kZAQvbu6ur6bmpo+t7a2vomIiL3e3V2/zcxMPuPi4j60szM/2NdXv+rpaT+GhQW/9vV1P7SzM7/Y11e/zcxMvr28PD6Qjw8/09LSPg==",
+      "vectorSha256": "9b9f6f7ae6f8d062df1cae9179b925cc3b506bd239119d7df000e5e2271a1e5a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f0f469ea92111ac5c9c00368fa7b51a652771199b8d914f43dfa26146697c7b4",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0202": {
+      "vector": "3NtbP4KBAT/+/X0/1NNTP4+Ojr6mpSU/9vV1P9va2r7d3Fy+jo0NP6alJT+SkRE/2tlZPwAAgL/6+Xm/q6qqvrm4uD3S0VE/pKMjP4yLC7/c21s/zMtLv7m4uL3a2Vk/vr09v7W0ND729XW/s7KyPqyrKz+ysTE/sbAwvfb1db/c21s/goEBP/79fT/U01M/j46OvqalJT/29XU/29ravt3cXL6OjQ0/pqUlP5KRET/a2Vk/AACAv/r5eb+rqqq+ubi4PdLRUT+koyM/jIsLv9zbWz/My0u/ubi4vdrZWT++vT2/tbQ0Pvb1db+zsrI+rKsrP7KxMT+xsDC99vV1vw==",
+      "vectorSha256": "ee5577d5cbf1d01407b125d1b8e85dc873af841b6850d2d038681a26f1c611dd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "edc0fee95cd2fa4964c6d2c8ec0003558be8d13aed1a74ec219605acd5d87a05",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0203": {
+      "vector": "yMdHv9HQUD2joqK+l5aWPpKREb+Pjo6+oaCgvJybGz+ioSE/2tlZP+zraz/19HS+AACAv7a1Nb/x8HA9mJcXP8XERL6opye/4eDgvMHAQLz+/X0/iIcHP4eGhr729XU/p6amvtLRUb/KyUm/oaCgPJOSkj6qqSm/9PNzP4yLCz/Ix0e/0dBQPaOior6XlpY+kpERv4+Ojr6hoKC8nJsbP6KhIT/a2Vk/7OtrP/X0dL4AAIC/trU1v/HwcD2Ylxc/xcREvqinJ7/h4OC8wcBAvP79fT+Ihwc/h4aGvvb1dT+npqa+0tFRv8rJSb+hoKA8k5KSPqqpKb/083M/jIsLPw==",
+      "vectorSha256": "e00aacc41283e4f2deb42b0d083cb08aa84929263fbe83e66b889b69b962c249",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1c8657a5375c7dcdd0ecf561002587cb672c7c7efec35efa56171b82a42bf9c5",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0204": {
+      "vector": "+/r6vt3cXD6rqqq+h4aGvpqZGT+GhQW/+fj4PainJz+BgIC7wcBAvNDPT7+bmpq+9vV1v6SjI7/KyUm/goEBv9fW1j76+Xk/hIMDP9HQUD3a2Vm/3t1dP+zra7/R0FC91dRUvujnZ7/m5WU/qaioPYOCgr7GxUU/jYwMvoOCgr77+vq+3dxcPquqqr6Hhoa+mpkZP4aFBb/5+Pg9qKcnP4GAgLvBwEC80M9Pv5uamr729XW/pKMjv8rJSb+CgQG/19bWPvr5eT+EgwM/0dBQPdrZWb/e3V0/7Otrv9HQUL3V1FS+6Odnv+blZT+pqKg9g4KCvsbFRT+NjAy+g4KCvg==",
+      "vectorSha256": "9d91026b102a13789df2126746c39ea4a804250233680dce7d8febcdfd430c9b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "419b555ecc3d8fd37f7e1859052e1b3fb5fcc18613ee0a79650cf28a5fe26e5f",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0205": {
+      "vector": "np0dP9TTUz/083O/hYQEPp6dHb+EgwM/1tVVv8jHRz+xsDA98fBwPeHg4DzY11e/urk5v5eWlj6SkRE/goEBP/Dvbz/g318/iIcHP97dXb/g318/t7a2PrW0ND7l5GQ+9fR0vrq5OT+8uzu/5+bmPqyrKz/l5GQ+4+Livu3sbD6enR0/1NNTP/Tzc7+FhAQ+np0dv4SDAz/W1VW/yMdHP7GwMD3x8HA94eDgPNjXV7+6uTm/l5aWPpKRET+CgQE/8O9vP+DfXz+Ihwc/3t1dv+DfXz+3trY+tbQ0PuXkZD719HS+urk5P7y7O7/n5uY+rKsrP+XkZD7j4uK+7exsPg==",
+      "vectorSha256": "b0210bb1413d7c149bc47656f2aa407e8531a7351793b928b1db44816d831e66",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cee9069031c115e38587831423a5c8c0f7efc311efad969c61dc22b9d59c479d",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0206": {
+      "vector": "8vFxv/v6+r6EgwO/rq0tP8C/Pz/S0VG/mZiYvQAAgL/FxEQ+xcREPoSDAz/29XU/zcxMvtTTUz+pqKg9ycjIPbu6uj7Pzs4+tLMzP/79fT+sqyu/np0dP87NTT/29XU/kZAQPbq5OT/19HQ+jo0Nv7i3N7/j4uK+0dBQPfr5eb/y8XG/+/r6voSDA7+urS0/wL8/P9LRUb+ZmJi9AACAv8XERD7FxEQ+hIMDP/b1dT/NzEy+1NNTP6moqD3JyMg9u7q6Ps/Ozj60szM//v19P6yrK7+enR0/zs1NP/b1dT+RkBA9urk5P/X0dD6OjQ2/uLc3v+Pi4r7R0FA9+vl5vw==",
+      "vectorSha256": "4a9231ec4e07b866653d6f91a4bb33e81a8f1246795ca897b8aefee9661ea4d5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "07413ed6df1776009898c1fa66e98a8caeb3d9fe2acee6fa84dc9e3924478603",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0207": {
+      "vector": "+fj4Pf38fL67urq+urk5v4WEBL7m5WW/8O9vv7KxMT/f3t4+/fx8vpeWlr7u7W0/wcBAvJeWlj7Y11e/7exsvtnY2L2amRk/goEBv6inJ7+6uTk/kZAQvcLBQb+JiIg98/LyPu7tbT/Z2Ni9oaCgvIeGhj69vDw+nJsbv7CvL7/5+Pg9/fx8vru6ur66uTm/hYQEvublZb/w72+/srExP9/e3j79/Hy+l5aWvu7tbT/BwEC8l5aWPtjXV7/t7Gy+2djYvZqZGT+CgQG/qKcnv7q5OT+RkBC9wsFBv4mIiD3z8vI+7u1tP9nY2L2hoKC8h4aGPr28PD6cmxu/sK8vvw==",
+      "vectorSha256": "f7ffee549948c89cc240d9f3d05204595fe0ed7d17ee9b3edcecd6b5c5f28106",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8f6051236f0d08d8b7605af67ea5146272cc3f2cdc7b1f88bcf6727da1973228",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0208": {
+      "vector": "sbAwPfr5eT+DgoK+AACAP4uKij79/Hy+hoUFP7GwML3t7Gy+4eDgvPX0dD7S0VG/0dBQvYuKir69vDw+1tVVv4eGhr6dnBw+8/LyvsrJST+vrq4+xcREPoeGhj6enR2/rq0tv5aVFb+6uTk/hYQEvpSTE7/d3Fy+g4KCPrCvL7+xsDA9+vl5P4OCgr4AAIA/i4qKPv38fL6GhQU/sbAwve3sbL7h4OC89fR0PtLRUb/R0FC9i4qKvr28PD7W1VW/h4aGvp2cHD7z8vK+yslJP6+urj7FxEQ+h4aGPp6dHb+urS2/lpUVv7q5OT+FhAS+lJMTv93cXL6DgoI+sK8vvw==",
+      "vectorSha256": "91810c5eccdce523ed32e8e144a253f73a7231decd62139f3ea096b3c0d196f4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "85fc5fffa260c27a627c9e17795d97155e9343e4ab98a1312935dc6f3664a028",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0209": {
+      "vector": "19bWPtPS0r6OjQ2/29ravtDPT7+KiQk/vLs7v5STEz+HhoY+09LSPtHQUL3X1ta+3t1dv/79fb/r6uo+h4aGvr28PD7CwUE/3t1dv8LBQb+qqSm/+fj4vYmIiL3t7Gy+7+7uvsbFRb/My0u/wcBAPI2MDD61tDS+jIsLP9DPT7/X1tY+09LSvo6NDb/b2tq+0M9Pv4qJCT+8uzu/lJMTP4eGhj7T0tI+0dBQvdfW1r7e3V2//v19v+vq6j6Hhoa+vbw8PsLBQT/e3V2/wsFBv6qpKb/5+Pi9iYiIve3sbL7v7u6+xsVFv8zLS7/BwEA8jYwMPrW0NL6Miws/0M9Pvw==",
+      "vectorSha256": "5d24acf468315fc1103444889f50509955053bb3cb9dfe98dd518df894b86b6c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b54b394918c422c9a1b4794a1101ba5e97e0111f2b707762441d1a819169c518",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0210": {
+      "vector": "1tVVv5eWlr7Hxsa+m5qavr++vj7Qz08/p6amPu/u7j7Hxsa+4+LiPqOior7Z2Ni9hoUFv4KBAb/CwUE/trU1v+7tbT/i4WG/r66uPuDfX7/r6uo+o6KivtjXVz/9/Hw+vr09P9rZWT+cmxu/tLMzP5ybGz+BgIA7iokJP5+enr7W1VW/l5aWvsfGxr6bmpq+v76+PtDPTz+npqY+7+7uPsfGxr7j4uI+o6KivtnY2L2GhQW/goEBv8LBQT+2tTW/7u1tP+LhYb+vrq4+4N9fv+vq6j6joqK+2NdXP/38fD6+vT0/2tlZP5ybG7+0szM/nJsbP4GAgDuKiQk/n56evg==",
+      "vectorSha256": "78e2b3ffc6caa466d5b730f78b381d077b3758d6db27fdd39a59a78fd9f67c56",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "155a4e59afe7a9bb4eb857723d3fe025f60fab10ba57eb9fdeec32d9cd80c458",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0211": {
+      "vector": "3t1dv9zbW7/9/Hw+6Odnv+XkZD6zsrK+wcBAvJWUFD7k42M/n56ePpaVFb/BwEA8sbAwPaempr6TkpK+jIsLP8jHRz+CgQG/zMtLv+3sbL6Ihwc/397evoaFBT/U01O/6ejovaqpKb+/vr6+zs1NP+no6D3CwUE/h4aGPpqZGb/e3V2/3Ntbv/38fD7o52e/5eRkPrOysr7BwEC8lZQUPuTjYz+fnp4+lpUVv8HAQDyxsDA9p6amvpOSkr6Miws/yMdHP4KBAb/My0u/7exsvoiHBz/f3t6+hoUFP9TTU7/p6Oi9qqkpv7++vr7OzU0/6ejoPcLBQT+HhoY+mpkZvw==",
+      "vectorSha256": "f9196cf08dadd2ac10724ce18dc8aef7602aa0bfd96ccb62337322ebbd1d2d9d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "11129f0c9c537e92f1a7358185565bc5e33f1a62c348c216712b50e68ee0a133",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0212": {
+      "vector": "nJsbv9nY2L2CgQE/urk5v7W0ND6fnp6+4uFhP4KBAb+npqa+6ejoverpaT+Hhoa+0dBQPaOior7y8XE/u7q6Ptva2j7GxUW/+vl5P5GQED2JiIi9pqUlv7Oysr6Ylxc/xcREvoKBAT/f3t6+/v19v4uKij7+/X2/jYwMvrSzMz+cmxu/2djYvYKBAT+6uTm/tbQ0Pp+enr7i4WE/goEBv6empr7p6Oi96ulpP4eGhr7R0FA9o6KivvLxcT+7uro+29raPsbFRb/6+Xk/kZAQPYmIiL2mpSW/s7KyvpiXFz/FxES+goEBP9/e3r7+/X2/i4qKPv79fb+NjAy+tLMzPw==",
+      "vectorSha256": "03e804fd6e9a124803d6b5d6fdfcf511583c9c4e579d87712e6e25a7148dab77",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3272c0239658f03f5671f45e8657f8aeb61dfc84772d53cb67c04801a2016ed9",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0213": {
+      "vector": "z87OPoSDAz+UkxM/iIcHv/j3d7+HhoY+vbw8vr++vr6XlpY+mZiYPZOSkj729XW/iokJP6inJ7+JiIg9+fj4PeHg4LypqKi9tbQ0vpiXFz/KyUm/pqUlv9bVVb/h4OC89/b2vufm5j7q6Wk/n56evrSzM7/5+Pi9g4KCPoyLC7/Pzs4+hIMDP5STEz+Ihwe/+Pd3v4eGhj69vDy+v76+vpeWlj6ZmJg9k5KSPvb1db+KiQk/qKcnv4mIiD35+Pg94eDgvKmoqL21tDS+mJcXP8rJSb+mpSW/1tVVv+Hg4Lz39va+5+bmPurpaT+fnp6+tLMzv/n4+L2DgoI+jIsLvw==",
+      "vectorSha256": "84c16e0a4fb20a6312ed405fadbc7c2459a02f6ebd2d06f9ab009ff5fad56172",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b3c1c93c04a16850a589a405c42c888f7c7569cb1b2d157c42b9f4582670a03a",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0214": {
+      "vector": "/v19P9HQUD2trCy+yslJP5+enj6CgQE/1tVVP7y7Oz/Pzs4+x8bGvs7NTb/f3t4+r66uPtTTUz/w728/iIcHP7u6ur7Ew0O/8/LyPoyLCz/9/Hy+AACAP5aVFT/q6Wm/iokJP6inJz+EgwO/g4KCvuPi4r6XlpY+s7KyPuzraz/+/X0/0dBQPa2sLL7KyUk/n56ePoKBAT/W1VU/vLs7P8/Ozj7Hxsa+zs1Nv9/e3j6vrq4+1NNTP/Dvbz+Ihwc/u7q6vsTDQ7/z8vI+jIsLP/38fL4AAIA/lpUVP+rpab+KiQk/qKcnP4SDA7+DgoK+4+LivpeWlj6zsrI+7OtrPw==",
+      "vectorSha256": "af7a0ed70f25d31af15828e98b6b619c62c4e5c2ae36abea8115a228501ac56c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fe866ae4a7c0eaddb34e19b7abe9f7c3511ebcc560ffca0bc4d33e5f47a5acf5",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0215": {
+      "vector": "h4aGvv79fb+vrq4+zs1NP8zLSz/o52e/oaCgPLi3N7+1tDS+g4KCvqqpKb/Hxsa+s7KyvuHg4Dzh4OC8q6qqPuzra7+JiIi9w8LCPrCvL7/R0FA96ejovYWEBL6bmpo+mJcXP+blZb/m5WU/urk5v6SjIz+EgwO/xcREPpCPDz+Hhoa+/v19v6+urj7OzU0/zMtLP+jnZ7+hoKA8uLc3v7W0NL6DgoK+qqkpv8fGxr6zsrK+4eDgPOHg4Lyrqqo+7Otrv4mIiL3DwsI+sK8vv9HQUD3p6Oi9hYQEvpuamj6Ylxc/5uVlv+blZT+6uTm/pKMjP4SDA7/FxEQ+kI8PPw==",
+      "vectorSha256": "162af39f4f5d7322a454e1211ccf34b6145d4b8425d0d89655c8d3bfeb165dc3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5e01abe6e50c8224695f2b4e53837caa0a77b02886716fa6cb0df223d13e98c7",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0216": {
+      "vector": "r66uvuXkZD7U01O/t7a2Pru6uj6RkBA9paQkPtTTU7+gnx8/ubi4PYiHB78AAIA/srExP6+urj6EgwO/pqUlv+/u7r719HQ+//7+vouKij7Qz0+/1NNTv4WEBL6VlBS+7exsPqCfH7/9/Hw+np0dP7GwML38+3u/w8LCvvLxcb+vrq6+5eRkPtTTU7+3trY+u7q6PpGQED2lpCQ+1NNTv6CfHz+5uLg9iIcHvwAAgD+ysTE/r66uPoSDA7+mpSW/7+7uvvX0dD7//v6+i4qKPtDPT7/U01O/hYQEvpWUFL7t7Gw+oJ8fv/38fD6enR0/sbAwvfz7e7/DwsK+8vFxvw==",
+      "vectorSha256": "3e396efc45f378ffe7b14dd14d59a532ceff29e6d37b3df120cd3a506b157324",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "549c16adae849416cf8b3cffd8ab3e2d449e40a218166f6d9d309fce7a024f07",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0217": {
+      "vector": "7u1tv6alJb+ZmJi9q6qqvoSDAz/e3V2/srExv/v6+r7a2Vm/5ONjP97dXT/v7u6+397ePtva2j6cmxs/q6qqPpSTEz+fnp6+rKsrv6alJT/Pzs6+yslJP9/e3r7GxUW/xcREvpuamr7f3t4+yMdHP/r5eb+5uLi9k5KSvtDPT7/u7W2/pqUlv5mYmL2rqqq+hIMDP97dXb+ysTG/+/r6vtrZWb/k42M/3t1dP+/u7r7f3t4+29raPpybGz+rqqo+lJMTP5+enr6sqyu/pqUlP8/Ozr7KyUk/397evsbFRb/FxES+m5qavt/e3j7Ix0c/+vl5v7m4uL2TkpK+0M9Pvw==",
+      "vectorSha256": "934e448d731666a58d681eeb203e07d3410756d002b94b8d9f2ef5516c2ac3f7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "092d7655c111274113f1ee44b7b6cdaac9582ad24ce4481d6759b7e303745b18",
+      "updatedAt": "2025-09-20T22:27:41.518Z"
+    },
+    "j-0218": {
+      "vector": "p6amPvz7e7+ZmJi9+Pd3P769Pb+zsrI+trU1P8rJSb+urS2/3NtbP6KhIb/FxEQ+/Pt7v/r5eT/Lysq+0dBQvbm4uD2EgwM//Pt7P8HAQDzo52c/+Pd3P6empj7KyUk/vbw8vqqpKT/w728/kpERP+fm5j6zsrK+vLs7v4aFBb+npqY+/Pt7v5mYmL3493c/vr09v7Oysj62tTU/yslJv66tLb/c21s/oqEhv8XERD78+3u/+vl5P8vKyr7R0FC9ubi4PYSDAz/8+3s/wcBAPOjnZz/493c/p6amPsrJST+9vDy+qqkpP/Dvbz+SkRE/5+bmPrOysr68uzu/hoUFvw==",
+      "vectorSha256": "63016681ac971c039baa64a2c1331a3a091756c59163030664cd66fb8330e0ef",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a90276fb21acda1b29ed2f9802fc4d798bc1fd81f3fba9e468d4f7c8b953223d",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0219": {
+      "vector": "vr09v+3sbD7h4OC8mZiYPYiHBz8AAIC/3t1dP5ybGz/FxES+mJcXP7y7O7+Ylxe/kI8PP5OSkr729XW/4N9fv/f29j7Hxsa+5uVlP8/Ozr7b2to+6ejoPYOCgr7c21u/AACAv/79fT+SkRE/v76+PrW0NL6RkBA9iYiIPfDvbz++vT2/7exsPuHg4LyZmJg9iIcHPwAAgL/e3V0/nJsbP8XERL6Ylxc/vLs7v5iXF7+Qjw8/k5KSvvb1db/g31+/9/b2PsfGxr7m5WU/z87Ovtva2j7p6Og9g4KCvtzbW78AAIC//v19P5KRET+/vr4+tbQ0vpGQED2JiIg98O9vPw==",
+      "vectorSha256": "253e0de364ecac36fd661fc292abb4acc2c8a4f30749c1b9ae2ab27ea85d79be",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "219d7c89c300eecd67cb2234c75b0510bd4ef24cb68e5f1200fec8af698488f7",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0220": {
+      "vector": "iIcHP/Py8r7JyMi9j46OPsjHR7/JyMg9rKsrP/Lxcb/OzU2/6+rqvr28PD6enR0/3t1dP8nIyD3u7W2/nJsbP7GwML39/Hy+5+bmPoSDA7/GxUU/4+LiPpWUFL6rqqo+tbQ0vv79fb+8uzu/hIMDv6uqqj68uzu/3Ntbv+no6D2Ihwc/8/LyvsnIyL2Pjo4+yMdHv8nIyD2sqys/8vFxv87NTb/r6uq+vbw8Pp6dHT/e3V0/ycjIPe7tbb+cmxs/sbAwvf38fL7n5uY+hIMDv8bFRT/j4uI+lZQUvquqqj61tDS+/v19v7y7O7+EgwO/q6qqPry7O7/c21u/6ejoPQ==",
+      "vectorSha256": "20beeceae0ae8128559e207718853d0400aba0b6ce44f0a7134f68a75d2a1f0a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c34373a31c8cd507194597ceee8c09cd7a60b93ee2b86daa6901223eaa22128e",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0221": {
+      "vector": "0dBQvZGQED2joqI++Pd3v/b1db+GhQU/sK8vv4iHBz/Pzs6+rawsvpWUFL6Qjw+/oaCgPI2MDD7d3Fw+qqkpv6Oioj7y8XE/397ePrCvLz+VlBQ+m5qaPri3N7+amRk/paQkvpybG7+TkpI+yMdHP9XUVD7V1FS++Pd3P7GwML3R0FC9kZAQPaOioj7493e/9vV1v4aFBT+wry+/iIcHP8/Ozr6trCy+lZQUvpCPD7+hoKA8jYwMPt3cXD6qqSm/o6KiPvLxcT/f3t4+sK8vP5WUFD6bmpo+uLc3v5qZGT+lpCS+nJsbv5OSkj7Ix0c/1dRUPtXUVL7493c/sbAwvQ==",
+      "vectorSha256": "5b4107fd5266ba59719f2313c795909d44391e37a877611a81741ad4e5fb0c0c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7984a80405c228c34c6a6d3882919b2ba8f8b7d792a624cc6b32a4e39a65fb7a",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0222": {
+      "vector": "qKcnP7KxMT/+/X0/09LSvqWkJL6qqSm/6ulpP93cXD6VlBS+np0dv/X0dD7u7W0/zs1Nv5aVFb/r6uo+q6qqPv79fb/DwsI+1dRUPpaVFT/39va+z87OPvr5eb+OjQ0/wcBAvNjXV7/39va+goEBv66tLb/n5uY+w8LCvtLRUT+opyc/srExP/79fT/T0tK+paQkvqqpKb/q6Wk/3dxcPpWUFL6enR2/9fR0Pu7tbT/OzU2/lpUVv+vq6j6rqqo+/v19v8PCwj7V1FQ+lpUVP/f29r7Pzs4++vl5v46NDT/BwEC82NdXv/f29r6CgQG/rq0tv+fm5j7DwsK+0tFRPw==",
+      "vectorSha256": "35041e57740033a91acd968e1643d472f2015f38c3656f065d335c6839d2070d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d3d8fe4b6b2bf49b6d319ef61935baaa01b09aca42b303c67e14423f29b94fe8",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0223": {
+      "vector": "9PNzv42MDL75+Pg94eDgPM3MTL6mpSU/19bWvuLhYT/Avz+/4uFhv5qZGT+joqI+oqEhP769PT/OzU0/lJMTP87NTT/Qz08/yMdHv6empr7493e/hIMDP9/e3r6Lioo+4uFhv+blZT/i4WG/wL8/v66tLb+5uLi9o6KivsLBQT/083O/jYwMvvn4+D3h4OA8zcxMvqalJT/X1ta+4uFhP8C/P7/i4WG/mpkZP6Oioj6ioSE/vr09P87NTT+UkxM/zs1NP9DPTz/Ix0e/p6amvvj3d7+EgwM/397evouKij7i4WG/5uVlP+LhYb/Avz+/rq0tv7m4uL2joqK+wsFBPw==",
+      "vectorSha256": "7a47e731400d13b4735aef7f252e381fb208380d131552f062de599a09f5ebae",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "066e8f8366d24af0200fcca8d0dee6c9e6e71c5604c148a20ff20f20297457e0",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0224": {
+      "vector": "4uFhP6moqL3g318/srExP9zbWz+cmxu/5ONjv/z7e7+KiQm/8/LyPqCfH78AAIA/vbw8PrOysj6ioSE/wcBAPMjHR7+enR0/s7KyvtjXVz+enR0/+vl5v9fW1j6wry8/rKsrP87NTb/Ew0O/5eRkPp2cHL69vDw+jo0Nv6WkJL7i4WE/qaioveDfXz+ysTE/3NtbP5ybG7/k42O//Pt7v4qJCb/z8vI+oJ8fvwAAgD+9vDw+s7KyPqKhIT/BwEA8yMdHv56dHT+zsrK+2NdXP56dHT/6+Xm/19bWPrCvLz+sqys/zs1Nv8TDQ7/l5GQ+nZwcvr28PD6OjQ2/paQkvg==",
+      "vectorSha256": "277e5966560d84ea64b50e3821ece34578a5d42db255efe38d0ce6436461d229",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f075efd8ed320e023bbc30ff97acd0811cce53ebce03b5d7d5191e9c6c97396b",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0225": {
+      "vector": "qaiovY2MDD6TkpI+nJsbP8zLSz/KyUk/29raPq+urr6wry8/+Pd3P5iXF7/+/X2/3Ntbv7a1Nb+FhAS+yslJP/r5eT/Avz+/sbAwvb++vr7g31+/v76+vsfGxr7s62u/oqEhv7KxMb+SkRG/t7a2Po2MDD79/Hy+8fBwvdbVVb+pqKi9jYwMPpOSkj6cmxs/zMtLP8rJST/b2to+r66uvrCvLz/493c/mJcXv/79fb/c21u/trU1v4WEBL7KyUk/+vl5P8C/P7+xsDC9v76+vuDfX7+/vr6+x8bGvuzra7+ioSG/srExv5KREb+3trY+jYwMPv38fL7x8HC91tVVvw==",
+      "vectorSha256": "62bb393e81ba5c9051fc0a6dd6a683a5387abb7f08ab98fea5b1f1175d7ee54b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7591a4cde5e4b654d7fb340112256fe4fc207a5010504e0a2f2737ad91607815",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0226": {
+      "vector": "6ulpv42MDD7My0s/1dRUvquqqj69vDw+h4aGvrm4uL2ZmJg9zs1Nv/Lxcb/e3V2/jYwMvsC/P7+HhoY+g4KCvtPS0j61tDQ+yMdHv/r5eT/V1FS+oqEhP8XERD7d3Fw+/v19P7m4uL2Miwu/4+LivvPy8r7x8HC94uFhP6moqL3q6Wm/jYwMPszLSz/V1FS+q6qqPr28PD6Hhoa+ubi4vZmYmD3OzU2/8vFxv97dXb+NjAy+wL8/v4eGhj6DgoK+09LSPrW0ND7Ix0e/+vl5P9XUVL6ioSE/xcREPt3cXD7+/X0/ubi4vYyLC7/j4uK+8/LyvvHwcL3i4WE/qaiovQ==",
+      "vectorSha256": "fffaf54f5d1f6e6919ce9991935f78406414c3ebc1a964a8228e2084b64eae4a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0b91e565aa975e74891907116e20a15fb4961cfc65d0989bfe743a474378f075",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0227": {
+      "vector": "t7a2vsC/P7+ysTE/AACAv5qZGT/c21u/sK8vv8XERD6WlRW/ubi4vZiXF7/Pzs6+7OtrP9rZWT+rqqo+jYwMvrW0ND7JyMi9lJMTP5OSkr7FxEQ+trU1v4qJCb/q6Wk/rawsvqGgoDyPjo4+3dxcPvHwcD3h4OA8iIcHv52cHL63tra+wL8/v7KxMT8AAIC/mpkZP9zbW7+wry+/xcREPpaVFb+5uLi9mJcXv8/Ozr7s62s/2tlZP6uqqj6NjAy+tbQ0PsnIyL2UkxM/k5KSvsXERD62tTW/iokJv+rpaT+trCy+oaCgPI+Ojj7d3Fw+8fBwPeHg4DyIhwe/nZwcvg==",
+      "vectorSha256": "330e523ece7f3c48794f5c44e08619e6893fd4a83afb61025b02b290df857b45",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5220d800cc1228983574344cf5ecaa6e9673c95b98253bf46a82a39b87833c6c",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0228": {
+      "vector": "n56evr++vr6Lioo+5eRkPr69Pb+Pjo6+n56ePvPy8j6Miwu/pqUlv62sLD6fnp6+4+LivoGAgDugnx+/0dBQPY6NDb+HhoY+4uFhP7u6uj7FxEQ+k5KSvq6tLT/T0tK+i4qKPo+Ojj6SkRE/gYCAu+TjYz/k42M/nJsbv4eGhj6fnp6+v76+vouKij7l5GQ+vr09v4+Ojr6fnp4+8/LyPoyLC7+mpSW/rawsPp+enr7j4uK+gYCAO6CfH7/R0FA9jo0Nv4eGhj7i4WE/u7q6PsXERD6TkpK+rq0tP9PS0r6Lioo+j46OPpKRET+BgIC75ONjP+TjYz+cmxu/h4aGPg==",
+      "vectorSha256": "18ecbb4c1bcc82ec6d63200ebe7ceaebab5d27bcd0ac739080b0f5cdf5fb77a6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5850a29c215ca7bc3a2d95584780308639a1f0ae985bd64ba2a3c87ff1f132a1",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0229": {
+      "vector": "j46OvrCvLz+7uro+8/LyvpaVFT+SkRG/8/LyvqGgoDy7uro+rq0tP+Pi4r719HS++fj4Pb28PD7l5GS+2djYPfHwcL23tra+goEBv+rpab/Lyso+uLc3P5ybG7+OjQ2/m5qavsPCwj63trY+/v19P62sLD78+3u/0M9Pv9PS0j6Pjo6+sK8vP7u6uj7z8vK+lpUVP5KREb/z8vK+oaCgPLu6uj6urS0/4+LivvX0dL75+Pg9vbw8PuXkZL7Z2Ng98fBwvbe2tr6CgQG/6ulpv8vKyj64tzc/nJsbv46NDb+bmpq+w8LCPre2tj7+/X0/rawsPvz7e7/Qz0+/09LSPg==",
+      "vectorSha256": "10dcc84c3c7204e69f48b1313a1fcbc495d2e6c51011ac336336b364e1a28048",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5cd7ae43ca374382aed647618f97638d78523f0bb2db323959b0adfe950218b4",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0230": {
+      "vector": "6OdnP7++vj7u7W2/yslJP7m4uD2ioSE/xMNDv7u6uj6mpSU/w8LCvp+enr6sqyu/u7q6PrSzMz+JiIi9j46OPuDfXz/V1FS+zcxMvv79fT8AAIC/zcxMPvz7e7/19HQ++Pd3v5OSkr7CwUG/v76+vpWUFL6ZmJg90dBQPcvKyr7o52c/v76+Pu7tbb/KyUk/ubi4PaKhIT/Ew0O/u7q6PqalJT/DwsK+n56evqyrK7+7uro+tLMzP4mIiL2Pjo4+4N9fP9XUVL7NzEy+/v19PwAAgL/NzEw+/Pt7v/X0dD7493e/k5KSvsLBQb+/vr6+lZQUvpmYmD3R0FA9y8rKvg==",
+      "vectorSha256": "f794a2a4f19c882035794fba9ea639275d4fe1b5784dadb4d23743aa8f85f958",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f3af09e48bd01eaed24f582aaed977a3ef6566fe0099029e045b1f506d89864d",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0231": {
+      "vector": "l5aWvqqpKT/OzU2/0M9Pv7a1NT+koyO/iIcHP4KBAb+vrq4+3dxcPrq5Ob+NjAw+rawsPoqJCb/o52e/0tFRv8vKyr60szO/i4qKvvb1db/Qz0+/sK8vP/z7e7+bmpq+5ONjv46NDb+zsrI+0M9Pv769Pb+KiQm/4eDgvIWEBD6Xlpa+qqkpP87NTb/Qz0+/trU1P6SjI7+Ihwc/goEBv6+urj7d3Fw+urk5v42MDD6trCw+iokJv+jnZ7/S0VG/y8rKvrSzM7+Lioq+9vV1v9DPT7+wry8//Pt7v5uamr7k42O/jo0Nv7Oysj7Qz0+/vr09v4qJCb/h4OC8hYQEPg==",
+      "vectorSha256": "a70cb1c259d6e7572c6026ddb9e82be30744b664e4918a64a281a6aa116417ff",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5ad41918da2ec33fab9b2391953b0c174d265d0518d702590e39ac18213b7c90",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0232": {
+      "vector": "x8bGPqinJz+enR2/uLc3P8jHR7/+/X0/wcBAvPr5eb+JiIg9mZiYvbSzM7+Hhoa+0dBQPcXERD6pqKi9sK8vP7y7Oz8AAIC/z87OPqGgoLwAAIC/+fj4PY2MDD60szM/4eDgvIWEBL6urS0/vLs7P6+urj7t7Gw+uLc3v4aFBb/HxsY+qKcnP56dHb+4tzc/yMdHv/79fT/BwEC8+vl5v4mIiD2ZmJi9tLMzv4eGhr7R0FA9xcREPqmoqL2wry8/vLs7PwAAgL/Pzs4+oaCgvAAAgL/5+Pg9jYwMPrSzMz/h4OC8hYQEvq6tLT+8uzs/r66uPu3sbD64tze/hoUFvw==",
+      "vectorSha256": "b735183da16492434cdbf1cb394faecf22d8fb09dd09796f17a73776dd4d270f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b1d331db1cfe7e038876265e869875d7dd00b37d008f91d97c6fd6ddab9d243d",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0233": {
+      "vector": "zs1Nv+vq6r7NzEy+9PNzP9LRUT/y8XE/lpUVP5GQED319HQ+wL8/P6qpKT+6uTm/v76+vvj3dz+ioSG/6ulpv5mYmD3r6uo+q6qqPufm5r7s62u/yMdHv8/Ozr7h4OC829raPqCfHz/W1VW/srExP7GwML2SkRE/u7q6PszLS7/OzU2/6+rqvs3MTL7083M/0tFRP/LxcT+WlRU/kZAQPfX0dD7Avz8/qqkpP7q5Ob+/vr6++Pd3P6KhIb/q6Wm/mZiYPevq6j6rqqo+5+bmvuzra7/Ix0e/z87OvuHg4Lzb2to+oJ8fP9bVVb+ysTE/sbAwvZKRET+7uro+zMtLvw==",
+      "vectorSha256": "28bd0559f45df7809b74a525aa6fe8d71f2415dfc9cecca6216202dc1da3293e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "194566f9e8f8ca849edfd42350fb2f0b89baaa460a1c4c7cb6cf15d87ac8ae1a",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0234": {
+      "vector": "3t1dv+zraz/p6Oi9kpERv4GAgDuTkpK+m5qaPp6dHT+9vDy+x8bGvvn4+L2Pjo6+zs1Nv9nY2L2Miws/4N9fP4mIiD2GhQW/iIcHP4mIiL2SkRG/vLs7v8TDQ7/U01O/6ejovbq5Ob+zsrI+zcxMPpGQED2Xlpa+qaiovf38fL7e3V2/7OtrP+no6L2SkRG/gYCAO5OSkr6bmpo+np0dP728PL7Hxsa++fj4vY+Ojr7OzU2/2djYvYyLCz/g318/iYiIPYaFBb+Ihwc/iYiIvZKREb+8uzu/xMNDv9TTU7/p6Oi9urk5v7Oysj7NzEw+kZAQPZeWlr6pqKi9/fx8vg==",
+      "vectorSha256": "4995971bacbb9a452b5e6a6f1ec28b0af33bec1057a57cf1c6c4a0f6702aafbe",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "11f57137805ba6ce684e705c1972c5ef883dc37737221e167123ac99845a7560",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0235": {
+      "vector": "u7q6vs3MTD63tra+6ulpP7W0ND6mpSU/6ulpv6inJ7///v4+vr09P4mIiL2wry8/7OtrP4eGhj7a2Vk/6ejoPfPy8r7g31+/2djYPaGgoLzo52e/qqkpv8/Ozj6CgQG/xMNDv5WUFL6enR0/5uVlv8vKyr6WlRW/jYwMPtbVVT+7urq+zcxMPre2tr7q6Wk/tbQ0PqalJT/q6Wm/qKcnv//+/j6+vT0/iYiIvbCvLz/s62s/h4aGPtrZWT/p6Og98/LyvuDfX7/Z2Ng9oaCgvOjnZ7+qqSm/z87OPoKBAb/Ew0O/lZQUvp6dHT/m5WW/y8rKvpaVFb+NjAw+1tVVPw==",
+      "vectorSha256": "f8d97ab2a5a53e3f8b0f05bbf5a697172ca244bb065e03705169cd8c0e84a781",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "519952f496d20b2cbfde77d7f5a1ec8e43108d7d0c2bb33f1e6dce0d4d3591ea",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0236": {
+      "vector": "5+bmPvn4+L2Xlpa+tbQ0Pra1Nb+TkpI+xMNDP//+/r6cmxs/rKsrP+7tbb/8+3s/5ONjP+vq6r61tDS+zs1Nv6Oioj6pqKi91NNTP62sLL7083M/+Pd3v7m4uL2bmpq+nZwcPpWUFL6SkRE/o6KiPrm4uL2CgQG/wcBAPNzbW7/n5uY++fj4vZeWlr61tDQ+trU1v5OSkj7Ew0M///7+vpybGz+sqys/7u1tv/z7ez/k42M/6+rqvrW0NL7OzU2/o6KiPqmoqL3U01M/rawsvvTzcz/493e/ubi4vZuamr6dnBw+lZQUvpKRET+joqI+ubi4vYKBAb/BwEA83Ntbvw==",
+      "vectorSha256": "f733b29897d86bd092836565ce5187c078473ffc50a759a4d37061831ec91c80",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b9705a9625a4e140cdd509fdf1456919a875e96af9047459936dc8a8743f8112",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0237": {
+      "vector": "q6qqPu/u7j6SkRE/sK8vP4WEBL4AAIC/hIMDv+XkZD7FxES+nZwcPo2MDD6fnp6+pKMjv5WUFD7l5GQ+hoUFv769PT+urS2///7+PoqJCT/083M/wsFBv+Pi4j7OzU0/5uVlv7y7Oz/g318/zs1Nv4eGhr6joqK+0dBQPePi4r6rqqo+7+7uPpKRET+wry8/hYQEvgAAgL+EgwO/5eRkPsXERL6dnBw+jYwMPp+enr6koyO/lZQUPuXkZD6GhQW/vr09P66tLb///v4+iokJP/Tzcz/CwUG/4+LiPs7NTT/m5WW/vLs7P+DfXz/OzU2/h4aGvqOior7R0FA94+Livg==",
+      "vectorSha256": "49b376eb2c4cf98f90cc3d0563a78b2f3a6f9fb80859f29834b7d5619bee5509",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "aabbc8d76f003e9c679391582e929c3dde29bfc4f91fb8e60dddef195e578647",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0238": {
+      "vector": "nJsbP4+Ojj7Ew0M/zcxMPsjHRz/m5WU/4+LiPuDfX7/HxsY+397ePo6NDb///v4+goEBP6qpKT+ioSE/paQkvtTTUz+cmxu/2NdXv/z7ez+fnp6+8/LyvtjXVz+vrq4+4N9fv83MTL7f3t4+4+LivujnZ7/W1VU/gYCAO5WUFL6cmxs/j46OPsTDQz/NzEw+yMdHP+blZT/j4uI+4N9fv8fGxj7f3t4+jo0Nv//+/j6CgQE/qqkpP6KhIT+lpCS+1NNTP5ybG7/Y11e//Pt7P5+enr7z8vK+2NdXP6+urj7g31+/zcxMvt/e3j7j4uK+6Odnv9bVVT+BgIA7lZQUvg==",
+      "vectorSha256": "d743086a2a52693c8570a021f28a65b98b44a5945eb970517b75bf6713e2b519",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cda3e199e3f2b810b1b739bfc0d4d06be93214fd5843ebab1066b7470cea806d",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0239": {
+      "vector": "8fBwPf/+/j6qqSm/urk5v7SzM7+hoKC8rKsrP/LxcT/p6Oi9l5aWPtTTU7/w728/n56evsLBQb+CgQE/mZiYvcjHRz+lpCQ+8fBwPdTTU7/s62u/tLMzP+no6D2Qjw8/hYQEvpiXFz/W1VW/wcBAPJ2cHD7NzEw+/v19P8C/P7/x8HA9//7+PqqpKb+6uTm/tLMzv6GgoLysqys/8vFxP+no6L2XlpY+1NNTv/Dvbz+fnp6+wsFBv4KBAT+ZmJi9yMdHP6WkJD7x8HA91NNTv+zra7+0szM/6ejoPZCPDz+FhAS+mJcXP9bVVb/BwEA8nZwcPs3MTD7+/X0/wL8/vw==",
+      "vectorSha256": "8b6657ee9cf04a8ef977e819ab5da9560ce7f6040b5966d2047e2b4394018615",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "87bf2b23267dd5f871a516f7581fc076e39487160ad98ec76fcb15819399fe20",
+      "updatedAt": "2025-09-20T22:27:41.519Z"
+    },
+    "j-0240": {
+      "vector": "zMtLv9rZWT/Y11c/2tlZP7Oysj7493e/0tFRP6yrKz+opyc/mZiYvbGwMD2DgoK+iIcHP6WkJD6zsrI+09LSPvDvb7/h4OA82NdXv4+Ojr6bmpo+tLMzv4yLC7+npqY+jYwMvra1NT+koyO/5ONjv7m4uD2ZmJi95eRkPuPi4j7My0u/2tlZP9jXVz/a2Vk/s7KyPvj3d7/S0VE/rKsrP6inJz+ZmJi9sbAwPYOCgr6Ihwc/paQkPrOysj7T0tI+8O9vv+Hg4DzY11e/j46Ovpuamj60szO/jIsLv6empj6NjAy+trU1P6SjI7/k42O/ubi4PZmYmL3l5GQ+4+LiPg==",
+      "vectorSha256": "ef9536d3e4e580c55ebbd035f66941c5210ba134ff285b13f57a212a5c1d8f01",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1aecebecac04e8d5d376855fc394acb40883145ca6263aa96eda2e0e8b769cb8",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0241": {
+      "vector": "4uFhP4aFBT+ysTG/yslJv5GQEL25uLi9m5qavuLhYb/x8HC9iokJv9zbW7+wry+/tbQ0vtLRUb8AAIA/pqUlv/v6+j7My0s/19bWvrKxMb+OjQ0/z87OvuDfXz8AAIA/kZAQveXkZL64tzc/lJMTP5uamr6Pjo4+s7Kyvq+urr7i4WE/hoUFP7KxMb/KyUm/kZAQvbm4uL2bmpq+4uFhv/HwcL2KiQm/3Ntbv7CvL7+1tDS+0tFRvwAAgD+mpSW/+/r6PszLSz/X1ta+srExv46NDT/Pzs6+4N9fPwAAgD+RkBC95eRkvri3Nz+UkxM/m5qavo+Ojj6zsrK+r66uvg==",
+      "vectorSha256": "fcbf7e3e66a0635487b40e2d5351c8cb6997947832c7926db2ce2f9b6ab1a340",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f0c2271b7b74590f783b12286917ff2dbee54a27c64cefff7b63dbc959a35354",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0242": {
+      "vector": "qaioPfz7ez/Z2Ng9lZQUPuzra7+4tzc/srExv4mIiD3Avz8/+Pd3v4yLC7+ZmJi9//7+vqKhIb+RkBC9k5KSPqalJT/W1VW//fx8PqCfHz/JyMg9srExP8XERD66uTk/hYQEPpOSkr6/vr6+rawsPouKir7u7W2/2tlZP6+urr6pqKg9/Pt7P9nY2D2VlBQ+7Otrv7i3Nz+ysTG/iYiIPcC/Pz/493e/jIsLv5mYmL3//v6+oqEhv5GQEL2TkpI+pqUlP9bVVb/9/Hw+oJ8fP8nIyD2ysTE/xcREPrq5OT+FhAQ+k5KSvr++vr6trCw+i4qKvu7tbb/a2Vk/r66uvg==",
+      "vectorSha256": "f244aeba1a5caa8b1186c9519c794f0cc9e35a6334b3e697a43f6124a389e00e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8afd8d920adb2788df043a76402f7ba4d2159fcf8cd898dc905b50955d09ec54",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0243": {
+      "vector": "kpERv7e2tr77+vq+zs1NP+Pi4r7k42O/0tFRP9bVVb+OjQ0/9PNzP5WUFL6TkpK+h4aGvtva2r78+3u/qaioPaempj7j4uK+vLs7P8TDQz+pqKg9k5KSvvn4+L2Ihwc/mZiYPbe2tj6Pjo6+rawsPqmoqD3OzU2/qaioPfX0dL6SkRG/t7a2vvv6+r7OzU0/4+LivuTjY7/S0VE/1tVVv46NDT/083M/lZQUvpOSkr6Hhoa+29ravvz7e7+pqKg9p6amPuPi4r68uzs/xMNDP6moqD2TkpK++fj4vYiHBz+ZmJg9t7a2Po+Ojr6trCw+qaioPc7NTb+pqKg99fR0vg==",
+      "vectorSha256": "72b01f66a5095d3fe9754182921dbdd0a91363d6a31f37e936924b3589c01622",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "375241e6470ee815c6f96d5b5e49028aa947dde18a5b70c389ad5c958a198a61",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0244": {
+      "vector": "1tVVP9TTUz/6+Xk//Pt7P7GwML3m5WW/mpkZv7q5Ob/p6Oi9nJsbv9zbW7+Ihwe/qqkpP4iHB7/b2tq+paQkPqyrKz/Avz+/2djYPaCfH7/19HS+6+rqvvj3dz/6+Xk/sbAwPZybGz/T0tI+9PNzv6CfH7+RkBC9x8bGPu3sbD7W1VU/1NNTP/r5eT/8+3s/sbAwveblZb+amRm/urk5v+no6L2cmxu/3Ntbv4iHB7+qqSk/iIcHv9va2r6lpCQ+rKsrP8C/P7/Z2Ng9oJ8fv/X0dL7r6uq++Pd3P/r5eT+xsDA9nJsbP9PS0j7083O/oJ8fv5GQEL3HxsY+7exsPg==",
+      "vectorSha256": "a703431c9c98137df6b0326158eb95e1aa6884ef88b3988670ec5857708b5980",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "eae9fcfd7a0d33237132123cd43c4994d5208d306145fbfc85cdb406307bb19d",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0245": {
+      "vector": "rawsPvr5eb+9vDy+u7q6PoyLCz/x8HC9//7+Pru6uj6sqyu/4eDgPKuqqr7j4uK+np0dP9PS0r719HQ+2tlZv6inJ7+EgwO/y8rKvrKxMb+5uLi9tLMzP+XkZD7493e/rKsrP9HQUD2hoKC8pKMjv4SDA7/Avz+//Pt7P6GgoLytrCw++vl5v728PL67uro+jIsLP/HwcL3//v4+u7q6PqyrK7/h4OA8q6qqvuPi4r6enR0/09LSvvX0dD7a2Vm/qKcnv4SDA7/Lysq+srExv7m4uL20szM/5eRkPvj3d7+sqys/0dBQPaGgoLykoyO/hIMDv8C/P7/8+3s/oaCgvA==",
+      "vectorSha256": "748b58206eb5154cb527beb51a9bbe149c20c90c4d41f648d91846465e35f631",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "950368aec578bfae2a835547ce4b9e132c3e4d2774d99c04d5867d2e3e20fd7d",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0246": {
+      "vector": "+Pd3v+LhYb/Qz08/0M9Pv7GwML3h4OA8x8bGvublZT+mpSU/ycjIPb69Pb/h4OC8nZwcPomIiL3x8HA9yMdHP5qZGT/Ix0c/vbw8voOCgr6qqSm/2djYvYOCgr6koyO/rKsrP4+Ojj6ysTE/v76+PqCfHz/HxsY+0tFRv9/e3r7493e/4uFhv9DPTz/Qz0+/sbAwveHg4DzHxsa+5uVlP6alJT/JyMg9vr09v+Hg4LydnBw+iYiIvfHwcD3Ix0c/mpkZP8jHRz+9vDy+g4KCvqqpKb/Z2Ni9g4KCvqSjI7+sqys/j46OPrKxMT+/vr4+oJ8fP8fGxj7S0VG/397evg==",
+      "vectorSha256": "8b5dca7a7a8d3e559b942353f5e35409a7e7cd40502674248e3855d991da3633",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "040fe7187a834ef2d28c217c937787e3cce3685f2b725f2ed5a3d8afcfb11748",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0247": {
+      "vector": "u7q6vpqZGb+mpSW/nJsbP5uamr6gnx+/7OtrP7y7O7/X1tY+2djYPby7Oz+opye/wcBAvKyrK7+pqKg9m5qavtPS0r6pqKg9zs1Nv6SjIz+VlBQ+iYiIPcPCwr64tze/yMdHP9fW1r6JiIg9goEBv4mIiD3+/X0/5eRkvuTjYz+7urq+mpkZv6alJb+cmxs/m5qavqCfH7/s62s/vLs7v9fW1j7Z2Ng9vLs7P6inJ7/BwEC8rKsrv6moqD2bmpq+09LSvqmoqD3OzU2/pKMjP5WUFD6JiIg9w8LCvri3N7/Ix0c/19bWvomIiD2CgQG/iYiIPf79fT/l5GS+5ONjPw==",
+      "vectorSha256": "326af365a8ed18083b9f5280eca8f08a0a5e52f2ab687c682820a2b324ed5c26",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "51332dcd5930f522b58ddd2c7e2a8a594b8a19d192884f24e34a883f88fe63f1",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0248": {
+      "vector": "y8rKPuTjY7+VlBQ++vl5P8LBQb/DwsI+7exsPuPi4r6koyO/8O9vP5eWlj7Avz+/8O9vP+/u7j7DwsI+pKMjv/n4+L3a2Vk/lpUVv/Tzcz/Qz0+/2tlZP/HwcD26uTm/t7a2PuHg4Lyfnp6+mpkZP5+enr7w72+/397ePt3cXD7Lyso+5ONjv5WUFD76+Xk/wsFBv8PCwj7t7Gw+4+LivqSjI7/w728/l5aWPsC/P7/w728/7+7uPsPCwj6koyO/+fj4vdrZWT+WlRW/9PNzP9DPT7/a2Vk/8fBwPbq5Ob+3trY+4eDgvJ+enr6amRk/n56evvDvb7/f3t4+3dxcPg==",
+      "vectorSha256": "a3f166498716371865e030802859b8132291840a04456c4a5504fc2a922bc151",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b20e92fc1fb09d472ef7a520f7bbb02e70ec35f918ec8723ad7c58cc5808b79b",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0249": {
+      "vector": "wcBAvOjnZ7/e3V2/pqUlP9DPT7+TkpI+4eDgPPPy8j6urS2/hoUFP9jXV7+trCy+9/b2vpuamr66uTm/yslJv7i3Nz/BwEC82NdXP5iXF7+sqyu/wcBAPN/e3r6VlBQ+q6qqPqqpKb/8+3s/lJMTP/f29j62tTW/yslJP5OSkj7BwEC86Odnv97dXb+mpSU/0M9Pv5OSkj7h4OA88/LyPq6tLb+GhQU/2NdXv62sLL739va+m5qavrq5Ob/KyUm/uLc3P8HAQLzY11c/mJcXv6yrK7/BwEA8397evpWUFD6rqqo+qqkpv/z7ez+UkxM/9/b2Pra1Nb/KyUk/k5KSPg==",
+      "vectorSha256": "7009b196608a6e33fb31e0736cee3d904baf5e10a6740f31482aa2f085bd1d5c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7e0c11d218a483bc29c2146a4259231bdb7eeb342a814892aa2bfdc9bd25e4a4",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0250": {
+      "vector": "5ONjP/v6+j6trCw+vr09P/f29j6FhAQ+nJsbP6KhIb/493c/sK8vv93cXD67uro+rq0tP9nY2D2EgwM/9PNzv5+enr7z8vI+pqUlP7y7O7/Qz08/s7Kyvt/e3r6XlpY+29raPvb1dT/493c/8/LyPuXkZD6Qjw+/7Otrv4uKir7k42M/+/r6Pq2sLD6+vT0/9/b2PoWEBD6cmxs/oqEhv/j3dz+wry+/3dxcPru6uj6urS0/2djYPYSDAz/083O/n56evvPy8j6mpSU/vLs7v9DPTz+zsrK+397evpeWlj7b2to+9vV1P/j3dz/z8vI+5eRkPpCPD7/s62u/i4qKvg==",
+      "vectorSha256": "eab6b7fa0ec2e3529eed0adb1ccc2335847c3b2744ceb7e1e94adfaa0acc9151",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f1be95debd90cd2ffb289baed68dc10658bcd222e75348a5b6fafbbc9c380a5d",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0251": {
+      "vector": "rKsrv+blZT+Xlpa+jo0NP5WUFL6gnx8/8fBwvfr5eb/My0s/zcxMPoeGhr7Y11c/kZAQPdLRUb+6uTk/lpUVP+LhYT/39va+8/Lyvtva2r7W1VW/kpERP7++vj6KiQk/+vl5P9HQUL2EgwM/mJcXP97dXb/V1FQ+6ejoPfPy8j6sqyu/5uVlP5eWlr6OjQ0/lZQUvqCfHz/x8HC9+vl5v8zLSz/NzEw+h4aGvtjXVz+RkBA90tFRv7q5OT+WlRU/4uFhP/f29r7z8vK+29ravtbVVb+SkRE/v76+PoqJCT/6+Xk/0dBQvYSDAz+Ylxc/3t1dv9XUVD7p6Og98/LyPg==",
+      "vectorSha256": "5fa783a6bcec93e52ecb1335e27a73bef6695add4a642d60cf6ffb42bf96ee7c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2af25ac66dcf7803e5995eeb8417dccaf042434915c8afc4fc79c1cb119a8ebc",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0252": {
+      "vector": "w8LCvvHwcL36+Xk/5+bmPv/+/r7Ix0e/hIMDP8jHRz/NzEw+xMNDP5eWlj61tDQ+y8rKPublZT+hoKA8urk5P6moqD2WlRW/8fBwPfj3dz+OjQ2/n56ePuDfX7+dnBw+k5KSvuHg4Ly3trY+nJsbP9zbW7+2tTW/iYiIva6tLT/DwsK+8fBwvfr5eT/n5uY+//7+vsjHR7+EgwM/yMdHP83MTD7Ew0M/l5aWPrW0ND7Lyso+5uVlP6GgoDy6uTk/qaioPZaVFb/x8HA9+Pd3P46NDb+fnp4+4N9fv52cHD6TkpK+4eDgvLe2tj6cmxs/3Ntbv7a1Nb+JiIi9rq0tPw==",
+      "vectorSha256": "0da570d15e546124c8d40a1e408f49efc082a982fda93410d58a7dd179c5c7c9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4f78fcb9401cc1e399e1a596b2f282dc8a3587fb39a710935b7cadcd122577d6",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0253": {
+      "vector": "yslJP9XUVL76+Xk/iokJP56dHT/r6uo+jo0NPwAAgD+KiQk/iokJv5OSkr7R0FC97+7uPoqJCb+pqKg97+7uPgAAgD/a2Vk/1NNTP/Py8j66uTk/4uFhP5mYmL2xsDA9+/r6PtLRUT+qqSk/5eRkvry7Oz+hoKA87exsvtzbWz/KyUk/1dRUvvr5eT+KiQk/np0dP+vq6j6OjQ0/AACAP4qJCT+KiQm/k5KSvtHQUL3v7u4+iokJv6moqD3v7u4+AACAP9rZWT/U01M/8/LyPrq5OT/i4WE/mZiYvbGwMD37+vo+0tFRP6qpKT/l5GS+vLs7P6GgoDzt7Gy+3NtbPw==",
+      "vectorSha256": "3e761b3f18ec5fbac003c58f4888f6f81b38c589fc93f7ef1d2d05ac29f6f25e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e465fcc4cebac6ffc43b5b79bb3b8abbffece9bcdcf07685bee8d463dd8262ed",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0254": {
+      "vector": "397ePq6tLb+joqK+09LSvp6dHT/t7Gy+o6KiPuXkZD739vY+5+bmvquqqr6gnx8/397evu7tbb+bmpq+29ravoaFBT/7+vq+h4aGvtbVVb+EgwM/xcREPtPS0r7f3t4+w8LCPuvq6r7FxEQ+zcxMPtfW1j6lpCS+hYQEvs3MTD7f3t4+rq0tv6Oior7T0tK+np0dP+3sbL6joqI+5eRkPvf29j7n5ua+q6qqvqCfHz/f3t6+7u1tv5uamr7b2tq+hoUFP/v6+r6Hhoa+1tVVv4SDAz/FxEQ+09LSvt/e3j7DwsI+6+rqvsXERD7NzEw+19bWPqWkJL6FhAS+zcxMPg==",
+      "vectorSha256": "352102daaa07d9c68b67eaff980eb427f079534c0f7a033797a65be850ad4540",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b729574bce62a89cbd4655cf48095949c2415e15c1984bb7b0459899b56b6f99",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0255": {
+      "vector": "vLs7v/v6+j6gnx8/lpUVP5CPD7/s62s/h4aGPrm4uL26uTm/ycjIvZeWlr7e3V0/oqEhP7GwMD3m5WW/nZwcvsPCwj7d3Fy+ubi4vdnY2D2xsDC98O9vv6+urj7W1VU/z87OPtrZWb+ioSE/p6amvtva2r7Y11c/4+LiPrW0ND68uzu/+/r6PqCfHz+WlRU/kI8Pv+zraz+HhoY+ubi4vbq5Ob/JyMi9l5aWvt7dXT+ioSE/sbAwPeblZb+dnBy+w8LCPt3cXL65uLi92djYPbGwML3w72+/r66uPtbVVT/Pzs4+2tlZv6KhIT+npqa+29ravtjXVz/j4uI+tbQ0Pg==",
+      "vectorSha256": "94aea705b6681356044556866b250e19d2edd787960c0e6fcdcb7b9a6a1d8116",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "22becfca38f5a17423735aeed0850d6cb064748d7a08abeab313d05649ebb896",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0256": {
+      "vector": "zcxMPry7Oz+zsrI+w8LCvvLxcb/c21u/p6amvvv6+j7NzEy+yMdHP5WUFD6trCw+3dxcvv79fT+4tzc/l5aWvoqJCb+xsDA9rawsPsC/Pz/a2Vk/t7a2PqmoqL3FxES+hoUFv7e2tr7v7u6+vbw8vsvKyr7493e/zs1Nv5KREb/NzEw+vLs7P7Oysj7DwsK+8vFxv9zbW7+npqa++/r6Ps3MTL7Ix0c/lZQUPq2sLD7d3Fy+/v19P7i3Nz+Xlpa+iokJv7GwMD2trCw+wL8/P9rZWT+3trY+qaiovcXERL6GhQW/t7a2vu/u7r69vDy+y8rKvvj3d7/OzU2/kpERvw==",
+      "vectorSha256": "3a912a074df1d39202a03130b3b8c96d63bf59a27bcfcc9c2468420984eb2642",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "99ddac4f071256be66e3929564fedb5a3b8595dfecad75673d5244684d041937",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0257": {
+      "vector": "yMdHv/v6+j6DgoI+sbAwPYKBAb/v7u6+xMNDP/z7ez/q6Wm/iIcHP4WEBD6sqyu/+fj4Peno6L2ioSG/6ulpv6Oioj7CwUE/hYQEPvPy8j7i4WE/4uFhP+blZT/FxEQ+6+rqPrGwMD2JiIg9u7q6PvDvb7/Lyso+9PNzv7y7O7/Ix0e/+/r6PoOCgj6xsDA9goEBv+/u7r7Ew0M//Pt7P+rpab+Ihwc/hYQEPqyrK7/5+Pg96ejovaKhIb/q6Wm/o6KiPsLBQT+FhAQ+8/LyPuLhYT/i4WE/5uVlP8XERD7r6uo+sbAwPYmIiD27uro+8O9vv8vKyj7083O/vLs7vw==",
+      "vectorSha256": "11fdb3bf6e0aef82a059e56d7ece52555e93395719c3073a863c9abe8581e613",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1cbea0853f44e1fd0bc3902a8f712f0ba8e090bcf0f0f298ba8588ae08b20622",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0258": {
+      "vector": "9/b2PuXkZL7V1FQ+x8bGvsPCwr7r6uo+0tFRP52cHL7h4OA8zcxMPvj3d7+CgQG/vr09v6empr6zsrK++vl5v4qJCb+urS0/+vl5v8nIyD3f3t4+5ONjv6Oior6VlBS+3dxcPoOCgr6VlBQ+rKsrv728PD6cmxu/k5KSPsnIyD339vY+5eRkvtXUVD7Hxsa+w8LCvuvq6j7S0VE/nZwcvuHg4DzNzEw++Pd3v4KBAb++vT2/p6amvrOysr76+Xm/iokJv66tLT/6+Xm/ycjIPd/e3j7k42O/o6KivpWUFL7d3Fw+g4KCvpWUFD6sqyu/vbw8PpybG7+TkpI+ycjIPQ==",
+      "vectorSha256": "7bbc624f4c5eecd1c55498c829a1ad2bc63747a6956aba99034a53be71c4c2c4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bd639a4e4fbae86c8399043f215653033bd6038cb70e576d9b5f922a9732a48c",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0259": {
+      "vector": "q6qqPsXERL6koyM/8fBwPaqpKb+2tTW/4uFhP9HQUL2HhoY+oJ8fP6qpKT/j4uK+8/LyPp6dHT+6uTm/7u1tv/f29r6Lioo+lJMTv8vKyj6pqKi94+LiPoOCgr6pqKg9srExv8C/Pz/39va+qKcnv6WkJD6NjAw+AACAP6moqD2rqqo+xcREvqSjIz/x8HA9qqkpv7a1Nb/i4WE/0dBQvYeGhj6gnx8/qqkpP+Pi4r7z8vI+np0dP7q5Ob/u7W2/9/b2vouKij6UkxO/y8rKPqmoqL3j4uI+g4KCvqmoqD2ysTG/wL8/P/f29r6opye/paQkPo2MDD4AAIA/qaioPQ==",
+      "vectorSha256": "15a7afe91adb04906903f2cce8864e10ea6f93d6badda807750ade366c78c95a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "aa67d1872b25f079a1cfd447bcce230942a236b275b85f8a27df422c9491ff8a",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0260": {
+      "vector": "0M9PP7++vj7Lyso+lpUVv66tLb/5+Pi9mJcXP7y7O7+vrq6+sbAwvbGwMD2Qjw+/t7a2vqqpKT/j4uK+4uFhP728PD6Ylxe/i4qKvsXERD7q6Wm/jYwMvvj3d7+pqKg93t1dP6inJz/NzEw+mpkZv6GgoDykoyM/h4aGvqGgoLzQz08/v76+PsvKyj6WlRW/rq0tv/n4+L2Ylxc/vLs7v6+urr6xsDC9sbAwPZCPD7+3tra+qqkpP+Pi4r7i4WE/vbw8PpiXF7+Lioq+xcREPurpab+NjAy++Pd3v6moqD3e3V0/qKcnP83MTD6amRm/oaCgPKSjIz+Hhoa+oaCgvA==",
+      "vectorSha256": "203f84554ba270355d49b440ba6b58b75ad3b6e27748eab4370411724bee0a6b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e7afb2352970cb22547a853852d447f097345d980b6e048aeed3993382d15e7d",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0261": {
+      "vector": "w8LCvoyLCz/U01O/s7KyPvDvbz+ysTE/vr09v9XUVD6Ihwc/v76+vpaVFT+xsDC9j46OPu3sbL6KiQk/kZAQPdfW1r6enR2/paQkvtjXVz/W1VU/1tVVP5eWlr6/vr4+//7+PuLhYb+zsrK+AACAv+no6L2Miwu/iYiIvdnY2L3DwsK+jIsLP9TTU7+zsrI+8O9vP7KxMT++vT2/1dRUPoiHBz+/vr6+lpUVP7GwML2Pjo4+7exsvoqJCT+RkBA919bWvp6dHb+lpCS+2NdXP9bVVT/W1VU/l5aWvr++vj7//v4+4uFhv7Oysr4AAIC/6ejovYyLC7+JiIi92djYvQ==",
+      "vectorSha256": "f0857c1665795ee4538d0f5c6032d4a890e7b2515f60c72b4955cb9dfae816e6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4fc516acf7d8219ac350ca7aa362c4844a316bebeaea5aafbf0f5300713a7772",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0262": {
+      "vector": "ubi4vZuamj6SkRG/8fBwPeLhYb+4tze/s7KyvuLhYb/b2to+3dxcPuLhYT/e3V2/3Ntbv62sLL6Hhoa+gYCAu+7tbb/i4WG/tLMzv4WEBD6Xlpa+l5aWvoqJCb/NzEy+8fBwvefm5r6OjQ2/g4KCPrq5Ob+KiQk/k5KSPpWUFL65uLi9m5qaPpKREb/x8HA94uFhv7i3N7+zsrK+4uFhv9va2j7d3Fw+4uFhP97dXb/c21u/rawsvoeGhr6BgIC77u1tv+LhYb+0szO/hYQEPpeWlr6Xlpa+iokJv83MTL7x8HC95+bmvo6NDb+DgoI+urk5v4qJCT+TkpI+lZQUvg==",
+      "vectorSha256": "7deddc8c90755ad94a0878fc3f79f78abf7fb07b6a6747e44b43242d32cfbd00",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "74a637870f24530fb69bf011126a5e7f090f26905a5a3b66784639a023c4a46d",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0263": {
+      "vector": "5uVlv4mIiD36+Xk/ubi4vdDPT7/g31+/nZwcvsC/P7+mpSU/hoUFP7++vj6pqKg95ONjP5eWlr7w728/0dBQPYOCgr7w728/iokJP6alJb/S0VE/397ePrW0NL61tDQ+3Ntbv9fW1r6JiIg95eRkPrm4uL3S0VG/hoUFP4WEBD7m5WW/iYiIPfr5eT+5uLi90M9Pv+DfX7+dnBy+wL8/v6alJT+GhQU/v76+PqmoqD3k42M/l5aWvvDvbz/R0FA9g4KCvvDvbz+KiQk/pqUlv9LRUT/f3t4+tbQ0vrW0ND7c21u/19bWvomIiD3l5GQ+ubi4vdLRUb+GhQU/hYQEPg==",
+      "vectorSha256": "a8fa09a146b9ac0d179da58e4c210e271645d5176e8abbd69f94c698754081dd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0d88fc7418106c20d2c2af8af15af7865ff7c42de8b76996124a889c7417c290",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0264": {
+      "vector": "2tlZPwAAgL/Ew0O/np0dv/Py8r7l5GQ+gYCAO+Pi4r7q6Wk/x8bGPtDPT7/x8HA9nZwcPo+Ojr7KyUk/19bWPu/u7r6OjQ0/ycjIPfX0dL6/vr4+mJcXP6moqL3Qz0+/y8rKvp+enj7V1FS+3dxcPvn4+D3W1VU/urk5P87NTb/a2Vk/AACAv8TDQ7+enR2/8/LyvuXkZD6BgIA74+LivurpaT/HxsY+0M9Pv/HwcD2dnBw+j46OvsrJST/X1tY+7+7uvo6NDT/JyMg99fR0vr++vj6Ylxc/qaiovdDPT7/Lysq+n56ePtXUVL7d3Fw++fj4PdbVVT+6uTk/zs1Nvw==",
+      "vectorSha256": "dd0766adc82dbedc6b51e03bd415123e41da0a3a06297a91f285e96ee2bb5d9b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ec001e31439c8047f4b11887935ce4b544c68c61afcb75184da7659b8feadc19",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0265": {
+      "vector": "4uFhv9jXV7+fnp4+5uVlv728PD6vrq4+zMtLv6yrKz+SkRE//fx8Puzra78AAIA/hYQEvujnZz+Miwu/ubi4vbq5Ob/f3t4++fj4vZuamj7HxsY+tbQ0vtjXV7+0szM/wL8/v8zLSz8AAIA/5+bmvvz7e7+3trY+hoUFP5qZGb/i4WG/2NdXv5+enj7m5WW/vbw8Pq+urj7My0u/rKsrP5KRET/9/Hw+7OtrvwAAgD+FhAS+6OdnP4yLC7+5uLi9urk5v9/e3j75+Pi9m5qaPsfGxj61tDS+2NdXv7SzMz/Avz+/zMtLPwAAgD/n5ua+/Pt7v7e2tj6GhQU/mpkZvw==",
+      "vectorSha256": "e4a85b9b6bf667daa64ada84081835bc7e1448f0fdba4c5f1f94e2bb2d6152fe",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0f14a70d97ab1ad5c89f0aff6ff33a7423b770a6b16914d920e5ff4602adc233",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0266": {
+      "vector": "hIMDv7e2tr6JiIg9v76+PoiHBz///v4+qqkpP56dHT/6+Xk/1tVVv/f29r6VlBQ+rawsPtLRUb/m5WU/oaCgPLq5Ob+SkRE/k5KSPs3MTD6gnx+/zMtLv93cXD67urq+vLs7P8nIyL2SkRE/j46OvtnY2L35+Pi96ejovfv6+j6EgwO/t7a2vomIiD2/vr4+iIcHP//+/j6qqSk/np0dP/r5eT/W1VW/9/b2vpWUFD6trCw+0tFRv+blZT+hoKA8urk5v5KRET+TkpI+zcxMPqCfH7/My0u/3dxcPru6ur68uzs/ycjIvZKRET+Pjo6+2djYvfn4+L3p6Oi9+/r6Pg==",
+      "vectorSha256": "f354457dcf0a3260df88d16bb50049b33220d576776be6a75ed7ee46f7bf5da1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3e5288afc3bfd4cefc1542929517f28223c8a499301a9b51dd73c85c727071be",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0267": {
+      "vector": "1NNTP/Py8r7083O/np0dP6WkJD7u7W2/o6KivpmYmL22tTU/1tVVP+/u7j7a2Vm/0tFRv5CPD7/Qz08/pKMjv/f29j68uzs/i4qKvsHAQLyJiIi9jIsLv9nY2D3m5WW/6ejoPcXERL6+vT2/8fBwveHg4LyMiwu/9fR0Pvn4+L3U01M/8/LyvvTzc7+enR0/paQkPu7tbb+joqK+mZiYvba1NT/W1VU/7+7uPtrZWb/S0VG/kI8Pv9DPTz+koyO/9/b2Pry7Oz+Lioq+wcBAvImIiL2Miwu/2djYPeblZb/p6Og9xcREvr69Pb/x8HC94eDgvIyLC7/19HQ++fj4vQ==",
+      "vectorSha256": "c118dce47a177ce640a25d7640bd60405cdb2f92bb4351e415addd3070d676f9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e94306ce94095776daeabb131738e72ebddd5d7e773a8d0d8e6721787c3a9e70",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0268": {
+      "vector": "oqEhv/Dvb7++vT0/+/r6vtDPTz/8+3s/9fR0PtbVVT/29XU/4+LiPpuamr7j4uK+o6Kivvb1dT/7+vq++/r6PrKxMb+8uzu/vbw8PoaFBT/8+3s/3NtbP6GgoDzEw0O/xMNDP6qpKT/Y11c/oqEhv4KBAb+joqK+vLs7v8nIyL2ioSG/8O9vv769PT/7+vq+0M9PP/z7ez/19HQ+1tVVP/b1dT/j4uI+m5qavuPi4r6joqK+9vV1P/v6+r77+vo+srExv7y7O7+9vDw+hoUFP/z7ez/c21s/oaCgPMTDQ7/Ew0M/qqkpP9jXVz+ioSG/goEBv6Oior68uzu/ycjIvQ==",
+      "vectorSha256": "d44c7ee253a909ebab499626b6a98dc12d35aed0188f5ee68158fc3f3298607a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2f08de41e7fd9eeafab8594757fa41be272297c2fded821ee1d4eb2f3f572273",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0269": {
+      "vector": "sK8vv8rJST+enR0/iIcHv62sLD7Avz+/7u1tP+blZb/Pzs4+v76+vrCvLz+dnBw+rq0tP+7tbb+rqqq+5eRkvrW0ND7T0tI+m5qavuXkZD6koyO/3dxcPuzra7/T0tI+ycjIvcTDQz/x8HA9jo0NP7y7O7/9/Hw+zMtLP5qZGT+wry+/yslJP56dHT+Ihwe/rawsPsC/P7/u7W0/5uVlv8/Ozj6/vr6+sK8vP52cHD6urS0/7u1tv6uqqr7l5GS+tbQ0PtPS0j6bmpq+5eRkPqSjI7/d3Fw+7Otrv9PS0j7JyMi9xMNDP/HwcD2OjQ0/vLs7v/38fD7My0s/mpkZPw==",
+      "vectorSha256": "dc9d10a3065eba899905b474bc2862b20cf5fe968d81a54c10865d9fecff1587",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "28e4ce3c9520f60db350d793d609556396b4599c2e9b0ab473e187c6229fe5cc",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0270": {
+      "vector": "rq0tv5STE7+Pjo4+q6qqvujnZz+dnBy+srExv//+/j6Pjo6+397evqKhIb+fnp6+9fR0Pt/e3j6Miwu/vLs7v8zLSz+FhAQ+8O9vv/v6+j7JyMg90dBQPYmIiD3t7Gy+9vV1v/X0dL6Lioq+v76+Po+Ojr6sqyu/w8LCPrSzMz+urS2/lJMTv4+Ojj6rqqq+6OdnP52cHL6ysTG///7+Po+Ojr7f3t6+oqEhv5+enr719HQ+397ePoyLC7+8uzu/zMtLP4WEBD7w72+/+/r6PsnIyD3R0FA9iYiIPe3sbL729XW/9fR0vouKir6/vr4+j46OvqyrK7/DwsI+tLMzPw==",
+      "vectorSha256": "3dd65c6c1f8496cbe597450c02e3ca0b335e06585866652cdf5b3ead5882c4ca",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2936a355f36c27bf5c482f589eb73a22e59008be8c86886205615daf5c2ab0d9",
+      "updatedAt": "2025-09-20T22:27:41.521Z"
+    },
+    "j-0271": {
+      "vector": "ycjIPbu6ur7NzEw+ubi4Pf/+/j6bmpo+2tlZv5CPD7+cmxs/jIsLP6SjIz+opye///7+vuDfX7+zsrI+n56evgAAgL+KiQm/9fR0vtzbWz/Lyso+5eRkPpiXFz/t7Gy+ubi4vdTTU7/c21s/tbQ0PuDfXz/JyMg9hYQEPomIiL3JyMg9u7q6vs3MTD65uLg9//7+Ppuamj7a2Vm/kI8Pv5ybGz+Miws/pKMjP6inJ7///v6+4N9fv7Oysj6fnp6+AACAv4qJCb/19HS+3NtbP8vKyj7l5GQ+mJcXP+3sbL65uLi91NNTv9zbWz+1tDQ+4N9fP8nIyD2FhAQ+iYiIvQ==",
+      "vectorSha256": "4f70410ffb14a5a8a92611333a7ebf11481f57f6cec44688c6b80dcd30bffd44",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8c51998bbfa61338cdc5d12c4010ac58003b61edb29ccb627416ed96ef8c9077",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0272": {
+      "vector": "9vV1P/j3d7/GxUW/z87OPpWUFD63trY+09LSPquqqj7w72+/4N9fv8jHR7/Ew0O/iokJP/j3d7+gnx+/vbw8vomIiL3R0FC9/fx8vpKREb+2tTU/t7a2vtPS0r7n5uY+trU1P8/Ozj6pqKg9k5KSvuLhYT+Ylxe/qqkpP6WkJL729XU/+Pd3v8bFRb/Pzs4+lZQUPre2tj7T0tI+q6qqPvDvb7/g31+/yMdHv8TDQ7+KiQk/+Pd3v6CfH7+9vDy+iYiIvdHQUL39/Hy+kpERv7a1NT+3tra+09LSvufm5j62tTU/z87OPqmoqD2TkpK+4uFhP5iXF7+qqSk/paQkvg==",
+      "vectorSha256": "fdba44555d4386ad08ed69765d3812c076792acabf1dd1011f7c38a544d9c346",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fa041db392adb4aa08101c1ec404306877796037da524bb9dab38a5bf034d46b",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0273": {
+      "vector": "x8bGvri3N7/FxES+0dBQvZmYmD3493e/wsFBP9rZWT/X1tY+h4aGPqmoqD3c21s/09LSvtDPT7/083O/1NNTP4OCgj7i4WE/o6Kivvv6+j7R0FA9u7q6vq2sLL77+vq+0M9PP87NTT+9vDw+z87Ovvf29j76+Xm/v76+vuno6D3Hxsa+uLc3v8XERL7R0FC9mZiYPfj3d7/CwUE/2tlZP9fW1j6HhoY+qaioPdzbWz/T0tK+0M9Pv/Tzc7/U01M/g4KCPuLhYT+joqK++/r6PtHQUD27urq+rawsvvv6+r7Qz08/zs1NP728PD7Pzs6+9/b2Pvr5eb+/vr6+6ejoPQ==",
+      "vectorSha256": "8c7ce7e2da24f7627b96c4e274602c5b04434a24944de2e081a4ca30a0df849f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4e2467798904e0ecb5a18aed4b1806e9a0f057be86516a41e7e6974cbd03508e",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0274": {
+      "vector": "4eDgvJaVFb+rqqq+v76+vsfGxj7f3t4+uLc3P5GQEL36+Xk/vLs7P+Hg4LzGxUW/0dBQPcfGxr7u7W2/mJcXP8jHRz/Hxsa+zcxMPo2MDL6hoKA8l5aWvpKRET/e3V0/8O9vv8HAQLzd3Fy+sbAwPaGgoLzEw0O/AACAP5WUFL7h4OC8lpUVv6uqqr6/vr6+x8bGPt/e3j64tzc/kZAQvfr5eT+8uzs/4eDgvMbFRb/R0FA9x8bGvu7tbb+Ylxc/yMdHP8fGxr7NzEw+jYwMvqGgoDyXlpa+kpERP97dXT/w72+/wcBAvN3cXL6xsDA9oaCgvMTDQ78AAIA/lZQUvg==",
+      "vectorSha256": "1849efdffd178a174735c6b3b2ec33597c470ff1b4f8d9d473b3c9262eb508a3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7c355550b1b7db7bfcdd7c1d864e09cbe34e996e825ac8ee087e64857d1eff6d",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0275": {
+      "vector": "xcREvpqZGT+Pjo6++Pd3v7GwML3l5GS+l5aWvufm5j6FhAS+q6qqPr28PL7Ix0e/n56evouKir4AAIA/6ulpP/r5eb/+/X2/9vV1P8PCwr6TkpK+rawsvpCPDz+enR2/y8rKPqempj6qqSk/wsFBv//+/r7n5uY+3t1dv+7tbT/FxES+mpkZP4+Ojr7493e/sbAwveXkZL6Xlpa+5+bmPoWEBL6rqqo+vbw8vsjHR7+fnp6+i4qKvgAAgD/q6Wk/+vl5v/79fb/29XU/w8LCvpOSkr6trCy+kI8PP56dHb/Lyso+p6amPqqpKT/CwUG///7+vufm5j7e3V2/7u1tPw==",
+      "vectorSha256": "93c3e75cd2501aa76282261bacc1b36746d5cc705860affe752e1dfd1f8239fd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "67cc5c047a635ab96faa681c585dfff40301fa4f5b6ac731b2a9d41f40b911f6",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0276": {
+      "vector": "+vl5v/n4+L3BwEC8y8rKPs3MTD7h4OA82djYPdva2j6urS2/zs1Nv6empj6mpSU/hoUFv6Oior6qqSm/rawsPsvKyj7l5GS+7Otrv7W0ND6NjAy+yMdHv9va2r6trCw+0M9PP93cXD7Lyso+7u1tv8LBQT+GhQU/+vl5P7q5Ob/6+Xm/+fj4vcHAQLzLyso+zcxMPuHg4DzZ2Ng929raPq6tLb/OzU2/p6amPqalJT+GhQW/o6KivqqpKb+trCw+y8rKPuXkZL7s62u/tbQ0Po2MDL7Ix0e/29ravq2sLD7Qz08/3dxcPsvKyj7u7W2/wsFBP4aFBT/6+Xk/urk5vw==",
+      "vectorSha256": "4abf7eec256fa08a1f58108e09616252359faf48ad4aeeee3048cea361e2466a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "03707eb299838db62919a9d23d572b95b2630a966e1c4995e79bb209e0c2fc23",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0277": {
+      "vector": "x8bGPo+Ojj7d3Fw+xMNDP6SjI7+DgoK+2djYPejnZz/w72+/rq0tP+7tbT+EgwO/9/b2vo6NDT+Ihwc/urk5P9zbW7+SkRG/u7q6Pu3sbD6vrq6+hYQEvouKir77+vo+9vV1P9va2j6joqI+jYwMvsLBQT+6uTk/h4aGPrKxMT/HxsY+j46OPt3cXD7Ew0M/pKMjv4OCgr7Z2Ng96OdnP/Dvb7+urS0/7u1tP4SDA7/39va+jo0NP4iHBz+6uTk/3Ntbv5KREb+7uro+7exsPq+urr6FhAS+i4qKvvv6+j729XU/29raPqOioj6NjAy+wsFBP7q5OT+HhoY+srExPw==",
+      "vectorSha256": "820d2b10e682fb1abb4ee4395ae0dbf030ef101400ab8130aeea1765a1552488",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b1a39be12e5f8df308d6f63e42c6c3dc1237ae9d546f5dbefab6a86ee0dca1d8",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0278": {
+      "vector": "oqEhv9va2r6DgoK+7exsPtLRUb+Ylxc/oqEhP42MDD6rqqo+2djYvcPCwr7My0s/6Odnv/v6+j7CwUE/3dxcPrW0NL6ioSG/6ulpP5GQEL25uLi9m5qavu3sbL7Avz+/kpERv9DPTz/Y11e/zcxMvsXERL7S0VE/y8rKPqyrK7+ioSG/29ravoOCgr7t7Gw+0tFRv5iXFz+ioSE/jYwMPquqqj7Z2Ni9w8LCvszLSz/o52e/+/r6PsLBQT/d3Fw+tbQ0vqKhIb/q6Wk/kZAQvbm4uL2bmpq+7exsvsC/P7+SkRG/0M9PP9jXV7/NzEy+xcREvtLRUT/Lyso+rKsrvw==",
+      "vectorSha256": "1b4a1b50e3d0d2e9f33bf032cbc057bcfe41c222a1b49c74fd37c83c68ed941a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2f495f9d17cbd091aa724fe50cbee09b692ff47b7459622037e7146667e8b22a",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0279": {
+      "vector": "9/b2vurpaT/S0VE/5+bmPsLBQb/h4OC89vV1P6alJT/HxsY+l5aWvpeWlj7s62u/qKcnP9nY2L3d3Fw+o6KiPsbFRb/c21s/iokJP+fm5r7//v6+7+7uvujnZ7/y8XE/nJsbv6uqqr7+/X0/urk5v6uqqr7JyMi9pKMjP42MDD739va+6ulpP9LRUT/n5uY+wsFBv+Hg4Lz29XU/pqUlP8fGxj6Xlpa+l5aWPuzra7+opyc/2djYvd3cXD6joqI+xsVFv9zbWz+KiQk/5+bmvv/+/r7v7u6+6Odnv/LxcT+cmxu/q6qqvv79fT+6uTm/q6qqvsnIyL2koyM/jYwMPg==",
+      "vectorSha256": "50f233a4d6d1a4ec1136c65787374e25bf6fb3f39adc0546abfaede6c4dc9c95",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "42f4e8b91f7cfad2b15aa50ad3729ba81dedc44640440cf83255fe235573d191",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0280": {
+      "vector": "lJMTP+LhYT+CgQG/hoUFP7m4uD3T0tK+xMNDv+Pi4r6VlBS+kpERP+jnZz/Ew0O/1dRUPpiXFz/k42O/k5KSPsLBQT/39vY+h4aGPvX0dD6Ylxe/s7KyPt/e3j60szO/8vFxP/z7ez/KyUm/0tFRv6+urj6JiIg929ravrKxMT+UkxM/4uFhP4KBAb+GhQU/ubi4PdPS0r7Ew0O/4+LivpWUFL6SkRE/6OdnP8TDQ7/V1FQ+mJcXP+TjY7+TkpI+wsFBP/f29j6HhoY+9fR0PpiXF7+zsrI+397ePrSzM7/y8XE//Pt7P8rJSb/S0VG/r66uPomIiD3b2tq+srExPw==",
+      "vectorSha256": "4039207ed9283837b5050ea8313f9bc4031f7869fe8e5b6bbdc2e6b20e18982a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c9f03fc28b4b1e476dc8f31e9acb0ea4e0bda19e34acb726f8fd1b17ab8849d8",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0281": {
+      "vector": "xcREvtrZWb/w728/s7KyvgAAgD+9vDy+v76+voWEBL6opyc/1tVVv+blZb/z8vI+lZQUvpybGz+joqI+sbAwPY+Ojr6KiQk/yslJv9XUVL7y8XE/mZiYvbCvLz+Pjo4+mZiYve/u7j6dnBy+y8rKvsjHRz/NzEy+3t1dP5STE7/FxES+2tlZv/Dvbz+zsrK+AACAP728PL6/vr6+hYQEvqinJz/W1VW/5uVlv/Py8j6VlBS+nJsbP6Oioj6xsDA9j46OvoqJCT/KyUm/1dRUvvLxcT+ZmJi9sK8vP4+Ojj6ZmJi97+7uPp2cHL7Lysq+yMdHP83MTL7e3V0/lJMTvw==",
+      "vectorSha256": "49a503b8254d6b1e23b425214f7257ce84e370da5aa59c0b8fb16de483927ee7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6713f753ff68506fd3150dbc6dcda8855cc41b65f876d7a376bb6c4de366ee36",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0282": {
+      "vector": "5ONjP8fGxr6enR0/mJcXP+no6L3i4WE/pKMjP4qJCT/h4OC8nZwcPsTDQ7+ZmJi9jIsLv7SzMz/o52e/x8bGPszLSz+2tTW//v19v8zLSz/Avz8/mZiYPZGQEL3g31+/5+bmPq6tLb+9vDw+wL8/P7i3N7/083M/lpUVP8jHRz/k42M/x8bGvp6dHT+Ylxc/6ejoveLhYT+koyM/iokJP+Hg4LydnBw+xMNDv5mYmL2Miwu/tLMzP+jnZ7/HxsY+zMtLP7a1Nb/+/X2/zMtLP8C/Pz+ZmJg9kZAQveDfX7/n5uY+rq0tv728PD7Avz8/uLc3v/Tzcz+WlRU/yMdHPw==",
+      "vectorSha256": "b45fc870a7dd14a0a2ba194fc5ffdba98ab630f83b85bc25c7a949746f25ad60",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f14ececb71f0d1c47c931e763ad90cb1e52501e5df897b10b92997df24f9cae3",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0283": {
+      "vector": "tLMzv4OCgj7w72+/qaiova6tLb+5uLg9hYQEPsC/Pz/d3Fw+r66uPtrZWT+lpCQ+8O9vv7q5OT/Hxsa+1dRUPtnY2D2mpSU/xcREPuLhYT+/vr6+5uVlv/r5eT/h4OA88/LyvrKxMT/y8XG/9vV1v769Pb+TkpI+4N9fP7e2tj60szO/g4KCPvDvb7+pqKi9rq0tv7m4uD2FhAQ+wL8/P93cXD6vrq4+2tlZP6WkJD7w72+/urk5P8fGxr7V1FQ+2djYPaalJT/FxEQ+4uFhP7++vr7m5WW/+vl5P+Hg4Dzz8vK+srExP/Lxcb/29XW/vr09v5OSkj7g318/t7a2Pg==",
+      "vectorSha256": "2c1e92de5a350b140c8ad5b386beba86ea5c11cdc752cc1afbb436969688c17d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "26a00875298b90df9babec9408dc4e9a8dd298f0500dfc8343d8070521a4efad",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0284": {
+      "vector": "xMNDP8HAQDzR0FA9//7+vsrJST+Pjo6+8O9vv5iXF7/U01O/q6qqvsXERL7o52e/gYCAO8PCwr6cmxu/9vV1v4SDA7/5+Pg9xMNDv9bVVb+0szO/mJcXP7Oysj6sqyu/o6KiPp6dHb+Miwu/s7KyPuDfXz+CgQE/q6qqvrOysj7Ew0M/wcBAPNHQUD3//v6+yslJP4+Ojr7w72+/mJcXv9TTU7+rqqq+xcREvujnZ7+BgIA7w8LCvpybG7/29XW/hIMDv/n4+D3Ew0O/1tVVv7SzM7+Ylxc/s7KyPqyrK7+joqI+np0dv4yLC7+zsrI+4N9fP4KBAT+rqqq+s7KyPg==",
+      "vectorSha256": "1183115e2c5e555c54125c72ba1ad9e2098e51bb9fa9f5a9480fe3db30c57d04",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e1818640e45c08341655670c804f32053e8f1e1526cbac2aa8313aacefc055ac",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0285": {
+      "vector": "nJsbP6+urj6/vr6+2tlZP6qpKb+2tTU/oaCgvNva2r7g31+/zMtLv9HQUL3w72+/lpUVP9/e3r78+3u/7OtrP8fGxr6WlRU/2djYPb69PT/y8XG/19bWvre2tj6mpSW/tLMzv/j3dz+sqyu/rawsvpmYmD3n5ua+h4aGvvj3dz+cmxs/r66uPr++vr7a2Vk/qqkpv7a1NT+hoKC829ravuDfX7/My0u/0dBQvfDvb7+WlRU/397evvz7e7/s62s/x8bGvpaVFT/Z2Ng9vr09P/Lxcb/X1ta+t7a2PqalJb+0szO/+Pd3P6yrK7+trCy+mZiYPefm5r6Hhoa++Pd3Pw==",
+      "vectorSha256": "d66b55e233d8bb3362bfc438da26e44a15207384b2a27f69d567f36986debf98",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cdab50ec2bda7d49101a7908ca4802f54eca8dde074aad2d26fb2a6a89465efb",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0286": {
+      "vector": "p6amPrm4uL2ZmJg98vFxP/b1dT/a2Vm//fx8Po6NDT+fnp6+s7KyvtLRUb+opye/j46OPpKRET+gnx8/4eDgPNDPT7+Hhoa+8vFxv4qJCb/7+vo+oqEhP66tLT+Qjw8/tLMzP+blZb/GxUU/AACAv5mYmD3b2tq+9fR0vqOior6npqY+ubi4vZmYmD3y8XE/9vV1P9rZWb/9/Hw+jo0NP5+enr6zsrK+0tFRv6inJ7+Pjo4+kpERP6CfHz/h4OA80M9Pv4eGhr7y8XG/iokJv/v6+j6ioSE/rq0tP5CPDz+0szM/5uVlv8bFRT8AAIC/mZiYPdva2r719HS+o6Kivg==",
+      "vectorSha256": "d58e3404b1ac36f3283ea8485e1da98e3680363b90f7c744c87151aafd46a825",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a97489f8fa139fc65853172ca3c8cf83185e073bbed0d6c7d90de20089496157",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0287": {
+      "vector": "np0dv93cXL7V1FQ+4uFhv7m4uD3083O/iYiIva2sLD7493c/1dRUvpWUFD729XW/trU1v4SDA7/JyMg929ravsLBQb/JyMg98fBwveno6L3v7u4+AACAP/v6+j6Lioo+hoUFP8/Ozj7k42M/wcBAvISDA7+/vr6+7OtrP5STE7+enR2/3dxcvtXUVD7i4WG/ubi4PfTzc7+JiIi9rawsPvj3dz/V1FS+lZQUPvb1db+2tTW/hIMDv8nIyD3b2tq+wsFBv8nIyD3x8HC96ejove/u7j4AAIA/+/r6PouKij6GhQU/z87OPuTjYz/BwEC8hIMDv7++vr7s62s/lJMTvw==",
+      "vectorSha256": "1cae1c78723dc11067756e1de945c11f7387bacb24f0ce2f82b099c866d63890",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "31649a0f8b067795fb659205253e8c491f8c7871bbffbea2c2b3f17e3e50f536",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0288": {
+      "vector": "urk5P5STE7/k42M/1dRUvqinJ7+ysTE/5ONjv/z7ez/8+3s/2NdXv6alJb+UkxO/kI8PP/n4+L3e3V0/mZiYPePi4j65uLg92tlZv+vq6j7n5ua+jIsLv93cXD6ioSE/9fR0vpuamj6HhoY+ubi4PejnZ7/o52c/mZiYPdHQUL26uTk/lJMTv+TjYz/V1FS+qKcnv7KxMT/k42O//Pt7P/z7ez/Y11e/pqUlv5STE7+Qjw8/+fj4vd7dXT+ZmJg94+LiPrm4uD3a2Vm/6+rqPufm5r6Miwu/3dxcPqKhIT/19HS+m5qaPoeGhj65uLg96Odnv+jnZz+ZmJg90dBQvQ==",
+      "vectorSha256": "fd43b77d6ba2e41d9308e621eaa0c5e8fb8061f310a96e81ec6f710708c13c08",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dc36f1652cd80efdfd142d36c770ee89b88b13ba463a9bd061a6a18b0cf38979",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0289": {
+      "vector": "p6amPvTzcz+CgQG/urk5P5STEz/9/Hy+zcxMPt7dXT/DwsK+1dRUvtDPT7+npqa+29raPpWUFL7v7u4+qKcnP46NDb/7+vo+zs1NP6KhIT+lpCS+0tFRv6+urj7U01M/kI8Pv8/Ozj7g31+/ubi4vfHwcD2qqSk/iokJv7u6ur6npqY+9PNzP4KBAb+6uTk/lJMTP/38fL7NzEw+3t1dP8PCwr7V1FS+0M9Pv6empr7b2to+lZQUvu/u7j6opyc/jo0Nv/v6+j7OzU0/oqEhP6WkJL7S0VG/r66uPtTTUz+Qjw+/z87OPuDfX7+5uLi98fBwPaqpKT+KiQm/u7q6vg==",
+      "vectorSha256": "d13eb80252681a98d22148b4775af34fba907167d5f1f50448c4f7182d6977ed",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a9f93fdcc96099ee4f651856b66dbbd339bee6d06b17abe938b3107487d43b51",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0290": {
+      "vector": "nZwcvoWEBD6Ylxe/x8bGvt7dXT/CwUE/x8bGvsrJST+GhQW/mZiYvYKBAb/Z2Ng96Odnv6+urr6sqys//v19P/Tzc7/S0VG/0dBQPfn4+L2BgIA7jYwMvvDvbz/W1VW/l5aWPoKBAb/KyUk/zs1NP5OSkr64tzc/iIcHP8nIyD2dnBy+hYQEPpiXF7/Hxsa+3t1dP8LBQT/Hxsa+yslJP4aFBb+ZmJi9goEBv9nY2D3o52e/r66uvqyrKz/+/X0/9PNzv9LRUb/R0FA9+fj4vYGAgDuNjAy+8O9vP9bVVb+XlpY+goEBv8rJST/OzU0/k5KSvri3Nz+Ihwc/ycjIPQ==",
+      "vectorSha256": "e0846cf7c9ed17c4279c43cbf5a7380e6847c3ab9be8d1f87155e90f8736c7de",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6c90344eeee04ee43d763f8d0c54d5fe06178670806ef715a53fe4e65bdbc38c",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0291": {
+      "vector": "+/r6vry7Oz+lpCS+urk5P52cHD7T0tI+zs1NP+jnZ7/v7u4+i4qKvu/u7j6zsrK+p6amPoaFBT/y8XG/q6qqvtzbWz+BgIA7qqkpv4uKir7y8XE/29raPpuamj7m5WW/6ejovfPy8j64tzc/8/LyvrOysr6vrq6+iIcHv6qpKT/7+vq+vLs7P6WkJL66uTk/nZwcPtPS0j7OzU0/6Odnv+/u7j6Lioq+7+7uPrOysr6npqY+hoUFP/Lxcb+rqqq+3NtbP4GAgDuqqSm/i4qKvvLxcT/b2to+m5qaPublZb/p6Oi98/LyPri3Nz/z8vK+s7Kyvq+urr6Ihwe/qqkpPw==",
+      "vectorSha256": "c4cae21aa2ce737859bcb7735ab610c2b5ae5cc966c4c5ce17597c401c123274",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "41dd6bdc93b4e60cbb5dbb53a9c20755ed802b5df8b6a60d71bcdb4353543cd4",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0292": {
+      "vector": "4uFhP7i3N7/X1tY+2NdXP9PS0r7z8vK+h4aGvq+urr7BwEC8wL8/P5uamj6dnBw+jIsLv+XkZL6npqa+mpkZP+zra7/29XU/hoUFv4uKij7083O/3dxcPo2MDL7Z2Ng97u1tP4OCgj7BwEA829raPsTDQz+UkxM///7+vuHg4Lzi4WE/uLc3v9fW1j7Y11c/09LSvvPy8r6Hhoa+r66uvsHAQLzAvz8/m5qaPp2cHD6Miwu/5eRkvqempr6amRk/7Otrv/b1dT+GhQW/i4qKPvTzc7/d3Fw+jYwMvtnY2D3u7W0/g4KCPsHAQDzb2to+xMNDP5STEz///v6+4eDgvA==",
+      "vectorSha256": "3d8aa5531aeb06d184761468645bc4eede4ebd892fb3fdf734168b3349a62d3e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f024b5eb4b435e547edfa6933a6356cc0afa3da2069b6e8df6a081b6e1c9407c",
+      "updatedAt": "2025-09-20T22:27:41.522Z"
+    },
+    "j-0293": {
+      "vector": "5eRkvqGgoDz7+vo+tbQ0PtjXVz+Pjo4+s7KyvtDPT7+cmxu/29raPtXUVL7My0u/nZwcPt/e3j6TkpK+7exsPp+enr6ysTE/z87OPu/u7r6cmxs/2NdXv5aVFb+SkRE/oaCgvOTjYz+VlBQ+ycjIvevq6j6Lioo+8fBwve/u7j7l5GS+oaCgPPv6+j61tDQ+2NdXP4+Ojj6zsrK+0M9Pv5ybG7/b2to+1dRUvszLS7+dnBw+397ePpOSkr7t7Gw+n56evrKxMT/Pzs4+7+7uvpybGz/Y11e/lpUVv5KRET+hoKC85ONjP5WUFD7JyMi96+rqPouKij7x8HC97+7uPg==",
+      "vectorSha256": "fb2c0dec8e4fda9788a61388a98ff23717de5055224fe6a16e7998c5a34873ab",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6382be96eba3531832b6651a93b75b9d58d8b344cd1435c87df19273baa278bb",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0294": {
+      "vector": "goEBv6GgoDycmxs/iIcHv4GAgDuWlRU/srExP5mYmD2joqI+qaiovZybG7+bmpq+1tVVP7a1NT+cmxs/4N9fP+no6D2BgIA78/LyPvPy8j6ZmJi9rawsPuTjYz/W1VU/4+LiPr28PL6KiQk/oJ8fP+7tbb++vT2/vr09P4uKij6CgQG/oaCgPJybGz+Ihwe/gYCAO5aVFT+ysTE/mZiYPaOioj6pqKi9nJsbv5uamr7W1VU/trU1P5ybGz/g318/6ejoPYGAgDvz8vI+8/LyPpmYmL2trCw+5ONjP9bVVT/j4uI+vbw8voqJCT+gnx8/7u1tv769Pb++vT0/i4qKPg==",
+      "vectorSha256": "5e878c6381e802e70193236f9456e13286b0c47140dcb1aeb15b5aa14bced900",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3f82cd3c80cad889a8753259eadacdef8e80bcbc7695f1eab868c4cf0921dea2",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0295": {
+      "vector": "k5KSvuDfXz///v6+r66uPvLxcT+sqyu/oqEhP/z7e7/w728/8vFxv7m4uL3t7Gw+x8bGvpuamj7m5WW/k5KSvpWUFD7R0FA9qaioPdrZWT+ioSE/k5KSvs/Ozj7My0u/8O9vP+no6L3d3Fy+paQkPrGwML3t7Gw+xMNDP7KxMb+TkpK+4N9fP//+/r6vrq4+8vFxP6yrK7+ioSE//Pt7v/Dvbz/y8XG/ubi4ve3sbD7Hxsa+m5qaPublZb+TkpK+lZQUPtHQUD2pqKg92tlZP6KhIT+TkpK+z87OPszLS7/w728/6ejovd3cXL6lpCQ+sbAwve3sbD7Ew0M/srExvw==",
+      "vectorSha256": "250cf913598f312db191c8430ebe8109eafe2bafe4bf4955942f91ebe871c58e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5bef40abf82ad002f707749d4ea60d5b92868aecd05bb31af77164947a9de127",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0296": {
+      "vector": "2NdXv7i3N7++vT0/hIMDv5OSkr7Z2Ng9gYCAO4SDAz/l5GQ+qqkpv6empr7FxEQ+/v19P46NDT/X1tY+4eDgvPn4+D2+vT0/vLs7v6SjI7/y8XE/+vl5v+TjYz/X1ta+lZQUPsPCwr69vDw+m5qavpiXFz/n5ua+m5qavri3N7/Y11e/uLc3v769PT+EgwO/k5KSvtnY2D2BgIA7hIMDP+XkZD6qqSm/p6amvsXERD7+/X0/jo0NP9fW1j7h4OC8+fj4Pb69PT+8uzu/pKMjv/LxcT/6+Xm/5ONjP9fW1r6VlBQ+w8LCvr28PD6bmpq+mJcXP+fm5r6bmpq+uLc3vw==",
+      "vectorSha256": "fdbb6adf8358abd6d41bad1fd57f4d9d656c6438ef973400b641c0d2aa4c5e42",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1424de3e5b8d80c19c2b5698fec6b57c8fde222ef803f14a924f9759cb465924",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0297": {
+      "vector": "1dRUvv/+/j7S0VE/6+rqPvb1db/h4OC88/LyPszLSz/R0FC9lZQUvp+enj7o52e/sK8vP4OCgj6gnx8/hYQEPvv6+j7Ix0c/4N9fv8/Ozr6pqKg97+7uPvn4+L3Avz8/2tlZv8XERD6rqqq+vLs7v8jHRz+urS0/5ONjP5STEz/V1FS+//7+PtLRUT/r6uo+9vV1v+Hg4Lzz8vI+zMtLP9HQUL2VlBS+n56ePujnZ7+wry8/g4KCPqCfHz+FhAQ++/r6PsjHRz/g31+/z87OvqmoqD3v7u4++fj4vcC/Pz/a2Vm/xcREPquqqr68uzu/yMdHP66tLT/k42M/lJMTPw==",
+      "vectorSha256": "e488a08fd3485f0386b26d9b9caa30cb31b76a471a13d2b2f0264360ae541f91",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "65bfe8ba057cbce5796da70cd7a0cf90bee3104c8abb70df13985522e3d6f1c9",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0298": {
+      "vector": "p6amPtTTUz/5+Pi92djYPfj3d7/f3t6+g4KCvq6tLT++vT0/mZiYPfPy8r7j4uI+3Ntbv6+urj7KyUm/goEBv/LxcT/BwEA8hoUFv7a1NT/X1ta+2tlZv+vq6r6ysTE/iIcHP/f29j7493e/+vl5v6inJz+rqqo+3t1dP+3sbL6npqY+1NNTP/n4+L3Z2Ng9+Pd3v9/e3r6DgoK+rq0tP769PT+ZmJg98/LyvuPi4j7c21u/r66uPsrJSb+CgQG/8vFxP8HAQDyGhQW/trU1P9fW1r7a2Vm/6+rqvrKxMT+Ihwc/9/b2Pvj3d7/6+Xm/qKcnP6uqqj7e3V0/7exsvg==",
+      "vectorSha256": "d5e1df1fc4694e52b246df86bb3f0ab9c042ed46494262912c0c7e01f7334215",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a9e9708d04485fd6de8943b812ab1b3ff8813dda4a1345d8c3bd0403d3aaee62",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0299": {
+      "vector": "qqkpv5CPDz/9/Hy+nJsbP/f29r7a2Vk/z87OvoiHB7+KiQk/nZwcPvb1dT/m5WU/+vl5v8PCwr7GxUU/rawsPpKREb+NjAw+9/b2PsTDQz+ZmJi95ONjv46NDb+Pjo4+7exsPpiXF7+npqY+mpkZv6CfH7/d3Fw+9vV1P/b1dT+qqSm/kI8PP/38fL6cmxs/9/b2vtrZWT/Pzs6+iIcHv4qJCT+dnBw+9vV1P+blZT/6+Xm/w8LCvsbFRT+trCw+kpERv42MDD739vY+xMNDP5mYmL3k42O/jo0Nv4+Ojj7t7Gw+mJcXv6empj6amRm/oJ8fv93cXD729XU/9vV1Pw==",
+      "vectorSha256": "8eaeffe71f70a975018df9cb44a8c05f7e936f7114ed79970b895452dde4d4a2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2bc760cd42ec4c3cc493faf2034fe2953791bde1760e39a39d34a933309bfafa",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0300": {
+      "vector": "s7Kyvuzra7/o52e/x8bGvrCvLz/c21s/3t1dP7m4uD3V1FQ+p6amPv/+/j6fnp4+lZQUPri3Nz/7+vq+397evv38fL6wry8/xcREPpiXF7/a2Vm/6+rqvra1NT+Miwu/3dxcvuHg4DzMy0u/vbw8vqCfH7/Ew0M//Pt7v42MDD6zsrK+7Otrv+jnZ7/Hxsa+sK8vP9zbWz/e3V0/ubi4PdXUVD6npqY+//7+Pp+enj6VlBQ+uLc3P/v6+r7f3t6+/fx8vrCvLz/FxEQ+mJcXv9rZWb/r6uq+trU1P4yLC7/d3Fy+4eDgPMzLS7+9vDy+oJ8fv8TDQz/8+3u/jYwMPg==",
+      "vectorSha256": "2a99ea58b47a3f047f03b96f702c66f99c29097c9214d38d3f13c55b00fd2992",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "530a0c4ed7edee8b9aa9bfa792db414860d798341345da3a64831a6830e10291",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0301": {
+      "vector": "5uVlv+zra7+Ihwe/1NNTv8C/Pz+2tTW/gYCAO/LxcT+Qjw8/6+rqPpKREb+Qjw8/sbAwvcLBQb/FxES+/fx8PqGgoLzR0FC9urk5P8/Ozr7s62s/pqUlv4SDAz/f3t4+kZAQvdbVVb+fnp4+2NdXP9TTUz+ZmJg91NNTv9DPT7/m5WW/7Otrv4iHB7/U01O/wL8/P7a1Nb+BgIA78vFxP5CPDz/r6uo+kpERv5CPDz+xsDC9wsFBv8XERL79/Hw+oaCgvNHQUL26uTk/z87Ovuzraz+mpSW/hIMDP9/e3j6RkBC91tVVv5+enj7Y11c/1NNTP5mYmD3U01O/0M9Pvw==",
+      "vectorSha256": "bdffae2316667ddc7641cd1a575616be2c62df41f73636648583f4248b1175e5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0d0a3c16df2580f8c7ba37c77a1f679f7d79dc4cf52dc1b77b15a7ebe9891618",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0302": {
+      "vector": "tLMzP+vq6r7a2Vm/hIMDv+LhYT+amRm/4eDgPKinJz+Miwu/gYCAu4KBAb/f3t6+2tlZP8HAQLyTkpI+paQkPpSTEz+WlRU/vLs7P728PL6ioSE/g4KCvsPCwr7y8XE/xsVFv9fW1r6/vr4+m5qaPs/Ozr6vrq4+q6qqPvv6+r60szM/6+rqvtrZWb+EgwO/4uFhP5qZGb/h4OA8qKcnP4yLC7+BgIC7goEBv9/e3r7a2Vk/wcBAvJOSkj6lpCQ+lJMTP5aVFT+8uzs/vbw8vqKhIT+DgoK+w8LCvvLxcT/GxUW/19bWvr++vj6bmpo+z87Ovq+urj6rqqo++/r6vg==",
+      "vectorSha256": "dfdf0a1165621ba1a2f6e53dd1ebcde83fa7c5f742830b330887d7d6024ca7e6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d945133ef03383d33a7f3f48ec7ea494c9cadd68d05f4ff81d4aafa64cabaa41",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0303": {
+      "vector": "5+bmPsvKyj7Y11c/4uFhv769PT/x8HA94N9fv/HwcL2KiQk/yMdHv6inJz+FhAQ+4eDgPNnY2D2urS2/iokJv6WkJL7l5GQ+goEBv56dHT+enR0/1tVVP6Oioj6SkRE/q6qqPvHwcD3Ix0c/5uVlP7SzMz/NzEw+5+bmPsjHRz/n5uY+y8rKPtjXVz/i4WG/vr09P/HwcD3g31+/8fBwvYqJCT/Ix0e/qKcnP4WEBD7h4OA82djYPa6tLb+KiQm/paQkvuXkZD6CgQG/np0dP56dHT/W1VU/o6KiPpKRET+rqqo+8fBwPcjHRz/m5WU/tLMzP83MTD7n5uY+yMdHPw==",
+      "vectorSha256": "ba8a75e3c4132a0fa2039448522bb0c8d78bf02f96860db064f940cba0e9ca85",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b9b2eb0fde871078c41cd390838d293b6b9c3fceceeaa8c8aa87e3f2d999b9e3",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0304": {
+      "vector": "vr09P7q5OT8AAIA/4eDgPNfW1r77+vo+5eRkvvPy8j6WlRW/1NNTP/z7ez/s62s/rq0tv9/e3j7v7u6+5uVlv6yrKz/8+3s/urk5v/v6+j7BwEA82djYPf/+/r7s62u/oqEhP7SzMz+NjAw+lZQUvv/+/r6dnBy+//7+vqmoqL2+vT0/urk5PwAAgD/h4OA819bWvvv6+j7l5GS+8/LyPpaVFb/U01M//Pt7P+zraz+urS2/397ePu/u7r7m5WW/rKsrP/z7ez+6uTm/+/r6PsHAQDzZ2Ng9//7+vuzra7+ioSE/tLMzP42MDD6VlBS+//7+vp2cHL7//v6+qaiovQ==",
+      "vectorSha256": "1b2c134b32d9d8ca42a0c0e8132786f1810346696dab7db82ae02bd4c0d42ab9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dedcff834abe63bc35e9fdf529b7440dd5fd23be818d400ad0d9916d406c4075",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0305": {
+      "vector": "mZiYPbSzMz/CwUE/jYwMPq+urj67urq+vbw8vvLxcb/7+vo+iIcHv4SDA7+koyM/k5KSvsPCwr7s62s/lpUVv9XUVL7r6uo+2djYvfj3dz+ioSG/qKcnP/n4+L2sqyu/sbAwPZiXFz/v7u6+7u1tP5CPDz/s62u/5eRkvu3sbL6ZmJg9tLMzP8LBQT+NjAw+r66uPru6ur69vDy+8vFxv/v6+j6Ihwe/hIMDv6SjIz+TkpK+w8LCvuzraz+WlRW/1dRUvuvq6j7Z2Ni9+Pd3P6KhIb+opyc/+fj4vayrK7+xsDA9mJcXP+/u7r7u7W0/kI8PP+zra7/l5GS+7exsvg==",
+      "vectorSha256": "18dc55fb145dbd89248a9023b26155dc3f9d49a2cdf14cad472b06fdc8561a98",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "89d9e091ab516807be3c3ed15b4ff53565ba72fb2fd3702a85cb44f6c70a6362",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0306": {
+      "vector": "1tVVP5iXFz/j4uK+3t1dP9jXVz+gnx8/pqUlP8nIyL3R0FC929ravtrZWT+koyO/sbAwva+urr6Hhoa+2NdXv7y7Oz+5uLg9gYCAO/r5eb/d3Fy+qqkpv7a1NT/+/X0/wL8/v5mYmL2dnBy+rKsrP+blZb+bmpo+l5aWvoyLCz/W1VU/mJcXP+Pi4r7e3V0/2NdXP6CfHz+mpSU/ycjIvdHQUL3b2tq+2tlZP6SjI7+xsDC9r66uvoeGhr7Y11e/vLs7P7m4uD2BgIA7+vl5v93cXL6qqSm/trU1P/79fT/Avz+/mZiYvZ2cHL6sqys/5uVlv5uamj6Xlpa+jIsLPw==",
+      "vectorSha256": "716908c6a7fd515a60146cbf823a8da2d720fab301e06150a85d1cdde5915254",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "eacb47eeebcfd2737949ec2e7a545e14dd8b8003642bdafe20766cd50da65ac5",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0307": {
+      "vector": "mJcXv62sLD7Ew0O/29raPsXERL7My0u/5ONjP9rZWb+KiQk/6ulpP9/e3j6FhAQ+397ePrOysr6qqSk/zMtLv66tLb+Miws/lJMTP8rJST/JyMg91dRUPr++vj68uzs/9/b2vpeWlj7Qz0+/ycjIveno6D2VlBS+qaioPeTjY7+Ylxe/rawsPsTDQ7/b2to+xcREvszLS7/k42M/2tlZv4qJCT/q6Wk/397ePoWEBD7f3t4+s7KyvqqpKT/My0u/rq0tv4yLCz+UkxM/yslJP8nIyD3V1FQ+v76+Pry7Oz/39va+l5aWPtDPT7/JyMi96ejoPZWUFL6pqKg95ONjvw==",
+      "vectorSha256": "4ca0c4968d9213d4f6b544185ad34052ddecc364af457e2950d8de37798e90cc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "34951eb6671af113c4f4b790b753d41a29c5c9e48c9aafdd42a518738e6d8a0e",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0308": {
+      "vector": "srExv/r5eT/o52c/hoUFv6yrKz+JiIi9oJ8fP6uqqj6Hhoa+ycjIvZmYmL3j4uI+uLc3v/Dvbz/HxsY+19bWPuHg4Lzb2to+09LSvsC/Pz+BgIC7qaiovY+Ojj6sqyu/w8LCvqSjI7/Ix0e/srExP+jnZz+trCy+7u1tv9bVVT+ysTG/+vl5P+jnZz+GhQW/rKsrP4mIiL2gnx8/q6qqPoeGhr7JyMi9mZiYvePi4j64tze/8O9vP8fGxj7X1tY+4eDgvNva2j7T0tK+wL8/P4GAgLupqKi9j46OPqyrK7/DwsK+pKMjv8jHR7+ysTE/6OdnP62sLL7u7W2/1tVVPw==",
+      "vectorSha256": "54b304f219827bf896902775f3196d312dd6b4555c101b73038f9681bf21032f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "27fcf33dd577cfaa5e7376b824f7b1b57cb64bdf7f75a32a4f2e1cd8f36a09ea",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0309": {
+      "vector": "5+bmPrSzMz+rqqo+gYCAO5eWlr7HxsY+rq0tP9rZWT+amRm/4uFhv9nY2D2wry8/m5qavry7O7+Pjo6+//7+PvX0dD739va+hIMDv4iHBz+KiQm/1tVVP8fGxr6HhoY+gYCAu+jnZ7/29XW/qaiovcjHR7///v6+zs1NP8LBQT/n5uY+tLMzP6uqqj6BgIA7l5aWvsfGxj6urS0/2tlZP5qZGb/i4WG/2djYPbCvLz+bmpq+vLs7v4+Ojr7//v4+9fR0Pvf29r6EgwO/iIcHP4qJCb/W1VU/x8bGvoeGhj6BgIC76Odnv/b1db+pqKi9yMdHv//+/r7OzU0/wsFBPw==",
+      "vectorSha256": "f1e13cda2d4c0be9ef62a18209e2ee4b2c48e9d93797de27740a58be69088b92",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b9d9aa805ab1d6ec330f8dd759225cbf9e423ec33bea4ea17f0c05751c40e6e0",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0310": {
+      "vector": "/v19v4SDAz/BwEA8iYiIvf/+/r6koyM/srExv8PCwr7k42O/qqkpv6empj7GxUU/vr09v8C/Pz///v4+/fx8Puno6L3s62s/j46Ovrq5Ob/q6Wm/sbAwPayrKz+XlpY++vl5P9nY2D2opye/6OdnP9fW1r6hoKC8/Pt7P4qJCT/+/X2/hIMDP8HAQDyJiIi9//7+vqSjIz+ysTG/w8LCvuTjY7+qqSm/p6amPsbFRT++vT2/wL8/P//+/j79/Hw+6ejovezraz+Pjo6+urk5v+rpab+xsDA9rKsrP5eWlj76+Xk/2djYPainJ7/o52c/19bWvqGgoLz8+3s/iokJPw==",
+      "vectorSha256": "150ef8fe51ce08bdb3b5fbfde2796679e73bfb60814844957d20e169f06c0861",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "01c1817740d1274f0e2ba9e221dfbf9f71f55c230b85d5a5fc8d2cf34a7dfdc4",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0311": {
+      "vector": "rq0tv+XkZL60szM/yslJv/z7ez+gnx+/sK8vP7CvL7+BgIC7lJMTP9DPTz+OjQ0/lJMTP4qJCb/e3V2/xMNDv5uamr6sqyu/lZQUvoSDAz/q6Wk/s7KyPr++vr61tDS+w8LCvs7NTb/29XU/0dBQPeblZb+Ylxe/3t1dP9LRUb+urS2/5eRkvrSzMz/KyUm//Pt7P6CfH7+wry8/sK8vv4GAgLuUkxM/0M9PP46NDT+UkxM/iokJv97dXb/Ew0O/m5qavqyrK7+VlBS+hIMDP+rpaT+zsrI+v76+vrW0NL7DwsK+zs1Nv/b1dT/R0FA95uVlv5iXF7/e3V0/0tFRvw==",
+      "vectorSha256": "d2530b3c68c64b3ba1e1306e73d5d46696cb8d8d1ce3c28a8911c35853f87d53",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2963d91bfd30d7287fc9e7c6c93b111e592a6dc1f4ac50694f19fa860d34ee17",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0312": {
+      "vector": "2tlZv5CPDz/My0s/qaioPerpaT/Ew0O/mZiYPc7NTT/39vY+8fBwvcXERL7BwEC8gYCAu4WEBD7Qz0+/urk5P4qJCb///v6+mpkZP7e2tr6ysTG/pKMjP6empr7Lyso+2NdXv/v6+j77+vo+qKcnP9zbWz8AAIC/wcBAPPb1dT/a2Vm/kI8PP8zLSz+pqKg96ulpP8TDQ7+ZmJg9zs1NP/f29j7x8HC9xcREvsHAQLyBgIC7hYQEPtDPT7+6uTk/iokJv//+/r6amRk/t7a2vrKxMb+koyM/p6amvsvKyj7Y11e/+/r6Pvv6+j6opyc/3NtbPwAAgL/BwEA89vV1Pw==",
+      "vectorSha256": "47f48d18f699501be81b02d3112fd401ad636142197ae9a4c40e14fe80ccbe41",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "13c7e58af41e89e6bd78677e7f9018dc3b40cc5227d156b214bebed3ed0081fa",
+      "updatedAt": "2025-09-20T22:27:41.523Z"
+    },
+    "j-0313": {
+      "vector": "zcxMPu7tbb+CgQG/qqkpv66tLT+3tra+4eDgvK+urr6UkxO/j46OPvz7e7+1tDQ+rq0tP5uamj6TkpI+7u1tP6Oioj68uzs/8vFxP5OSkj6urS2/oaCgPNzbWz/w72+/xsVFP6WkJD7Y11e/6ulpP+XkZD63trY+uLc3P8HAQLzNzEw+7u1tv4KBAb+qqSm/rq0tP7e2tr7h4OC8r66uvpSTE7+Pjo4+/Pt7v7W0ND6urS0/m5qaPpOSkj7u7W0/o6KiPry7Oz/y8XE/k5KSPq6tLb+hoKA83NtbP/Dvb7/GxUU/paQkPtjXV7/q6Wk/5eRkPre2tj64tzc/wcBAvA==",
+      "vectorSha256": "b32c4001ab08a6b979b40c8f40eca41784aea030800d66c2b9425ebc870e1955",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "99093f2bd6527c5436a30296d6a6a4f6a8ddf8a42982ed08e29414f49caddb7e",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0314": {
+      "vector": "i4qKPri3N7+CgQG/uLc3v8bFRb/29XW/g4KCvrq5Ob/Ix0c/7+7uPqyrK7/f3t4+7exsvp+enj7Pzs4+mpkZP8HAQLzx8HC9+Pd3P5+enj6cmxu/8/LyPqSjI7+zsrK+z87OvpKREb+zsrK+4+LivtfW1r6BgIC7kpERv4uKir6Lioo+uLc3v4KBAb+4tze/xsVFv/b1db+DgoK+urk5v8jHRz/v7u4+rKsrv9/e3j7t7Gy+n56ePs/Ozj6amRk/wcBAvPHwcL3493c/n56ePpybG7/z8vI+pKMjv7Oysr7Pzs6+kpERv7Oysr7j4uK+19bWvoGAgLuSkRG/i4qKvg==",
+      "vectorSha256": "298f12547050c7e2a462859fa83bf0029b768b3e2da5af7f8a4b677866931aef",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a2243f241d055f23e3bb2ab762a7b3cc7e78fba732bc2e534c3753474a7f375d",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0315": {
+      "vector": "oJ8fv7y7Oz/BwEC8hIMDv6GgoDyioSG/x8bGvsLBQT+zsrK+29ravu3sbL6Lioo+/Pt7v/Tzcz/KyUk/s7KyvtHQUL3a2Vk/qaioPYeGhr6FhAQ+uLc3P+jnZ7+ioSE/jYwMPvn4+L2xsDC91dRUPpeWlj6SkRE/xsVFv+XkZD6gnx+/vLs7P8HAQLyEgwO/oaCgPKKhIb/Hxsa+wsFBP7Oysr7b2tq+7exsvouKij78+3u/9PNzP8rJST+zsrK+0dBQvdrZWT+pqKg9h4aGvoWEBD64tzc/6Odnv6KhIT+NjAw++fj4vbGwML3V1FQ+l5aWPpKRET/GxUW/5eRkPg==",
+      "vectorSha256": "9d4c6fb748091186ccb06bc005c0e9934ca92b6b5d77ab855c15ad34c9ae9d36",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "30dd7e3e822f4ee0534962a202f9e45379ec8a5e90db0cd091707a9aa5c81d9c",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0316": {
+      "vector": "pKMjv+Hg4Lzr6uo+m5qaPr69Pb+OjQ0/k5KSvsrJSb/s62u/mZiYPaKhIT///v4+yslJP6SjIz/BwEA8w8LCvuLhYb/m5WW/u7q6vqWkJD7493c/397ePr++vr7u7W2//v19P769PT/R0FA9kI8PP+no6L3g31+/hoUFP+zra7+koyO/4eDgvOvq6j6bmpo+vr09v46NDT+TkpK+yslJv+zra7+ZmJg9oqEhP//+/j7KyUk/pKMjP8HAQDzDwsK+4uFhv+blZb+7urq+paQkPvj3dz/f3t4+v76+vu7tbb/+/X0/vr09P9HQUD2Qjw8/6ejoveDfX7+GhQU/7Otrvw==",
+      "vectorSha256": "f33f2c736771776332be3a95941b313cef7ae5c2255fc852294ab50aca1ef678",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2e7cbaa621c65b1b0a89d0bfe4d1814f0f0d5194fbb75009fede86c77110c20a",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0317": {
+      "vector": "hoUFv5ybG7+mpSW/nJsbv7++vr64tzc/oJ8fP5WUFD6TkpI+3NtbP6qpKT+Pjo6+np0dP7SzMz+0szO/4eDgPKinJ7+cmxu/6ejoPYmIiD3FxEQ+yslJv/79fT/q6Wk/x8bGPqyrKz+gnx+/mJcXv/79fb+trCy+sK8vP9nY2L2GhQW/nJsbv6alJb+cmxu/v76+vri3Nz+gnx8/lZQUPpOSkj7c21s/qqkpP4+Ojr6enR0/tLMzP7SzM7/h4OA8qKcnv5ybG7/p6Og9iYiIPcXERD7KyUm//v19P+rpaT/HxsY+rKsrP6CfH7+Ylxe//v19v62sLL6wry8/2djYvQ==",
+      "vectorSha256": "a278be6d7f5fa994007aea3bafb895c737e9752041efc6aa5f13363fea8b6d7f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3d322d3250dbcf92a4edd45cced926832c328e88981bfef4b1d53034016ad772",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0318": {
+      "vector": "7exsvtrZWT/o52c/g4KCvpSTE7++vT0/sK8vv8vKyr7CwUE/nZwcPoqJCb+FhAQ+l5aWPtfW1r7W1VW/goEBv4mIiL2WlRU/6Odnv6+urj7FxES+zMtLv87NTb/n5uY++fj4PerpaT+npqY+/fx8vra1NT+mpSW/h4aGvr28PL7t7Gy+2tlZP+jnZz+DgoK+lJMTv769PT+wry+/y8rKvsLBQT+dnBw+iokJv4WEBD6XlpY+19bWvtbVVb+CgQG/iYiIvZaVFT/o52e/r66uPsXERL7My0u/zs1Nv+fm5j75+Pg96ulpP6empj79/Hy+trU1P6alJb+Hhoa+vbw8vg==",
+      "vectorSha256": "73aecf9575100e174f07f570ca2f995b3e2ecf63e8a30a512ee0ea9a45c1e4e7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "62ecf35f36de284de0933b90a54a153f77ca0cab671a19b98ff4a960da2d5e68",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0319": {
+      "vector": "jIsLv6Oioj6joqK+AACAv/b1db+9vDw+kZAQPefm5r6amRm/nJsbP+DfXz+3tra+rKsrP8fGxj7n5uY+goEBP4WEBL7e3V2/8vFxP4aFBT/Y11c/6ejovcrJSb+TkpI+zs1NP7SzMz+zsrK+lpUVP5STEz/U01O/9fR0Ps/Ozr6Miwu/o6KiPqOior4AAIC/9vV1v728PD6RkBA95+bmvpqZGb+cmxs/4N9fP7e2tr6sqys/x8bGPufm5j6CgQE/hYQEvt7dXb/y8XE/hoUFP9jXVz/p6Oi9yslJv5OSkj7OzU0/tLMzP7Oysr6WlRU/lJMTP9TTU7/19HQ+z87Ovg==",
+      "vectorSha256": "44c70f301400221012f4171f0e1d7fec286f96a437f33b990ed7ef26f8027cb4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3aa857000597844633cdef52d5b1b9c06f11f8c2eb711ba4e6d953cac9169e4c",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0320": {
+      "vector": "/fx8vpaVFT/g31+/nZwcvqCfH7+Qjw+/s7KyPuvq6r6vrq6+0dBQvbe2tj6CgQG/6ejovayrKz/X1tY+5ONjv66tLT+EgwO/vLs7P93cXD7KyUk/qaioPYmIiL26uTm/nZwcvoSDA7/OzU0/k5KSPoSDAz/p6Oi97+7uvpOSkj79/Hy+lpUVP+DfX7+dnBy+oJ8fv5CPD7+zsrI+6+rqvq+urr7R0FC9t7a2PoKBAb/p6Oi9rKsrP9fW1j7k42O/rq0tP4SDA7+8uzs/3dxcPsrJST+pqKg9iYiIvbq5Ob+dnBy+hIMDv87NTT+TkpI+hIMDP+no6L3v7u6+k5KSPg==",
+      "vectorSha256": "faedfcd3b6a92fbb1eb10757befb865a0cabef97de00efae84c99c5197af23b8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "60ca106c3038ac455479ad3f71d5b50ed63edd9be48a77236c3ee6a4c17144a4",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0321": {
+      "vector": "pKMjv5ybG7/y8XE/lpUVP/j3d7+gnx8/urk5v52cHL7BwEA8tLMzv4mIiL3o52e/oJ8fv8rJST+UkxO/vLs7v6uqqj6EgwO/goEBv+Pi4r78+3s/8fBwvbGwMD2ZmJg9oaCgvMvKyj6OjQ0/l5aWPomIiL2opye/v76+Pri3N7+koyO/nJsbv/LxcT+WlRU/+Pd3v6CfHz+6uTm/nZwcvsHAQDy0szO/iYiIvejnZ7+gnx+/yslJP5STE7+8uzu/q6qqPoSDA7+CgQG/4+Livvz7ez/x8HC9sbAwPZmYmD2hoKC8y8rKPo6NDT+XlpY+iYiIvainJ7+/vr4+uLc3vw==",
+      "vectorSha256": "304c72c2f74866ecd4c1743fb947495b186547f140c705d97d46de6f1fe516ba",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2e32f8ca04cf236c8126770c30e43622aa3e3f47fd7885897db2c6a5772caf24",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0322": {
+      "vector": "mZiYvaSjIz/y8XE/vLs7v/j3d7+DgoI+iYiIPe7tbT+2tTW/z87Ovvz7ez/w72+/r66uvujnZz/c21u/p6amPsPCwj7x8HC9oJ8fP7i3N7/v7u6+8fBwvfz7e7/k42O/zs1NP+3sbD7i4WE/x8bGvoKBAb+Qjw8/x8bGvsHAQLyZmJi9pKMjP/LxcT+8uzu/+Pd3v4OCgj6JiIg97u1tP7a1Nb/Pzs6+/Pt7P/Dvb7+vrq6+6OdnP9zbW7+npqY+w8LCPvHwcL2gnx8/uLc3v+/u7r7x8HC9/Pt7v+TjY7/OzU0/7exsPuLhYT/Hxsa+goEBv5CPDz/Hxsa+wcBAvA==",
+      "vectorSha256": "8b45898f7eb338b4a0166f094a6d5e9e90268b9463bc9678b5a16083a5c68350",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "76d1f82204a088f6254cfd0854f312a9b078cf244478020ee69df04e3fc74e7e",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0323": {
+      "vector": "qKcnP7W0NL6WlRW/tbQ0vqWkJD7NzEy+kpERv+3sbL7KyUk/iokJv9TTUz/j4uK+vr09P+XkZD7t7Gw+/v19v/Lxcb+/vr6+u7q6Pru6uj6bmpq+yslJP8XERL76+Xm/1tVVP5STE7/t7Gy+iYiIvePi4j729XU/oqEhP/HwcL2opyc/tbQ0vpaVFb+1tDS+paQkPs3MTL6SkRG/7exsvsrJST+KiQm/1NNTP+Pi4r6+vT0/5eRkPu3sbD7+/X2/8vFxv7++vr67uro+u7q6Ppuamr7KyUk/xcREvvr5eb/W1VU/lJMTv+3sbL6JiIi94+LiPvb1dT+ioSE/8fBwvQ==",
+      "vectorSha256": "40963a47f0c1966fc31945c5dda12b9cb5b52f8ddfdffa04e0679e7884685132",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d369356994663762e43be947de9c9d010750aeae59e46703ea366277b8fad078",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0324": {
+      "vector": "5uVlv4mIiL21tDS+pqUlP5CPDz/W1VW/m5qavublZT/DwsI+wL8/v7u6ur65uLi9mpkZP5ybG7+WlRU/np0dP9fW1j7JyMi97+7uvpybG7+npqa+ycjIPe3sbL7l5GS+/Pt7v7y7O7/OzU2/k5KSvpmYmL2fnp6+kI8Pv5WUFL7m5WW/iYiIvbW0NL6mpSU/kI8PP9bVVb+bmpq+5uVlP8PCwj7Avz+/u7q6vrm4uL2amRk/nJsbv5aVFT+enR0/19bWPsnIyL3v7u6+nJsbv6empr7JyMg97exsvuXkZL78+3u/vLs7v87NTb+TkpK+mZiYvZ+enr6Qjw+/lZQUvg==",
+      "vectorSha256": "0e23129219a5b74c81d3dfd6bde7085c097a8222601698c527c408d87f2d2b2c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0d7769d2c71559f2b0205174cc32caceb5734432568c62630222195b7658386d",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0325": {
+      "vector": "+/r6PoSDAz/V1FQ+5ONjP728PL6bmpq+pqUlv6+urj719HS+0dBQPaSjIz/j4uI+7+7uPvr5eT+NjAw++fj4vZiXFz+qqSk/+Pd3P+zra7/W1VW/wcBAvMXERD6amRk/qKcnP9/e3j7Avz8/rq0tP/b1db+mpSW/ubi4vb28PL77+vo+hIMDP9XUVD7k42M/vbw8vpuamr6mpSW/r66uPvX0dL7R0FA9pKMjP+Pi4j7v7u4++vl5P42MDD75+Pi9mJcXP6qpKT/493c/7Otrv9bVVb/BwEC8xcREPpqZGT+opyc/397ePsC/Pz+urS0/9vV1v6alJb+5uLi9vbw8vg==",
+      "vectorSha256": "e67c6a8c74784d69a116a7b443dee6a2115b5d7ef08dc363dede6630ce50d706",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bec19af168592dab6186d1b8bbfc9170cbd4fb0a157e98ccd3b7dfd6052d7468",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0326": {
+      "vector": "rKsrv4aFBT/+/X0/2tlZv/X0dL7b2to+oqEhv4eGhr7b2to+8vFxP5WUFD7Lysq+hoUFP728PL7GxUW/mJcXv6uqqj6RkBC94eDgPMnIyD28uzu/3Ntbv93cXL6ZmJi9oJ8fv9XUVL6dnBy+oJ8fP/79fT/g318/0M9PP5qZGb+sqyu/hoUFP/79fT/a2Vm/9fR0vtva2j6ioSG/h4aGvtva2j7y8XE/lZQUPsvKyr6GhQU/vbw8vsbFRb+Ylxe/q6qqPpGQEL3h4OA8ycjIPby7O7/c21u/3dxcvpmYmL2gnx+/1dRUvp2cHL6gnx8//v19P+DfXz/Qz08/mpkZvw==",
+      "vectorSha256": "902866244b4dfe7da1e7d6851049eb0bbb86f466812eec7b87f394199dcaaccb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2ac2fe1361b62f5eb6f8924dc2681d34aa7b838c2212647630656ccffeefe733",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0327": {
+      "vector": "/fx8vpybGz+NjAw+iYiIPZuamj6hoKA81tVVP6uqqj7l5GQ+jo0Nv9nY2D3JyMg97u1tv52cHL7BwEA8m5qaPry7Oz+gnx+/trU1P66tLb+KiQk/rawsvpuamr6BgIC7j46Ovr69Pb/BwEA8n56evuTjY7+SkRG/m5qavvv6+j79/Hy+nJsbP42MDD6JiIg9m5qaPqGgoDzW1VU/q6qqPuXkZD6OjQ2/2djYPcnIyD3u7W2/nZwcvsHAQDybmpo+vLs7P6CfH7+2tTU/rq0tv4qJCT+trCy+m5qavoGAgLuPjo6+vr09v8HAQDyfnp6+5ONjv5KREb+bmpq++/r6Pg==",
+      "vectorSha256": "3c6df1e3a920b320eba10e333bae4a67e1ff919bc9c26f18d4ad7eed173427ed",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "60cd9188a682eaaa9c398d8c096c81a6dd30da29c46a597f5c2181580e3759be",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0328": {
+      "vector": "+fj4Pfb1db+Hhoa+1NNTv5WUFL7y8XG/vbw8PtXUVD6hoKA89/b2PpCPDz/Avz8/7u1tP9nY2L319HS+4+LiPpqZGb/x8HC9+/r6vtnY2L2KiQm/z87OPuDfX7/5+Pi95eRkvt3cXD7Z2Ni9nJsbv728PL67urq+mpkZP4eGhj75+Pg99vV1v4eGhr7U01O/lZQUvvLxcb+9vDw+1dRUPqGgoDz39vY+kI8PP8C/Pz/u7W0/2djYvfX0dL7j4uI+mpkZv/HwcL37+vq+2djYvYqJCb/Pzs4+4N9fv/n4+L3l5GS+3dxcPtnY2L2cmxu/vbw8vru6ur6amRk/h4aGPg==",
+      "vectorSha256": "ad51ad8525f2f8fc80d4b319809a931806e63f79d8ebd96bac302cff4568ef72",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8f055e166d07979a82bdc7dff67261b8337841723bb31070639b72326851cca1",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0329": {
+      "vector": "6ejovfDvb7/9/Hw+kpERv4WEBD7Qz0+/wsFBv+/u7j7+/X2/1dRUPoyLC7+npqa+h4aGvs7NTb++vT2/vr09v/38fL6urS0/5eRkPqinJz+UkxO/g4KCvsHAQLzNzEw+/Pt7v4SDAz+DgoK+paQkPtbVVb+0szM/goEBP4KBAb/p6Oi98O9vv/38fD6SkRG/hYQEPtDPT7/CwUG/7+7uPv79fb/V1FQ+jIsLv6empr6Hhoa+zs1Nv769Pb++vT2//fx8vq6tLT/l5GQ+qKcnP5STE7+DgoK+wcBAvM3MTD78+3u/hIMDP4OCgr6lpCQ+1tVVv7SzMz+CgQE/goEBvw==",
+      "vectorSha256": "d54b3ff6d03d4f781840296ff53d79dff42a817125e84031f44c481433f8fdee",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "71089f3790181fbb019a3a565e19212160d69cd3365f7e9902c15f9415d9c03f",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0330": {
+      "vector": "hIMDv5WUFD62tTW/jYwMPvn4+D22tTU/5+bmvtjXVz/z8vI+19bWvqGgoDyOjQ0/2tlZP6+urj6SkRG/kpERP4WEBD7+/X0/yMdHP9bVVT/S0VE/1dRUvq6tLb+Ylxc/t7a2PqinJ7/z8vK+AACAv5OSkj6FhAS+wcBAvJSTEz+EgwO/lZQUPra1Nb+NjAw++fj4Pba1NT/n5ua+2NdXP/Py8j7X1ta+oaCgPI6NDT/a2Vk/r66uPpKREb+SkRE/hYQEPv79fT/Ix0c/1tVVP9LRUT/V1FS+rq0tv5iXFz+3trY+qKcnv/Py8r4AAIC/k5KSPoWEBL7BwEC8lJMTPw==",
+      "vectorSha256": "8bb8e232732e72b2d6ee4d794f7c234116948e945aff99055aee3321ae1e0d0f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3e9225918fda46ebbc4a82c6ecab37c890fee3eae86529cbad2c4300a46f7ec9",
+      "updatedAt": "2025-09-20T22:27:41.524Z"
+    },
+    "j-0331": {
+      "vector": "rawsvvTzc7+mpSW/AACAP7e2tr7w72+/mpkZP6empj7Hxsa+lZQUPtzbWz+EgwO/29ravp+enr6NjAw+uLc3P5WUFD7083M/uLc3v/n4+L38+3u/v76+vry7O7/Ix0c/vbw8PoiHBz+7urq+wcBAPPHwcL3Y11e/4N9fv/b1db+trCy+9PNzv6alJb8AAIA/t7a2vvDvb7+amRk/p6amPsfGxr6VlBQ+3NtbP4SDA7/b2tq+n56evo2MDD64tzc/lZQUPvTzcz+4tze/+fj4vfz7e7+/vr6+vLs7v8jHRz+9vDw+iIcHP7u6ur7BwEA88fBwvdjXV7/g31+/9vV1vw==",
+      "vectorSha256": "70301e938556d3cc3cc5e5f5f8dae4328c26787100595774823ec59cb5da8a43",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6a062dff5208cca94e92ed3e495891db92f92470025022e397c3518178141005",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0332": {
+      "vector": "x8bGPs7NTT+OjQ2/hYQEvtTTUz/29XW/p6amPoOCgr6WlRW/paQkvvLxcb+2tTU/sK8vP7m4uL2urS0/xMNDv4GAgLu4tzc/09LSPv38fD6VlBQ+zs1NP87NTT+trCy+7+7uvujnZ7+qqSk/2djYPe7tbb/x8HC96ulpP6inJz/HxsY+zs1NP46NDb+FhAS+1NNTP/b1db+npqY+g4KCvpaVFb+lpCS+8vFxv7a1NT+wry8/ubi4va6tLT/Ew0O/gYCAu7i3Nz/T0tI+/fx8PpWUFD7OzU0/zs1NP62sLL7v7u6+6Odnv6qpKT/Z2Ng97u1tv/HwcL3q6Wk/qKcnPw==",
+      "vectorSha256": "d8e0f968aa3362382edb627b52dcf953608ede73d51d7faa87bdfe04e64fa4bf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b1e6396fe905a95f356b07dad774d61e7fdbb49f92e6e66a440cd48d0978f4d3",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0333": {
+      "vector": "oaCgPIKBAT/Qz08/vbw8PtXUVD6xsDC9w8LCvoSDAz/19HS+8O9vv7Oysr6KiQm/+Pd3v83MTD6vrq4+5+bmvvPy8r62tTU/wL8/v7Oysj7o52c/3dxcPpiXF7+8uzs/lJMTv/HwcL3g31+/8vFxP87NTT+4tze/oaCgPMnIyL2hoKA8goEBP9DPTz+9vDw+1dRUPrGwML3DwsK+hIMDP/X0dL7w72+/s7KyvoqJCb/493e/zcxMPq+urj7n5ua+8/Lyvra1NT/Avz+/s7KyPujnZz/d3Fw+mJcXv7y7Oz+UkxO/8fBwveDfX7/y8XE/zs1NP7i3N7+hoKA8ycjIvQ==",
+      "vectorSha256": "0ce8117276000f75de64799f14d423975959a6e738d8094c3c80e1fe07caaa38",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "82c0e7979a7a4fc16108533b0499ab4643da20acf39b34dd367810f8e6248273",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0334": {
+      "vector": "6+rqvuno6D2lpCQ+9PNzP/j3dz+ZmJi9g4KCvuTjY7/z8vK+9/b2vv38fL6+vT0/yMdHv8XERD6WlRW/kpERP/Tzc7+OjQ2/paQkvqqpKb/OzU0/6+rqvs/Ozj6xsDC909LSPry7O7+joqI+rKsrP+7tbT/083M/kI8PP8TDQz/r6uq+6ejoPaWkJD7083M/+Pd3P5mYmL2DgoK+5ONjv/Py8r739va+/fx8vr69PT/Ix0e/xcREPpaVFb+SkRE/9PNzv46NDb+lpCS+qqkpv87NTT/r6uq+z87OPrGwML3T0tI+vLs7v6Oioj6sqys/7u1tP/Tzcz+Qjw8/xMNDPw==",
+      "vectorSha256": "46522b9d273e85603418e5db604f4d2c5c526d517a1c0e72b6758a5afcbc870e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "458e94f9fb765f0e434260de1c9835c806396b2be645b37ab422a8d5f6f9c7e1",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0335": {
+      "vector": "np0dv5mYmD2npqa+2tlZv93cXL6UkxO/5ONjP97dXT/6+Xk/5eRkvpWUFD7n5ua+4+Livuzraz///v4+mZiYPeblZb/8+3s/6ejovbW0NL64tzc/trU1P/LxcT+TkpK+i4qKvszLS7/j4uI+k5KSvoKBAb/r6uq+4+LivtLRUb+enR2/mZiYPaempr7a2Vm/3dxcvpSTE7/k42M/3t1dP/r5eT/l5GS+lZQUPufm5r7j4uK+7OtrP//+/j6ZmJg95uVlv/z7ez/p6Oi9tbQ0vri3Nz+2tTU/8vFxP5OSkr6Lioq+zMtLv+Pi4j6TkpK+goEBv+vq6r7j4uK+0tFRvw==",
+      "vectorSha256": "b12bef7c2f6324366911a368e9395c25b6b2d74b16ab48bab9d1fdd5e468f4fe",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "318956136436f1eefc63924647f5bf890dfd7169dbdaf85b5d1ab85b3f454717",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0336": {
+      "vector": "//7+vvj3dz/e3V0/6ulpP769PT+UkxO/5ONjv8TDQz+UkxO/l5aWvqKhIT/y8XG/oJ8fP6inJz/w72+/8/LyPrOysr6xsDC96ulpv+fm5r7DwsI+//7+PuHg4Dyvrq4+v76+vr28PL7n5uY+pKMjP7m4uD3My0s/qqkpv4SDA7///v6++Pd3P97dXT/q6Wk/vr09P5STE7/k42O/xMNDP5STE7+Xlpa+oqEhP/Lxcb+gnx8/qKcnP/Dvb7/z8vI+s7KyvrGwML3q6Wm/5+bmvsPCwj7//v4+4eDgPK+urj6/vr6+vbw8vufm5j6koyM/ubi4PczLSz+qqSm/hIMDvw==",
+      "vectorSha256": "92b64ea33894e6ab6918ca823961d932ef9b84777d5e199f9b7aa14b029faba5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "40fbeef4de360ee1365ad007cfd308bc537a0b46b0bf83ab5068b9d18be52b3e",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0337": {
+      "vector": "4+LivqGgoLykoyM/kI8PP+7tbb/t7Gy+mZiYPfj3d7+ysTE/qqkpP8bFRb/y8XG/4uFhv6Oior7u7W2/7exsvu3sbL6WlRW/2NdXv5ybG7+ioSE/i4qKvqqpKb/l5GQ+w8LCvtfW1j7S0VG/2NdXP7m4uD3g31+/mZiYvZKRET/j4uK+oaCgvKSjIz+Qjw8/7u1tv+3sbL6ZmJg9+Pd3v7KxMT+qqSk/xsVFv/Lxcb/i4WG/o6Kivu7tbb/t7Gy+7exsvpaVFb/Y11e/nJsbv6KhIT+Lioq+qqkpv+XkZD7DwsK+19bWPtLRUb/Y11c/ubi4PeDfX7+ZmJi9kpERPw==",
+      "vectorSha256": "faf1c9e1ccd53568bb08a94a1415af95a7a7fe581ca2b42e8219ae3fe7360b64",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "477dd1c709628904d8d41d070f57096262351432d05d2b9c4fb517eb8b1076c8",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0338": {
+      "vector": "n56ePsbFRT/DwsK+8O9vP9TTU7+1tDQ+7exsPrm4uD3Qz08/zs1NP6empr61tDQ+2tlZv4uKij7r6uo+0tFRv7Oysr6GhQW/v76+vqCfH7/i4WG/hoUFv9va2r6Qjw+/xMNDP9PS0j7NzEw+8/LyvpWUFL7Ix0e/m5qavublZT+fnp4+xsVFP8PCwr7w728/1NNTv7W0ND7t7Gw+ubi4PdDPTz/OzU0/p6amvrW0ND7a2Vm/i4qKPuvq6j7S0VG/s7KyvoaFBb+/vr6+oJ8fv+LhYb+GhQW/29ravpCPD7/Ew0M/09LSPs3MTD7z8vK+lZQUvsjHR7+bmpq+5uVlPw==",
+      "vectorSha256": "a3d949099848ae07c6e06488281f6f8ab645f7cfeaa27d972eb06f15993675b1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a7e24ff716969d8be7e6569613a2ba17533d50300f3d4938e1b499436d1c59f2",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0339": {
+      "vector": "3dxcvtjXVz/CwUG/19bWvvTzc7/c21u/vbw8Pq2sLD7DwsK+xsVFv6Oioj7CwUE/9/b2PtzbWz/k42O/0tFRv4iHBz/s62u/ycjIPfj3d7/c21s/mpkZP7y7O7+ysTG/sK8vP9PS0r6trCy+4N9fP5eWlr6hoKA8qqkpP9va2j7d3Fy+2NdXP8LBQb/X1ta+9PNzv9zbW7+9vDw+rawsPsPCwr7GxUW/o6KiPsLBQT/39vY+3NtbP+TjY7/S0VG/iIcHP+zra7/JyMg9+Pd3v9zbWz+amRk/vLs7v7KxMb+wry8/09LSvq2sLL7g318/l5aWvqGgoDyqqSk/29raPg==",
+      "vectorSha256": "3ac0fb17f11826b4afc62634953011c9b097da8a4678a214c8389079be7a9f35",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "64eb1f4a061297954f1da8e0bded0e17c30a8c04edcc2227d74b6aef5a82d4b6",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0340": {
+      "vector": "jIsLP8/Ozj7Hxsa+2NdXv52cHD7t7Gw+lZQUPrKxMT/6+Xk/vr09P4qJCb+koyO/np0dP/HwcL38+3s/6+rqvo2MDD7w728/zMtLv5qZGb+NjAw+kI8Pv/b1db+gnx+/0dBQPYqJCT+fnp6+vr09v7CvLz+amRk/4+LivuHg4LyMiws/z87OPsfGxr7Y11e/nZwcPu3sbD6VlBQ+srExP/r5eT++vT0/iokJv6SjI7+enR0/8fBwvfz7ez/r6uq+jYwMPvDvbz/My0u/mpkZv42MDD6Qjw+/9vV1v6CfH7/R0FA9iokJP5+enr6+vT2/sK8vP5qZGT/j4uK+4eDgvA==",
+      "vectorSha256": "c23a20ecf9d19bd57641e5df90c1967b6e06f068da00e3d514b13be0b12430a0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c5b34e14939d92d8fcde3b2ece78fd4591f71a339138053086c45821d7cc477c",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0341": {
+      "vector": "//7+vqSjI7+mpSW/z87OPsrJSb+lpCS+7u1tP5OSkr6opye/8O9vv9va2j7r6uo+oJ8fv/b1db/b2to+5eRkPsnIyD2Pjo4+lpUVv83MTD6FhAQ+gYCAu9XUVD7g318/t7a2vvv6+j6VlBS+ubi4vcvKyj739va+x8bGPv/+/r7//v6+pKMjv6alJb/Pzs4+yslJv6WkJL7u7W0/k5KSvqinJ7/w72+/29raPuvq6j6gnx+/9vV1v9va2j7l5GQ+ycjIPY+Ojj6WlRW/zcxMPoWEBD6BgIC71dRUPuDfXz+3tra++/r6PpWUFL65uLi9y8rKPvf29r7HxsY+//7+vg==",
+      "vectorSha256": "a70d756bc4220004a9b99752e4973b0bb24bfe07cc17c9c8df73b76ba9365846",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "402e2db31b6bf65b2c08b6ba3005b69c8ca33599907f9aef52be6d74b242b140",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0342": {
+      "vector": "6+rqvtXUVL6sqys/qKcnv6CfHz+KiQm/m5qaPvj3dz+Miwu/3t1dv9DPT7+EgwO/sK8vP8zLSz/e3V0/h4aGPpeWlr68uzu/zcxMvvHwcD3X1ta+z87OvrOysj77+vo+9fR0PrGwMD3v7u6+2NdXP9/e3r6Ylxc/8/LyPr69Pb/r6uq+1dRUvqyrKz+opye/oJ8fP4qJCb+bmpo++Pd3P4yLC7/e3V2/0M9Pv4SDA7+wry8/zMtLP97dXT+HhoY+l5aWvry7O7/NzEy+8fBwPdfW1r7Pzs6+s7KyPvv6+j719HQ+sbAwPe/u7r7Y11c/397evpiXFz/z8vI+vr09vw==",
+      "vectorSha256": "7db1bdc71db5ae5a10f6899d43466a793c1435429560c93269fae55eb23370dc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4565d52ccf3ba6fb3a11183ed7e5eea15a2266874a4cacbe9e8544eb48cbbc21",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0343": {
+      "vector": "/fx8PtPS0j6/vr6+srExv8HAQDzY11c/19bWvq+urr6rqqq+k5KSPri3Nz+Qjw+/8vFxP8fGxr6VlBQ+rKsrP/X0dD7R0FC9paQkvpGQED2dnBy+lZQUvpuamj68uzu/yslJv7CvL7+ZmJi96+rqvrSzMz+ZmJi97u1tv/r5eT/9/Hw+09LSPr++vr6ysTG/wcBAPNjXVz/X1ta+r66uvquqqr6TkpI+uLc3P5CPD7/y8XE/x8bGvpWUFD6sqys/9fR0PtHQUL2lpCS+kZAQPZ2cHL6VlBS+m5qaPry7O7/KyUm/sK8vv5mYmL3r6uq+tLMzP5mYmL3u7W2/+vl5Pw==",
+      "vectorSha256": "d645c7311237cf7b93d20269ffef0b35e6d0fef2259a68ddf771fcbf68336d4a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9fb4502781eb4a5455a4db38f84e92d59e796b846c6da6221b287645d97609fc",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0344": {
+      "vector": "hIMDP8XERL7S0VE/6ejoPcC/Pz+trCw+wsFBP5eWlj7T0tI+8fBwvYqJCT+SkRG/j46OPvb1db/q6Wm/srExv+XkZD6FhAQ+jIsLv+7tbT/b2to+iokJP+LhYb/e3V0/np0dv9bVVb/493e/h4aGvsPCwr6joqK+mJcXP5aVFT+EgwM/xcREvtLRUT/p6Og9wL8/P62sLD7CwUE/l5aWPtPS0j7x8HC9iokJP5KREb+Pjo4+9vV1v+rpab+ysTG/5eRkPoWEBD6Miwu/7u1tP9va2j6KiQk/4uFhv97dXT+enR2/1tVVv/j3d7+Hhoa+w8LCvqOior6Ylxc/lpUVPw==",
+      "vectorSha256": "3c18229c93bdcc7756c7dff8cf48b4be7fed7cc0e16e0d5243d536666089a39f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c167e88edf95e0a5b478c437a3050b279c903af6b6c40fee3115045e4f57cbca",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0345": {
+      "vector": "nZwcvqqpKb/X1ta+u7q6Pr69PT/r6uq+zcxMPuzra7///v4+hYQEvoKBAb/083O//Pt7P769Pb+Ylxe/y8rKvvTzcz+CgQG/iIcHv/Dvbz/s62s/trU1v5iXFz+BgIA7sbAwPY6NDT+NjAw+2djYvbq5OT+wry+/pKMjP//+/r6dnBy+qqkpv9fW1r67uro+vr09P+vq6r7NzEw+7Otrv//+/j6FhAS+goEBv/Tzc7/8+3s/vr09v5iXF7/Lysq+9PNzP4KBAb+Ihwe/8O9vP+zraz+2tTW/mJcXP4GAgDuxsDA9jo0NP42MDD7Z2Ni9urk5P7CvL7+koyM///7+vg==",
+      "vectorSha256": "a9db79282efbafee640819bee96015a813b90629dbf9f9bca2d99a8540f5fa70",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6c2b4aaede45990abf6f3f06fd21344df93f3cf7f525cb8085c69172dc28d140",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0346": {
+      "vector": "5uVlv7m4uL3Z2Ni9mpkZP9LRUb+hoKC8oJ8fPwAAgD/f3t6+vr09v7CvLz/BwEC84+LivsfGxj60szO/ubi4PdLRUb+2tTW/t7a2vpiXF7/X1tY+/Pt7P8PCwj6DgoI+hoUFP4qJCT/Ew0M/1tVVv8bFRT/X1ta+29ravre2tj7m5WW/ubi4vdnY2L2amRk/0tFRv6GgoLygnx8/AACAP9/e3r6+vT2/sK8vP8HAQLzj4uK+x8bGPrSzM7+5uLg90tFRv7a1Nb+3tra+mJcXv9fW1j78+3s/w8LCPoOCgj6GhQU/iokJP8TDQz/W1VW/xsVFP9fW1r7b2tq+t7a2Pg==",
+      "vectorSha256": "2a0e428da8168b27abeb480782f050e6664f31829288f62ed0661c6f6ea08a22",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0d7472cc177dcfff4821d77e47b1268b17255234b5fdb0a0c2c4e115e24a49ad",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0347": {
+      "vector": "l5aWPrKxMb/CwUE/6ulpP/r5eb/t7Gw+np0dv5WUFD7r6uq+rKsrP+rpaT/NzEw+w8LCPuno6L3i4WG/trU1v8LBQb/R0FC9rawsPpiXF7+hoKC8397evpKREb+Ihwe/oaCgPKKhIT+opye/lJMTP6+urj7n5ua+3t1dP//+/j6XlpY+srExv8LBQT/q6Wk/+vl5v+3sbD6enR2/lZQUPuvq6r6sqys/6ulpP83MTD7DwsI+6ejoveLhYb+2tTW/wsFBv9HQUL2trCw+mJcXv6GgoLzf3t6+kpERv4iHB7+hoKA8oqEhP6inJ7+UkxM/r66uPufm5r7e3V0///7+Pg==",
+      "vectorSha256": "3ebd0a10bc378ba527f03bd37823197dc0473ff8a62ab83a9e59a871c2b0913c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a527e0f4039d319245d5f499b0710f251f7995347d48373c82d02cc9ab46eebf",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0348": {
+      "vector": "s7KyvqalJT/39va+urk5v9DPTz/u7W2/urk5P/HwcL2Ihwc/09LSPsbFRT/g318/np0dP7KxMb/a2Vk/4eDgvMzLSz/m5WU/r66uvo2MDD6fnp6+uLc3P6CfH7/CwUG/2djYvf79fT+Ylxe/goEBP8TDQz+enR2/6ulpP+blZT+zsrK+pqUlP/f29r66uTm/0M9PP+7tbb+6uTk/8fBwvYiHBz/T0tI+xsVFP+DfXz+enR0/srExv9rZWT/h4OC8zMtLP+blZT+vrq6+jYwMPp+enr64tzc/oJ8fv8LBQb/Z2Ni9/v19P5iXF7+CgQE/xMNDP56dHb/q6Wk/5uVlPw==",
+      "vectorSha256": "a9c36c0d6593374aeb4719c0ca61dd3db3c75c6eee3885cd68cbb4d226b4a2f0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "53d24223e709dc78c3b4e2efce27ec7ce5f2549158db301f72fe34c0e131f4f2",
+      "updatedAt": "2025-09-20T22:27:41.525Z"
+    },
+    "j-0349": {
+      "vector": "/fx8vuDfX7+ioSE///7+PuPi4j6FhAQ+5ONjv6empj7b2to+5+bmvsC/P7/Ix0c/paQkvvj3d7/DwsI+yslJv6empr7p6Og99vV1v83MTL6KiQk//v19P8HAQDzX1tY+kZAQvZ2cHD7g318/+vl5P7KxMb+zsrI+mZiYvdPS0r79/Hy+4N9fv6KhIT///v4+4+LiPoWEBD7k42O/p6amPtva2j7n5ua+wL8/v8jHRz+lpCS++Pd3v8PCwj7KyUm/p6amvuno6D329XW/zcxMvoqJCT/+/X0/wcBAPNfW1j6RkBC9nZwcPuDfXz/6+Xk/srExv7Oysj6ZmJi909LSvg==",
+      "vectorSha256": "e10f96e04590016dab305bba6f2a7d70746a33b33e55f9d003433a78becef677",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6010d0bfb8900ea9b64620e36b04b01b568e0566c4fe81b57b93effc27ac764b",
+      "updatedAt": "2025-09-20T22:27:41.526Z"
+    },
+    "j-0350": {
+      "vector": "s7KyPoeGhr6cmxu/iokJv7GwMD2enR2/4eDgvNnY2L2dnBy+yMdHv/v6+r6zsrI+x8bGvvPy8j6koyM/l5aWvp2cHL7Ix0e/m5qaPv38fD67uro+yslJv8HAQLykoyM/i4qKvqWkJL7JyMg9jIsLv/v6+r7KyUm/o6KivuLhYb+zsrI+h4aGvpybG7+KiQm/sbAwPZ6dHb/h4OC82djYvZ2cHL7Ix0e/+/r6vrOysj7Hxsa+8/LyPqSjIz+Xlpa+nZwcvsjHR7+bmpo+/fx8Pru6uj7KyUm/wcBAvKSjIz+Lioq+paQkvsnIyD2Miwu/+/r6vsrJSb+joqK+4uFhvw==",
+      "vectorSha256": "c576601f02b5b579b7f6448d739df07fdc35d3da60425c604b8162e60b6e4f49",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ac5e323b85317c726c1c41ac4ebcd15a6c1ca69fae1b7ed15d6b8c3a411b570f",
+      "updatedAt": "2025-09-20T22:27:41.526Z"
+    },
+    "j-0351": {
+      "vector": "qaioveXkZD6zsrK+iIcHP6WkJD7b2tq+jIsLP9PS0j7R0FA90M9PP4WEBL7NzEw+yMdHP7++vr67uro+q6qqPra1Nb/OzU2/3Ntbv5GQEL3Ix0c/8fBwPZCPDz///v6+wL8/v9fW1j7NzEw+9vV1P+rpaT+Ihwe/6ulpv5aVFT+pqKi95eRkPrOysr6Ihwc/paQkPtva2r6Miws/09LSPtHQUD3Qz08/hYQEvs3MTD7Ix0c/v76+vru6uj6rqqo+trU1v87NTb/c21u/kZAQvcjHRz/x8HA9kI8PP//+/r7Avz+/19bWPs3MTD729XU/6ulpP4iHB7/q6Wm/lpUVPw==",
+      "vectorSha256": "496768aab5bdf4075ef9ad098436f1bbdfe6046076bc99f8c86324e2c60be461",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "759c53c39449c5b486e76f99e350aeaa2519127be387c74020b599faf43c0bca",
+      "updatedAt": "2025-09-20T22:27:41.526Z"
+    },
+    "j-0352": {
+      "vector": "qqkpP/79fb/GxUW/x8bGvsXERD68uzu/4uFhv4WEBD6xsDC9kpERv6SjIz+gnx8/lpUVP62sLL6WlRW/xsVFP5aVFb/j4uI+o6KiPp6dHT++vT0/w8LCPqKhIT/Lyso+np0dv/LxcT/Avz8/k5KSvpOSkj7n5ua+p6amvvr5eb+qqSk//v19v8bFRb/Hxsa+xcREPry7O7/i4WG/hYQEPrGwML2SkRG/pKMjP6CfHz+WlRU/rawsvpaVFb/GxUU/lpUVv+Pi4j6joqI+np0dP769PT/DwsI+oqEhP8vKyj6enR2/8vFxP8C/Pz+TkpK+k5KSPufm5r6npqa++vl5vw==",
+      "vectorSha256": "227070e66a04d1a3e3520cbb66d69cfb254fafff00f26bd6577974fb2b188092",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d4011d4e98220f907a37d1cfca6a35e235b8a8cedeb0d0b231f8df5ba4465603",
+      "updatedAt": "2025-09-20T22:27:41.526Z"
+    },
+    "j-0353": {
+      "vector": "jo0NP4SDAz+Lioq+8/LyvoKBAb++vT2/7exsPtLRUb/CwUG/jIsLP4iHB7+wry8/hoUFP+zra7+1tDQ+yMdHP+fm5j6xsDA9pqUlv/r5eb+7urq++fj4vcfGxr6lpCS+3Ntbv+rpab+dnBy+8O9vP7y7O7/x8HC9vLs7P6uqqr6OjQ0/hIMDP4uKir7z8vK+goEBv769Pb/t7Gw+0tFRv8LBQb+Miws/iIcHv7CvLz+GhQU/7Otrv7W0ND7Ix0c/5+bmPrGwMD2mpSW/+vl5v7u6ur75+Pi9x8bGvqWkJL7c21u/6ulpv52cHL7w728/vLs7v/HwcL28uzs/q6qqvg==",
+      "vectorSha256": "aa4567e40b0d4031474b15de33693bcedc3ebff508f100e897ade38fd0e956fe",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c6c15d433f219d171fc53cd7c20a96e3b9852d0351704e6b120b6cf72278dd55",
+      "updatedAt": "2025-09-20T22:27:41.526Z"
+    },
+    "j-0354": {
+      "vector": "/fx8PtXUVD6mpSW/4eDgPM7NTT+dnBy+/Pt7P8vKyr7Ix0c/8/LyPqinJz+DgoK+4+LiPru6ur7OzU2/kZAQvd/e3r7DwsI+397evvj3d7/Z2Ni9+fj4vcPCwr75+Pi919bWvsfGxr6WlRU/1tVVP/Dvbz/o52e/oqEhv9zbW7/9/Hw+1dRUPqalJb/h4OA8zs1NP52cHL78+3s/y8rKvsjHRz/z8vI+qKcnP4OCgr7j4uI+u7q6vs7NTb+RkBC9397evsPCwj7f3t6++Pd3v9nY2L35+Pi9w8LCvvn4+L3X1ta+x8bGvpaVFT/W1VU/8O9vP+jnZ7+ioSG/3Ntbvw==",
+      "vectorSha256": "bee90f672aea03e1cab90c6d45387887ea3ec67e663d8abe295d3f52b8023989",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9f9a2d83e66cfd4de3bcd35fb851197b48b0480472704f704a4ecaeaf70c2f12",
+      "updatedAt": "2025-09-20T22:27:41.526Z"
+    },
+    "j-0355": {
+      "vector": "hoUFP7q5OT/BwEA8i4qKvujnZ7/R0FC9rawsvvv6+r6xsDA9//7+vsfGxj7o52e/h4aGPry7Oz/DwsK+mZiYPdDPT7/19HQ+tbQ0PsnIyD2xsDA919bWPqCfH78AAIA/hoUFP5qZGT/l5GS+mJcXP7u6uj6sqys/rq0tP//+/j6GhQU/urk5P8HAQDyLioq+6Odnv9HQUL2trCy++/r6vrGwMD3//v6+x8bGPujnZ7+HhoY+vLs7P8PCwr6ZmJg90M9Pv/X0dD61tDQ+ycjIPbGwMD3X1tY+oJ8fvwAAgD+GhQU/mpkZP+XkZL6Ylxc/u7q6PqyrKz+urS0///7+Pg==",
+      "vectorSha256": "33bbd814f2c7f0bb727a6d00d4c1af7c9f9022439d75853a8eb2bdd193b7256e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c2dc815d0c796a418540b10ca1dd4f89189e968c85b530ffc2cc63cbaed5d6bf",
+      "updatedAt": "2025-09-20T22:27:41.526Z"
+    },
+    "j-0356": {
+      "vector": "+Pd3v5iXFz+rqqq+sbAwPbi3N7/JyMi9paQkvqmoqD2urS0/4+LivtDPTz/19HQ+/fx8Po2MDL7i4WG/3dxcPvDvb7+Pjo6+lJMTv+3sbL6cmxs/vLs7P+LhYb+Ihwe/2NdXv+vq6j61tDS+4+LivujnZ7/o52e/9vV1P+TjYz/493e/mJcXP6uqqr6xsDA9uLc3v8nIyL2lpCS+qaioPa6tLT/j4uK+0M9PP/X0dD79/Hw+jYwMvuLhYb/d3Fw+8O9vv4+Ojr6UkxO/7exsvpybGz+8uzs/4uFhv4iHB7/Y11e/6+rqPrW0NL7j4uK+6Odnv+jnZ7/29XU/5ONjPw==",
+      "vectorSha256": "4b2312c3bcdd90207d0ed8e520fc1e671c6cc8bf306b49491812b2681089716f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "04cb558524736b8ad647e79e9f6e0f9b085c3662cddd0f3c14ba69470c0cfaf1",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0357": {
+      "vector": "j46Ovt3cXL61tDS+gYCAu+zraz/X1ta+m5qavoaFBb+pqKi9lZQUPp2cHL7CwUE///7+vru6uj6XlpY+pqUlP//+/r6NjAy++Pd3v7u6uj7Ew0M/2tlZP4SDAz/HxsY+vbw8voyLC7/x8HA9x8bGPsbFRT/083O//Pt7v8jHRz+Pjo6+3dxcvrW0NL6BgIC77OtrP9fW1r6bmpq+hoUFv6moqL2VlBQ+nZwcvsLBQT///v6+u7q6PpeWlj6mpSU///7+vo2MDL7493e/u7q6PsTDQz/a2Vk/hIMDP8fGxj69vDy+jIsLv/HwcD3HxsY+xsVFP/Tzc7/8+3u/yMdHPw==",
+      "vectorSha256": "1ece131c42610c5d46535e31de1075027fe9b53deca56904cabee48856f9a08f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5c64697ff54a593d75926ce040aea5d2406e04aee1ecc1b1683a87b1e20602e3",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0358": {
+      "vector": "x8bGPpKREb/s62u/9/b2PvX0dL7T0tK+sbAwvfDvb7+4tzc/srExv4eGhr6Miwu/wsFBP+zra7/CwUG/19bWvpybG7+Miws/yslJv/Tzcz+opye/tbQ0vtTTU7/T0tK+mZiYvbOysj7Lysq+2djYPYqJCb+FhAS+6+rqvr28PL7HxsY+kpERv+zra7/39vY+9fR0vtPS0r6xsDC98O9vv7i3Nz+ysTG/h4aGvoyLC7/CwUE/7Otrv8LBQb/X1ta+nJsbv4yLCz/KyUm/9PNzP6inJ7+1tDS+1NNTv9PS0r6ZmJi9s7KyPsvKyr7Z2Ng9iokJv4WEBL7r6uq+vbw8vg==",
+      "vectorSha256": "7077a120004b5595ea638e6414597995e27d9c3a9317e57f350f28bc42f3feb1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b1370abd614b7a08db275e3ae00a1f4a32c51bf92c69164b76ac4d8d3b6f4568",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0359": {
+      "vector": "hIMDP4SDAz/x8HC94+LivvTzcz/f3t4+5eRkPtPS0j6TkpI+9vV1v/Tzc7/083O/6ejovaCfHz+KiQk/sbAwvbKxMT/5+Pi9g4KCPp2cHL7y8XE/tbQ0Purpab+rqqq+q6qqPpOSkr79/Hy+yMdHv9LRUT/493e/0M9PP9va2r6EgwM/hIMDP/HwcL3j4uK+9PNzP9/e3j7l5GQ+09LSPpOSkj729XW/9PNzv/Tzc7/p6Oi9oJ8fP4qJCT+xsDC9srExP/n4+L2DgoI+nZwcvvLxcT+1tDQ+6ulpv6uqqr6rqqo+k5KSvv38fL7Ix0e/0tFRP/j3d7/Qz08/29ravg==",
+      "vectorSha256": "f4d2abdc291cc44f8b68fb0fc87b86a78d61bb18b740e25662e58eacd0b76289",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c1c17847f9b79cb4a405060671cfc47ad870a06cf8960b55aa5b601ce804e749",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0360": {
+      "vector": "6+rqvtbVVb+xsDC9hYQEPvX0dL6vrq4+j46Ovuzra7+VlBS+1dRUvv79fb/JyMi9w8LCvpOSkj7o52e/lJMTP769PT/39vY+7exsvpeWlr60szM/09LSPvDvbz/g31+/lZQUPuXkZD7w72+/+Pd3v7KxMT/T0tI+AACAv4OCgr7r6uq+1tVVv7GwML2FhAQ+9fR0vq+urj6Pjo6+7Otrv5WUFL7V1FS+/v19v8nIyL3DwsK+k5KSPujnZ7+UkxM/vr09P/f29j7t7Gy+l5aWvrSzMz/T0tI+8O9vP+DfX7+VlBQ+5eRkPvDvb7/493e/srExP9PS0j4AAIC/g4KCvg==",
+      "vectorSha256": "e7d17277ba2aaef982816c1cad3276f339ef5f80ef1ef976ce4dee1dd5db4c04",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "45157a9061ab5c0a6d6501734fa40cc9debd625ad9b4f710929c0804d8b4005f",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0361": {
+      "vector": "8vFxP4eGhj7p6Og9paQkvvj3dz+qqSm/rKsrP8rJST/My0u/nJsbP/z7ez+Pjo4+tLMzv8XERL7m5WW/pqUlP8vKyj7c21u/1dRUvpKRET/19HS+zMtLv+XkZD6qqSk/z87OPry7Oz/W1VU/hIMDv6Oioj6ysTE/8vFxv9LRUT/y8XE/h4aGPuno6D2lpCS++Pd3P6qpKb+sqys/yslJP8zLS7+cmxs//Pt7P4+Ojj60szO/xcREvublZb+mpSU/y8rKPtzbW7/V1FS+kpERP/X0dL7My0u/5eRkPqqpKT/Pzs4+vLs7P9bVVT+EgwO/o6KiPrKxMT/y8XG/0tFRPw==",
+      "vectorSha256": "857466795affbc37f70c13604c7a1c09eee992599db9c9e21b9aeb60291b53fc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f8a18e6bfb2bd5e41acdfda326670dd2b21265c8611a9cd4b3ddea3ea8d807e8",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0362": {
+      "vector": "urk5P5eWlj6JiIi97u1tv/b1dT+2tTU/29raPsTDQ7+enR0/mpkZv/r5eb/KyUk/vbw8PrSzM7/Ix0e/n56evu/u7j62tTW/vbw8PvHwcL2gnx8/lZQUPquqqr63tra+6+rqPq2sLL64tze/y8rKPpSTEz/7+vo+t7a2vpKRET+6uTk/l5aWPomIiL3u7W2/9vV1P7a1NT/b2to+xMNDv56dHT+amRm/+vl5v8rJST+9vDw+tLMzv8jHR7+fnp6+7+7uPra1Nb+9vDw+8fBwvaCfHz+VlBQ+q6qqvre2tr7r6uo+rawsvri3N7/Lyso+lJMTP/v6+j63tra+kpERPw==",
+      "vectorSha256": "140dc5daf80f1cca2c564ed7640aa3e07c3d0e35091e076d36f7eb2898445d2b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dca57709fadab61ece3303e497261c58bb259778cf925552ba6a24b2c9be52c8",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0363": {
+      "vector": "zcxMvsPCwr7y8XG/hYQEvuzraz+UkxM/wcBAPPHwcD2ioSG/3t1dP42MDL719HS++fj4vbm4uD2OjQ0/rawsPvv6+j6SkRG/29raPgAAgD+pqKg91NNTvwAAgL+Pjo6+jo0Nv62sLD7V1FS+8O9vP7SzM7/y8XG/wsFBv9HQUD3NzEy+w8LCvvLxcb+FhAS+7OtrP5STEz/BwEA88fBwPaKhIb/e3V0/jYwMvvX0dL75+Pi9ubi4PY6NDT+trCw++/r6PpKREb/b2to+AACAP6moqD3U01O/AACAv4+Ojr6OjQ2/rawsPtXUVL7w728/tLMzv/Lxcb/CwUG/0dBQPQ==",
+      "vectorSha256": "b080a928311017aacb488d65416a87893232a7f5c323cd91405038ab4299a5cb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "664f076ff5c981872fee6e61708bc695be37b6ff8a16005c399565f726071f86",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0364": {
+      "vector": "7OtrP+TjYz/Z2Ni99/b2Pvv6+j6ZmJi9u7q6vurpaT/S0VE/t7a2vouKir4AAIA/y8rKvublZT+CgQG//v19v4uKij66uTk/3NtbP8rJST/v7u6+wsFBP8rJST+NjAy+xMNDv/79fb+hoKC81dRUPtjXVz/o52c/xsVFv4WEBL7s62s/5ONjP9nY2L339vY++/r6PpmYmL27urq+6ulpP9LRUT+3tra+i4qKvgAAgD/Lysq+5uVlP4KBAb/+/X2/i4qKPrq5OT/c21s/yslJP+/u7r7CwUE/yslJP42MDL7Ew0O//v19v6GgoLzV1FQ+2NdXP+jnZz/GxUW/hYQEvg==",
+      "vectorSha256": "907065b86e27a8a37792bae0fd5f00c6cdc7a4aa727d82b9bda4fc7f3a38b51a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f5f172bdbe7651f4e8525dff4df23f01a2dcede444e0e46e1e017d9aebf31d6f",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0365": {
+      "vector": "7u1tP7q5OT+0szO/xcREvqCfHz/q6Wk//v19v7a1Nb+pqKg9tLMzP4OCgr77+vq+3dxcPsPCwj6ioSG/oJ8fv6moqL2mpSU/oJ8fP4qJCT+NjAy+vr09P87NTb+ioSE/rq0tv66tLT/j4uI+g4KCvqKhIb+fnp4+h4aGPoKBAb/u7W0/urk5P7SzM7/FxES+oJ8fP+rpaT/+/X2/trU1v6moqD20szM/g4KCvvv6+r7d3Fw+w8LCPqKhIb+gnx+/qaiovaalJT+gnx8/iokJP42MDL6+vT0/zs1Nv6KhIT+urS2/rq0tP+Pi4j6DgoK+oqEhv5+enj6HhoY+goEBvw==",
+      "vectorSha256": "2b6fcf7e6c8775255d0c4c1b6dc34e612e7ac01b397c25bd44d0c31c2d57a28d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f6dc2667cff401258ad95f419bb02f3075d2cfc46ede19d029d6b85f2fa7a13f",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0366": {
+      "vector": "0tFRP6alJT/S0VG/0M9PP6Oior7Qz0+/mpkZv9bVVT/i4WG/oJ8fv728PL7493e/vbw8PvPy8j7KyUm/iIcHP9rZWT+TkpK+8O9vP9bVVb/KyUm/hoUFP4KBAT+Miwu/vLs7v+TjYz/l5GS+2tlZv+LhYb/w72+/xsVFv/Dvbz/S0VE/pqUlP9LRUb/Qz08/o6KivtDPT7+amRm/1tVVP+LhYb+gnx+/vbw8vvj3d7+9vDw+8/LyPsrJSb+Ihwc/2tlZP5OSkr7w728/1tVVv8rJSb+GhQU/goEBP4yLC7+8uzu/5ONjP+XkZL7a2Vm/4uFhv/Dvb7/GxUW/8O9vPw==",
+      "vectorSha256": "5dc80f55650c8873a7b00a024e4b7d68bec12bf109b99f11d1a659d39d30abd5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e8d217e7571833ea0f30680497bc1bc3ec5bf7151bc2c03a22f163130f081df7",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0367": {
+      "vector": "x8bGvqalJT+TkpI+hYQEvquqqj729XU/0tFRv4KBAb/j4uI+jYwMPsHAQLzu7W0/sK8vP7GwML25uLg98/LyvpaVFb/OzU2/7Otrv6KhIT+gnx+/xcREvqWkJD7i4WE/7u1tv5qZGT+Ihwe/7Otrv+fm5r6xsDA96Odnv5ybG7/Hxsa+pqUlP5OSkj6FhAS+q6qqPvb1dT/S0VG/goEBv+Pi4j6NjAw+wcBAvO7tbT+wry8/sbAwvbm4uD3z8vK+lpUVv87NTb/s62u/oqEhP6CfH7/FxES+paQkPuLhYT/u7W2/mpkZP4iHB7/s62u/5+bmvrGwMD3o52e/nJsbvw==",
+      "vectorSha256": "fa53097efb242b2301c5702c044a829526dd733892a0c4342b0fe7dcf79c32c0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4ed2a46faafa173fb8917ef6d77a8b4335190ad0306794f009cc3c0a46850c32",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0368": {
+      "vector": "//7+vo6NDb+gnx8/zMtLP6uqqj7W1VU/xsVFP9XUVD6Ihwc/4+LivtLRUT/7+vq+4N9fP5ybG7+cmxs/1tVVv6yrK7+ysTE/vbw8PpqZGT+0szO/4N9fv7W0ND7BwEC8oJ8fP97dXb/t7Gy+sK8vP56dHT+4tzc/kpERP5+enj7//v6+jo0Nv6CfHz/My0s/q6qqPtbVVT/GxUU/1dRUPoiHBz/j4uK+0tFRP/v6+r7g318/nJsbv5ybGz/W1VW/rKsrv7KxMT+9vDw+mpkZP7SzM7/g31+/tbQ0PsHAQLygnx8/3t1dv+3sbL6wry8/np0dP7i3Nz+SkRE/n56ePg==",
+      "vectorSha256": "c9c46ccc2cb323f19f400d7cfa2e39f4a2d3371ae471a1e2c860f9409e63f074",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4039cfe5aaeae29ac347e841ef32cd152ad897cc2610967ecf1162d7cedbc8a7",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0369": {
+      "vector": "m5qaPvn4+L37+vo+hoUFv728PD76+Xm/4N9fP9rZWT/S0VG/0M9Pv5WUFD7k42O/q6qqPre2tr6KiQm/rq0tv6KhIT/n5uY+nZwcvuLhYT8AAIA/9fR0vpiXFz/KyUm/i4qKvqmoqD3b2tq+pqUlv5mYmD2VlBQ+qqkpv//+/r6bmpo++fj4vfv6+j6GhQW/vbw8Pvr5eb/g318/2tlZP9LRUb/Qz0+/lZQUPuTjY7+rqqo+t7a2voqJCb+urS2/oqEhP+fm5j6dnBy+4uFhPwAAgD/19HS+mJcXP8rJSb+Lioq+qaioPdva2r6mpSW/mZiYPZWUFD6qqSm///7+vg==",
+      "vectorSha256": "7538b4f1aa663a84ec1c4af62af7930248d9d2daf7278d44b71f233d3ddf6536",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a670be3d9703efec1718920eaa523b29d0b96cf0ff61cb1b5d8a492d89922b40",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0370": {
+      "vector": "/Pt7v7y7Oz+Miws/kI8Pv9jXVz+ioSE/t7a2vtjXV7+lpCQ+8vFxP4KBAb++vT2//Pt7P6moqD37+vq+s7KyvomIiD3//v4+k5KSvoWEBD7l5GQ+qKcnP8zLSz+5uLi9q6qqPu7tbT+DgoI+wL8/v8bFRT+urS2/oqEhv8nIyD38+3u/vLs7P4yLCz+Qjw+/2NdXP6KhIT+3tra+2NdXv6WkJD7y8XE/goEBv769Pb/8+3s/qaioPfv6+r6zsrK+iYiIPf/+/j6TkpK+hYQEPuXkZD6opyc/zMtLP7m4uL2rqqo+7u1tP4OCgj7Avz+/xsVFP66tLb+ioSG/ycjIPQ==",
+      "vectorSha256": "fc40b8c20bd13b12b3a557d22a99392748387ab2ef46434103e6ead2ec6459c1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "02ddc538ebd0521494f83f21fd8a415388bf5b909cd3e574aaf6a020e2292f8c",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0371": {
+      "vector": "kpERP9va2r7Lysq+7u1tP7SzMz+ysTE/4N9fv769Pb+bmpq+xsVFP/n4+D2npqY+wcBAvK2sLL6hoKC86+rqvra1NT+0szM/xMNDv/v6+j6BgIA7rawsvt3cXL7Ew0M/5ONjv4+Ojr79/Hy+gYCAu+blZb+7urq++vl5v+no6D2SkRE/29ravsvKyr7u7W0/tLMzP7KxMT/g31+/vr09v5uamr7GxUU/+fj4Paempj7BwEC8rawsvqGgoLzr6uq+trU1P7SzMz/Ew0O/+/r6PoGAgDutrCy+3dxcvsTDQz/k42O/j46Ovv38fL6BgIC75uVlv7u6ur76+Xm/6ejoPQ==",
+      "vectorSha256": "2cd62a0aac2d8ae673cce46a49be102b054efffa77072a22b158cec3250f4ae5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c8494df6d9d8102159e28fa97e6a7d45dad91ebe806a64e10e5c607f0d51038e",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0372": {
+      "vector": "k5KSvuXkZD6TkpI+s7Kyvv38fD7R0FC9qqkpP+7tbb+Ylxe/3t1dP5ybG7/c21s/lZQUvsLBQT///v6+1NNTP+blZT/v7u4+m5qavoqJCT+RkBC9qKcnv4uKir6mpSW/oJ8fP8vKyr6XlpY+8/LyPu/u7r7r6uq+5uVlv93cXL6TkpK+5eRkPpOSkj6zsrK+/fx8PtHQUL2qqSk/7u1tv5iXF7/e3V0/nJsbv9zbWz+VlBS+wsFBP//+/r7U01M/5uVlP+/u7j6bmpq+iokJP5GQEL2opye/i4qKvqalJb+gnx8/y8rKvpeWlj7z8vI+7+7uvuvq6r7m5WW/3dxcvg==",
+      "vectorSha256": "92f8c640e4b198cf6a9439e5cb4af1766655aac427376c994887ddd9ff0cebf9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5b9ca4539f79d40934ee32ed6de040e9f2bb59c47b2c5d2dcf4da5bc44450d64",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0373": {
+      "vector": "+/r6vsjHR7+7urq+5uVlP+zra7+KiQm/xsVFv5iXF7+fnp6+7u1tv83MTL75+Pi90dBQPcfGxj739va+4eDgvPHwcD3493c/8fBwPc/Ozr62tTU/3NtbP5KREb/BwEC8lpUVv8/Ozj7m5WW/6+rqvpeWlj7Pzs6+jIsLv+7tbb/7+vq+yMdHv7u6ur7m5WU/7Otrv4qJCb/GxUW/mJcXv5+enr7u7W2/zcxMvvn4+L3R0FA9x8bGPvf29r7h4OC88fBwPfj3dz/x8HA9z87Ovra1NT/c21s/kpERv8HAQLyWlRW/z87OPublZb/r6uq+l5aWPs/Ozr6Miwu/7u1tvw==",
+      "vectorSha256": "369929f9377402ed80aa0af6a5c9d22cde7336f67a7a0a59e01a4f9a5362e59d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "411c51f20a3b1d345809667086b1427c87fb874cdaed377e35b30d45a54c3a09",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0374": {
+      "vector": "lJMTP9LRUb/v7u6+trU1v4GAgLuJiIg94+LivoiHBz+trCw+u7q6vvb1dT+GhQU/7Otrv6SjIz+1tDS+6OdnP/r5eb+Lioq+9PNzP6inJz/7+vo+rawsvoiHB7+mpSU/yMdHv//+/r6rqqq++Pd3P/f29j7Qz0+/qaiovaCfH7+UkxM/0tFRv+/u7r62tTW/gYCAu4mIiD3j4uK+iIcHP62sLD67urq+9vV1P4aFBT/s62u/pKMjP7W0NL7o52c/+vl5v4uKir7083M/qKcnP/v6+j6trCy+iIcHv6alJT/Ix0e///7+vquqqr7493c/9/b2PtDPT7+pqKi9oJ8fvw==",
+      "vectorSha256": "451a60bed5eaff6ab7f29f6e4973ea8d0f82f85fdbe87b949f89ee4390200938",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c91744257f8847c39551fac20ad169f3035df9d3be6a3cd21c4055fbbd187530",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0375": {
+      "vector": "w8LCPvX0dL6xsDA9trU1v8bFRb/W1VW/vr09P9nY2D2XlpY+oJ8fv6empr7l5GS+t7a2Pu7tbT/W1VU/tLMzP+fm5j78+3u/0M9PP8PCwj7My0s/3t1dP+rpab/b2to+8fBwPZCPD7/My0s/9PNzv4KBAb/9/Hy+qaiovfr5eb/DwsI+9fR0vrGwMD22tTW/xsVFv9bVVb++vT0/2djYPZeWlj6gnx+/p6amvuXkZL63trY+7u1tP9bVVT+0szM/5+bmPvz7e7/Qz08/w8LCPszLSz/e3V0/6ulpv9va2j7x8HA9kI8Pv8zLSz/083O/goEBv/38fL6pqKi9+vl5vw==",
+      "vectorSha256": "db873768747a89788687526e1ddb6d5dd69507f149a2acc7de926f71579b6407",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b06185251d15de8da5305663adf6ead9b902e7b0e5ee0bb68738e5063f607503",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0376": {
+      "vector": "kI8PP6yrKz+npqY+5+bmPqOioj7k42M/nZwcPoGAgLutrCy+k5KSvqCfHz+2tTW/qaioPefm5j6VlBQ+6Odnv9zbWz/k42M/8vFxP5ybG7+qqSk/z87Ovpuamj6Qjw+/np0dv7m4uL3p6Oi97+7uvuDfXz/V1FS+kpERv4mIiL2Qjw8/rKsrP6empj7n5uY+o6KiPuTjYz+dnBw+gYCAu62sLL6TkpK+oJ8fP7a1Nb+pqKg95+bmPpWUFD7o52e/3NtbP+TjYz/y8XE/nJsbv6qpKT/Pzs6+m5qaPpCPD7+enR2/ubi4veno6L3v7u6+4N9fP9XUVL6SkRG/iYiIvQ==",
+      "vectorSha256": "d265307f081d70671d49448abc22eef78eb46e9a34ac61904ed75db1e5662193",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c7d5a9b9a8f1937f6a5bcf258ab9920cedf1f832d44ca63831747144ef653777",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0377": {
+      "vector": "np0dv9/e3r6dnBw+tLMzP+3sbL6pqKi9vbw8vpeWlr6NjAy+4eDgPLW0NL6Ihwe/wL8/P/Dvbz/DwsK+iIcHP7++vr7JyMi929raPqKhIb+wry+/6OdnP4mIiD3a2Vk/6ejoPby7O7/DwsK+1dRUvsTDQ7/j4uK+1tVVv/f29j6enR2/397evp2cHD60szM/7exsvqmoqL29vDy+l5aWvo2MDL7h4OA8tbQ0voiHB7/Avz8/8O9vP8PCwr6Ihwc/v76+vsnIyL3b2to+oqEhv7CvL7/o52c/iYiIPdrZWT/p6Og9vLs7v8PCwr7V1FS+xMNDv+Pi4r7W1VW/9/b2Pg==",
+      "vectorSha256": "88ac7232d2e6c841d5daa1ffe1316e82edc5c962ac5ee232f6317033fba4b117",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "314893d96275685a6e83693cdff74fc35073b62f28f388ec8e224f651e4715bd",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0378": {
+      "vector": "trU1P8/Ozj6Ylxc/g4KCPq2sLD729XW/vr09P9DPT7/S0VG/q6qqvsPCwr7z8vK+t7a2PoKBAb+DgoK+yMdHv4eGhj7q6Wk/6ulpP6GgoLyopyc/s7Kyvs7NTT/CwUG/p6amPomIiL329XW//Pt7v4yLC7/a2Vm/09LSvtfW1j62tTU/z87OPpiXFz+DgoI+rawsPvb1db++vT0/0M9Pv9LRUb+rqqq+w8LCvvPy8r63trY+goEBv4OCgr7Ix0e/h4aGPurpaT/q6Wk/oaCgvKinJz+zsrK+zs1NP8LBQb+npqY+iYiIvfb1db/8+3u/jIsLv9rZWb/T0tK+19bWPg==",
+      "vectorSha256": "1a33a2d41b8daf3b398bd653e674340aff74a935e3f944e43b07c17eca8792df",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dab3cba09505de1817554f43ad3f5f1ca1f4f47dd353e61fa97705023a134bb5",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0379": {
+      "vector": "vbw8vufm5j6+vT0/urk5P8vKyj78+3u/tLMzP7y7Oz+enR2/y8rKvoWEBL6zsrK+p6amPsTDQ7/g318/y8rKvsLBQb+urS2/zMtLv4aFBT/KyUm/vbw8voWEBD7b2tq++Pd3P83MTL6Xlpa+0dBQPYKBAb/f3t4+9/b2PrGwML29vDy+5+bmPr69PT+6uTk/y8rKPvz7e7+0szM/vLs7P56dHb/Lysq+hYQEvrOysr6npqY+xMNDv+DfXz/Lysq+wsFBv66tLb/My0u/hoUFP8rJSb+9vDy+hYQEPtva2r7493c/zcxMvpeWlr7R0FA9goEBv9/e3j739vY+sbAwvQ==",
+      "vectorSha256": "06d4ae06d72a1777852d8fe24cd99ef56e2068594f4b7f5972d6ff216b985bce",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "68b9dedcb202d9dd314d6f53a91eef4d1f291ac21b689049fb665a863fb7bd7a",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0380": {
+      "vector": "lZQUPvPy8r65uLg9oJ8fP7e2tr6GhQU/oaCgvImIiD2VlBS+n56evqWkJD6urS0///7+PtrZWb+KiQk/29ravqCfH7+BgIC7tLMzv+DfXz+zsrI+oqEhv4eGhr7f3t6+/v19P83MTD7NzEy+5eRkvvr5eb/i4WG/5eRkvt/e3r6VlBQ+8/Lyvrm4uD2gnx8/t7a2voaFBT+hoKC8iYiIPZWUFL6fnp6+paQkPq6tLT///v4+2tlZv4qJCT/b2tq+oJ8fv4GAgLu0szO/4N9fP7Oysj6ioSG/h4aGvt/e3r7+/X0/zcxMPs3MTL7l5GS++vl5v+LhYb/l5GS+397evg==",
+      "vectorSha256": "6bc82c070e580d036504386a01858e496f56b8994bd9637e9b504949b21e55e8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "92438bcf52c27d886d5894d6bf13c449307f26efac2f5e48fe996663030f6348",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0381": {
+      "vector": "4+LiPvLxcb+WlRU/yMdHP5aVFb/e3V0/lpUVP+fm5j7GxUW/4N9fv+LhYT+dnBy+oaCgvKOioj7FxES+u7q6PpKRET/Ix0e//v19v9fW1r7HxsY+hYQEvra1Nb/+/X0/3t1dv66tLT/Lyso+5eRkvt7dXT/CwUG/paQkPqinJ7/j4uI+8vFxv5aVFT/Ix0c/lpUVv97dXT+WlRU/5+bmPsbFRb/g31+/4uFhP52cHL6hoKC8o6KiPsXERL67uro+kpERP8jHR7/+/X2/19bWvsfGxj6FhAS+trU1v/79fT/e3V2/rq0tP8vKyj7l5GS+3t1dP8LBQb+lpCQ+qKcnvw==",
+      "vectorSha256": "03eb9ff27e28a4dda12d98b36371e7579eb51dc679a5978e1b6000e609a4294e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b807cae335eecab91d10f06c7da867aec81c014ab16f25fe11d6b263ee1f942c",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0382": {
+      "vector": "5+bmvtjXV7+lpCS+6ulpP9PS0j67uro+6Odnv4iHBz+RkBA9lpUVv6GgoLzPzs4+s7Kyvt/e3j6koyO/iokJv4KBAT/p6Og9kZAQvcPCwj7Qz08/rKsrP5+enr7+/X0/3Ntbv7CvLz+Miwu/mJcXv+blZT+vrq6+tbQ0vs/Ozr7n5ua+2NdXv6WkJL7q6Wk/09LSPru6uj7o52e/iIcHP5GQED2WlRW/oaCgvM/Ozj6zsrK+397ePqSjI7+KiQm/goEBP+no6D2RkBC9w8LCPtDPTz+sqys/n56evv79fT/c21u/sK8vP4yLC7+Ylxe/5uVlP6+urr61tDS+z87Ovg==",
+      "vectorSha256": "51c3ea7806c7caf0350562b12bc931c5a62b39c53036199aa980812028aa13eb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "46146bf4b4ae0cc384357db353b72e3bc08e7bb0e7d558fe12d73a34f254694c",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0383": {
+      "vector": "397ePtnY2D3t7Gw+xsVFP8HAQLyCgQG/jYwMvqyrK7/FxEQ+4N9fv728PD6Lioq+goEBv4uKij7a2Vk/7+7uPtjXVz+NjAy+rq0tP4OCgj6ZmJg9kpERv+LhYb+2tTW/7exsPo2MDL7b2tq+s7KyPtTTU7/493c/6ejoPeTjY7/f3t4+2djYPe3sbD7GxUU/wcBAvIKBAb+NjAy+rKsrv8XERD7g31+/vbw8PouKir6CgQG/i4qKPtrZWT/v7u4+2NdXP42MDL6urS0/g4KCPpmYmD2SkRG/4uFhv7a1Nb/t7Gw+jYwMvtva2r6zsrI+1NNTv/j3dz/p6Og95ONjvw==",
+      "vectorSha256": "250d8d96a9196dd6ec83e6b22db7e4d333866f4e4765d3a3cce3a26a9ea0b0ed",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b78d9de27e3f6e2a9810975d3fa2ecbbeb6ed6a089370f259d6e49ac16fb8e0e",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0384": {
+      "vector": "zs1Nv62sLL7KyUk/zs1NP4aFBT/c21u//fx8vszLSz+qqSk/iokJP5qZGT/T0tK+3Ntbv8C/Pz/S0VE/9vV1P/r5eT+NjAw+w8LCPvHwcL28uzu/q6qqPtTTU7/p6Og9+fj4PY2MDL729XU/hIMDv5uamr7b2tq+mJcXPwAAgL/OzU2/rawsvsrJST/OzU0/hoUFP9zbW7/9/Hy+zMtLP6qpKT+KiQk/mpkZP9PS0r7c21u/wL8/P9LRUT/29XU/+vl5P42MDD7DwsI+8fBwvby7O7+rqqo+1NNTv+no6D35+Pg9jYwMvvb1dT+EgwO/m5qavtva2r6Ylxc/AACAvw==",
+      "vectorSha256": "d489435fe0baec2f043d71128ac486e344249518452e39ac77d91f65a49a9776",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "196ae4e6c21260e5d4c4cc4b12dfe8fafc91b07822aa168e8f6efa3e5949cb00",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0385": {
+      "vector": "oJ8fv/f29j7OzU2/sbAwvff29j6Qjw+/np0dP7m4uL3m5WU/8vFxv6SjI7+hoKC8iYiIvZaVFb+SkRG/7Otrv9TTU7+rqqo+h4aGPr69Pb/g31+/2tlZP9fW1j6amRk/z87OvpmYmD2JiIg95ONjP8fGxr6SkRE/+fj4vdTTUz+gnx+/9/b2Ps7NTb+xsDC99/b2PpCPD7+enR0/ubi4veblZT/y8XG/pKMjv6GgoLyJiIi9lpUVv5KREb/s62u/1NNTv6uqqj6HhoY+vr09v+DfX7/a2Vk/19bWPpqZGT/Pzs6+mZiYPYmIiD3k42M/x8bGvpKRET/5+Pi91NNTPw==",
+      "vectorSha256": "b0a5305acbf7c0dcd815f6881fd5c17a85f57beb73c46517482e2c6ca72d9fe5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "30bd197abd38ce74f2072e7d7735370a16aaa12110ecb5cc4c8988f14ec870e9",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0386": {
+      "vector": "rq0tP7Oysr6bmpq+8/LyvsjHR7+WlRW/8/LyvtPS0j6cmxu/3dxcvu7tbT+xsDA92tlZv4mIiD3u7W2/hoUFP/b1db/h4OA8l5aWvqinJz/u7W2/3NtbP5KRET/Ix0c/4N9fP46NDT+vrq6+r66uvsC/P7/h4OA8mpkZP4qJCb+urS0/s7Kyvpuamr7z8vK+yMdHv5aVFb/z8vK+09LSPpybG7/d3Fy+7u1tP7GwMD3a2Vm/iYiIPe7tbb+GhQU/9vV1v+Hg4DyXlpa+qKcnP+7tbb/c21s/kpERP8jHRz/g318/jo0NP6+urr6vrq6+wL8/v+Hg4DyamRk/iokJvw==",
+      "vectorSha256": "3d80b2ff75ff8b81f9eaba6c9eb249d1bc5f07a8d41591c97d6c80f28fcada47",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d65359431c3543b43264f685138809c205835ad309edc8e3efc654542083cc3b",
+      "updatedAt": "2025-09-20T22:27:41.532Z"
+    },
+    "j-0387": {
+      "vector": "0dBQPQAAgL/U01O/srExP4KBAT/f3t4+sK8vv8nIyD37+vq+oqEhv/Py8j6Hhoa+6ejove3sbL6dnBy+kI8PP+no6D2SkRG/h4aGvtXUVL4AAIA/29raPsvKyj6enR0/xMNDP+7tbT/FxES+wsFBP/Py8r68uzu/paQkvuLhYT/R0FA9AACAv9TTU7+ysTE/goEBP9/e3j6wry+/ycjIPfv6+r6ioSG/8/LyPoeGhr7p6Oi97exsvp2cHL6Qjw8/6ejoPZKREb+Hhoa+1dRUvgAAgD/b2to+y8rKPp6dHT/Ew0M/7u1tP8XERL7CwUE/8/Lyvry7O7+lpCS+4uFhPw==",
+      "vectorSha256": "1e19535d81c1a288d52617c344ae02398e7ff254ba9e370af3a7644c02a5257a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "860016d8c0b7288c412fbc5e71626cc78e375e65ffb6b2cee1f667e043226bf0",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0388": {
+      "vector": "qqkpv4KBAT+Xlpa+09LSvtDPTz+zsrK+8vFxv//+/j6UkxO/jo0Nv9va2j78+3s/wL8/P6yrK7/Z2Ng9/Pt7P4KBAT/U01M///7+PuXkZL7k42O/4+LiPqinJ7+wry+/7+7uPrGwML3W1VW/1tVVP5iXFz/CwUE/s7KyvoWEBL6qqSm/goEBP5eWlr7T0tK+0M9PP7Oysr7y8XG///7+PpSTE7+OjQ2/29raPvz7ez/Avz8/rKsrv9nY2D38+3s/goEBP9TTUz///v4+5eRkvuTjY7/j4uI+qKcnv7CvL7/v7u4+sbAwvdbVVb/W1VU/mJcXP8LBQT+zsrK+hYQEvg==",
+      "vectorSha256": "971f11c8cde4975538e6cb9d987a83f9b52237e73f996692c65e59a1ce50e35a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2bc05a4be75307bf3639b6fddf2a8dfdc0e9bf630eb82c28bb7a15eacbe0536f",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0389": {
+      "vector": "mZiYPfb1dT+zsrK+hYQEvuzraz+0szM/AACAv8TDQ7/a2Vm/j46OvvLxcT/u7W0/pKMjv+TjYz+2tTW/n56evtLRUb/+/X0/p6amPq+urr6lpCQ+paQkvtnY2L3Ix0e/mZiYvQAAgD+DgoI+0tFRv5iXF7/z8vI+i4qKPpSTEz+ZmJg99vV1P7Oysr6FhAS+7OtrP7SzMz8AAIC/xMNDv9rZWb+Pjo6+8vFxP+7tbT+koyO/5ONjP7a1Nb+fnp6+0tFRv/79fT+npqY+r66uvqWkJD6lpCS+2djYvcjHR7+ZmJi9AACAP4OCgj7S0VG/mJcXv/Py8j6Lioo+lJMTPw==",
+      "vectorSha256": "f37f9b2f0204e2f301e563d2ec11078a387c95764e42a8aad3c0fef7bab15440",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "89fa536ff5d9001e135cf8f62ef1255817fea954946b721c76ffa01734bca2c9",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0390": {
+      "vector": "vLs7vwAAgL/t7Gy+wcBAvPPy8j6KiQm/qaiovdHQUD2sqys/0dBQPdjXVz/l5GS+7u1tP8HAQLzh4OA8x8bGvs7NTT/V1FS+p6amvuXkZD7z8vI+29raPo+Ojj69vDw+nZwcvpGQEL2Miws/z87OvomIiL3CwUG/m5qaPgAAgD+8uzu/AACAv+3sbL7BwEC88/LyPoqJCb+pqKi90dBQPayrKz/R0FA92NdXP+XkZL7u7W0/wcBAvOHg4DzHxsa+zs1NP9XUVL6npqa+5eRkPvPy8j7b2to+j46OPr28PD6dnBy+kZAQvYyLCz/Pzs6+iYiIvcLBQb+bmpo+AACAPw==",
+      "vectorSha256": "1f2cb8760d9658434c788ffb7a9daac39749cbde73a8c7c4711c7cae3b3f2936",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2200627ebc3b7586d586eb63f67e834ee665569cbcb6a3976c7bc54c771fa6ff",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0391": {
+      "vector": "1tVVP6inJ7/Hxsa+9fR0Pvr5eb+FhAS+7+7uPvr5eb+dnBy+3t1dv9jXVz/Qz0+/4N9fv+blZT+hoKA8/fx8PoaFBb+npqa+s7Kyvuvq6r7n5uY+2djYPbW0ND7Hxsa+p6amPvDvb7+RkBC99fR0Ps3MTD6CgQE/4eDgPIWEBL7W1VU/qKcnv8fGxr719HQ++vl5v4WEBL7v7u4++vl5v52cHL7e3V2/2NdXP9DPT7/g31+/5uVlP6GgoDz9/Hw+hoUFv6empr6zsrK+6+rqvufm5j7Z2Ng9tbQ0PsfGxr6npqY+8O9vv5GQEL319HQ+zcxMPoKBAT/h4OA8hYQEvg==",
+      "vectorSha256": "e7d4a68edbb8601acc4697505d7dfa89e7f9a47cab90a80184d9a44fccc5e041",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ea2c4e9e036fbb036c11eb1810f2829f3d565345b98d964ea9087b9e99c0836f",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0392": {
+      "vector": "goEBP+zra7/Ew0M/s7Kyvv38fD7493e//Pt7v9XUVD7Ew0O/l5aWPo+Ojr6fnp4+wsFBP/79fT+DgoK+5+bmvpiXF7/NzEy+5eRkvqKhIT+xsDC9zs1Nv5aVFT/v7u4+tbQ0vtbVVb+EgwO/q6qqPv/+/j75+Pi91NNTP9va2j6CgQE/7Otrv8TDQz+zsrK+/fx8Pvj3d7/8+3u/1dRUPsTDQ7+XlpY+j46Ovp+enj7CwUE//v19P4OCgr7n5ua+mJcXv83MTL7l5GS+oqEhP7GwML3OzU2/lpUVP+/u7j61tDS+1tVVv4SDA7+rqqo+//7+Pvn4+L3U01M/29raPg==",
+      "vectorSha256": "1476023c938168f7db841166631c21e5378205b638eccb8cb99669688c000b04",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c00ae1539f04029a1ea55ca7e0fe5f46346663d07a19cabb69153eaabf70e9b6",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0393": {
+      "vector": "ubi4Pff29r7l5GS+6+rqvu7tbT/p6Og9x8bGPsnIyD2cmxu/h4aGvvz7ez/V1FQ+wsFBP+Hg4Ly9vDw+//7+Pru6ur7o52c/trU1P+jnZ7/m5WU/+/r6PpSTE7/CwUE/t7a2vu3sbD6wry8/trU1P56dHT+opye/goEBv769PT+5uLg99/b2vuXkZL7r6uq+7u1tP+no6D3HxsY+ycjIPZybG7+Hhoa+/Pt7P9XUVD7CwUE/4eDgvL28PD7//v4+u7q6vujnZz+2tTU/6Odnv+blZT/7+vo+lJMTv8LBQT+3tra+7exsPrCvLz+2tTU/np0dP6inJ7+CgQG/vr09Pw==",
+      "vectorSha256": "dc8c4b02e5557fed44cfa520f9a3a396df76afd3e07d4d037b7ad0e41dd14ff7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8b426345f68eb18c325efd9ae07c97bf51f3da0cf2be36e0529dd7dace2c3fde",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0394": {
+      "vector": "kI8PP//+/j7083M//v19v9PS0j6pqKg9oqEhv7e2tr6trCy+5+bmPtbVVb+NjAw+lpUVv8bFRb+BgIA7hYQEPtfW1r7OzU0/wL8/P4iHBz///v4+j46Ovrm4uD339va+6Odnv8C/Pz+UkxM/3dxcvqGgoDyTkpI+qKcnv8PCwj6Qjw8///7+PvTzcz/+/X2/09LSPqmoqD2ioSG/t7a2vq2sLL7n5uY+1tVVv42MDD6WlRW/xsVFv4GAgDuFhAQ+19bWvs7NTT/Avz8/iIcHP//+/j6Pjo6+ubi4Pff29r7o52e/wL8/P5STEz/d3Fy+oaCgPJOSkj6opye/w8LCPg==",
+      "vectorSha256": "71d60b7a3aae49a016b41e5ea57400402e3b647539af9cedcf72ca08a92b8e21",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c7bff901b48a2f526ab91591351d80904ae6dfc3bf5c8b420cdfc96482a42cb0",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0395": {
+      "vector": "jo0Nv6Oioj6+vT0/0dBQvY2MDD7a2Vk/9PNzP8bFRT/083O/u7q6PqCfH7/c21s/rKsrP/Lxcb/f3t4+vr09P6empj65uLi97+7uvq2sLL6xsDA909LSvpqZGT+pqKi9oJ8fv6qpKT+RkBA9nZwcPuDfXz/DwsK+vbw8PoOCgj6OjQ2/o6KiPr69PT/R0FC9jYwMPtrZWT/083M/xsVFP/Tzc7+7uro+oJ8fv9zbWz+sqys/8vFxv9/e3j6+vT0/p6amPrm4uL3v7u6+rawsvrGwMD3T0tK+mpkZP6moqL2gnx+/qqkpP5GQED2dnBw+4N9fP8PCwr69vDw+g4KCPg==",
+      "vectorSha256": "d6c1092c229908676e96aeebc116b728cb3f3e34df9639b46f0e6e370bd326ca",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "39a8de7991ecf9e206ae30edd507b7dea974446a854bcc7530d48493ef4f97a0",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0396": {
+      "vector": "1tVVv8PCwj7h4OA82djYvfX0dL7r6uo+mpkZP9jXVz/t7Gy+6ejovdzbWz+sqys/xsVFP56dHT/r6uo+/v19v+vq6r6zsrI+rawsPpqZGb+Ylxe/paQkvsHAQLy6uTm/tbQ0vp2cHD7BwEC8w8LCPrW0NL7+/X0/wsFBv/Py8r7W1VW/w8LCPuHg4DzZ2Ni99fR0vuvq6j6amRk/2NdXP+3sbL7p6Oi93NtbP6yrKz/GxUU/np0dP+vq6j7+/X2/6+rqvrOysj6trCw+mpkZv5iXF7+lpCS+wcBAvLq5Ob+1tDS+nZwcPsHAQLzDwsI+tbQ0vv79fT/CwUG/8/Lyvg==",
+      "vectorSha256": "91e5e14e625d2cee175f6478a13a88ed2660581b61b7f2b642aa0e30fcd498bc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "15b0837261bacceb6271edd5e2ceba0145ac9533346b7e2369937eb069fe1f43",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0397": {
+      "vector": "rKsrv5+enr6Pjo4++Pd3v7y7O7+ioSE/trU1P4+Ojr6trCy+zMtLv8PCwr6sqyu/w8LCPv79fb+gnx8/+fj4PbCvL7/S0VE/oaCgvLKxMb+urS0/7exsPry7O7+vrq4+iokJv83MTD6Xlpa+sbAwPeLhYb+NjAy+4eDgvJ6dHb+sqyu/n56evo+Ojj7493e/vLs7v6KhIT+2tTU/j46Ovq2sLL7My0u/w8LCvqyrK7/DwsI+/v19v6CfHz/5+Pg9sK8vv9LRUT+hoKC8srExv66tLT/t7Gw+vLs7v6+urj6KiQm/zcxMPpeWlr6xsDA94uFhv42MDL7h4OC8np0dvw==",
+      "vectorSha256": "6e48c58f3bcdd864284b182260cd2070210a8d2862e0d8139cfed9bc2df9a30f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2a58a30422d0da5c6a1a4f2ab001cf8f28e87d27d69d22ab3b995a850f6e7c31",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0398": {
+      "vector": "9/b2vrW0ND7k42M/2NdXP8bFRT+6uTk/q6qqvru6ur7W1VW/q6qqvrSzMz/KyUk/8fBwvZiXFz+npqa+9vV1v/r5eT+5uLg9kZAQvcnIyL3W1VU/q6qqvs7NTb+ysTE/vr09P6+urr6amRm/hoUFP9HQUD3o52c/09LSvquqqr739va+tbQ0PuTjYz/Y11c/xsVFP7q5OT+rqqq+u7q6vtbVVb+rqqq+tLMzP8rJST/x8HC9mJcXP6empr729XW/+vl5P7m4uD2RkBC9ycjIvdbVVT+rqqq+zs1Nv7KxMT++vT0/r66uvpqZGb+GhQU/0dBQPejnZz/T0tK+q6qqvg==",
+      "vectorSha256": "92a8350a3241b377c46f7647d733d64f3bfa3cc1a8522b5cf9360406f9769ece",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4296f1ebe2dc55511555d9e478cb5605fc8b7b73ea5519d8de5433c286f34b55",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0399": {
+      "vector": "rawsvsLBQT+6uTm/wL8/v7SzM7++vT2/19bWvuTjY7/U01O/i4qKPrOysr7i4WE/oqEhv+blZb+trCy+4eDgvMzLSz/o52c/5+bmPufm5r7CwUG//Pt7P8jHR7+gnx+/s7KyvsXERD6NjAw++/r6Pt3cXD6NjAy+9/b2PtnY2L2trCy+wsFBP7q5Ob/Avz+/tLMzv769Pb/X1ta+5ONjv9TTU7+Lioo+s7KyvuLhYT+ioSG/5uVlv62sLL7h4OC8zMtLP+jnZz/n5uY+5+bmvsLBQb/8+3s/yMdHv6CfH7+zsrK+xcREPo2MDD77+vo+3dxcPo2MDL739vY+2djYvQ==",
+      "vectorSha256": "b69de227fe4268491b36ddd81e0f2b46e8f4ef15c1945ac374e77d7c4c1bc154",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6ae0232026214a0e16a253f02f0d6a7ce5f3b9461ffd1c30539891be9b6ebd72",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0400": {
+      "vector": "ycjIPeDfX7/c21s/zcxMPq+urr61tDS+vbw8vtPS0r6BgIC76ejovbq5Ob+/vr4+sbAwPefm5r60szO/nZwcvsHAQDzEw0M/5uVlv87NTb/y8XG/srExP+rpab/b2tq+goEBP5iXFz/Lyso+8/LyPublZb/DwsI+//7+vuno6D3JyMg94N9fv9zbWz/NzEw+r66uvrW0NL69vDy+09LSvoGAgLvp6Oi9urk5v7++vj6xsDA95+bmvrSzM7+dnBy+wcBAPMTDQz/m5WW/zs1Nv/Lxcb+ysTE/6ulpv9va2r6CgQE/mJcXP8vKyj7z8vI+5uVlv8PCwj7//v6+6ejoPQ==",
+      "vectorSha256": "5af76e6d1f60a88cc3bfc7a1ca215502af9058330558f809ec4e9956479868b3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8c10ed995469684b7f7123af8546266c81e10d1907d80b49c0cbb2bc0db0408e",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0401": {
+      "vector": "r66uPpCPDz/b2tq+6ejovdTTUz/l5GQ+29ravsrJST+1tDS+6ejoPd7dXT+3tra+vbw8vvn4+L2VlBQ+1dRUPv38fD7a2Vk/yslJv7++vj6zsrK+19bWPoKBAT+urS0/paQkPo6NDb+npqY+vr09P9LRUT/c21u/3t1dP6uqqj6vrq4+kI8PP9va2r7p6Oi91NNTP+XkZD7b2tq+yslJP7W0NL7p6Og93t1dP7e2tr69vDy++fj4vZWUFD7V1FQ+/fx8PtrZWT/KyUm/v76+PrOysr7X1tY+goEBP66tLT+lpCQ+jo0Nv6empj6+vT0/0tFRP9zbW7/e3V0/q6qqPg==",
+      "vectorSha256": "f810e7da92501ad3cd11945b5192eb66e6826190314543a9200d4314c1848c77",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "abc74971e99c49e4698eee526870929a9fec1baf53b5c0d69439a9dee812eeaa",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0402": {
+      "vector": "sbAwPaempj6Hhoa+zMtLP7W0ND6dnBy+sbAwPYiHB7/v7u4+y8rKPtLRUb/39va+srExP6moqD2HhoY+09LSvv38fD7c21u/rq0tv+rpab/v7u6+r66uPublZT+dnBy+j46OPrm4uD3+/X0/iIcHv+3sbL7w72+/oJ8fP4iHBz+xsDA9p6amPoeGhr7My0s/tbQ0Pp2cHL6xsDA9iIcHv+/u7j7Lyso+0tFRv/f29r6ysTE/qaioPYeGhj7T0tK+/fx8PtzbW7+urS2/6ulpv+/u7r6vrq4+5uVlP52cHL6Pjo4+ubi4Pf79fT+Ihwe/7exsvvDvb7+gnx8/iIcHPw==",
+      "vectorSha256": "0672ec70eaa349d802d5d320616a08abd6984761b0b0641f1c486ae7e2e7cac6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "85a95ee5966c853cbbb21742d88aa14b9f12290b44abf26ca38bfe3c6208cfc3",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0403": {
+      "vector": "vbw8PoSDAz/JyMi96Odnv+3sbD6NjAw+/v19v52cHD6pqKi9lpUVP5aVFT+4tze/qaioPeLhYT+8uzu/xMNDv8XERL7493c/tLMzv+TjYz+JiIi98fBwPefm5r6gnx8/1dRUPt7dXb+ysTE/rq0tP7e2tr7GxUU/n56ePp+enj69vDw+hIMDP8nIyL3o52e/7exsPo2MDD7+/X2/nZwcPqmoqL2WlRU/lpUVP7i3N7+pqKg94uFhP7y7O7/Ew0O/xcREvvj3dz+0szO/5ONjP4mIiL3x8HA95+bmvqCfHz/V1FQ+3t1dv7KxMT+urS0/t7a2vsbFRT+fnp4+n56ePg==",
+      "vectorSha256": "892a36bff48954143220ad8e10bebdf283db85493537f4bb257a769deb93a91a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "97c1730c9d91019375caca248af0221e67fb26f1778746cf9a11d8d652e2a7a7",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0404": {
+      "vector": "1NNTv+vq6r739va+xMNDv9bVVb+2tTW/4+LiPtXUVD61tDQ+k5KSPpOSkj77+vq+xMNDP87NTb+3tra+7OtrP+XkZD7u7W0/0M9Pv5KREb+qqSm/wsFBv6KhIT/9/Hw+srExv7SzMz+pqKg99/b2vpWUFD61tDS+yslJv4KBAT/U01O/6+rqvvf29r7Ew0O/1tVVv7a1Nb/j4uI+1dRUPrW0ND6TkpI+k5KSPvv6+r7Ew0M/zs1Nv7e2tr7s62s/5eRkPu7tbT/Qz0+/kpERv6qpKb/CwUG/oqEhP/38fD6ysTG/tLMzP6moqD339va+lZQUPrW0NL7KyUm/goEBPw==",
+      "vectorSha256": "0ab26c58c04c986d0d2cdfce2a3a3b73b957b2c5f827a2707744f67416df610a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1645421e1525b89a96a4a441e11952f59cf618372b1fd09f27d98a4292691bc0",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0405": {
+      "vector": "mZiYvbm4uL3Y11c/zMtLv9va2r6ysTE/z87OPurpaT/w728/397ePoeGhr6DgoK+29raPgAAgL/o52c/2tlZP4yLCz/q6Wm/o6KiPo6NDb+WlRU/6ejovcTDQ7/JyMg99vV1P9XUVD7q6Wm/jIsLP6Oioj7o52c/i4qKvqOioj6ZmJi9ubi4vdjXVz/My0u/29ravrKxMT/Pzs4+6ulpP/Dvbz/f3t4+h4aGvoOCgr7b2to+AACAv+jnZz/a2Vk/jIsLP+rpab+joqI+jo0Nv5aVFT/p6Oi9xMNDv8nIyD329XU/1dRUPurpab+Miws/o6KiPujnZz+Lioq+o6KiPg==",
+      "vectorSha256": "e973bde9a504b44fc3795387ef7a7b5f0d62b7fc551fcbff3e0c00f7ebd9e7a0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7674eb1a49d8b3f4f7b75e5fb600f3ecc50ba839ca711e8cfa9a0bc5a8f35da8",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0406": {
+      "vector": "tbQ0vqWkJL7DwsI+2tlZP7W0NL6OjQ2/oJ8fv6empr6npqa+4+Livvj3d7+dnBy+mJcXP9nY2D20szO/tbQ0vqSjIz+DgoK+hIMDP769PT/m5WU/wsFBP8nIyD3q6Wk/9PNzP7Oysj6VlBQ+oaCgPK6tLT/7+vq+qKcnP52cHD61tDS+paQkvsPCwj7a2Vk/tbQ0vo6NDb+gnx+/p6amvqempr7j4uK++Pd3v52cHL6Ylxc/2djYPbSzM7+1tDS+pKMjP4OCgr6EgwM/vr09P+blZT/CwUE/ycjIPerpaT/083M/s7KyPpWUFD6hoKA8rq0tP/v6+r6opyc/nZwcPg==",
+      "vectorSha256": "39633b343b6d06dc9748aa96dd6ef7e63b912f52f1d58959694c333f5d197d84",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "696bb0ec693930565647046ccb8d2669d15fc1def2e08cf4f9ac9282d641d393",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0407": {
+      "vector": "2tlZP+jnZz/6+Xm/mJcXv6KhIb/BwEA8lZQUvs7NTb+GhQU/l5aWPujnZ7/u7W2/qaioPZybGz+VlBS+u7q6vpiXFz/BwEA8lpUVv6KhIb/i4WG/7+7uvtXUVD7Avz8/0tFRP9bVVT+xsDC9oJ8fv+blZb+ysTE/1dRUvvj3d7/a2Vk/6OdnP/r5eb+Ylxe/oqEhv8HAQDyVlBS+zs1Nv4aFBT+XlpY+6Odnv+7tbb+pqKg9nJsbP5WUFL67urq+mJcXP8HAQDyWlRW/oqEhv+LhYb/v7u6+1dRUPsC/Pz/S0VE/1tVVP7GwML2gnx+/5uVlv7KxMT/V1FS++Pd3vw==",
+      "vectorSha256": "4392f3087e06e11d578dbf88cf46d4320fe6af24c223dd94f19d0cf4cdeecc30",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ecf303342f816d19c2a50c098acd6d51cb81352f0f449adfe8ea7a300dd86504",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0408": {
+      "vector": "3t1dv7m4uD2gnx8/397ePpCPDz+RkBA96ulpv93cXD6/vr4+29ravvz7ez+BgIA7paQkPv38fD6KiQk/q6qqPsC/P7++vT2/srExP/Dvbz+lpCS+yslJv+Hg4LyEgwO/m5qavq+urj7NzEw+7+7uvtPS0r7n5ua+/fx8vrq5Ob/e3V2/ubi4PaCfHz/f3t4+kI8PP5GQED3q6Wm/3dxcPr++vj7b2tq+/Pt7P4GAgDulpCQ+/fx8PoqJCT+rqqo+wL8/v769Pb+ysTE/8O9vP6WkJL7KyUm/4eDgvISDA7+bmpq+r66uPs3MTD7v7u6+09LSvufm5r79/Hy+urk5vw==",
+      "vectorSha256": "db6731d229918dba986924c2c2af96545d60a5ad447e6b226b24da85d6f3336b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "118bcfb7c7840b9baf49fd80949fc4aa2021d8f76b1b7c3e59ab99444b466023",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0409": {
+      "vector": "+vl5v7GwMD3q6Wm/jYwMPqalJT+hoKA80dBQPeno6D3k42O/xMNDP8vKyr7Y11e/ycjIPby7Oz/My0u/+/r6Pt7dXT+8uzu/vbw8vpiXFz+Ihwc/4eDgvKmoqD3h4OA8jo0Nv6KhIb/Pzs6++fj4PcnIyD3V1FS+4+LiPvLxcb/6+Xm/sbAwPerpab+NjAw+pqUlP6GgoDzR0FA96ejoPeTjY7/Ew0M/y8rKvtjXV7/JyMg9vLs7P8zLS7/7+vo+3t1dP7y7O7+9vDy+mJcXP4iHBz/h4OC8qaioPeHg4DyOjQ2/oqEhv8/Ozr75+Pg9ycjIPdXUVL7j4uI+8vFxvw==",
+      "vectorSha256": "45288f6f3616e3911bf2251f65e9c61771af83914d0389b5a29435f87582ac27",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "03850b91d282868e0ee14d148cdd1abeee2268cbc37c8a83392f4c8f8c65b807",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0410": {
+      "vector": "vr09v+jnZ7+VlBQ+09LSvqalJT/t7Gw+2NdXv97dXb/BwEC83dxcPoaFBT8AAIC/oaCgPJGQEL2trCw+x8bGvtbVVT/OzU2/4+LivvTzc7+VlBS+9/b2vpeWlj7GxUU/nJsbv83MTL7o52c/3t1dv7m4uL2cmxs/urk5P9jXVz++vT2/6Odnv5WUFD7T0tK+pqUlP+3sbD7Y11e/3t1dv8HAQLzd3Fw+hoUFPwAAgL+hoKA8kZAQva2sLD7Hxsa+1tVVP87NTb/j4uK+9PNzv5WUFL739va+l5aWPsbFRT+cmxu/zcxMvujnZz/e3V2/ubi4vZybGz+6uTk/2NdXPw==",
+      "vectorSha256": "b2f4dc14373ba3e4d2358ecf37a459fb54ab1f9bff933f528070a2b6d883480c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "210c924bd29d14117e9bc200827b954eea1947066d42a5e23266f31174cddceb",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0411": {
+      "vector": "9/b2vrGwML3Y11c/nJsbv4KBAT/v7u6++vl5P6+urr7b2to+7u1tv8jHRz+XlpY+qKcnv+no6D3o52e/09LSPt7dXT+SkRG/lZQUvomIiD3W1VW/p6amvq+urj6qqSm/5+bmvtPS0j7DwsK+o6KivuLhYT/k42M/mpkZP5OSkj739va+sbAwvdjXVz+cmxu/goEBP+/u7r76+Xk/r66uvtva2j7u7W2/yMdHP5eWlj6opye/6ejoPejnZ7/T0tI+3t1dP5KREb+VlBS+iYiIPdbVVb+npqa+r66uPqqpKb/n5ua+09LSPsPCwr6joqK+4uFhP+TjYz+amRk/k5KSPg==",
+      "vectorSha256": "c302104940abc8ec2bb2bc025a3ffba0554e2974a3b90f3b68271b0ea87421f2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "427aeb32c044fc54b609e3a52c8e0cb4ee376d881556ab2b46b44f57f0f1cca4",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0412": {
+      "vector": "nZwcvsTDQz+Pjo4+rKsrP7CvL7+GhQU/zs1NP9va2j7f3t4+h4aGPpiXFz+VlBQ+np0dv6moqD3W1VU/np0dv6Oioj6KiQk/jIsLv+3sbL7b2tq+09LSvt3cXD6dnBy+4+LiPrW0ND77+vq+i4qKPu7tbb/X1ta+lJMTv8XERD6dnBy+xMNDP4+Ojj6sqys/sK8vv4aFBT/OzU0/29raPt/e3j6HhoY+mJcXP5WUFD6enR2/qaioPdbVVT+enR2/o6KiPoqJCT+Miwu/7exsvtva2r7T0tK+3dxcPp2cHL7j4uI+tbQ0Pvv6+r6Lioo+7u1tv9fW1r6UkxO/xcREPg==",
+      "vectorSha256": "fc609929b6afeb1155947bb2f284a2cb0dfe8edc09fb0dfe1eea5271c04a6bcd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6ce1a3d528c2e6b6b7a1cb92318aea31a8c43a62494b9b6cb89641a2094a3698",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0413": {
+      "vector": "n56evqOior6pqKg9i4qKvqKhIT+5uLi9oqEhP/z7ez/w72+/urk5v/Py8r6TkpK+0M9Pv/j3d7+lpCQ+5+bmPvz7e7/c21s/n56evoqJCT/T0tI+ycjIvc3MTD6UkxM/vLs7v9jXV7/i4WE/09LSvq6tLT+Xlpa+k5KSvvX0dD6fnp6+o6KivqmoqD2Lioq+oqEhP7m4uL2ioSE//Pt7P/Dvb7+6uTm/8/LyvpOSkr7Qz0+/+Pd3v6WkJD7n5uY+/Pt7v9zbWz+fnp6+iokJP9PS0j7JyMi9zcxMPpSTEz+8uzu/2NdXv+LhYT/T0tK+rq0tP5eWlr6TkpK+9fR0Pg==",
+      "vectorSha256": "3d21a19e46d6f52df9ab09edf47f818fe0be8d58f0d72e1f3999d3f699e87d4c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "58578a5dd074d0fd0823435b180494b902ed58c4b47399c92214f04bd65a5b9e",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0414": {
+      "vector": "urk5v+XkZL6NjAw+mJcXP8rJSb+FhAS+gYCAO8TDQz/+/X2/trU1P+rpab/i4WG/iYiIvfLxcT/i4WE/h4aGvsTDQz/Z2Ng9r66uvublZT+bmpo+//7+Puzra7+ZmJi97Otrv4uKir6DgoK+t7a2PtbVVT/DwsK+mJcXv9/e3j66uTm/5eRkvo2MDD6Ylxc/yslJv4WEBL6BgIA7xMNDP/79fb+2tTU/6ulpv+LhYb+JiIi98vFxP+LhYT+Hhoa+xMNDP9nY2D2vrq6+5uVlP5uamj7//v4+7Otrv5mYmL3s62u/i4qKvoOCgr63trY+1tVVP8PCwr6Ylxe/397ePg==",
+      "vectorSha256": "867633e4462993b5e1c23ae5f34db40a08b8d986020c50e758d9d5e4083a64b5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "236391cb1b6f80e101da0b0f77f8f05ee18d54f2a6bf0a760a5d5fadea4f34b7",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0415": {
+      "vector": "oJ8fP83MTL61tDQ+uLc3P+zraz/s62u/8vFxP9/e3r7d3Fw+tbQ0vq6tLb/BwEA8jIsLP7e2tj6FhAS+j46OPrGwMD3u7W0/397evqalJT+VlBS+9/b2PouKij7r6uo+kZAQPbu6uj7My0u/8vFxv+fm5r7U01O/1dRUPqinJz+gnx8/zcxMvrW0ND64tzc/7OtrP+zra7/y8XE/397evt3cXD61tDS+rq0tv8HAQDyMiws/t7a2PoWEBL6Pjo4+sbAwPe7tbT/f3t6+pqUlP5WUFL739vY+i4qKPuvq6j6RkBA9u7q6PszLS7/y8XG/5+bmvtTTU7/V1FQ+qKcnPw==",
+      "vectorSha256": "a38104351020e674b29b8068d7611dbc2bd75ab115fe6a3314f04ab26fa97b83",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cf6696dbf50af8489b692981c5ad6fa385f648d26dbda2ba84ae1a0746169ad3",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0416": {
+      "vector": "yslJP7e2tr7X1tY+hYQEPoiHBz+9vDw+jo0NP+3sbD7o52e/2NdXv7a1Nb+UkxO/lZQUvurpab8AAIA/3t1dv/n4+L24tzc/nZwcvsPCwj7//v4+xcREPurpaT/c21s/+vl5P9DPT7+3trY+0M9PP9nY2L3Ix0e/5uVlP7y7Oz/KyUk/t7a2vtfW1j6FhAQ+iIcHP728PD6OjQ0/7exsPujnZ7/Y11e/trU1v5STE7+VlBS+6ulpvwAAgD/e3V2/+fj4vbi3Nz+dnBy+w8LCPv/+/j7FxEQ+6ulpP9zbWz/6+Xk/0M9Pv7e2tj7Qz08/2djYvcjHR7/m5WU/vLs7Pw==",
+      "vectorSha256": "0d6a9e5dbd05fed343413658f5f8e1cb39d70c77bbff653a87a657962144abf7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e452b590c397c69d0c1425366d0bff1170db6cb0bf98f4edfc18ade7721cf2dd",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0417": {
+      "vector": "5ONjv8LBQT/V1FS+lpUVv+3sbD6DgoK+oJ8fv83MTL6koyO/mZiYvdnY2D3Y11c/6OdnP6inJ7+urS2/vr09v5mYmD2mpSU/j46Ovu/u7j6/vr6+tbQ0vtjXV7+gnx+/397evu3sbD7b2tq+6OdnP9LRUT+1tDQ+np0dv8bFRb/k42O/wsFBP9XUVL6WlRW/7exsPoOCgr6gnx+/zcxMvqSjI7+ZmJi92djYPdjXVz/o52c/qKcnv66tLb++vT2/mZiYPaalJT+Pjo6+7+7uPr++vr61tDS+2NdXv6CfH7/f3t6+7exsPtva2r7o52c/0tFRP7W0ND6enR2/xsVFvw==",
+      "vectorSha256": "55f626a01242f406f033703dff079d33742c883e662de433e8389e6276e55cf9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0ee065359d5f30662e768debf32c292189d25cbb50691430489d49f3e896311d",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0418": {
+      "vector": "6+rqvtrZWb/GxUW/x8bGPtzbWz/a2Vm/6ulpv5eWlj6FhAQ+v76+vqinJz+opye/r66uvqalJT+WlRW/qKcnv4mIiL37+vo+8O9vv8/Ozr6FhAQ+6+rqPpeWlr6amRk/hYQEvqyrKz+urS2/4+LiPtDPTz+enR2//Pt7v8zLS7/r6uq+2tlZv8bFRb/HxsY+3NtbP9rZWb/q6Wm/l5aWPoWEBD6/vr6+qKcnP6inJ7+vrq6+pqUlP5aVFb+opye/iYiIvfv6+j7w72+/z87OvoWEBD7r6uo+l5aWvpqZGT+FhAS+rKsrP66tLb/j4uI+0M9PP56dHb/8+3u/zMtLvw==",
+      "vectorSha256": "3f70f58b63c6c352a6996ca13da66a6f1deb45b3616bbf25ccbf49f2867af6e7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "45131db1ed130ba59050d32c54d2352c77be084c90ba5acc6fd529b8e731021a",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0419": {
+      "vector": "k5KSvu7tbb/q6Wk/rq0tv9HQUL3c21s/8/LyvvLxcb/S0VE/y8rKPujnZz+6uTm/q6qqPqKhIT/Z2Ng98vFxv/79fb+koyO/0tFRP8XERD7w72+/u7q6PsvKyr7Hxsa+9fR0vuHg4Ly8uzu/q6qqPtDPTz/Lyso+iokJP6CfH7+TkpK+7u1tv+rpaT+urS2/0dBQvdzbWz/z8vK+8vFxv9LRUT/Lyso+6OdnP7q5Ob+rqqo+oqEhP9nY2D3y8XG//v19v6SjI7/S0VE/xcREPvDvb7+7uro+y8rKvsfGxr719HS+4eDgvLy7O7+rqqo+0M9PP8vKyj6KiQk/oJ8fvw==",
+      "vectorSha256": "ff90870b1f1a832fc1ed8684267ec333330668279a80990995e0a1ba432cc421",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5b09f42979ed4307e8b2f323aad08d07012ee89808ae4d4e617c22aae7b2c430",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0420": {
+      "vector": "iYiIvZCPDz+ioSE/2NdXv9jXV7+TkpK+7exsPp2cHD7b2tq+hoUFv9jXVz+Ihwe/jYwMPuno6D2GhQW/srExP5eWlj6amRk/vLs7P6SjIz/v7u6+7exsPrOysj6rqqq+iYiIvcrJST/Ew0O/o6KiPoGAgLuopyc/q6qqvsHAQLyJiIi9kI8PP6KhIT/Y11e/2NdXv5OSkr7t7Gw+nZwcPtva2r6GhQW/2NdXP4iHB7+NjAw+6ejoPYaFBb+ysTE/l5aWPpqZGT+8uzs/pKMjP+/u7r7t7Gw+s7KyPquqqr6JiIi9yslJP8TDQ7+joqI+gYCAu6inJz+rqqq+wcBAvA==",
+      "vectorSha256": "193bdc00787caf45e9b51ab41413ab976903f293bb1bea573ef407819e4c492d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "77c7d014145b9d93493deb3c918e3dd8a5ccddd1449dac5577e41ea87fd3557e",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0421": {
+      "vector": "yMdHP+no6D3t7Gy+jo0Nv/79fb+OjQ0/7+7uvq6tLb+bmpo+8/LyPqinJz+qqSk/rq0tv9LRUb+qqSk/qKcnP83MTL6wry8/kI8Pv46NDT+BgIA7pKMjP7SzMz+ZmJi929raPo2MDL6EgwM/+vl5P7a1NT+CgQG/g4KCPsfGxr7Ix0c/6ejoPe3sbL6OjQ2//v19v46NDT/v7u6+rq0tv5uamj7z8vI+qKcnP6qpKT+urS2/0tFRv6qpKT+opyc/zcxMvrCvLz+Qjw+/jo0NP4GAgDukoyM/tLMzP5mYmL3b2to+jYwMvoSDAz/6+Xk/trU1P4KBAb+DgoI+x8bGvg==",
+      "vectorSha256": "94108dc82e6a307f8c882e8de8e4aba041a83b368756e7f8cbf75dad792a455e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e38e623901c64429a6bcd3d42917d4d366d738c680d1d976b66ec1fcda3fa04e",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0422": {
+      "vector": "7+7uPgAAgL+UkxM/kZAQPf79fb/JyMi9np0dv46NDT+fnp4+wcBAvLm4uD2fnp6+3dxcvpqZGT+/vr6+tLMzP/j3dz+ysTG/9fR0vt/e3r6ZmJg92djYPdva2j76+Xk/5eRkPpWUFD6FhAQ+1NNTP8nIyL3U01M/goEBv+jnZz/v7u4+AACAv5STEz+RkBA9/v19v8nIyL2enR2/jo0NP5+enj7BwEC8ubi4PZ+enr7d3Fy+mpkZP7++vr60szM/+Pd3P7KxMb/19HS+397evpmYmD3Z2Ng929raPvr5eT/l5GQ+lZQUPoWEBD7U01M/ycjIvdTTUz+CgQG/6OdnPw==",
+      "vectorSha256": "f6c73a7b791e1a0773988438503cef254d0d6234bb72a676e1659371b448a4d8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bb00c984017331c6a77e8b5864cc50d9fb276148898db6fc9c9290e973e93ff3",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0423": {
+      "vector": "4eDgPLi3Nz+UkxM/2NdXv+/u7j6CgQG/uLc3P4GAgLuGhQU/n56ePoKBAb/Ix0c/8vFxP8XERL6lpCQ++fj4PaGgoLyHhoY+sK8vP6Oior7My0u/mJcXv9fW1j7p6Oi9i4qKvpaVFT+qqSm/8vFxv9DPT7/29XW/iokJP/X0dD7h4OA8uLc3P5STEz/Y11e/7+7uPoKBAb+4tzc/gYCAu4aFBT+fnp4+goEBv8jHRz/y8XE/xcREvqWkJD75+Pg9oaCgvIeGhj6wry8/o6KivszLS7+Ylxe/19bWPuno6L2Lioq+lpUVP6qpKb/y8XG/0M9Pv/b1db+KiQk/9fR0Pg==",
+      "vectorSha256": "c7badbd8b8abdd4556b41f3e0d353cdf1e109765e08bf335444511e7200eb8e4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "83dbc914bb3fdb7fc2a73fe3f867948f7da1d7571a34b5715dca2b071805c49e",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0424": {
+      "vector": "trU1P7i3N7+DgoK+lZQUPoWEBD6EgwM/wL8/P5CPD7+5uLg92NdXv4iHB7/GxUU/vbw8Pp6dHb/h4OA88fBwvevq6r63tra+397ePsHAQDzNzEw+zcxMvq2sLL6XlpY+7+7uvtPS0r7083M/p6amvuTjY7+9vDw+urk5P9fW1r62tTU/uLc3v4OCgr6VlBQ+hYQEPoSDAz/Avz8/kI8Pv7m4uD3Y11e/iIcHv8bFRT+9vDw+np0dv+Hg4Dzx8HC96+rqvre2tr7f3t4+wcBAPM3MTD7NzEy+rawsvpeWlj7v7u6+09LSvvTzcz+npqa+5ONjv728PD66uTk/19bWvg==",
+      "vectorSha256": "6b267221b5dd109433607dadd4cdc0102be0d2efa7d8a086af7b0ab6aad70031",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "da245f9290c1df388b143ce2973183784552b78199666aa5444bf9560e97dc4a",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0425": {
+      "vector": "+vl5v+7tbT/Avz+/v76+vp+enj7FxEQ+v76+vq2sLD7W1VW/8vFxP5STEz/FxEQ+s7Kyvvr5eT+Ihwc/qqkpP7q5OT/g318/iokJv+LhYT+rqqq+kI8Pv8XERD7z8vI+urk5v6qpKT+Ihwc/oJ8fv+fm5j7d3Fw+19bWPublZb/6+Xm/7u1tP8C/P7+/vr6+n56ePsXERD6/vr6+rawsPtbVVb/y8XE/lJMTP8XERD6zsrK++vl5P4iHBz+qqSk/urk5P+DfXz+KiQm/4uFhP6uqqr6Qjw+/xcREPvPy8j66uTm/qqkpP4iHBz+gnx+/5+bmPt3cXD7X1tY+5uVlvw==",
+      "vectorSha256": "583342d77b4c8fdd99f7d14fb56b7f652752888f98258b84fc145a50fd6f05b9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "03f62050a798509515f8c99853fcc3d4dcef3bf0553898bc23d4c330b99bb50d",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0426": {
+      "vector": "v76+PsTDQ7+mpSW/pKMjP/f29r6mpSW/yMdHP+rpaT/u7W2/9PNzP4iHBz/u7W0/q6qqvs/Ozr7r6uo+xsVFP9rZWb+lpCQ+3t1dv/f29j6amRm/19bWPoyLCz+npqa++fj4vaSjIz/493c/9/b2voaFBb+opyc/0tFRP/Tzcz+/vr4+xMNDv6alJb+koyM/9/b2vqalJb/Ix0c/6ulpP+7tbb/083M/iIcHP+7tbT+rqqq+z87Ovuvq6j7GxUU/2tlZv6WkJD7e3V2/9/b2PpqZGb/X1tY+jIsLP6empr75+Pi9pKMjP/j3dz/39va+hoUFv6inJz/S0VE/9PNzPw==",
+      "vectorSha256": "28e942f20fa8965c29078d9cb8321bd9b2ad03d8e662e48e75efdee71345466a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "af1e2dd1422de3f409f9c3f6554cbae2139411bd33b5c55670d1fb423dd3e8f9",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0427": {
+      "vector": "rKsrv8bFRb/+/X0/1NNTv+vq6r6sqys/zs1NP9zbWz+gnx8/19bWvv79fT/Z2Ng9urk5v4OCgj7s62s/1NNTv/79fT+XlpY+pKMjv5STEz+zsrI+xsVFP/Py8r6/vr6+xsVFv5aVFT+WlRW/5+bmPsC/Pz/n5ua+v76+vpSTE7+sqyu/xsVFv/79fT/U01O/6+rqvqyrKz/OzU0/3NtbP6CfHz/X1ta+/v19P9nY2D26uTm/g4KCPuzraz/U01O//v19P5eWlj6koyO/lJMTP7Oysj7GxUU/8/Lyvr++vr7GxUW/lpUVP5aVFb/n5uY+wL8/P+fm5r6/vr6+lJMTvw==",
+      "vectorSha256": "1aa50401b9791107b98ffcfba1c8552e4985f05c6938c4ac72002c9c6cf428ac",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2a1dfe1645d5e6edcf4afe8d23a0f516fea52ec9ace243501dca35b9df465036",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0428": {
+      "vector": "4N9fv83MTD6CgQG/9PNzv5iXFz+CgQE/z87OPtLRUT/k42M/+/r6vrOysr6enR2/g4KCvpCPDz/a2Vm/zs1NP4yLCz/k42O/iIcHv8rJSb/Z2Ng9trU1v/n4+D2+vT0/6+rqvvz7e7/29XW/2djYvaqpKT+zsrK+lZQUPoyLCz/g31+/zcxMPoKBAb/083O/mJcXP4KBAT/Pzs4+0tFRP+TjYz/7+vq+s7Kyvp6dHb+DgoK+kI8PP9rZWb/OzU0/jIsLP+TjY7+Ihwe/yslJv9nY2D22tTW/+fj4Pb69PT/r6uq+/Pt7v/b1db/Z2Ni9qqkpP7Oysr6VlBQ+jIsLPw==",
+      "vectorSha256": "66bd48857ec5e500869b16b4adfe1f23667d651e54705ce0cb00cf26bde68244",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "10993f06cbc0b3e8f14153315fc713e6c50e3c1b8d258fde45020572d45392c5",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0429": {
+      "vector": "uLc3v5KREb/493c/pKMjv9jXVz/g31+/i4qKvpiXF7+OjQ0/rKsrv7KxMT/Ew0M/5uVlv+TjYz/Y11c/sK8vP87NTb/Ix0c/3t1dP6SjI7+opye/kpERv6KhIT+8uzs/wsFBv+LhYb/5+Pg9gYCAu9LRUb/i4WE/srExv9va2r64tze/kpERv/j3dz+koyO/2NdXP+DfX7+Lioq+mJcXv46NDT+sqyu/srExP8TDQz/m5WW/5ONjP9jXVz+wry8/zs1Nv8jHRz/e3V0/pKMjv6inJ7+SkRG/oqEhP7y7Oz/CwUG/4uFhv/n4+D2BgIC70tFRv+LhYT+ysTG/29ravg==",
+      "vectorSha256": "76c44066ecc4a2cd402b40bbaeb9b441bf72ebe50ed40605f3ab8705efaca4c6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2437fb2eeb105d34c62ad8e10df1ebd719e3ee2e2c37d0dd1f0f8f7f17f02749",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0430": {
+      "vector": "0dBQPby7O7+lpCQ+4eDgvNXUVD7My0u/iIcHP7++vr7g31+/19bWvtrZWb+opye/ycjIvZmYmD3g31+/z87OPvb1dT/x8HA9q6qqPtDPT7/c21s/9PNzP7y7O7/s62s/qaiovainJz+JiIg9iYiIPdjXVz+XlpY+rq0tv+jnZ7/R0FA9vLs7v6WkJD7h4OC81dRUPszLS7+Ihwc/v76+vuDfX7/X1ta+2tlZv6inJ7/JyMi9mZiYPeDfX7/Pzs4+9vV1P/HwcD2rqqo+0M9Pv9zbWz/083M/vLs7v+zraz+pqKi9qKcnP4mIiD2JiIg92NdXP5eWlj6urS2/6Odnvw==",
+      "vectorSha256": "98985419a2569b28f5643f3e684480bfc0c942dc66e2c7489bb9ff2beb6e9b86",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8622947c9a1ac350104a132c738910b3fa87aa18edf922f575d38888eba5290c",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0431": {
+      "vector": "mpkZv42MDD6BgIC7+vl5P6yrK7++vT0/np0dP+3sbD65uLg929raPurpab+sqys/3dxcvoSDAz/n5ua+5ONjv7SzM7+amRk/09LSPs3MTD7Lyso++fj4veDfX7/z8vK++vl5v7CvLz+joqK+goEBv46NDb+0szM/hYQEPvDvb7+amRm/jYwMPoGAgLv6+Xk/rKsrv769PT+enR0/7exsPrm4uD3b2to+6ulpv6yrKz/d3Fy+hIMDP+fm5r7k42O/tLMzv5qZGT/T0tI+zcxMPsvKyj75+Pi94N9fv/Py8r76+Xm/sK8vP6Oior6CgQG/jo0Nv7SzMz+FhAQ+8O9vvw==",
+      "vectorSha256": "f8007f143387a9d50152c1e47d7bb9a0b65ae869280f101ae1e16f7cc14bd863",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "33917ffc2adece9d8bb60bd564c1460e26ccb499b270104303d7573f39d99008",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0432": {
+      "vector": "t7a2Pri3N7/l5GQ+//7+Pqempj7W1VW/kI8Pv7a1Nb/39vY+5+bmvqGgoDyNjAy+tbQ0PujnZz+ioSE/mpkZP6alJb+Lioo+iokJP+blZT+enR0/0dBQvaempj60szM/rq0tP8PCwr65uLi93dxcvr28PL6Lioq+8O9vP+LhYT+3trY+uLc3v+XkZD7//v4+p6amPtbVVb+Qjw+/trU1v/f29j7n5ua+oaCgPI2MDL61tDQ+6OdnP6KhIT+amRk/pqUlv4uKij6KiQk/5uVlP56dHT/R0FC9p6amPrSzMz+urS0/w8LCvrm4uL3d3Fy+vbw8vouKir7w728/4uFhPw==",
+      "vectorSha256": "93039a45b2b4d6749a90479896c93e906ec85ba09222cd4f25051368d312eb87",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ad249cbfa9153825bd46826e96f3d0cc2da2c4f2ce79a9d9d64f7464685df7f0",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0433": {
+      "vector": "vbw8Pvf29r6SkRE/1NNTP5WUFL6+vT2/trU1P9zbW7/HxsY+hYQEvouKir6RkBC9oaCgvO7tbb+ZmJi9goEBv9PS0r6xsDA9/v19P+/u7r6enR0/AACAv+Hg4Dzl5GQ+8fBwPY6NDT/T0tK+0tFRP4qJCb+dnBy+4uFhP83MTL69vDw+9/b2vpKRET/U01M/lZQUvr69Pb+2tTU/3Ntbv8fGxj6FhAS+i4qKvpGQEL2hoKC87u1tv5mYmL2CgQG/09LSvrGwMD3+/X0/7+7uvp6dHT8AAIC/4eDgPOXkZD7x8HA9jo0NP9PS0r7S0VE/iokJv52cHL7i4WE/zcxMvg==",
+      "vectorSha256": "296f468883fb1dad4d5cfe95a16e22724a7d475cfe306d37a5595c8b85e6f050",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9742c8e96d21da12b16f5d7b7d09763f4b85fe44ce00839c87c64be83b6cf066",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0434": {
+      "vector": "1NNTP5ybG7+sqyu/k5KSPsPCwj7z8vI+kI8Pv4eGhj7Avz+/4uFhv/Dvbz///v4+mJcXP4yLC7///v4+1NNTP5CPDz/q6Wm/+vl5P8HAQDzn5uY+4uFhP5ybG7+JiIi9hYQEvr28PL7NzEw+zcxMPpKREb+5uLi9jIsLv8/Ozj7U01M/nJsbv6yrK7+TkpI+w8LCPvPy8j6Qjw+/h4aGPsC/P7/i4WG/8O9vP//+/j6Ylxc/jIsLv//+/j7U01M/kI8PP+rpab/6+Xk/wcBAPOfm5j7i4WE/nJsbv4mIiL2FhAS+vbw8vs3MTD7NzEw+kpERv7m4uL2Miwu/z87OPg==",
+      "vectorSha256": "b55db9be9bd8fa083321ac7335eee557223e27a759a043faa6a7e0f9c8166c54",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e9322aa4b0bc38a1200ff7bfcb3abfe9c70bfc81b9f032776f68999937743ab3",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0435": {
+      "vector": "zMtLP+/u7j6xsDA96ulpP9zbWz/V1FQ+9PNzP8zLSz/w72+/nZwcvrSzMz+Ylxe/iokJv5uamr7f3t4+rq0tv9jXVz+trCw+tbQ0vsjHRz+UkxM/AACAP6GgoDz083O/pqUlv4KBAT/083M/4eDgPLCvLz/b2to+0dBQPQAAgD/My0s/7+7uPrGwMD3q6Wk/3NtbP9XUVD7083M/zMtLP/Dvb7+dnBy+tLMzP5iXF7+KiQm/m5qavt/e3j6urS2/2NdXP62sLD61tDS+yMdHP5STEz8AAIA/oaCgPPTzc7+mpSW/goEBP/Tzcz/h4OA8sK8vP9va2j7R0FA9AACAPw==",
+      "vectorSha256": "de429233363075193ee6eefaef70a7a421b01460c62100818bc1d88357f8d366",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e5bb85f4ed9af9e5086cd9343b59b729eb9569e3c9ff82062dc0f983d7b686ff",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0436": {
+      "vector": "kI8PP7W0NL6Lioo+4eDgPLq5Ob/c21s/tbQ0Pu3sbL7q6Wm/1dRUvtjXV7+wry8/mJcXP9TTU7+wry8/lZQUvoWEBD6hoKC8tLMzP5eWlr7u7W0/rawsPpSTEz+/vr6++Pd3P+blZb+FhAS+5+bmvgAAgL/V1FS+3t1dP728PL6Qjw8/tbQ0vouKij7h4OA8urk5v9zbWz+1tDQ+7exsvurpab/V1FS+2NdXv7CvLz+Ylxc/1NNTv7CvLz+VlBS+hYQEPqGgoLy0szM/l5aWvu7tbT+trCw+lJMTP7++vr7493c/5uVlv4WEBL7n5ua+AACAv9XUVL7e3V0/vbw8vg==",
+      "vectorSha256": "6924e5c52975cfa942e6e8f32d66f6b5316f2bfe8d8ed83e66b3d8f5fbabdacf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c769a28323ed96620b6514d7cb16d76d907dd95af695c950fb0d6f460065ee68",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0437": {
+      "vector": "p6amvublZb/Lysq+rq0tv6moqL2hoKA85uVlP+DfXz/DwsI+sbAwPaOioj6VlBS+oqEhv6SjI7+koyM/h4aGvtbVVT/Qz08///7+PujnZz/KyUm/np0dv6uqqr7i4WG///7+vr++vj7h4OA8r66uPvr5eb/c21s/7u1tP8LBQT+npqa+5uVlv8vKyr6urS2/qaiovaGgoDzm5WU/4N9fP8PCwj6xsDA9o6KiPpWUFL6ioSG/pKMjv6SjIz+Hhoa+1tVVP9DPTz///v4+6OdnP8rJSb+enR2/q6qqvuLhYb///v6+v76+PuHg4Dyvrq4++vl5v9zbWz/u7W0/wsFBPw==",
+      "vectorSha256": "7ba9cd8475a37ec92c0fddd1ffec4ad9acbbe43534ba575bb315dcd370ae7cc0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "560d4d297582f2efb085a86d2f2ed15eeae7bff31b31550f40af83ab03edf6e0",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0438": {
+      "vector": "xMNDP7m4uL2rqqq+s7Kyvvv6+r60szO/qKcnv5qZGT/HxsY+u7q6vo6NDT/29XW/4eDgvLKxMb/R0FC9kpERv/f29r6trCw+lpUVP769PT+zsrK+h4aGvtHQUL3p6Og9oaCgPPv6+r6/vr4+p6amvpmYmD2DgoI+jIsLP/f29r7Ew0M/ubi4vauqqr6zsrK++/r6vrSzM7+opye/mpkZP8fGxj67urq+jo0NP/b1db/h4OC8srExv9HQUL2SkRG/9/b2vq2sLD6WlRU/vr09P7Oysr6Hhoa+0dBQveno6D2hoKA8+/r6vr++vj6npqa+mZiYPYOCgj6Miws/9/b2vg==",
+      "vectorSha256": "7047b642f8f84b8c853a5687cbba9f0f941b1ef3815d7f3fd0909d9b4e738d5e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e174555341262cccb151c6057c2779374295cade535e798e8241af5689a0c542",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0439": {
+      "vector": "2tlZv5ybG7+zsrK+iokJv9TTU7+8uzu/jo0NP/38fL6qqSm/2djYvcbFRb/t7Gw+8vFxv9zbW7/S0VE/nZwcPuzra7/v7u6+5eRkPo6NDb/493c/8/LyvsC/P7+7uro+j46OPvDvb7/o52e/r66uvpKREb/m5WW/7u1tP8XERD7a2Vm/nJsbv7Oysr6KiQm/1NNTv7y7O7+OjQ0//fx8vqqpKb/Z2Ni9xsVFv+3sbD7y8XG/3Ntbv9LRUT+dnBw+7Otrv+/u7r7l5GQ+jo0Nv/j3dz/z8vK+wL8/v7u6uj6Pjo4+8O9vv+jnZ7+vrq6+kpERv+blZb/u7W0/xcREPg==",
+      "vectorSha256": "5bfdc63cb52ab3764343cc31a9f23651666bf8d3ff4367a22c2989e605a34744",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1332533b1622c6602b721d9d0712e8930a449c39fb4320aea3080c54370df698",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0440": {
+      "vector": "v76+vtbVVb/m5WU/2NdXv6KhIb/OzU2/k5KSPtTTUz+OjQ0/urk5v6empj68uzs/k5KSvr28PD7FxEQ+vbw8vru6uj6hoKA8//7+voyLC7+CgQG/hoUFP4uKir6ZmJi92NdXv+Pi4r7p6Oi97u1tv/r5eT/e3V0/s7KyPpuamj6/vr6+1tVVv+blZT/Y11e/oqEhv87NTb+TkpI+1NNTP46NDT+6uTm/p6amPry7Oz+TkpK+vbw8PsXERD69vDy+u7q6PqGgoDz//v6+jIsLv4KBAb+GhQU/i4qKvpmYmL3Y11e/4+Livuno6L3u7W2/+vl5P97dXT+zsrI+m5qaPg==",
+      "vectorSha256": "1c69dd419277f68b52cda4768bde4b5dceb65fc48b0779d5e6eea84f7c01671f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5015f2142f19a4e9c623a9dd5b979868ae82403a3fc25d7614477109fceeaca6",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0441": {
+      "vector": "8vFxP6WkJL7NzEy+sbAwPcnIyD3083O/8vFxv//+/r6pqKg96+rqPpybG7+fnp6+i4qKPsfGxj6+vT0/s7KyPsbFRb+5uLg93Ntbv+/u7r7m5WW/y8rKPoKBAT/t7Gw+hIMDv+jnZ7/OzU2/p6amPgAAgL+9vDw+l5aWPo2MDL7y8XE/paQkvs3MTL6xsDA9ycjIPfTzc7/y8XG///7+vqmoqD3r6uo+nJsbv5+enr6Lioo+x8bGPr69PT+zsrI+xsVFv7m4uD3c21u/7+7uvublZb/Lyso+goEBP+3sbD6EgwO/6Odnv87NTb+npqY+AACAv728PD6XlpY+jYwMvg==",
+      "vectorSha256": "3bf27f0f54086f17c348145c12e926f6e4bb52e94492458d61a9164fd4613f8b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f86b66858c0607408aba3258a2b1deac1d8b12440db2c09d3e0c19a90097a56e",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0442": {
+      "vector": "5uVlv6qpKb+CgQE/rawsvqalJT+CgQG/lpUVv/38fL7d3Fy+zcxMPqalJb/t7Gy+rq0tv8HAQDzf3t4+nZwcvtjXV7+ysTG/+fj4vfv6+j6JiIi9n56evrW0NL7R0FA9v76+Ps/Ozr7c21s/rKsrP5OSkr64tzc/kpERv8nIyD3m5WW/qqkpv4KBAT+trCy+pqUlP4KBAb+WlRW//fx8vt3cXL7NzEw+pqUlv+3sbL6urS2/wcBAPN/e3j6dnBy+2NdXv7KxMb/5+Pi9+/r6PomIiL2fnp6+tbQ0vtHQUD2/vr4+z87OvtzbWz+sqys/k5KSvri3Nz+SkRG/ycjIPQ==",
+      "vectorSha256": "52e292bdb42598b74b89c5d19908bf312f885a424268580fc54121c813817970",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0d2bc06ad23f356064992d622981b76c142770be77586986af4cedd55bdb378c",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0443": {
+      "vector": "nJsbP+Hg4LzLyso++/r6Pvn4+L3h4OC829raPri3Nz+bmpo+h4aGvsXERL69vDy+5eRkPuXkZD6Xlpa+vbw8vo+Ojr7//v4+goEBP93cXD7BwEC84+Livr28PL7c21u/iYiIvcHAQLyurS2/5uVlv8vKyr76+Xm/goEBP+zraz+cmxs/4eDgvMvKyj77+vo++fj4veHg4Lzb2to+uLc3P5uamj6Hhoa+xcREvr28PL7l5GQ+5eRkPpeWlr69vDy+j46Ovv/+/j6CgQE/3dxcPsHAQLzj4uK+vbw8vtzbW7+JiIi9wcBAvK6tLb/m5WW/y8rKvvr5eb+CgQE/7OtrPw==",
+      "vectorSha256": "84def8d587bbb32916e6b412cbda0f8698d5643a9037fad7a2fb4a97bdf5f22e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cd7cb2be707cb6dba65e67689c9c5a685cbfc09b7e476812777e290d4d03c0f5",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0444": {
+      "vector": "1dRUvru6ur7V1FQ+w8LCvt/e3r7T0tI+v76+vtLRUb+WlRW/7+7uvqWkJD6rqqq+8fBwvZSTE7+1tDQ+3Ntbv4KBAT/8+3s/yMdHP4+Ojr6TkpK+6ulpP9zbW7+cmxs/6Odnv6KhIT/g31+/lJMTv769PT+8uzs/lJMTv8XERD7V1FS+u7q6vtXUVD7DwsK+397evtPS0j6/vr6+0tFRv5aVFb/v7u6+paQkPquqqr7x8HC9lJMTv7W0ND7c21u/goEBP/z7ez/Ix0c/j46OvpOSkr7q6Wk/3Ntbv5ybGz/o52e/oqEhP+DfX7+UkxO/vr09P7y7Oz+UkxO/xcREPg==",
+      "vectorSha256": "4054b6e67d1fc1c6582b77c3d1c001abd07401c6851f974d6a921d39c3aee844",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "65519a4f48b450173544945578369612c0fde35c5bf412cd0cd01036dedd3698",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0445": {
+      "vector": "9fR0vpOSkj7z8vI+jIsLv+zra7/s62s/5eRkPrGwML29vDy+6ulpv+blZT/Ew0M/pKMjv6moqL3Lyso+7Otrv7W0NL7NzEw+q6qqPsC/Pz+trCy+zcxMvvPy8j7z8vK+iYiIvainJ7+SkRG/yslJP4WEBD7n5ua+7u1tv7i3N7/19HS+k5KSPvPy8j6Miwu/7Otrv+zraz/l5GQ+sbAwvb28PL7q6Wm/5uVlP8TDQz+koyO/qaiovcvKyj7s62u/tbQ0vs3MTD6rqqo+wL8/P62sLL7NzEy+8/LyPvPy8r6JiIi9qKcnv5KREb/KyUk/hYQEPufm5r7u7W2/uLc3vw==",
+      "vectorSha256": "605521f37804d29c6ea21ef00eaac300a4507047d8cb5baaaf286c7bc7fe7622",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "61a4bc3a0af59c7a680bf2e12e75b20a6999aadf6a66bc43772c37e490460924",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0446": {
+      "vector": "+/r6vurpaT/DwsI+7+7uPqqpKT/Lysq+tLMzP8C/P7/+/X2/0M9PP46NDb/Ew0O/xMNDv7e2tr6BgIC7srExP8vKyr6SkRG/2tlZP+fm5r7083O/AACAP7GwML2VlBS+6OdnP6empr7p6Og9397evoaFBT/Z2Ng9vr09P8jHRz/7+vq+6ulpP8PCwj7v7u4+qqkpP8vKyr60szM/wL8/v/79fb/Qz08/jo0Nv8TDQ7/Ew0O/t7a2voGAgLuysTE/y8rKvpKREb/a2Vk/5+bmvvTzc78AAIA/sbAwvZWUFL7o52c/p6amvuno6D3f3t6+hoUFP9nY2D2+vT0/yMdHPw==",
+      "vectorSha256": "f9909bc51afa6d2caffedadb521f836e625237873edc60894dea912d2c823208",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "41f4b0bbd44dd92001e7391e1e527fd84d37ec4606ff7a6df3568e48c28ddee3",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0447": {
+      "vector": "lZQUPvb1db+EgwM/9fR0Po6NDb/R0FC9uLc3v5OSkr6cmxs/u7q6vpmYmL38+3u/5ONjv/Tzc7/X1ta+/v19P/v6+j7w72+/vLs7P5KREb+cmxu/nJsbP8fGxr6KiQm/+Pd3P+7tbb/w72+/2djYPaWkJD6trCw+nJsbv52cHL6VlBQ+9vV1v4SDAz/19HQ+jo0Nv9HQUL24tze/k5KSvpybGz+7urq+mZiYvfz7e7/k42O/9PNzv9fW1r7+/X0/+/r6PvDvb7+8uzs/kpERv5ybG7+cmxs/x8bGvoqJCb/493c/7u1tv/Dvb7/Z2Ng9paQkPq2sLD6cmxu/nZwcvg==",
+      "vectorSha256": "856f1e7526711838d2812ca6694e639b80aaec4f118017d84eb931e00deb14a1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9205c19e3979245bcd5176020e064afebe08dd3732cd4e3bfb09088d9495326c",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0448": {
+      "vector": "qKcnP8XERL69vDw+mZiYPYqJCb+pqKi9vLs7P/79fb/+/X2/yslJv56dHb+rqqo+5eRkvtHQUD3S0VE/h4aGvpybGz/NzEy+y8rKvqqpKb/9/Hw+1tVVv6uqqr7NzEy+w8LCvrW0NL6NjAy+mZiYPdrZWb+9vDy+5eRkvqCfHz+opyc/xcREvr28PD6ZmJg9iokJv6moqL28uzs//v19v/79fb/KyUm/np0dv6uqqj7l5GS+0dBQPdLRUT+Hhoa+nJsbP83MTL7Lysq+qqkpv/38fD7W1VW/q6qqvs3MTL7DwsK+tbQ0vo2MDL6ZmJg92tlZv728PL7l5GS+oJ8fPw==",
+      "vectorSha256": "5706b956daea7641e2975e6b9c6aa3f3280dc2f898028e01dd5459f1eb0197bd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d36797893b75dd01011b31aa6386e85ecd664d2b9f1555664f696e89136863cf",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0449": {
+      "vector": "wsFBv8zLS7+enR0/+Pd3P9PS0r6Qjw8/rKsrP7KxMT/i4WG/urk5P4iHBz+BgIA7i4qKvre2tr7Qz08/1NNTP66tLT/Qz08/9fR0Pri3Nz/l5GQ+5+bmvsPCwr6Ihwc/mJcXP66tLb/r6uo+xMNDP6qpKT/KyUm/4eDgvIuKij7CwUG/zMtLv56dHT/493c/09LSvpCPDz+sqys/srExP+LhYb+6uTk/iIcHP4GAgDuLioq+t7a2vtDPTz/U01M/rq0tP9DPTz/19HQ+uLc3P+XkZD7n5ua+w8LCvoiHBz+Ylxc/rq0tv+vq6j7Ew0M/qqkpP8rJSb/h4OC8i4qKPg==",
+      "vectorSha256": "8209a724ff484f3cf0d18b0702d233034bca83d1caa5cc6329f4d02a808bd8a9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1f1acefb4bc7d5d80fdcc3805d52e7e9d6e79edb9c464fc3cb29bae1d41b7ca2",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0450": {
+      "vector": "lpUVv4aFBb+7urq+mpkZP6Oioj7//v6+09LSvpybG7/BwEC8i4qKPpSTE7+opyc/urk5P46NDb/S0VG/w8LCPsbFRb+amRm/0tFRv+LhYT+qqSm/7exsvs7NTT/JyMg96ejoPYGAgDvs62u/3t1dP8HAQLyzsrK+kpERv83MTL6WlRW/hoUFv7u6ur6amRk/o6KiPv/+/r7T0tK+nJsbv8HAQLyLioo+lJMTv6inJz+6uTk/jo0Nv9LRUb/DwsI+xsVFv5qZGb/S0VG/4uFhP6qpKb/t7Gy+zs1NP8nIyD3p6Og9gYCAO+zra7/e3V0/wcBAvLOysr6SkRG/zcxMvg==",
+      "vectorSha256": "651a6f5eec1444bee956f4f96ae742aa93f5a9bd40f27d94338544ccb2d068f9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "353d51cca8404b327ea236d3dc3917b01d3317f02b62e68c8e800aee7e533766",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0451": {
+      "vector": "k5KSPvb1dT/U01M/hoUFP4SDA7+joqI+ubi4PbKxMb+3trY+urk5v6SjI7+Lioo+qaiova2sLL6cmxu/rq0tv6qpKb/j4uI+2NdXP+zra7+urS2/mJcXv+TjY7/Ew0M/x8bGvpiXFz/y8XG/hoUFP6inJz/o52e/q6qqvsXERL6TkpI+9vV1P9TTUz+GhQU/hIMDv6Oioj65uLg9srExv7e2tj66uTm/pKMjv4uKij6pqKi9rawsvpybG7+urS2/qqkpv+Pi4j7Y11c/7Otrv66tLb+Ylxe/5ONjv8TDQz/Hxsa+mJcXP/Lxcb+GhQU/qKcnP+jnZ7+rqqq+xcREvg==",
+      "vectorSha256": "c450182194b158beed55161c2cff696c85315720d1a80644112cdddb3b86154e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a4fae9c23ea88b27ad232ea2756a32292bb8eb0a29340ee14ecb07c2d30c5567",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0452": {
+      "vector": "jo0Nv/f29r7Qz08/5+bmvgAAgD/19HQ+uLc3P4aFBb+Pjo4+29raPuXkZL6Ylxe/qKcnv8LBQT/d3Fy+7+7uPtTTUz+Xlpa+jo0NP46NDT/a2Vk/3t1dP+TjYz/My0s/2djYvf/+/r6/vr4+iokJP6GgoLz5+Pi98O9vP769Pb+OjQ2/9/b2vtDPTz/n5ua+AACAP/X0dD64tzc/hoUFv4+Ojj7b2to+5eRkvpiXF7+opye/wsFBP93cXL7v7u4+1NNTP5eWlr6OjQ0/jo0NP9rZWT/e3V0/5ONjP8zLSz/Z2Ni9//7+vr++vj6KiQk/oaCgvPn4+L3w728/vr09vw==",
+      "vectorSha256": "cdef324eba084291dca2ba3304792f9c74232e0eabe218758aaab95252a94360",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3942e746ff9edb3da3b663342ce064bbe95ac6c6eceef1e57240afc47d70f721",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0453": {
+      "vector": "mJcXP56dHT/p6Og919bWPpuamj7T0tI+p6amvq+urj6/vr6+z87OPpeWlr7BwEC8vr09v7++vj7o52e/oqEhv6CfH7/s62u/6ejoPf38fD63tra+yMdHP8nIyL2Hhoa+xMNDP8fGxr75+Pg9g4KCPuXkZD7BwEA8+Pd3v7KxMb+Ylxc/np0dP+no6D3X1tY+m5qaPtPS0j6npqa+r66uPr++vr7Pzs4+l5aWvsHAQLy+vT2/v76+PujnZ7+ioSG/oJ8fv+zra7/p6Og9/fx8Pre2tr7Ix0c/ycjIvYeGhr7Ew0M/x8bGvvn4+D2DgoI+5eRkPsHAQDz493e/srExvw==",
+      "vectorSha256": "8ce1bb21a4f294b39bb8ca355891e2233305bd8d20a2b5f27e935a0980355416",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cbce8eb5a6b456ab50b35a7e21af0c2f300a8e9f52e3735ee14e8fa09c810427",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0454": {
+      "vector": "4eDgvNbVVb/GxUW/ubi4vZ6dHT+Miws/s7KyPuPi4r7V1FS+5eRkPpmYmD3OzU0/z87OPuTjY7/39va++Pd3P8nIyD2cmxs/rq0tv+Hg4LzT0tK+8/LyPrKxMT/w72+/0M9PP5ybG7/U01O/8vFxP/z7ez+mpSU/2tlZv/HwcL3h4OC81tVVv8bFRb+5uLi9np0dP4yLCz+zsrI+4+LivtXUVL7l5GQ+mZiYPc7NTT/Pzs4+5ONjv/f29r7493c/ycjIPZybGz+urS2/4eDgvNPS0r7z8vI+srExP/Dvb7/Qz08/nJsbv9TTU7/y8XE//Pt7P6alJT/a2Vm/8fBwvQ==",
+      "vectorSha256": "9f2556dcfd9ee7817f36f5087f878b63840908fb869f6c631426a9b42bf05d9f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7c151d74cec5ac47659c89e6b30e42fb8ccd297c4bbcd808e73216f8fdd21378",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0455": {
+      "vector": "5ONjv6moqD339va+0tFRP8LBQb+wry+/sbAwPYWEBL7Lyso+hoUFv9jXVz+2tTU/wcBAvI+Ojj76+Xm/s7KyPrOysj7s62s/u7q6Pu7tbb/h4OC8urk5P97dXb/S0VE/mZiYPbq5OT/Pzs4+8O9vv769Pb+joqK+yMdHP/j3d7/k42O/qaioPff29r7S0VE/wsFBv7CvL7+xsDA9hYQEvsvKyj6GhQW/2NdXP7a1NT/BwEC8j46OPvr5eb+zsrI+s7KyPuzraz+7uro+7u1tv+Hg4Ly6uTk/3t1dv9LRUT+ZmJg9urk5P8/Ozj7w72+/vr09v6Oior7Ix0c/+Pd3vw==",
+      "vectorSha256": "6bdb8b29aa893ad722784d5dce5bbbcc285679d834b406b415c26d46f21bdca8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0e8a42e81f28856fb23debda7ea303acacf5ae097cdc11e889dcb3082157e304",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0456": {
+      "vector": "lpUVv4OCgr7q6Wk/xsVFv7u6ur61tDS+trU1v8PCwj7a2Vm/lJMTP6Oioj6trCy+iIcHv6yrKz+BgIA7trU1v9XUVL7083M/7+7uvrSzM7+mpSU/y8rKPv79fb/S0VE/uLc3P8nIyD3R0FC9kZAQvc/Ozj6cmxu/6ejove/u7r6WlRW/g4KCvurpaT/GxUW/u7q6vrW0NL62tTW/w8LCPtrZWb+UkxM/o6KiPq2sLL6Ihwe/rKsrP4GAgDu2tTW/1dRUvvTzcz/v7u6+tLMzv6alJT/Lyso+/v19v9LRUT+4tzc/ycjIPdHQUL2RkBC9z87OPpybG7/p6Oi97+7uvg==",
+      "vectorSha256": "dd3847d65464e38175940b700695fe80f50ec302c50bc535cb267f0cf054634e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "355ff41d516925b013c9a86a3cd5802565f94426d2b201e8db8c797bb3327144",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0457": {
+      "vector": "/v19P56dHT/b2to+pKMjv6inJ7/6+Xm/mJcXP+Pi4r7j4uK+4N9fv/b1dT+joqI+5+bmvq6tLb/Lyso+rKsrP8XERD66uTk/trU1P+XkZD6hoKA8qKcnv6CfHz/7+vo+//7+PoGAgLvW1VU/m5qavu/u7j6vrq4+5uVlP5CPDz/+/X0/np0dP9va2j6koyO/qKcnv/r5eb+Ylxc/4+LivuPi4r7g31+/9vV1P6Oioj7n5ua+rq0tv8vKyj6sqys/xcREPrq5OT+2tTU/5eRkPqGgoDyopye/oJ8fP/v6+j7//v4+gYCAu9bVVT+bmpq+7+7uPq+urj7m5WU/kI8PPw==",
+      "vectorSha256": "84c6ab6864ffd022502b8284ca100acd9dc83a68c59d9fa66b9b8ce57d3cfee1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "feceb62e2c03cb474710faa84629b2d598dcda9c822ccfbebf7fea59bbabf2c7",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0458": {
+      "vector": "goEBv8jHR7+Ihwe/6ulpP46NDT/o52c/mJcXv/Py8r6VlBQ+wL8/P8/Ozr7Qz08/z87Ovu/u7j7493e/r66uPublZb/Avz+/xsVFv+Hg4DzNzEw+xsVFP66tLb/z8vI+zMtLv7u6uj78+3s/wL8/v4qJCb/V1FS+4+Livt3cXL6CgQG/yMdHv4iHB7/q6Wk/jo0NP+jnZz+Ylxe/8/LyvpWUFD7Avz8/z87OvtDPTz/Pzs6+7+7uPvj3d7+vrq4+5uVlv8C/P7/GxUW/4eDgPM3MTD7GxUU/rq0tv/Py8j7My0u/u7q6Pvz7ez/Avz+/iokJv9XUVL7j4uK+3dxcvg==",
+      "vectorSha256": "b0e7595fe4c998ddd2cc85a0969de540bd128b304e758fac26ba06043b1928d3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3f1c3cf4c6f3344392df4ce74cbb04ab0d201d8399e229bc1aaefd203b654764",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0459": {
+      "vector": "rq0tv8TDQz/a2Vk/2tlZP7KxMT+trCy+o6KivsbFRT+OjQ0/6ulpv7KxMb/493e/nZwcvo+Ojr7T0tK+l5aWvv/+/j7BwEA8xcREvp6dHb+CgQE/oqEhv7e2tj64tzc/sK8vv769PT/19HQ+n56ePt3cXD68uzu/iYiIPZSTEz+urS2/xMNDP9rZWT/a2Vk/srExP62sLL6joqK+xsVFP46NDT/q6Wm/srExv/j3d7+dnBy+j46OvtPS0r6Xlpa+//7+PsHAQDzFxES+np0dv4KBAT+ioSG/t7a2Pri3Nz+wry+/vr09P/X0dD6fnp4+3dxcPry7O7+JiIg9lJMTPw==",
+      "vectorSha256": "1346807a5fdcb691a5b8581b03cd2585ab8432a59dd8337077983ecc7232eb7b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "29e1ececd86a57e2c60b27046c5c4b5abf816731c02faddb28de9ea79b2288c9",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0460": {
+      "vector": "9fR0PuLhYT/U01M/urk5v+3sbD6pqKi97exsPsrJST/c21u/jIsLP7m4uL2pqKi9jIsLP8zLS7+dnBy+6+rqPv/+/j7t7Gy+qaioPcXERL7g31+/nZwcvvLxcb/k42M/7u1tv4eGhr6trCy+urk5v42MDD6KiQm/h4aGPqalJT/19HQ+4uFhP9TTUz+6uTm/7exsPqmoqL3t7Gw+yslJP9zbW7+Miws/ubi4vamoqL2Miws/zMtLv52cHL7r6uo+//7+Pu3sbL6pqKg9xcREvuDfX7+dnBy+8vFxv+TjYz/u7W2/h4aGvq2sLL66uTm/jYwMPoqJCb+HhoY+pqUlPw==",
+      "vectorSha256": "e73857e55df3a3ce4344553166008f0acd4761ff1a4688fcdb4c9e624cb334f5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9ef0e9239d759de412c57475c51a6cbabf628a67106c07f1095e6a23913ba1d2",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0461": {
+      "vector": "kZAQvZuamr69vDy+y8rKPvj3dz+BgIC7wsFBv7u6uj6opye/x8bGvvPy8r7KyUm//fx8vpmYmL2Pjo6+7Otrv8PCwr6sqys/vLs7P9va2r6bmpo+jYwMvtHQUD21tDQ+gYCAO7m4uD2CgQE/x8bGvrCvLz/GxUW/iYiIPaGgoLyRkBC9m5qavr28PL7Lyso++Pd3P4GAgLvCwUG/u7q6PqinJ7/Hxsa+8/LyvsrJSb/9/Hy+mZiYvY+Ojr7s62u/w8LCvqyrKz+8uzs/29ravpuamj6NjAy+0dBQPbW0ND6BgIA7ubi4PYKBAT/Hxsa+sK8vP8bFRb+JiIg9oaCgvA==",
+      "vectorSha256": "265dae54f39c41d9eb9de31c02ffcd6e7fe36041eb57e8b8ec4474ff497141d1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7b5968b2fb7f1fae2c4e431b60765c0a4fd5dd49a66e8696808bc04ed71d887d",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0462": {
+      "vector": "0dBQvfz7ez/T0tK+xMNDv/Dvbz+Miwu/wcBAPOTjY7/OzU2/np0dv9jXV7/CwUG/6ulpv8bFRT/Pzs4+jo0Nv4OCgj6dnBw+pKMjP+TjY7/5+Pi9jIsLP5mYmD29vDw+/v19P8vKyj7o52e/+vl5v9HQUL3l5GQ+vLs7v5OSkr7R0FC9/Pt7P9PS0r7Ew0O/8O9vP4yLC7/BwEA85ONjv87NTb+enR2/2NdXv8LBQb/q6Wm/xsVFP8/Ozj6OjQ2/g4KCPp2cHD6koyM/5ONjv/n4+L2Miws/mZiYPb28PD7+/X0/y8rKPujnZ7/6+Xm/0dBQveXkZD68uzu/k5KSvg==",
+      "vectorSha256": "ad831831bcf05543eaff18a2224107200cceb9d10f7ed231721ceabd7c68279c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "79fd4b1ef73a810e1931141f0be2b339a093d10e70c58997feb20c03799c225b",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0463": {
+      "vector": "2tlZv/79fb+amRm/mZiYPcnIyD2amRm/nJsbP8HAQDyurS2/8O9vP4+Ojr66uTk/jIsLP6moqL3493e/iYiIvayrK7+xsDC95+bmPt7dXT+2tTU/p6amvu3sbD7083M/gYCAu//+/r6JiIi95ONjv5CPD7/OzU0/i4qKPsPCwr7a2Vm//v19v5qZGb+ZmJg9ycjIPZqZGb+cmxs/wcBAPK6tLb/w728/j46Ovrq5OT+Miws/qaiovfj3d7+JiIi9rKsrv7GwML3n5uY+3t1dP7a1NT+npqa+7exsPvTzcz+BgIC7//7+vomIiL3k42O/kI8Pv87NTT+Lioo+w8LCvg==",
+      "vectorSha256": "41a5b49cef532a25e87a8d6e0c50b0fda47dbd8f6e259da1ba89d12a68eb8ec4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "130133898c33cd8129f75cdcc57504772a7ab9eeda569df97f40770e38e6a24f",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0464": {
+      "vector": "8O9vP8PCwr6FhAS+tbQ0vuPi4j77+vo+ubi4vYiHBz+sqyu/o6KivqOioj6/vr4+n56ePt/e3r62tTU/hYQEvtDPT7/493e/iIcHv6empj6EgwO/paQkvp2cHD7R0FC9k5KSPqCfH7+WlRW/zs1NP8TDQ7+opyc/m5qaPri3Nz/w728/w8LCvoWEBL61tDS+4+LiPvv6+j65uLi9iIcHP6yrK7+joqK+o6KiPr++vj6fnp4+397evra1NT+FhAS+0M9Pv/j3d7+Ihwe/p6amPoSDA7+lpCS+nZwcPtHQUL2TkpI+oJ8fv5aVFb/OzU0/xMNDv6inJz+bmpo+uLc3Pw==",
+      "vectorSha256": "82e52e893b04444af09061e4921e5657c687c4b51c96692378f3f4d3ba97d2ca",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f74f6f69b8be74c32a57a8afa748da6f18043ca93e6b9379a43035e61ed3a6db",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0466": {
+      "vector": "xsVFv+/u7r6urS2/qaioPcTDQ7/h4OC8urk5P6Oior64tze/qKcnv4+Ojr6fnp4+2tlZP7u6ur7h4OA8rq0tv4eGhr65uLi9s7KyPoyLC7+zsrI+29ravtfW1j6TkpK+q6qqvo2MDD66uTm/k5KSPsbFRT/Hxsa+trU1v9jXV7/GxUW/7+7uvq6tLb+pqKg9xMNDv+Hg4Ly6uTk/o6Kivri3N7+opye/j46Ovp+enj7a2Vk/u7q6vuHg4DyurS2/h4aGvrm4uL2zsrI+jIsLv7Oysj7b2tq+19bWPpOSkr6rqqq+jYwMPrq5Ob+TkpI+xsVFP8fGxr62tTW/2NdXvw==",
+      "vectorSha256": "59d6949e02fdb8abcd8de649b5b249c20d3a00b904fbd823cf280ce403170369",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1d44298a1e7cdc57242c5ca7ec5183295e74ac3aac49b55b559123a4e24e2514",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0467": {
+      "vector": "zMtLP+zraz/Qz08/qqkpP5uamr6+vT2/19bWvsnIyL2Ylxc/9vV1P6empj66uTk/oJ8fv87NTT/c21s/qKcnv97dXT/BwEC84+LivszLS7++vT0/tbQ0voKBAT+Ylxe/s7KyvsrJSb/X1tY+9PNzv7u6ur65uLi94+LiPqqpKT/My0s/7OtrP9DPTz+qqSk/m5qavr69Pb/X1ta+ycjIvZiXFz/29XU/p6amPrq5OT+gnx+/zs1NP9zbWz+opye/3t1dP8HAQLzj4uK+zMtLv769PT+1tDS+goEBP5iXF7+zsrK+yslJv9fW1j7083O/u7q6vrm4uL3j4uI+qqkpPw==",
+      "vectorSha256": "6fa13087ccb2375879128b3beb5f2692f6f90266dc1f42b3649c290cbfae30a0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e5f5e7d459214a73cbfaa9dc30e6ed2cee7e471ade69c034531bb5065174b8d4",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0468": {
+      "vector": "//7+PrOysj7g318/5uVlP+rpab+mpSU/urk5v7KxMT/493c/goEBv4GAgDvv7u6+wcBAvKyrK7+xsDA9zs1NP+TjYz/l5GS+zMtLP8PCwr6EgwM/sbAwveTjY7+6uTm/kI8Pv7m4uD2opye/ycjIvY2MDD7493c/6Odnv/38fD7//v4+s7KyPuDfXz/m5WU/6ulpv6alJT+6uTm/srExP/j3dz+CgQG/gYCAO+/u7r7BwEC8rKsrv7GwMD3OzU0/5ONjP+XkZL7My0s/w8LCvoSDAz+xsDC95ONjv7q5Ob+Qjw+/ubi4PainJ7/JyMi9jYwMPvj3dz/o52e//fx8Pg==",
+      "vectorSha256": "51eba6add50437907c74eb20e32bb0f50918ba24ae6b9075796195d62dc41410",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bfaceff20bd223d8fb3f80447e2a85e6f163e54fc17a0e23388b2c7391fb0c9f",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0469": {
+      "vector": "xsVFv8zLSz/l5GQ+i4qKPoyLC7/r6uo+/Pt7P9HQUD2Ylxc///7+voOCgr6hoKC819bWPre2tr7n5ua+qaiovYWEBD7n5uY+29ravr69PT/v7u4+hoUFP+Hg4DykoyO/s7KyvtPS0r6HhoY+oaCgvJ6dHT/My0s/t7a2Pry7Oz/GxUW/zMtLP+XkZD6Lioo+jIsLv+vq6j78+3s/0dBQPZiXFz///v6+g4KCvqGgoLzX1tY+t7a2vufm5r6pqKi9hYQEPufm5j7b2tq+vr09P+/u7j6GhQU/4eDgPKSjI7+zsrK+09LSvoeGhj6hoKC8np0dP8zLSz+3trY+vLs7Pw==",
+      "vectorSha256": "5080cb365947cf74ade88d1fe82bd2659bccf70df298217bd7d7a03b5bf93fea",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1de59ca23abafd86cb405f7db552467590b949debbc2832e534ba17dcee5addd",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0470": {
+      "vector": "4uFhP7GwMD3q6Wm/09LSPublZT+hoKC85uVlv/38fL7BwEC87Otrv/X0dL7X1ta+l5aWPsfGxj6Pjo6+tbQ0Pquqqr719HQ+l5aWvtjXVz+XlpY+4N9fv7u6uj6GhQU/oJ8fv9bVVb+amRk/6ejoPZSTE7+2tTW/8/LyvoiHBz/i4WE/sbAwPerpab/T0tI+5uVlP6GgoLzm5WW//fx8vsHAQLzs62u/9fR0vtfW1r6XlpY+x8bGPo+Ojr61tDQ+q6qqvvX0dD6Xlpa+2NdXP5eWlj7g31+/u7q6PoaFBT+gnx+/1tVVv5qZGT/p6Og9lJMTv7a1Nb/z8vK+iIcHPw==",
+      "vectorSha256": "947916c557ff099ec8dbe896c13ed78be2a7d7da5d510fc28c1315bda25bc5f2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f0850bb4f27d0d607e0a614aa5b15c96559e5aeba510aec23015cc8e362543c3",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0471": {
+      "vector": "i4qKvpOSkj64tze/x8bGPpaVFT/Ew0O/rq0tP/X0dD7Ix0c/jo0Nv9TTU7/CwUE/trU1v6alJT+CgQG/3t1dP4aFBT/Y11c/7u1tP+3sbD6JiIg96ejoPaalJb+hoKC89fR0Ps7NTb+0szM/l5aWPtXUVD7+/X0/AACAv9TTU7+Lioq+k5KSPri3N7/HxsY+lpUVP8TDQ7+urS0/9fR0PsjHRz+OjQ2/1NNTv8LBQT+2tTW/pqUlP4KBAb/e3V0/hoUFP9jXVz/u7W0/7exsPomIiD3p6Og9pqUlv6GgoLz19HQ+zs1Nv7SzMz+XlpY+1dRUPv79fT8AAIC/1NNTvw==",
+      "vectorSha256": "f85add8b3f939dc1ec30e6a16d5367bc627d1609566c3e81a9b187154f906c76",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5da424b1ca1ed69ee33916e025d23feec2ebf69d888e2d7d9e19d9a59afe0016",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0472": {
+      "vector": "xMNDv6empj7My0s/nJsbv6moqL37+vq+lpUVv/n4+D2RkBA9wL8/v+XkZD7s62u/lpUVv66tLb/My0u/i4qKvsC/Pz/493e/8/LyvqinJ7/R0FA9goEBv/v6+j7W1VW//fx8PoOCgr6KiQm/+fj4vdrZWb/OzU2/sbAwPfv6+j7Ew0O/p6amPszLSz+cmxu/qaiovfv6+r6WlRW/+fj4PZGQED3Avz+/5eRkPuzra7+WlRW/rq0tv8zLS7+Lioq+wL8/P/j3d7/z8vK+qKcnv9HQUD2CgQG/+/r6PtbVVb/9/Hw+g4KCvoqJCb/5+Pi92tlZv87NTb+xsDA9+/r6Pg==",
+      "vectorSha256": "9308151032af0543d4750450523f0aab058e827844f9f4de7a1f69b91bfbf08a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1ea9e5327541358f84209c0a35291a5ddf04432c863fbe159f5f3b70131985be",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0473": {
+      "vector": "4N9fP9XUVL7Y11c/iYiIPfb1dT/JyMi9vbw8vpCPD7+1tDS+AACAv4aFBb/f3t6+lpUVP9DPT7+cmxs/pKMjP/HwcD23trY+qaiovc/Ozr7493e/h4aGvvDvbz/My0u/2tlZv4uKij6dnBw+AACAv+LhYT+WlRW/397ePpeWlj7g318/1dRUvtjXVz+JiIg99vV1P8nIyL29vDy+kI8Pv7W0NL4AAIC/hoUFv9/e3r6WlRU/0M9Pv5ybGz+koyM/8fBwPbe2tj6pqKi9z87Ovvj3d7+Hhoa+8O9vP8zLS7/a2Vm/i4qKPp2cHD4AAIC/4uFhP5aVFb/f3t4+l5aWPg==",
+      "vectorSha256": "dd41830da0b674fd51c57f80da27b7c74f6ebbd2e72b46eb94d33652528dcc55",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ef65eb88fa73683869003d48ca18cdd187ad754c045ef71a13a29300f035b7a5",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0474": {
+      "vector": "jYwMPvTzc7/9/Hw+7OtrP9XUVD6Lioq+09LSPtTTUz/FxEQ+7+7uvrKxMT+bmpq+2djYvfTzc7/Avz8/np0dP7a1Nb+mpSW/xMNDv9zbWz/t7Gw+n56ePtHQUL2npqY+i4qKPvDvb7+fnp6+xsVFP9XUVD7//v4+zcxMPoOCgr6NjAw+9PNzv/38fD7s62s/1dRUPouKir7T0tI+1NNTP8XERD7v7u6+srExP5uamr7Z2Ni99PNzv8C/Pz+enR0/trU1v6alJb/Ew0O/3NtbP+3sbD6fnp4+0dBQvaempj6Lioo+8O9vv5+enr7GxUU/1dRUPv/+/j7NzEw+g4KCvg==",
+      "vectorSha256": "03f5444a246a58d4fe7521af1c9b5ab24956520e60b34317d6ae637db93cea1a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "91069ff59a5db4e99844d8597206dfce252d1eed9da779a9a20858e29abf995f",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0475": {
+      "vector": "vr09P/n4+D36+Xk/sK8vP//+/j6Pjo6+kI8PP/v6+r7k42M/h4aGPrOysj6qqSk/7+7uvoWEBL6DgoI+3dxcPsHAQLz39vY+ycjIPZaVFb+2tTW/+vl5P8TDQ7+OjQ0/iIcHP5STEz+RkBC9rq0tv5KRET+fnp4+5uVlP9XUVD6+vT0/+fj4Pfr5eT+wry8///7+Po+Ojr6Qjw8/+/r6vuTjYz+HhoY+s7KyPqqpKT/v7u6+hYQEvoOCgj7d3Fw+wcBAvPf29j7JyMg9lpUVv7a1Nb/6+Xk/xMNDv46NDT+Ihwc/lJMTP5GQEL2urS2/kpERP5+enj7m5WU/1dRUPg==",
+      "vectorSha256": "f243f75cd1091dcd7309fe3203c78c83366626bb278b70417bfe220cb0f5be7a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "de8ffcd7bf5cc741f1a1acd4446fa09b7ebd8c3525fc1ec6c3c97b29c8a7f29a",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0476": {
+      "vector": "rawsvoaFBT/Qz0+/oaCgvKSjIz+1tDQ+i4qKPri3Nz/Y11e/m5qaPtTTU7/r6uo+397evqinJz+GhQU/4uFhP8rJSb/FxES+xcREPv79fb/JyMg9np0dv5uamj6dnBy+o6KiPoGAgDuPjo4+k5KSPtHQUL2KiQk/kpERP8zLSz+trCy+hoUFP9DPT7+hoKC8pKMjP7W0ND6Lioo+uLc3P9jXV7+bmpo+1NNTv+vq6j7f3t6+qKcnP4aFBT/i4WE/yslJv8XERL7FxEQ+/v19v8nIyD2enR2/m5qaPp2cHL6joqI+gYCAO4+Ojj6TkpI+0dBQvYqJCT+SkRE/zMtLPw==",
+      "vectorSha256": "7d3ba5dd12946d2096146ac347c5eed0029a6801a7f7cb81d1c8164e8618683d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6ac2187dd196a2db14a616ba48d3c2f01b6798018c31a66ca880a3a479c4c8e5",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0477": {
+      "vector": "np0dv42MDD7W1VU/s7KyPvj3d7/BwEC8mZiYvZSTE7+EgwM/rKsrv+7tbT+BgIA7nJsbP+XkZL62tTW/t7a2vtDPT7+BgIC75+bmPoiHB7+TkpK+paQkPp+enr6Lioo+8vFxP4uKir6hoKC8yslJv42MDL6KiQm/wsFBP62sLL6enR2/jYwMPtbVVT+zsrI++Pd3v8HAQLyZmJi9lJMTv4SDAz+sqyu/7u1tP4GAgDucmxs/5eRkvra1Nb+3tra+0M9Pv4GAgLvn5uY+iIcHv5OSkr6lpCQ+n56evouKij7y8XE/i4qKvqGgoLzKyUm/jYwMvoqJCb/CwUE/rawsvg==",
+      "vectorSha256": "34bd1d7733b59b3487b4edd7cfcc6102739d9a6bc5b6f18182c93a859ab6b107",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3191eaac047e7636c12af680cd632552187fb93c5b9458a2f85d7d1b6e3be06a",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0478": {
+      "vector": "oaCgPLq5Ob/493c/r66uPo6NDT+NjAy++/r6PqWkJD6xsDA9uLc3P93cXD7Z2Ng94N9fv5ybG7/Ew0M/o6KivvX0dD6+vT0/sK8vv4+Ojj7Ix0c/4+LiPpqZGT+koyM/9/b2Pq2sLL6TkpI+7u1tv8jHRz+Ylxc/n56ePrGwML2hoKA8urk5v/j3dz+vrq4+jo0NP42MDL77+vo+paQkPrGwMD24tzc/3dxcPtnY2D3g31+/nJsbv8TDQz+joqK+9fR0Pr69PT+wry+/j46OPsjHRz/j4uI+mpkZP6SjIz/39vY+rawsvpOSkj7u7W2/yMdHP5iXFz+fnp4+sbAwvQ==",
+      "vectorSha256": "77b668bb95f2fdbde237e8b7a1ee7d61802ab4d7c603251d5438b4fad570e6ea",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8223fbabc66ebe9485db9b8d1032e1579ede28a3e3b8ccd1bd6aa409e3cba77a",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0479": {
+      "vector": "r66uvqSjIz+fnp6+7exsPpybGz++vT2/7u1tv4WEBL7DwsI+g4KCvrCvLz/d3Fw+ycjIPdTTU7+cmxs/0M9PP4mIiL3GxUU/nJsbP/HwcD2TkpK+yMdHv6GgoDy0szM/mZiYvcnIyL3Ew0O/mZiYvczLSz+7urq+wcBAPNbVVb+vrq6+pKMjP5+enr7t7Gw+nJsbP769Pb/u7W2/hYQEvsPCwj6DgoK+sK8vP93cXD7JyMg91NNTv5ybGz/Qz08/iYiIvcbFRT+cmxs/8fBwPZOSkr7Ix0e/oaCgPLSzMz+ZmJi9ycjIvcTDQ7+ZmJi9zMtLP7u6ur7BwEA81tVVvw==",
+      "vectorSha256": "2cae5b479aebbb62e15f13f6ec86cfa384ec1fb6de3e8a2f61aa1006dc00897e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "54d1589dcd21096fb05fd79b8c16cde777e2cd875b1c82d976731e76e5518115",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0480": {
+      "vector": "rawsvt3cXD7l5GQ+29ravtrZWT/HxsY+5eRkPqmoqD3BwEA8sbAwveno6D27urq+9/b2Pr69Pb/u7W2/n56ePu7tbb+XlpY+wsFBv9bVVb+sqys/4uFhv5OSkj7h4OC819bWvrCvL7/d3Fy+i4qKPomIiD2FhAQ+5uVlP7KxMb+trCy+3dxcPuXkZD7b2tq+2tlZP8fGxj7l5GQ+qaioPcHAQDyxsDC96ejoPbu6ur739vY+vr09v+7tbb+fnp4+7u1tv5eWlj7CwUG/1tVVv6yrKz/i4WG/k5KSPuHg4LzX1ta+sK8vv93cXL6Lioo+iYiIPYWEBD7m5WU/srExvw==",
+      "vectorSha256": "388f32006825fbf9b346f75871b6bda05c5da1b86f1df65ecaeb48aacc261f74",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6a9b9c49ecb19c8a817a8e51bd2109a709a51f15d50fa47c4a2864a28890f227",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0481": {
+      "vector": "+fj4PcXERD7S0VE/lZQUPu/u7r69vDy+trU1v7m4uL2wry+/x8bGvpybGz+KiQk/+vl5v9PS0j78+3s///7+vqalJb/6+Xm/7exsvv79fT+bmpq+sK8vP+XkZL6Ihwc/3t1dv5STE7/i4WE/xMNDP4yLC7+7urq+2tlZPwAAgD/5+Pg9xcREPtLRUT+VlBQ+7+7uvr28PL62tTW/ubi4vbCvL7/Hxsa+nJsbP4qJCT/6+Xm/09LSPvz7ez///v6+pqUlv/r5eb/t7Gy+/v19P5uamr6wry8/5eRkvoiHBz/e3V2/lJMTv+LhYT/Ew0M/jIsLv7u6ur7a2Vk/AACAPw==",
+      "vectorSha256": "b86e8a4acd469688ee1e96abe36ef2eb5606cebbaf981892af327554ba10fc23",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8f98e89244682574284ecdc403b4fd402d0362fe59d763c31136f0e13a51ecff",
+      "updatedAt": "2025-09-20T22:27:41.534Z"
+    },
+    "j-0482": {
+      "vector": "/v19v+7tbb+amRk/nJsbP4+Ojj6pqKi9y8rKvoyLC7/DwsI+zMtLv728PD7Ix0c/hoUFv/LxcT+1tDS+6ejovauqqr7T0tK+jo0Nv9XUVL6wry+/qKcnv/79fb+WlRU/xcREvvz7e7+ysTE///7+vuTjY7+hoKC8n56ePtnY2D3+/X2/7u1tv5qZGT+cmxs/j46OPqmoqL3Lysq+jIsLv8PCwj7My0u/vbw8PsjHRz+GhQW/8vFxP7W0NL7p6Oi9q6qqvtPS0r6OjQ2/1dRUvrCvL7+opye//v19v5aVFT/FxES+/Pt7v7KxMT///v6+5ONjv6GgoLyfnp4+2djYPQ==",
+      "vectorSha256": "09ec0e7df206aca281bf9bbdb1279f172c59a6e1fdae0efb602a1538f2a9db98",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0109cccda3754d3ab01a97e33df86971554b3965282c01ca6702d8400e7da78d",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0483": {
+      "vector": "29ravtHQUD2GhQW/oqEhv/b1dT+bmpo+v76+PpmYmD3493c/oJ8fv9PS0r6UkxO/uLc3v+fm5r6Miwu/+fj4vZiXF7+gnx8///7+Pp6dHb+joqK+u7q6vqGgoDzFxES+/Pt7v6KhIb/k42O/rawsPvn4+D2opye/t7a2vq2sLD7b2tq+0dBQPYaFBb+ioSG/9vV1P5uamj6/vr4+mZiYPfj3dz+gnx+/09LSvpSTE7+4tze/5+bmvoyLC7/5+Pi9mJcXv6CfHz///v4+np0dv6Oior67urq+oaCgPMXERL78+3u/oqEhv+TjY7+trCw++fj4PainJ7+3tra+rawsPg==",
+      "vectorSha256": "364869b9b28f07949709548e2a13fc2d4991ebd31c5fe6577cc0d6039a1c466d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "49863d2ffaa6af89fb304b3624463a7034cfbf3157518267022f0e958f2c5295",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0484": {
+      "vector": "rq0tv+no6D2npqY+jo0Nv+LhYb+SkRE/tLMzP9HQUD3CwUE/xsVFP+fm5j6amRm/zcxMPoeGhr6NjAy+9vV1P5aVFb/q6Wk/z87OPoaFBb+4tze/p6amvqWkJL7r6uo+9vV1v9XUVD69vDw+mJcXP/Py8r7X1ta+i4qKPt7dXb+urS2/6ejoPaempj6OjQ2/4uFhv5KRET+0szM/0dBQPcLBQT/GxUU/5+bmPpqZGb/NzEw+h4aGvo2MDL729XU/lpUVv+rpaT/Pzs4+hoUFv7i3N7+npqa+paQkvuvq6j729XW/1dRUPr28PD6Ylxc/8/LyvtfW1r6Lioo+3t1dvw==",
+      "vectorSha256": "fbea6fd1effb99a1f1cc28357de3f5e85cd57edb232bc7050fbe3b2b974bd18f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "298ea9390fc8d986e0e2b933995e6efa35f4b33d24566bba059a97cb434aa211",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0485": {
+      "vector": "AACAv7i3Nz+ZmJg9AACAv7CvLz+FhAQ++Pd3P5mYmD2koyM/+fj4PbCvLz/BwEC85uVlv728PD7BwEA8wL8/v4eGhj7Pzs6+7OtrP87NTb+enR2/19bWvv38fL6ysTG/397evtXUVL6Lioo+qaiovcHAQLydnBy+oqEhP5mYmD0AAIC/uLc3P5mYmD0AAIC/sK8vP4WEBD7493c/mZiYPaSjIz/5+Pg9sK8vP8HAQLzm5WW/vbw8PsHAQDzAvz+/h4aGPs/Ozr7s62s/zs1Nv56dHb/X1ta+/fx8vrKxMb/f3t6+1dRUvouKij6pqKi9wcBAvJ2cHL6ioSE/mZiYPQ==",
+      "vectorSha256": "fda7c3bcdfa1cbe0a233480a9af95bb0b473b66093b23da5a9c19a4257d16b5f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "00db8900d790fb89d18fd77e0d978120a14cf519314a60274865a2757e6cd089",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0486": {
+      "vector": "n56ePrKxMb/n5uY+goEBv7m4uD3KyUm/lZQUvuPi4r6BgIC7l5aWPvn4+L2VlBQ+iokJv8XERD7l5GQ+hIMDP/n4+D3x8HC9urk5P7++vr68uzu/1NNTv+vq6r6amRm/trU1P/f29j6UkxO/urk5v9bVVb/NzEy+8fBwve3sbL6fnp4+srExv+fm5j6CgQG/ubi4PcrJSb+VlBS+4+LivoGAgLuXlpY++fj4vZWUFD6KiQm/xcREPuXkZD6EgwM/+fj4PfHwcL26uTk/v76+vry7O7/U01O/6+rqvpqZGb+2tTU/9/b2PpSTE7+6uTm/1tVVv83MTL7x8HC97exsvg==",
+      "vectorSha256": "69257f8b0e05cc64d462aa8eb76794a5558cc233a3f1953490c509df1375112f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a727b93f8b1b6d477fa570923b989cc18f78dc5022164533dabd362315667862",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0487": {
+      "vector": "8vFxP/j3dz+2tTW/vLs7P7u6ur6bmpo+vLs7v/Dvbz+koyM/np0dP6CfH7+ioSG/goEBv6uqqj7KyUk///7+vqalJb/u7W0/2djYPYqJCT+CgQG/xcREvpybG7+4tzc/r66uvra1NT+OjQ0/4N9fv5iXF7+3trY+29ravre2tr7y8XE/+Pd3P7a1Nb+8uzs/u7q6vpuamj68uzu/8O9vP6SjIz+enR0/oJ8fv6KhIb+CgQG/q6qqPsrJST///v6+pqUlv+7tbT/Z2Ng9iokJP4KBAb/FxES+nJsbv7i3Nz+vrq6+trU1P46NDT/g31+/mJcXv7e2tj7b2tq+t7a2vg==",
+      "vectorSha256": "4e6d3ba76ca9851f523882224371beca99e092ea6b3eff5f623a0030d5b5173d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f8fb25dd51a622f7d1ce302f3faae4402df68dc43f6732db54dac61034ad4952",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0488": {
+      "vector": "jYwMPsTDQz/JyMg94N9fP42MDD7h4OA8mpkZP/v6+r76+Xm/9vV1v4qJCb/b2to+0M9PP/b1db+bmpq+mpkZv9rZWT/a2Vm/mpkZv8zLSz+xsDA9np0dP87NTb/t7Gw+n56evpeWlj7r6uq+jo0NP9rZWb+XlpY+0dBQPdTTU7+NjAw+xMNDP8nIyD3g318/jYwMPuHg4DyamRk/+/r6vvr5eb/29XW/iokJv9va2j7Qz08/9vV1v5uamr6amRm/2tlZP9rZWb+amRm/zMtLP7GwMD2enR0/zs1Nv+3sbD6fnp6+l5aWPuvq6r6OjQ0/2tlZv5eWlj7R0FA91NNTvw==",
+      "vectorSha256": "e8f74c945411d119c185611d0e6beab11c78c5ed9ebb31496530c661e28e7698",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "91e18cef9183cc4103053bb6e7055933ec1333e585ce199d58a545c613a58616",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0489": {
+      "vector": "nZwcPvz7ez+vrq4+0tFRP7i3Nz/NzEw+iIcHv+TjYz++vT0/iYiIPd/e3r69vDy+1dRUPsbFRb+Pjo4+4N9fvwAAgL/Y11c/sbAwvcbFRT/Qz08/7+7uPqalJT++vT2/t7a2Pt7dXb/a2Vk/8fBwPZybG7+bmpq+sbAwPZWUFL6dnBw+/Pt7P6+urj7S0VE/uLc3P83MTD6Ihwe/5ONjP769PT+JiIg9397evr28PL7V1FQ+xsVFv4+Ojj7g31+/AACAv9jXVz+xsDC9xsVFP9DPTz/v7u4+pqUlP769Pb+3trY+3t1dv9rZWT/x8HA9nJsbv5uamr6xsDA9lZQUvg==",
+      "vectorSha256": "b0418b1172aafd9ccd7c838306ea33c9977ddcb79940f391f3a0fd793f8af9c1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "93fdabe8db993cf1de8848689a1da31000eb7ae2e7bbd221ad11ec873259856d",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0490": {
+      "vector": "qaioPcTDQz/GxUU/pqUlP6+urj6EgwM/19bWPs/Ozj6zsrK+j46Ovo+Ojr6JiIi9o6KivtnY2L2pqKg95eRkPqSjIz/7+vo+s7KyvsbFRb+BgIC7rawsvoOCgj6dnBy+kI8Pv+jnZz/u7W0/q6qqvp2cHD7FxEQ+8/LyvtfW1r6pqKg9xMNDP8bFRT+mpSU/r66uPoSDAz/X1tY+z87OPrOysr6Pjo6+j46OvomIiL2joqK+2djYvamoqD3l5GQ+pKMjP/v6+j6zsrK+xsVFv4GAgLutrCy+g4KCPp2cHL6Qjw+/6OdnP+7tbT+rqqq+nZwcPsXERD7z8vK+19bWvg==",
+      "vectorSha256": "f2d6d7a24e234c82de43b588c9a3d4a1cf07ae367b5356bc0fb7584cd8f4cb8f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8ae1e2d2abc1b5b3535c5c7757728a9cd1be531d7f6aa06c38f3f6559398434a",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0491": {
+      "vector": "3Ntbv+vq6j65uLg98O9vP5mYmD27uro+29raPqCfHz/JyMg94+Livvn4+D3Qz0+/yMdHv+jnZz/+/X0/r66uPqinJ7/DwsI+nJsbP+TjYz+wry8/w8LCPpWUFL7w728/w8LCPrW0NL7m5WU/i4qKPu7tbb+KiQk/yslJv5mYmL3c21u/6+rqPrm4uD3w728/mZiYPbu6uj7b2to+oJ8fP8nIyD3j4uK++fj4PdDPT7/Ix0e/6OdnP/79fT+vrq4+qKcnv8PCwj6cmxs/5ONjP7CvLz/DwsI+lZQUvvDvbz/DwsI+tbQ0vublZT+Lioo+7u1tv4qJCT/KyUm/mZiYvQ==",
+      "vectorSha256": "4961ff480be412f656efd01f38e9fb3451a805f97e66826b3e26ccdb70f284ed",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "12ba8bf789aeb6cf8c478f181cf3feab2cb0cdf1d7b06df7b069f2a209c41b76",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0492": {
+      "vector": "09LSvry7O7/JyMg9+fj4vZuamj6Pjo6+7+7uPqWkJD7BwEC8yslJP//+/r6mpSU/7OtrP9XUVL7n5uY+oaCgPNnY2D2wry8/6+rqvs/Ozr6FhAQ+nJsbP87NTT/JyMg9t7a2vqWkJL7X1tY+AACAP52cHL6DgoI++/r6vuLhYT/T0tK+vLs7v8nIyD35+Pi9m5qaPo+Ojr7v7u4+paQkPsHAQLzKyUk///7+vqalJT/s62s/1dRUvufm5j6hoKA82djYPbCvLz/r6uq+z87OvoWEBD6cmxs/zs1NP8nIyD23tra+paQkvtfW1j4AAIA/nZwcvoOCgj77+vq+4uFhPw==",
+      "vectorSha256": "325c3d75aa974f88d7cc83fe8bb49e6992c289986b8700095992a573abef5bbf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4b228c70a65cbb947ee440d2f565b9828dd7454c90cde68c526bb5ff6ca041f0",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0493": {
+      "vector": "hIMDv/j3dz+1tDQ+g4KCPurpaT/n5uY+4eDgPJiXFz/p6Og9jo0Nv7CvL7/r6uo+xMNDv/Dvb7+1tDQ+oqEhv62sLD66uTk/+fj4PYWEBL66uTk/5eRkvuHg4DzLyso+g4KCPo+Ojr76+Xk/iYiIvff29j7HxsY+sK8vP9va2r6EgwO/+Pd3P7W0ND6DgoI+6ulpP+fm5j7h4OA8mJcXP+no6D2OjQ2/sK8vv+vq6j7Ew0O/8O9vv7W0ND6ioSG/rawsPrq5OT/5+Pg9hYQEvrq5OT/l5GS+4eDgPMvKyj6DgoI+j46Ovvr5eT+JiIi99/b2PsfGxj6wry8/29ravg==",
+      "vectorSha256": "4c544c0a170fa5cfdbe6fd97bd5bc838e33db603f7bb8f4a7ae8dfd6ef7c6cf3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3efb96a0f4b983cb8e3928ba1e08962f95dc8f6fdc6383b2a05cfc77bdb1d749",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0494": {
+      "vector": "hoUFv9va2r7k42M/q6qqvvTzc7/8+3u/1dRUvpybG7/r6uq+9/b2vpGQEL3Avz+/z87OPqempj6UkxO/i4qKvrCvLz/i4WE/09LSPoKBAT/DwsK+q6qqvuLhYT/s62s/+/r6PvDvbz+SkRG/goEBv+/u7r7Pzs6+6OdnP/b1db+GhQW/29ravuTjYz+rqqq+9PNzv/z7e7/V1FS+nJsbv+vq6r739va+kZAQvcC/P7/Pzs4+p6amPpSTE7+Lioq+sK8vP+LhYT/T0tI+goEBP8PCwr6rqqq+4uFhP+zraz/7+vo+8O9vP5KREb+CgQG/7+7uvs/Ozr7o52c/9vV1vw==",
+      "vectorSha256": "cb0bcc8ab20e4d4b91f0ffb06942617632df50cb435d14aa2fbee2f5402f4e27",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3d49f1550602653245427b20b3a9365dd7f0b4c04f55f0f5bef7373f444cf305",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0495": {
+      "vector": "4N9fv4SDA7/+/X2/w8LCPtbVVT/d3Fw+h4aGPpOSkr7p6Og9sK8vv/Tzcz+FhAS+lZQUvoyLCz/t7Gw+1tVVP/Tzc7/8+3u/jIsLv+Pi4r7f3t6+lJMTv/j3dz/u7W2/19bWPtHQUD3FxES+urk5v8TDQz/HxsY+qqkpP7e2tj7g31+/hIMDv/79fb/DwsI+1tVVP93cXD6HhoY+k5KSvuno6D2wry+/9PNzP4WEBL6VlBS+jIsLP+3sbD7W1VU/9PNzv/z7e7+Miwu/4+Livt/e3r6UkxO/+Pd3P+7tbb/X1tY+0dBQPcXERL66uTm/xMNDP8fGxj6qqSk/t7a2Pg==",
+      "vectorSha256": "5d6275080a76c4688f6fd51917d21274c1dc8015923b9156660df7d909a32267",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "103e01b0ea9ba15b8e28f96f6dc59dea06023a474836fb09b5866723e1b1d4ad",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0496": {
+      "vector": "jIsLv8XERD7X1ta+nJsbP5ybGz/Y11c/oaCgPOLhYT/083O/8vFxP9jXVz/Avz+/AACAv4OCgj64tze/kZAQPdHQUL3NzEy+mZiYPdjXVz/V1FS+xcREvvr5eT+EgwM/5+bmPurpaT/FxEQ+6+rqPtrZWb/z8vK+5+bmvuDfXz+Miwu/xcREPtfW1r6cmxs/nJsbP9jXVz+hoKA84uFhP/Tzc7/y8XE/2NdXP8C/P78AAIC/g4KCPri3N7+RkBA90dBQvc3MTL6ZmJg92NdXP9XUVL7FxES++vl5P4SDAz/n5uY+6ulpP8XERD7r6uo+2tlZv/Py8r7n5ua+4N9fPw==",
+      "vectorSha256": "26728b1a9005ee9dbe8b5d0c94b62c3b76c3daf6e3890795c5dd39207f9b63fc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3a984acdcdeb82f006f8eb2000a02484796689eb6567fcc1b9f498ba134346ef",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0497": {
+      "vector": "h4aGvoWEBL7GxUU/l5aWPsXERD7083O/z87OPr28PL7493e/l5aWvvPy8r65uLg9/v19P8fGxr6lpCQ+wcBAPL++vj79/Hy+5ONjv5WUFL6pqKi9zcxMvoGAgLvw728/0dBQvfr5eb/HxsY+7OtrP8LBQT+wry8/p6amvqyrKz+Hhoa+hYQEvsbFRT+XlpY+xcREPvTzc7/Pzs4+vbw8vvj3d7+Xlpa+8/Lyvrm4uD3+/X0/x8bGvqWkJD7BwEA8v76+Pv38fL7k42O/lZQUvqmoqL3NzEy+gYCAu/Dvbz/R0FC9+vl5v8fGxj7s62s/wsFBP7CvLz+npqa+rKsrPw==",
+      "vectorSha256": "66a89a0c4387034b2edfbc691f612cb12235cf7bf9061aa52383ace6e6640eaf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5e6fe2a59806b368045a438bfe4e9481af600e6d75667ff77903b1f5e0d756d5",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0498": {
+      "vector": "yMdHP+no6D2rqqo+AACAv5OSkr7v7u6+sK8vv6KhIT+qqSk/n56ePqyrKz+joqI+8O9vP4mIiD3j4uK+sK8vv+/u7j7GxUW/7+7uPtrZWb+ioSE/sbAwPfb1dT/X1tY+/v19P8nIyD2pqKg94uFhv5eWlr6vrq6+i4qKvtfW1r7Ix0c/6ejoPauqqj4AAIC/k5KSvu/u7r6wry+/oqEhP6qpKT+fnp4+rKsrP6Oioj7w728/iYiIPePi4r6wry+/7+7uPsbFRb/v7u4+2tlZv6KhIT+xsDA99vV1P9fW1j7+/X0/ycjIPamoqD3i4WG/l5aWvq+urr6Lioq+19bWvg==",
+      "vectorSha256": "f07626f8eedb0024324c872b2edafc2a436025e8d1b0595f9f246dea919ae054",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e38eaa005b4428d0d4a7d5a8f7884728bb1dbb13d085fab5fe8c8a0f5a545d4a",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0499": {
+      "vector": "2tlZP46NDb+amRm/6+rqPpaVFb/o52e/+/r6PpWUFL6fnp4+wsFBP+3sbD66uTm/lZQUPq+urj6JiIi92djYvYOCgj7Z2Ng91dRUvsLBQb/BwEC8lJMTP8fGxr7f3t6+xcREvtbVVT+DgoK+2NdXv4yLCz/6+Xm/09LSPrGwML3a2Vk/jo0Nv5qZGb/r6uo+lpUVv+jnZ7/7+vo+lZQUvp+enj7CwUE/7exsPrq5Ob+VlBQ+r66uPomIiL3Z2Ni9g4KCPtnY2D3V1FS+wsFBv8HAQLyUkxM/x8bGvt/e3r7FxES+1tVVP4OCgr7Y11e/jIsLP/r5eb/T0tI+sbAwvQ==",
+      "vectorSha256": "6bdbf2d25f7b30c7c3af4a750a6b75be078da255ab245d6b497199c381e32350",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ec3933ba350cbe6da7e09d2392ab7772a08d651f7ec94e4867ea5f14c503b47a",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0500": {
+      "vector": "3dxcPq2sLD6cmxs/jIsLv+no6D26uTk/paQkPqqpKT/m5WU/zs1Nv5eWlj6sqys/iIcHP4mIiD29vDy+mpkZv+7tbb+fnp4+6Odnv/Tzc7+amRk/y8rKPvPy8j7u7W0/hIMDP+zra7+dnBw+rawsvpCPD7/Ix0c/o6KiPuTjYz/d3Fw+rawsPpybGz+Miwu/6ejoPbq5OT+lpCQ+qqkpP+blZT/OzU2/l5aWPqyrKz+Ihwc/iYiIPb28PL6amRm/7u1tv5+enj7o52e/9PNzv5qZGT/Lyso+8/LyPu7tbT+EgwM/7Otrv52cHD6trCy+kI8Pv8jHRz+joqI+5ONjPw==",
+      "vectorSha256": "200cdd6430d12865dcf233599b36d5c12a52f512c3f2966e440fa7e01c203bba",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9b95cd3a8edc94d4f219a5d5c388683309a70c06ccb2bcf6c10a936a38e3a8f1",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0501": {
+      "vector": "s7KyPt7dXT/BwEA87u1tP9va2r7CwUE/nZwcvvTzc7+gnx8/7u1tP8HAQLzv7u6+1dRUvomIiL3p6Og98vFxP//+/r7r6uq+m5qaPsfGxr6WlRW/rKsrv+XkZL7CwUG/9fR0vquqqr66uTk/j46OvtzbW7/T0tI+9PNzP5eWlr6zsrI+3t1dP8HAQDzu7W0/29ravsLBQT+dnBy+9PNzv6CfHz/u7W0/wcBAvO/u7r7V1FS+iYiIveno6D3y8XE///7+vuvq6r6bmpo+x8bGvpaVFb+sqyu/5eRkvsLBQb/19HS+q6qqvrq5OT+Pjo6+3Ntbv9PS0j7083M/l5aWvg==",
+      "vectorSha256": "7753f5f2b1c659bbc3cfdc837d3ec7f685cf1c0aefba4775cb0c6e7305144e9f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "acee81f649e06c06cff67e4465778ef84045a64e352a631f6155dc5c12b4f95a",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0502": {
+      "vector": "m5qavpCPDz/+/X0/i4qKvqempr6urS0/oJ8fv+rpab/19HS+lpUVP7m4uD37+vo+3dxcPrKxMb+WlRU/yslJP/n4+D24tzc/j46Ovq2sLD61tDQ+gYCAu/r5eT/y8XE/jIsLv+zraz/s62s/pKMjP7GwMD3c21s/kI8PP7u6uj6bmpq+kI8PP/79fT+Lioq+p6amvq6tLT+gnx+/6ulpv/X0dL6WlRU/ubi4Pfv6+j7d3Fw+srExv5aVFT/KyUk/+fj4Pbi3Nz+Pjo6+rawsPrW0ND6BgIC7+vl5P/LxcT+Miwu/7OtrP+zraz+koyM/sbAwPdzbWz+Qjw8/u7q6Pg==",
+      "vectorSha256": "da90f8ca8084b299eea611628e893aae638ff4efaa9dd327ea0ff24e44196a0c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "59c7fe5d56d6300b61ca8bbe9b27cae48fdb5c95967ffcf83af5f5d185edc7ae",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0503": {
+      "vector": "hYQEvpaVFT/Lysq+0M9PP5ybG7/8+3s/5+bmPoeGhr7//v6+/Pt7P8jHRz+Pjo6+29raPr28PL6Qjw8/qKcnP7u6uj76+Xk/8fBwPa+urj7083M/8/LyvpKRET+sqys/mpkZP5uamr6Xlpa+2NdXP+LhYb/o52c/1dRUvq6tLb+FhAS+lpUVP8vKyr7Qz08/nJsbv/z7ez/n5uY+h4aGvv/+/r78+3s/yMdHP4+Ojr7b2to+vbw8vpCPDz+opyc/u7q6Pvr5eT/x8HA9r66uPvTzcz/z8vK+kpERP6yrKz+amRk/m5qavpeWlr7Y11c/4uFhv+jnZz/V1FS+rq0tvw==",
+      "vectorSha256": "678ecf885bee5ca1be038b1d8d1cba5b6e3268d6550e8d68f818be0c2215cb85",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6fca4de732fdb95e40fde35cb668c7d3aefc87abf943c8d5cc595aeb0ff36529",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0504": {
+      "vector": "u7q6Po6NDT+UkxM/0M9PP5ybG7/19HS+paQkvp6dHT/39va+4eDgPIKBAT+9vDy+xsVFP7GwMD2JiIi99vV1v+rpab/KyUm/vLs7v+vq6r64tzc/h4aGvqmoqD3e3V2/kZAQvbSzM7/Lysq+0tFRP7u6ur6wry+/g4KCPvv6+j67uro+jo0NP5STEz/Qz08/nJsbv/X0dL6lpCS+np0dP/f29r7h4OA8goEBP728PL7GxUU/sbAwPYmIiL329XW/6ulpv8rJSb+8uzu/6+rqvri3Nz+Hhoa+qaioPd7dXb+RkBC9tLMzv8vKyr7S0VE/u7q6vrCvL7+DgoI++/r6Pg==",
+      "vectorSha256": "6734306cc99f54e29237f7d284b9b7136e065e88ba235c96c24ee70ca8a4ecc8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "aec6c9e732616bce4283c068e28577050b1b2245db5e8a117b264de85128a0be",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0505": {
+      "vector": "pqUlP+Pi4r6Lioo+o6KiPvn4+D2hoKA8r66uPqWkJL7k42M/zs1Nv5qZGb/i4WE//Pt7v/n4+D3Ew0M/mpkZP9nY2D2lpCS+v76+PqSjI7+sqys/6ejoPQAAgD++vT0/tbQ0vo+Ojj6enR0/vbw8vqKhIb/r6uq+n56evsHAQDympSU/4+LivouKij6joqI++fj4PaGgoDyvrq4+paQkvuTjYz/OzU2/mpkZv+LhYT/8+3u/+fj4PcTDQz+amRk/2djYPaWkJL6/vr4+pKMjv6yrKz/p6Og9AACAP769PT+1tDS+j46OPp6dHT+9vDy+oqEhv+vq6r6fnp6+wcBAPA==",
+      "vectorSha256": "e6290accbcd053b17e565a75f1ef749d8e5ad6ad827192ccc631f475628cf39d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d247a2a88f82ab6bf11933f0028fe1cc8d6baf2ed58effde69a3ce682f455881",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0506": {
+      "vector": "+Pd3v5mYmL2TkpK+1tVVv8nIyD3U01M/o6Kivq+urj719HQ+oqEhP4iHBz/Z2Ni9lJMTP4uKij7JyMg9mpkZv5KRET+3trY+wsFBv4SDA7+DgoK+vLs7v66tLT+ioSE/q6qqPsLBQT/7+vq+4N9fP//+/j7u7W0/l5aWPtfW1j7493e/mZiYvZOSkr7W1VW/ycjIPdTTUz+joqK+r66uPvX0dD6ioSE/iIcHP9nY2L2UkxM/i4qKPsnIyD2amRm/kpERP7e2tj7CwUG/hIMDv4OCgr68uzu/rq0tP6KhIT+rqqo+wsFBP/v6+r7g318///7+Pu7tbT+XlpY+19bWPg==",
+      "vectorSha256": "05103aefca06a98f35b2586257e7d66cff7f56f43a66e40aefa79eec7b1ddfd8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "04765b158ce957ab9ed0c372c9a28c33c8ad1f3e5f22d6d0aae041efbff6a5b5",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0507": {
+      "vector": "p6amPrOysr61tDQ+l5aWPp+enr7m5WW/wcBAvPLxcT+VlBS+g4KCPtPS0r7k42O/9vV1P/v6+r7BwEC8sK8vv6alJT/Ix0c/zMtLP6WkJL6HhoY+vbw8PtzbW7+3trY+gYCAO4OCgr6xsDC92djYvdjXV7/CwUE/oqEhP/Tzcz+npqY+s7KyvrW0ND6XlpY+n56evublZb/BwEC88vFxP5WUFL6DgoI+09LSvuTjY7/29XU/+/r6vsHAQLywry+/pqUlP8jHRz/My0s/paQkvoeGhj69vDw+3Ntbv7e2tj6BgIA7g4KCvrGwML3Z2Ni92NdXv8LBQT+ioSE/9PNzPw==",
+      "vectorSha256": "6591d1e011af414d5016b10ff0761061f803de9fddc0ab14a4d0024241ee190e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a95396a5580d7ef86da04b0efa417e28d2e3e56ba19712ad805f7a7214e0d0f9",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0508": {
+      "vector": "iIcHP8rJSb/OzU0/wsFBv8C/P7/z8vK+zs1NP5+enr79/Hy+zs1NP5iXFz+DgoI+kI8PP46NDb+fnp6+4eDgvKKhIb+Ihwe/8O9vv4GAgDvi4WE/ubi4vYGAgLuwry+/zcxMPuXkZD6koyO/mpkZv6qpKb+wry+/uLc3v5eWlr6Ihwc/yslJv87NTT/CwUG/wL8/v/Py8r7OzU0/n56evv38fL7OzU0/mJcXP4OCgj6Qjw8/jo0Nv5+enr7h4OC8oqEhv4iHB7/w72+/gYCAO+LhYT+5uLi9gYCAu7CvL7/NzEw+5eRkPqSjI7+amRm/qqkpv7CvL7+4tze/l5aWvg==",
+      "vectorSha256": "fc904074ce1cd9b136f1d9acfcce6855a4003d39b68633e047fc0e9d71060863",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c31be61f2043e65860e6cba0c739587c2f3c0880f0747f28999c2e332b28245a",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0509": {
+      "vector": "9vV1v8TDQz/493c/zs1Nv+LhYb+7urq+kI8Pv+/u7j7g31+/+Pd3P8HAQLzf3t6+vr09P56dHT+gnx+/+/r6Ppuamr64tzc/6Odnv8TDQ7+urS0/AACAP8XERD7a2Vk/mpkZv/v6+r7o52c/09LSvsLBQT/q6Wm/h4aGvoyLCz/29XW/xMNDP/j3dz/OzU2/4uFhv7u6ur6Qjw+/7+7uPuDfX7/493c/wcBAvN/e3r6+vT0/np0dP6CfH7/7+vo+m5qavri3Nz/o52e/xMNDv66tLT8AAIA/xcREPtrZWT+amRm/+/r6vujnZz/T0tK+wsFBP+rpab+Hhoa+jIsLPw==",
+      "vectorSha256": "cca3f375b0b41b7a3de2c3e68523abbd5b06b4770ddf2f83680e5904bc74d91e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "05e1fb190f5138bb10fb7e48dece30be59db0c1ed6ff98ec3341f34be00b5ec5",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0510": {
+      "vector": "wL8/P+no6L0AAIC/mJcXP8/Ozr6joqI+m5qaPpGQED3l5GQ+z87OvqSjI7/DwsK+2NdXP/v6+j6bmpq+yslJP9bVVT/k42O/iokJv5CPD7+EgwM/u7q6PuDfX7+OjQ2/3t1dv+/u7r6CgQG/vLs7P6Oioj6npqa+u7q6vo+Ojj7Avz8/6ejovQAAgL+Ylxc/z87OvqOioj6bmpo+kZAQPeXkZD7Pzs6+pKMjv8PCwr7Y11c/+/r6Ppuamr7KyUk/1tVVP+TjY7+KiQm/kI8Pv4SDAz+7uro+4N9fv46NDb/e3V2/7+7uvoKBAb+8uzs/o6KiPqempr67urq+j46OPg==",
+      "vectorSha256": "a60812aa4713c32be3f78fa78de92d0b08eb7d279c068967de1099478e35052d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "df7100cb4ca8a6849c4c2e4febbe59e4ea0e3b38c1ae103911443fdda85651a3",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0511": {
+      "vector": "vr09v6yrKz/Pzs6+kI8Pv/n4+L3k42O/5+bmvpuamj6WlRW/4uFhv7u6ur7r6uq+1tVVP8C/P7+lpCQ+gYCAO5STEz/7+vo+7OtrP8fGxr729XW/k5KSPvb1dT/GxUW/rq0tv9XUVL6Pjo4+6+rqPtfW1j6gnx+/5uVlv4aFBT++vT2/rKsrP8/Ozr6Qjw+/+fj4veTjY7/n5ua+m5qaPpaVFb/i4WG/u7q6vuvq6r7W1VU/wL8/v6WkJD6BgIA7lJMTP/v6+j7s62s/x8bGvvb1db+TkpI+9vV1P8bFRb+urS2/1dRUvo+Ojj7r6uo+19bWPqCfH7/m5WW/hoUFPw==",
+      "vectorSha256": "e4b2b5811bf95e2e8cc35c7ec284bae74792dbc92bbb3bcedf5964dae92f0c49",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "21d54c38700e46a6350f5145ea209480c9bef54e05a4fa1d2965a3bab5300dc2",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0512": {
+      "vector": "gYCAu6qpKT+RkBA9l5aWPoWEBL6CgQG/4eDgvP79fb/q6Wk/jYwMPs3MTL7g31+/t7a2Pvr5eb+JiIi90tFRv6Oior7c21s/wL8/P8TDQ7+gnx8/iIcHv/f29j6pqKg9zMtLv9bVVT/a2Vk//fx8vr28PL6mpSW/9vV1P9HQUL2BgIC7qqkpP5GQED2XlpY+hYQEvoKBAb/h4OC8/v19v+rpaT+NjAw+zcxMvuDfX7+3trY++vl5v4mIiL3S0VG/o6KivtzbWz/Avz8/xMNDv6CfHz+Ihwe/9/b2PqmoqD3My0u/1tVVP9rZWT/9/Hy+vbw8vqalJb/29XU/0dBQvQ==",
+      "vectorSha256": "a385e729a03200230eab48733e17a86a3f71331164581394337a899c1f558aba",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7fd484a56f3f7c01f4916610ad03771757eddf1ecf3cbd8a1aeaec60682dfa79",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0513": {
+      "vector": "wL8/PwAAgD/8+3s/7+7uvrGwML3Y11e/6+rqvr28PL68uzs/goEBv/b1dT+vrq4+qKcnP8bFRb+koyO/vr09v769PT+KiQm/7+7uvsC/Pz/Qz08/9PNzv7i3N7/x8HC9trU1P5qZGT/k42M/2NdXv83MTL7DwsI+z87OPtXUVL7Avz8/AACAP/z7ez/v7u6+sbAwvdjXV7/r6uq+vbw8vry7Oz+CgQG/9vV1P6+urj6opyc/xsVFv6SjI7++vT2/vr09P4qJCb/v7u6+wL8/P9DPTz/083O/uLc3v/HwcL22tTU/mpkZP+TjYz/Y11e/zcxMvsPCwj7Pzs4+1dRUvg==",
+      "vectorSha256": "dfe6cdf2290229f244abf8b94ab6b7aaf5583672b8808ffec770d8e57347af69",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dffffd447a144568dd3ffaabd31d2e21de3b44dfe7062478daccf11466b0b365",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0514": {
+      "vector": "xcREvpqZGb/g31+/gYCAO8zLS7+Pjo4+v76+PqyrK7+urS0/r66uPtHQUL36+Xm/8vFxP/Tzc7+Pjo6+u7q6vr28PD60szO/7exsPuzraz/q6Wk/zMtLP/38fL7FxEQ++Pd3v7W0ND7083O/vLs7P5uamr7NzEw+vbw8PrSzM7/FxES+mpkZv+DfX7+BgIA7zMtLv4+Ojj6/vr4+rKsrv66tLT+vrq4+0dBQvfr5eb/y8XE/9PNzv4+Ojr67urq+vbw8PrSzM7/t7Gw+7OtrP+rpaT/My0s//fx8vsXERD7493e/tbQ0PvTzc7+8uzs/m5qavs3MTD69vDw+tLMzvw==",
+      "vectorSha256": "21a217337904dcf2785d236c82a99b3ef376551af81fc249fdbecadbe4e219ac",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "673310801aa3af2ad6ab7903f8065c5197269df5f4e56098049606dd59999726",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0515": {
+      "vector": "nZwcvsPCwj7b2to+/v19P6SjIz/9/Hw+7Otrv/Tzcz/S0VG/29ravq2sLD69vDy+ubi4PfTzcz+vrq4+AACAv83MTL7d3Fw++fj4vfX0dL4AAIC/jIsLv7SzM7/g31+/hIMDv+jnZz+lpCS+u7q6vvb1db/S0VE/l5aWvomIiL2dnBy+w8LCPtva2j7+/X0/pKMjP/38fD7s62u/9PNzP9LRUb/b2tq+rawsPr28PL65uLg99PNzP6+urj4AAIC/zcxMvt3cXD75+Pi99fR0vgAAgL+Miwu/tLMzv+DfX7+EgwO/6OdnP6WkJL67urq+9vV1v9LRUT+Xlpa+iYiIvQ==",
+      "vectorSha256": "9bf8654a9508c9769efeeee8f17c954109088f1377ae2156fd4bf3cb3c9fcf58",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6cb0b6fed19f0af9174995688bf9ab00669b7061003a26103ef36b5105e85a77",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0516": {
+      "vector": "trU1v+DfXz+1tDS+19bWvu7tbb/Qz08/vr09v5mYmL2vrq6+pKMjP/n4+L3CwUE/paQkPqKhIT/Qz0+/4eDgPNva2j7493c/l5aWvsLBQT/DwsI+2djYPZiXFz/w728/8/LyPvLxcT/w728/gYCAO6yrKz/i4WE/iokJv8fGxr62tTW/4N9fP7W0NL7X1ta+7u1tv9DPTz++vT2/mZiYva+urr6koyM/+fj4vcLBQT+lpCQ+oqEhP9DPT7/h4OA829raPvj3dz+Xlpa+wsFBP8PCwj7Z2Ng9mJcXP/Dvbz/z8vI+8vFxP/Dvbz+BgIA7rKsrP+LhYT+KiQm/x8bGvg==",
+      "vectorSha256": "0077f1122c28601e00481564bf9f0a89639f5904d5e3806a2226dfaf68cca690",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "25ef694a09e7217654d170e094d01883b6fb5ae0b08dcbf7bcf8f780d5f03b4e",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0517": {
+      "vector": "1tVVP6moqL3Z2Ng9np0dv6yrKz+joqK+7Otrv+TjY7/f3t6+3dxcPt/e3r7S0VE/2tlZv9rZWT+Ylxe/oaCgPOno6D3w72+/u7q6vpybGz/OzU0/0dBQvZuamr6koyM/0M9PP5uamj7JyMi9pKMjv52cHL6qqSm/8/LyPv79fb/W1VU/qaiovdnY2D2enR2/rKsrP6Oior7s62u/5ONjv9/e3r7d3Fw+397evtLRUT/a2Vm/2tlZP5iXF7+hoKA86ejoPfDvb7+7urq+nJsbP87NTT/R0FC9m5qavqSjIz/Qz08/m5qaPsnIyL2koyO/nZwcvqqpKb/z8vI+/v19vw==",
+      "vectorSha256": "563f0b228aaa9e0aaea1cf023799b0caa91042b534f7afcd6ecfd00d623bba15",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ea758d31d5570a0e489b48e813ec34828e0851cde67959d1e7a6732e6c2bbc01",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0518": {
+      "vector": "pKMjP6KhIT/NzEw+4N9fP6moqL3V1FQ+kpERP/HwcL24tze/vLs7P/X0dD6Pjo4+wsFBP5+enj7Avz+/oJ8fP8/Ozr7t7Gy+7exsvrq5Ob/g31+/qaiovZybG7/BwEC82djYvYOCgr7HxsY+/Pt7v7u6uj7493e/urk5P6qpKT+koyM/oqEhP83MTD7g318/qaiovdXUVD6SkRE/8fBwvbi3N7+8uzs/9fR0Po+Ojj7CwUE/n56ePsC/P7+gnx8/z87Ovu3sbL7t7Gy+urk5v+DfX7+pqKi9nJsbv8HAQLzZ2Ni9g4KCvsfGxj78+3u/u7q6Pvj3d7+6uTk/qqkpPw==",
+      "vectorSha256": "87d94379e78c312c83c156214a0e74d52b4b7cd4187c917081860e48d100bd0f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d1d099ef759ac87824dd9ea3e0a720cf4c6262231075327e725fb102ae04dcd4",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0519": {
+      "vector": "ubi4Pfr5eT+UkxO/5uVlv8/Ozj7i4WG/vLs7v46NDb+koyO/5eRkPsPCwj7OzU2/9PNzv5ybG7+lpCS+srExP7SzM7+ioSE/wcBAPN/e3r62tTW/6Odnv5OSkr6ZmJi9iokJP+no6D2amRk/2djYvfLxcb+FhAQ+rKsrP/f29j65uLg9+vl5P5STE7/m5WW/z87OPuLhYb+8uzu/jo0Nv6SjI7/l5GQ+w8LCPs7NTb/083O/nJsbv6WkJL6ysTE/tLMzv6KhIT/BwEA8397evra1Nb/o52e/k5KSvpmYmL2KiQk/6ejoPZqZGT/Z2Ni98vFxv4WEBD6sqys/9/b2Pg==",
+      "vectorSha256": "3e09a8c7f3c090c1be9ebac25dad9baad0c0976a4330a9425916aea3a5f4ebed",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8bfc360db30f22392e9cb01906326bd826d08148250c5b76c48ecc720790d5bd",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0520": {
+      "vector": "i4qKvpOSkr7Lyso+uLc3P/n4+L2mpSU/2djYPff29r7i4WE/kZAQvcjHR7/Qz08//Pt7v6+urr7k42O/3t1dv/f29r6trCw+sK8vv7W0ND7u7W0/4eDgvKCfH7/Ew0M/3t1dP52cHD6fnp6+19bWPr++vr7My0u/ubi4veXkZD6Lioq+k5KSvsvKyj64tzc/+fj4vaalJT/Z2Ng99/b2vuLhYT+RkBC9yMdHv9DPTz/8+3u/r66uvuTjY7/e3V2/9/b2vq2sLD6wry+/tbQ0Pu7tbT/h4OC8oJ8fv8TDQz/e3V0/nZwcPp+enr7X1tY+v76+vszLS7+5uLi95eRkPg==",
+      "vectorSha256": "0493995de949b2c0de6ca255fbd53459b925500ce395fd5e6c25037a642d404c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5d5bb2db70d28d42f07b1ce702540e1142952896f67c30e1ee9358b5501a749c",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0521": {
+      "vector": "tbQ0vqalJT+cmxu/lJMTv6alJT///v6+zcxMPsC/P7+cmxs/6ulpP7W0ND7o52c/iokJP+DfX7+Ihwc/tLMzv66tLT/Lysq+7+7uvpmYmL2lpCQ+l5aWPoiHB7/8+3u/xcREvu/u7r7i4WG/4N9fv4SDAz/c21s/jo0NP+no6D21tDS+pqUlP5ybG7+UkxO/pqUlP//+/r7NzEw+wL8/v5ybGz/q6Wk/tbQ0PujnZz+KiQk/4N9fv4iHBz+0szO/rq0tP8vKyr7v7u6+mZiYvaWkJD6XlpY+iIcHv/z7e7/FxES+7+7uvuLhYb/g31+/hIMDP9zbWz+OjQ0/6ejoPQ==",
+      "vectorSha256": "86963172ccc275d8e4352fd849227a3838dbfc0c35ece3fa04939975f66255dd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "69d23236d2409920cdf496f3c410c326d64d447694a53c0267440f10c1edc68e",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0522": {
+      "vector": "oJ8fP4uKir6bmpo+7exsPqGgoLyVlBS+pKMjv6moqD22tTW/nZwcPuvq6r6npqa+jo0Nv5uamj7o52c/l5aWvt7dXb+8uzs/sbAwvZeWlr7R0FC90tFRP7Oysr7Ew0O/8O9vP7KxMT/Pzs6++vl5v4OCgr6Ihwe/g4KCPp6dHb+gnx8/i4qKvpuamj7t7Gw+oaCgvJWUFL6koyO/qaioPba1Nb+dnBw+6+rqvqempr6OjQ2/m5qaPujnZz+Xlpa+3t1dv7y7Oz+xsDC9l5aWvtHQUL3S0VE/s7KyvsTDQ7/w728/srExP8/Ozr76+Xm/g4KCvoiHB7+DgoI+np0dvw==",
+      "vectorSha256": "b14aaa15e4bef272c17eadbfdc3948934803fe5bffdeb16f018f038033e74f78",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cf5da69d7d6d2e8a2593455639a6f35a11dd7a5a79e8531ef7d84c035f3ca031",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0523": {
+      "vector": "nJsbv/Tzc7+vrq6+3t1dP7SzM7/t7Gw+3t1dP/38fL4AAIC/urk5v8PCwr79/Hw+7OtrP6moqD2Qjw+/w8LCPrSzMz+ysTE/xMNDv+/u7r7t7Gw+0M9Pv/38fD6JiIg919bWvvPy8r7FxEQ+qaiovaGgoDyGhQW/7Otrv5uamr6cmxu/9PNzv6+urr7e3V0/tLMzv+3sbD7e3V0//fx8vgAAgL+6uTm/w8LCvv38fD7s62s/qaioPZCPD7/DwsI+tLMzP7KxMT/Ew0O/7+7uvu3sbD7Qz0+//fx8PomIiD3X1ta+8/LyvsXERD6pqKi9oaCgPIaFBb/s62u/m5qavg==",
+      "vectorSha256": "33c901842926e41639a7a42779bfc31aeca8a39ffac595bee9f10f2932f324a3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "320654ee269dee6000234f9ff58a38b0d9d81e449d189f884a439875823d0a59",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0524": {
+      "vector": "mZiYPfv6+r6FhAQ+tLMzP52cHL7k42M/xMNDv9fW1r7u7W0/wL8/v6KhIT+rqqo+oJ8fP7SzM7/GxUU/tLMzv8rJST+npqY+y8rKvpKRET+4tze/ubi4vY+Ojj7//v4+3dxcPre2tr6GhQW/4uFhv8/Ozj7c21u/y8rKvpGQED2ZmJg9+/r6voWEBD60szM/nZwcvuTjYz/Ew0O/19bWvu7tbT/Avz+/oqEhP6uqqj6gnx8/tLMzv8bFRT+0szO/yslJP6empj7Lysq+kpERP7i3N7+5uLi9j46OPv/+/j7d3Fw+t7a2voaFBb/i4WG/z87OPtzbW7/Lysq+kZAQPQ==",
+      "vectorSha256": "962cb9ab825f78588814440fd4e748fa62b32de9f67834d77fa98799b328d233",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "894190d96cf11e4af620d0aacf26e226e4a94dc82474a3bf9b523d0fb3124d84",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0525": {
+      "vector": "vLs7v7u6ur6GhQW/29ravtXUVL68uzu/7u1tP83MTD6Miwu/6ulpP5eWlr7j4uK+zcxMvqempr60szO/pKMjv8/Ozj6ioSG/2NdXP4SDA7+2tTU/rawsPtnY2D2DgoI+rKsrv83MTL6hoKC8//7+PrSzM7/x8HA9//7+Pq2sLL68uzu/u7q6voaFBb/b2tq+1dRUvry7O7/u7W0/zcxMPoyLC7/q6Wk/l5aWvuPi4r7NzEy+p6amvrSzM7+koyO/z87OPqKhIb/Y11c/hIMDv7a1NT+trCw+2djYPYOCgj6sqyu/zcxMvqGgoLz//v4+tLMzv/HwcD3//v4+rawsvg==",
+      "vectorSha256": "8f0676c3b705cd9959e7aebec5f81d73800c2b49483ad2cfc448191783f8f924",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "22513d496522f6993af45a476656262eb32feb3eda958da02a667dbf2687bf6a",
+      "updatedAt": "2025-09-20T22:27:41.535Z"
+    },
+    "j-0526": {
+      "vector": "9fR0vp6dHb+/vr4+np0dv7a1Nb+fnp4+//7+Ps/Ozr7v7u6+5+bmPuDfX7/BwEC85eRkvre2tr7p6Og99PNzv5STE7/7+vq++/r6Pra1Nb+pqKg9+fj4PcTDQz+SkRE/mZiYvcnIyL2joqK+pKMjv7Oysj7T0tI+o6KiPqKhIT/19HS+np0dv7++vj6enR2/trU1v5+enj7//v4+z87Ovu/u7r7n5uY+4N9fv8HAQLzl5GS+t7a2vuno6D3083O/lJMTv/v6+r77+vo+trU1v6moqD35+Pg9xMNDP5KRET+ZmJi9ycjIvaOior6koyO/s7KyPtPS0j6joqI+oqEhPw==",
+      "vectorSha256": "10957be9f188e5fba2dc85d1535ea0f530c9f47488865c6ff0bd886b9d923db9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6131af3125a7bf4c44b9107e63528e063641be258a8fe1c87673572eacb4a8d0",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0527": {
+      "vector": "8O9vP+rpab/m5WU/zs1NP+Hg4Dz9/Hy+7u1tv8bFRb/NzEy+tbQ0PqGgoDyTkpI+4N9fP+TjY7+opye/kpERv4eGhj7s62s/6Odnv9bVVb/+/X0/pqUlP6GgoLze3V0/iIcHv4SDAz+SkRG/uLc3v+DfXz+trCy+6ejovePi4j7w728/6ulpv+blZT/OzU0/4eDgPP38fL7u7W2/xsVFv83MTL61tDQ+oaCgPJOSkj7g318/5ONjv6inJ7+SkRG/h4aGPuzraz/o52e/1tVVv/79fT+mpSU/oaCgvN7dXT+Ihwe/hIMDP5KREb+4tze/4N9fP62sLL7p6Oi94+LiPg==",
+      "vectorSha256": "109e6a7c038f7b19693a1d04ec90da4c5e4036bd555fb4992f0afc808104d3f7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f70bf2e68360091d669682a4ef0e2c37a1f50c15fed27dee3cc13724ef6a71b8",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0528": {
+      "vector": "8/Lyvq6tLb+/vr6+zMtLv8vKyr7n5ua+hoUFv6WkJL7U01O/s7KyPquqqj63tra+mpkZv7a1Nb+zsrI+mpkZP8zLS7/Pzs4+mZiYPcbFRT+wry+/sbAwvcTDQz/u7W0/qqkpv8LBQT/8+3u/AACAP83MTD6KiQm/qqkpv769Pb/z8vK+rq0tv7++vr7My0u/y8rKvufm5r6GhQW/paQkvtTTU7+zsrI+q6qqPre2tr6amRm/trU1v7Oysj6amRk/zMtLv8/Ozj6ZmJg9xsVFP7CvL7+xsDC9xMNDP+7tbT+qqSm/wsFBP/z7e78AAIA/zcxMPoqJCb+qqSm/vr09vw==",
+      "vectorSha256": "f9c651c5f2d92c6405e6ec3b245c63d4e2aed80d901dd4761f67c56297a91706",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4329501a4d463d6b16acaa523325accc1ab389e2287ae1f62be002ff993b2b21",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0529": {
+      "vector": "mZiYvfPy8r7R0FC9rKsrP7W0NL7o52e/0dBQPYaFBb+urS0/gYCAO5KREb+dnBy+7exsvpuamr7+/X2/5uVlv+TjYz+3tra+x8bGPoiHB7/DwsI+kI8Pv5uamj6RkBC9wcBAPO/u7j6GhQU/kZAQPbSzMz+gnx+/trU1P7SzM7+ZmJi98/LyvtHQUL2sqys/tbQ0vujnZ7/R0FA9hoUFv66tLT+BgIA7kpERv52cHL7t7Gy+m5qavv79fb/m5WW/5ONjP7e2tr7HxsY+iIcHv8PCwj6Qjw+/m5qaPpGQEL3BwEA87+7uPoaFBT+RkBA9tLMzP6CfH7+2tTU/tLMzvw==",
+      "vectorSha256": "ef7ace5325b76b8124ebdb059d8cbbef161c7181a71cadfcb736aef441067caa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "764379d5690c863dd680376c6259010df152b13cb038a67b81bbc284d930da26",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0530": {
+      "vector": "zs1Nv9/e3j6rqqo+q6qqPtnY2L2/vr6+hoUFP9jXVz+gnx+/rq0tP7++vj7R0FC9zs1Nv/f29r7OzU0/tLMzP4uKir7OzU2/yMdHP/Tzc7/493c/xsVFP769Pb/39va+09LSvsC/Pz+sqyu/sK8vP5mYmD3CwUE/lZQUvpGQED3OzU2/397ePquqqj6rqqo+2djYvb++vr6GhQU/2NdXP6CfH7+urS0/v76+PtHQUL3OzU2/9/b2vs7NTT+0szM/i4qKvs7NTb/Ix0c/9PNzv/j3dz/GxUU/vr09v/f29r7T0tK+wL8/P6yrK7+wry8/mZiYPcLBQT+VlBS+kZAQPQ==",
+      "vectorSha256": "cf118ea1341489c325690bfb9fd389687c7ef81cc20058fe1b612cefee808894",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "19b7aaaa7250c2eb30d6af791942e6d95d19e306fbe221424bdf2ad789e06d84",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0531": {
+      "vector": "w8LCPrKxMT+vrq4+09LSvuzra7/e3V2/xcREPp2cHD6/vr6+vr09P8/Ozj6VlBS+lZQUvsrJSb+zsrI+mJcXv/j3d7/U01M/wL8/v4SDA7/Avz8/h4aGvpmYmL3My0s/h4aGvrCvL7/S0VG/vr09v9PS0j7HxsY+rawsPs7NTb/DwsI+srExP6+urj7T0tK+7Otrv97dXb/FxEQ+nZwcPr++vr6+vT0/z87OPpWUFL6VlBS+yslJv7Oysj6Ylxe/+Pd3v9TTUz/Avz+/hIMDv8C/Pz+Hhoa+mZiYvczLSz+Hhoa+sK8vv9LRUb++vT2/09LSPsfGxj6trCw+zs1Nvw==",
+      "vectorSha256": "5b47509e2c4284cdd8c7ca62a0ee03c4a6fd928a8348c557ba9fef85b9d2e74a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b0d8ab4b0a11989350deb36d6d1bac3404e9203edf5e76e55e281721b4b19519",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0532": {
+      "vector": "2tlZv4uKir6urS0/sK8vv7KxMT+ioSE/jo0Nv5mYmD2trCy+09LSPpOSkr77+vo+rawsPt/e3r6OjQ2/zs1NP7CvL7+ZmJi9397ePsC/P7+vrq4+lpUVP66tLT+WlRU/6ulpP8LBQb/n5uY+paQkPp2cHL6DgoI+mZiYvdzbWz/a2Vm/i4qKvq6tLT+wry+/srExP6KhIT+OjQ2/mZiYPa2sLL7T0tI+k5KSvvv6+j6trCw+397evo6NDb/OzU0/sK8vv5mYmL3f3t4+wL8/v6+urj6WlRU/rq0tP5aVFT/q6Wk/wsFBv+fm5j6lpCQ+nZwcvoOCgj6ZmJi93NtbPw==",
+      "vectorSha256": "134d23be81fcca22709a12d2465b08a72b7ed6761fffa418e055d65a24a9dfb1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "135dd628d8d039896ab45bbe954839e62876b720abcad6caf41fb9946ca076ed",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0533": {
+      "vector": "4eDgPIuKir6zsrK+9fR0voSDAz+koyO/rKsrP5qZGb/h4OC8qqkpv97dXT/19HS+AACAv8jHR7/l5GS+5ONjP8PCwr7a2Vk/z87OPu/u7r7JyMg9uLc3P7e2tj6KiQm/zs1NP56dHb/z8vI+p6amPuPi4r7JyMg9h4aGPri3N7/h4OA8i4qKvrOysr719HS+hIMDP6SjI7+sqys/mpkZv+Hg4LyqqSm/3t1dP/X0dL4AAIC/yMdHv+XkZL7k42M/w8LCvtrZWT/Pzs4+7+7uvsnIyD24tzc/t7a2PoqJCb/OzU0/np0dv/Py8j6npqY+4+LivsnIyD2HhoY+uLc3vw==",
+      "vectorSha256": "9479f75898471ee0562bd6af24bb63781b532e9f6084cd32fd7bc8606ceebb11",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "835d5361c12ed5337c2bee61001c63f14fecb3448cdbad3be631bca9478ca124",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0534": {
+      "vector": "zcxMvoiHBz/JyMi9vbw8vo+Ojr7//v6+1NNTv/j3dz+JiIi9sbAwPeHg4DyUkxO/+/r6vp+enr6lpCS+xcREvs3MTL6cmxu/hYQEPqqpKT+Pjo4+h4aGvvz7ez+zsrK+m5qaPsTDQ7/Hxsa+7exsvsXERL7Qz0+/iYiIvYuKir7NzEy+iIcHP8nIyL29vDy+j46Ovv/+/r7U01O/+Pd3P4mIiL2xsDA94eDgPJSTE7/7+vq+n56evqWkJL7FxES+zcxMvpybG7+FhAQ+qqkpP4+Ojj6Hhoa+/Pt7P7Oysr6bmpo+xMNDv8fGxr7t7Gy+xcREvtDPT7+JiIi9i4qKvg==",
+      "vectorSha256": "afadfdd4819ca2c82f7820ee4fd474b603c9ae2b41e83d4d530cf946350576d9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "66c373685c4016fb7785833641586b67663290d4a35efd53a61e4e626718775d",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0535": {
+      "vector": "397evri3Nz+UkxM/n56evre2tj7JyMg9hYQEPpCPDz/Lyso+uLc3v+DfXz/U01O/pKMjv5iXF7/OzU0/rKsrv5CPD7+WlRW/jYwMPtzbW7/Qz08/rKsrP/r5eT+0szO/gYCAO83MTL7CwUE/zMtLP6uqqj78+3s/iIcHv7i3Nz/f3t6+uLc3P5STEz+fnp6+t7a2PsnIyD2FhAQ+kI8PP8vKyj64tze/4N9fP9TTU7+koyO/mJcXv87NTT+sqyu/kI8Pv5aVFb+NjAw+3Ntbv9DPTz+sqys/+vl5P7SzM7+BgIA7zcxMvsLBQT/My0s/q6qqPvz7ez+Ihwe/uLc3Pw==",
+      "vectorSha256": "9392e78bcc01bbd00d4b8004910815d1dc23530858880dda3a69fa6384f6f54b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "48dbc958ad8c90c7b224ef162e34e62a38359112e7d5fc268066e0e5aafd3cdb",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0536": {
+      "vector": "9PNzP8HAQDzBwEA8hoUFP9zbWz///v4+5eRkPqalJb/9/Hw+uLc3P97dXb+WlRW/nZwcvt3cXD7o52e/iIcHv4KBAb++vT2/qKcnP4qJCT+Ylxe/oqEhP8C/Pz+ysTG/j46OPo+Ojr79/Hy+4+LiPvj3dz+urS2/o6Kivvv6+j7083M/wcBAPMHAQDyGhQU/3NtbP//+/j7l5GQ+pqUlv/38fD64tzc/3t1dv5aVFb+dnBy+3dxcPujnZ7+Ihwe/goEBv769Pb+opyc/iokJP5iXF7+ioSE/wL8/P7KxMb+Pjo4+j46Ovv38fL7j4uI++Pd3P66tLb+joqK++/r6Pg==",
+      "vectorSha256": "7d4ce5e1022f6b07dd4f9efa87f0296c28793d110ee31647448b35230cb2a41c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f98181c2edbf9c2d9fdb11356c9b0c3c3f21d3c434d0df27a35c60b8fb2957be",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0537": {
+      "vector": "7u1tP7Oysj68uzs/7+7uvt3cXL6/vr6+7u1tP4KBAT/BwEA87+7uvoaFBb/l5GQ+kI8PP+Pi4j75+Pg9r66uPq+urj7Ew0O/+fj4Pb++vj6enR0/lpUVv97dXb+ysTE/lZQUvt3cXL7W1VU/5uVlv+vq6r7V1FS+lpUVP/Dvb7/u7W0/s7KyPry7Oz/v7u6+3dxcvr++vr7u7W0/goEBP8HAQDzv7u6+hoUFv+XkZD6Qjw8/4+LiPvn4+D2vrq4+r66uPsTDQ7/5+Pg9v76+Pp6dHT+WlRW/3t1dv7KxMT+VlBS+3dxcvtbVVT/m5WW/6+rqvtXUVL6WlRU/8O9vvw==",
+      "vectorSha256": "9b7638ed4f58b0f2c40a429eeb612212083c149fb79430fff6bf820ac60b99c9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f6acdd446450f6c081443d9cc7b88fabab1e8fafce3511d86d64ea0d4565ca08",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0538": {
+      "vector": "sbAwPcLBQb/o52e/x8bGvvLxcT/g318/k5KSPpGQED2bmpo+8O9vv/v6+r7T0tI+0tFRv5uamj6rqqo++Pd3P5OSkr7d3Fy+v76+vt/e3j729XW/+/r6vqSjI7+JiIg9//7+vsTDQz/KyUk/k5KSPoSDA7/DwsK+/Pt7v+zraz+xsDA9wsFBv+jnZ7/Hxsa+8vFxP+DfXz+TkpI+kZAQPZuamj7w72+/+/r6vtPS0j7S0VG/m5qaPquqqj7493c/k5KSvt3cXL6/vr6+397ePvb1db/7+vq+pKMjv4mIiD3//v6+xMNDP8rJST+TkpI+hIMDv8PCwr78+3u/7OtrPw==",
+      "vectorSha256": "477b29e4a048667d88d3a8b7acd5ef88ceef61e6e86ead31fd7100efd0c0fa58",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "851f0c4ef8efa484a60841b417a6aafb5b6450b705412e8840e1e4a43e4f02f5",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0539": {
+      "vector": "ycjIvb++vj7Ew0O/oJ8fv4SDA7/p6Og90tFRv8HAQDyhoKC8nJsbv+jnZ7+SkRE/w8LCPpGQED3DwsI+paQkvt3cXD6WlRU/rawsPvPy8r6WlRW/8fBwvfz7e7/t7Gy+srExP5aVFb/FxES+6ulpv/b1dT+4tzc/zcxMPufm5j7JyMi9v76+PsTDQ7+gnx+/hIMDv+no6D3S0VG/wcBAPKGgoLycmxu/6Odnv5KRET/DwsI+kZAQPcPCwj6lpCS+3dxcPpaVFT+trCw+8/LyvpaVFb/x8HC9/Pt7v+3sbL6ysTE/lpUVv8XERL7q6Wm/9vV1P7i3Nz/NzEw+5+bmPg==",
+      "vectorSha256": "f593984334b49d093d2be82027ae10c0a3f35a62dd6aacb5239082b1621b5b68",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "73af1e303e8e17817d320cc8b084b06b9bca954335780262d835670bfadb99b9",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0540": {
+      "vector": "6+rqPtnY2D3Lysq+kI8Pv6yrKz+bmpo+7u1tv52cHL7Hxsa+p6amvvPy8r6amRk/qqkpv5ybGz+6uTk/qaiovba1NT/f3t4+8/LyvrCvL7/5+Pi9oaCgPLq5Ob/V1FS+6ulpv/Tzcz/29XU/j46OPtXUVL7+/X2/5uVlP/r5eb/r6uo+2djYPcvKyr6Qjw+/rKsrP5uamj7u7W2/nZwcvsfGxr6npqa+8/LyvpqZGT+qqSm/nJsbP7q5OT+pqKi9trU1P9/e3j7z8vK+sK8vv/n4+L2hoKA8urk5v9XUVL7q6Wm/9PNzP/b1dT+Pjo4+1dRUvv79fb/m5WU/+vl5vw==",
+      "vectorSha256": "3842bbcc71d79331c2e874cf8cbf5f773b7080b120fdce18dc16dccf9152d431",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ba8d4d38d5a6096c4e5643cc2bcddc75dab74328708223650bf9faa36501f203",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0541": {
+      "vector": "h4aGvv79fb/Pzs4+ubi4vcXERD7//v4+kpERv52cHD7KyUm/zMtLP5aVFb/f3t6+8fBwvaqpKb+npqY+pKMjv9zbWz/5+Pg9hIMDv5GQEL2amRm/uLc3v/X0dL6bmpo+9/b2Pra1NT++vT2/5+bmvrSzMz/v7u4+lpUVv4GAgDuHhoa+/v19v8/Ozj65uLi9xcREPv/+/j6SkRG/nZwcPsrJSb/My0s/lpUVv9/e3r7x8HC9qqkpv6empj6koyO/3NtbP/n4+D2EgwO/kZAQvZqZGb+4tze/9fR0vpuamj739vY+trU1P769Pb/n5ua+tLMzP+/u7j6WlRW/gYCAOw==",
+      "vectorSha256": "ee676d94d047ba59cb015db4a23ed1ee37bff02f627c22cdfff7f17271f9684b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5e01b37498bf37931be53548782ba92eed8f3e7b332461a6bdda2146d9bb3580",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0542": {
+      "vector": "lJMTP5uamj7n5uY+s7KyPoWEBD62tTW/x8bGPuPi4r7o52e/5uVlv/Py8j7e3V2/np0dv62sLL6amRm/z87OPufm5r6Lioq+z87OvvHwcL329XW/lZQUPpKRET+xsDA9trU1P+vq6j7s62s//fx8vvv6+r7k42O/xsVFP5OSkr6UkxM/m5qaPufm5j6zsrI+hYQEPra1Nb/HxsY+4+LivujnZ7/m5WW/8/LyPt7dXb+enR2/rawsvpqZGb/Pzs4+5+bmvouKir7Pzs6+8fBwvfb1db+VlBQ+kpERP7GwMD22tTU/6+rqPuzraz/9/Hy++/r6vuTjY7/GxUU/k5KSvg==",
+      "vectorSha256": "74f4a9cb804a1b381143e238c36504a06c5b47063da0bfd348e9f7aa04dd9ac4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c9a6b9ac9025b1470c0dbc11316a33b3465d4c780592c885dabaf560410ee25b",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0543": {
+      "vector": "jIsLv9LRUT+4tzc/9vV1v4aFBb/w728/4uFhP8C/P7+Ihwc/kpERP6moqL2rqqo+vr09v7a1NT+dnBy+nJsbP/LxcT+ysTE/qqkpv4SDAz+JiIg9kI8Pv7++vj7a2Vm/5+bmPsLBQT/d3Fw+pqUlP62sLD6Qjw+//fx8vsC/P7+Miwu/0tFRP7i3Nz/29XW/hoUFv/Dvbz/i4WE/wL8/v4iHBz+SkRE/qaiovauqqj6+vT2/trU1P52cHL6cmxs/8vFxP7KxMT+qqSm/hIMDP4mIiD2Qjw+/v76+PtrZWb/n5uY+wsFBP93cXD6mpSU/rawsPpCPD7/9/Hy+wL8/vw==",
+      "vectorSha256": "0fba0e39a9afc49e56e77a40d61b1a123981d2dd6b7fb3377c01d28639b2238e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3ae8db053df7f020c3c875aa21da6ccdf8d82bc18838af13b9e09bd295386020",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0544": {
+      "vector": "j46OPsXERL6sqys/7u1tv+jnZz+4tze/4+LiPuzraz/JyMi98O9vP9LRUT/o52e/5uVlP6empr7Lysq+5eRkvuDfX7/g31+/8vFxP+7tbb/c21u/2tlZv+7tbb+Ihwe/9PNzv5KRET+Ihwc/urk5v8/Ozr7i4WE/7u1tP5WUFD6Pjo4+xcREvqyrKz/u7W2/6OdnP7i3N7/j4uI+7OtrP8nIyL3w728/0tFRP+jnZ7/m5WU/p6amvsvKyr7l5GS+4N9fv+DfX7/y8XE/7u1tv9zbW7/a2Vm/7u1tv4iHB7/083O/kpERP4iHBz+6uTm/z87OvuLhYT/u7W0/lZQUPg==",
+      "vectorSha256": "8fadb3fbd085b17d223e0db96468e15a23cea928a4e1de86e9955bf108245ee0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a367d509f324b8f573f7e80cf2564d631010f8091213093c06c8c3234cf0f692",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0545": {
+      "vector": "kI8Pv8nIyL2lpCQ+urk5v6uqqr6sqyu/yslJv97dXb+RkBA9yslJv9zbW7+EgwM/srExP7y7O7+5uLi94+LiPtPS0r7OzU2/7OtrP56dHb/KyUm/7exsPuTjY7+TkpI+9vV1v6WkJD7Hxsa+v76+vvv6+j7b2to+iYiIvcXERL6Qjw+/ycjIvaWkJD66uTm/q6qqvqyrK7/KyUm/3t1dv5GQED3KyUm/3Ntbv4SDAz+ysTE/vLs7v7m4uL3j4uI+09LSvs7NTb/s62s/np0dv8rJSb/t7Gw+5ONjv5OSkj729XW/paQkPsfGxr6/vr6++/r6Ptva2j6JiIi9xcREvg==",
+      "vectorSha256": "d91599cdcfa4585d5c22158027c9d47b39e4424b19330115b3d6630a41841b85",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "38739423552a1b11841b12c1d82274b84b19f5311b9d0ea405944e50beb67767",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0546": {
+      "vector": "AACAP6KhIb/t7Gy+0dBQvcLBQT/r6uo+4N9fP/38fD7W1VU/r66uvs7NTT/w728//fx8PqOior7FxES+8/Lyvt7dXb+ZmJg9zcxMPoiHB7+rqqq+2NdXP4WEBL6urS2/urk5P6GgoDzGxUW/5ONjP4aFBT+VlBQ+4uFhP4mIiD0AAIA/oqEhv+3sbL7R0FC9wsFBP+vq6j7g318//fx8PtbVVT+vrq6+zs1NP/Dvbz/9/Hw+o6KivsXERL7z8vK+3t1dv5mYmD3NzEw+iIcHv6uqqr7Y11c/hYQEvq6tLb+6uTk/oaCgPMbFRb/k42M/hoUFP5WUFD7i4WE/iYiIPQ==",
+      "vectorSha256": "7fcbfd4a475e4bab0af9abb4a7840e10f0681227a129a8126378e2756bebb834",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ff2f6279e0baef9fea54e6f79f5767431189993c55eb6f29dc821df1c292f088",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0547": {
+      "vector": "rawsPtTTU7+urS0/ycjIPYqJCb+lpCS+g4KCPs7NTT/k42O/qqkpP7++vr7S0VG/v76+vs3MTD6Ihwe/1tVVP/Dvb7/Lyso+hIMDP8HAQDyenR0/jo0NP7W0ND7Ix0e/gYCAO/z7ez/493e/qaiovYOCgr7x8HA90dBQvbSzM7+trCw+1NNTv66tLT/JyMg9iokJv6WkJL6DgoI+zs1NP+TjY7+qqSk/v76+vtLRUb+/vr6+zcxMPoiHB7/W1VU/8O9vv8vKyj6EgwM/wcBAPJ6dHT+OjQ0/tbQ0PsjHR7+BgIA7/Pt7P/j3d7+pqKi9g4KCvvHwcD3R0FC9tLMzvw==",
+      "vectorSha256": "a375aa7ddaa838b2164b59d36d9baab443489bd725cfd0337bf6af8e39e23fdb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9516d68c3b6ba0e60ed4501750993cea08b2c181cec6961c80fd04755f877926",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0548": {
+      "vector": "sK8vv6CfH7+VlBS+lpUVP6alJT+4tze/7u1tv4qJCb+UkxO/AACAP7W0ND7x8HC9j46OPvf29j7V1FQ+t7a2vpOSkr6ZmJi96OdnP93cXL7c21u/ycjIvb28PD7KyUk/6ulpv+DfX7+0szO/hIMDP+Pi4r6rqqo+xMNDv9PS0r6wry+/oJ8fv5WUFL6WlRU/pqUlP7i3N7/u7W2/iokJv5STE78AAIA/tbQ0PvHwcL2Pjo4+9/b2PtXUVD63tra+k5KSvpmYmL3o52c/3dxcvtzbW7/JyMi9vbw8PsrJST/q6Wm/4N9fv7SzM7+EgwM/4+Livquqqj7Ew0O/09LSvg==",
+      "vectorSha256": "fece6cb87d93541093317b60fdb9ff69494ce59b20a8bf528fe7c137f1ab08b5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "28306dcad224093b36ff9678a3bd9a525b76f364127397e40b1026c147aa1e4b",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0549": {
+      "vector": "9fR0vtXUVL6Hhoa+r66uPqyrKz+6uTk/19bWvpeWlj7OzU0/wsFBv7CvLz/Y11c/jIsLv83MTL7X1tY+oJ8fv5aVFT///v6+l5aWvp2cHD7GxUW/kZAQPb28PD6dnBw+xsVFP8C/P7/GxUU/vbw8PpOSkj6enR0/9fR0PuLhYb/19HS+1dRUvoeGhr6vrq4+rKsrP7q5OT/X1ta+l5aWPs7NTT/CwUG/sK8vP9jXVz+Miwu/zcxMvtfW1j6gnx+/lpUVP//+/r6Xlpa+nZwcPsbFRb+RkBA9vbw8Pp2cHD7GxUU/wL8/v8bFRT+9vDw+k5KSPp6dHT/19HQ+4uFhvw==",
+      "vectorSha256": "bf5b8a1e48de76e22be88b9635fff9766735e3da1440b39b13fd64a2252ca91d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "61655eabd5dc4aa5e61fd7eb3a66b530ca405a931d849793e220e297a4ce9e0f",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0550": {
+      "vector": "5+bmPpuamr7//v6+zcxMvt/e3j7Y11c/9fR0vuLhYb/V1FQ+29raPoOCgj66uTm/kI8Pv6Oioj6VlBS+29ravpuamr6DgoK+h4aGvvPy8j719HQ+yslJv+no6L3h4OC8+/r6voKBAb+zsrI+np0dv52cHL7c21s/g4KCvrCvLz/n5uY+m5qavv/+/r7NzEy+397ePtjXVz/19HS+4uFhv9XUVD7b2to+g4KCPrq5Ob+Qjw+/o6KiPpWUFL7b2tq+m5qavoOCgr6Hhoa+8/LyPvX0dD7KyUm/6ejoveHg4Lz7+vq+goEBv7Oysj6enR2/nZwcvtzbWz+DgoK+sK8vPw==",
+      "vectorSha256": "509e40d41f31a381a6e91d91b23c2648ca035fa0f99cdbfdfc10747b836a0748",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b9594066b7eb610f9ab6a02338a86d49595f5ebc9e1b717c413fac316ced5fd7",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0551": {
+      "vector": "g4KCPqalJT/R0FC9w8LCPvTzc7+0szO/7exsPrW0NL60szM/7u1tv4SDAz+0szO/lZQUvvv6+j64tzc/4N9fv7q5Ob/j4uI+/v19P7q5OT+wry8/+Pd3v/f29j6SkRG/4N9fP8nIyL22tTW/+vl5P/v6+j7k42O/xMNDP9jXV7+DgoI+pqUlP9HQUL3DwsI+9PNzv7SzM7/t7Gw+tbQ0vrSzMz/u7W2/hIMDP7SzM7+VlBS++/r6Pri3Nz/g31+/urk5v+Pi4j7+/X0/urk5P7CvLz/493e/9/b2PpKREb/g318/ycjIvba1Nb/6+Xk/+/r6PuTjY7/Ew0M/2NdXvw==",
+      "vectorSha256": "2eb23e7741541871b8fe3096ebff9b6bf2e361e54faa2443980a51c400cff187",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a0d279b006269d69d909c1266dbedb1023b8fedcd704bd37ef7325fcbe0ee114",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0552": {
+      "vector": "pKMjv7i3N7/7+vo+397ePtDPTz+SkRG/xMNDv8nIyD3HxsY+qKcnv/79fb+urS2/6ulpP+XkZL6opyc/5uVlv66tLT/Qz08/tLMzv6KhIb/Y11e/2djYvayrK7///v6+9vV1v5WUFL6enR2/9/b2Pr++vj6ioSG/hIMDv+3sbD6koyO/uLc3v/v6+j7f3t4+0M9PP5KREb/Ew0O/ycjIPcfGxj6opye//v19v66tLb/q6Wk/5eRkvqinJz/m5WW/rq0tP9DPTz+0szO/oqEhv9jXV7/Z2Ni9rKsrv//+/r729XW/lZQUvp6dHb/39vY+v76+PqKhIb+EgwO/7exsPg==",
+      "vectorSha256": "03630ed0b3752c49135e3b6ae03cfab1ebed1bb576748a36c32308a0dd8edebb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2e24beb7e7371e8cb12c0129f463d30dd6e7262f14722a40056d31bdaf2f3e9d",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0553": {
+      "vector": "09LSvs/Ozr77+vq+s7Kyvuno6L3t7Gy+wL8/v6moqL2ZmJi95ONjv9DPT7+Ylxe/j46Ovry7O7+sqys/qKcnP//+/j6WlRU/o6KiPpybG7/7+vq+yMdHv4KBAT+rqqo+kI8PP/v6+j7083M/np0dP6empr7Qz08///7+Pra1Nb/T0tK+z87Ovvv6+r6zsrK+6ejove3sbL7Avz+/qaiovZmYmL3k42O/0M9Pv5iXF7+Pjo6+vLs7v6yrKz+opyc///7+PpaVFT+joqI+nJsbv/v6+r7Ix0e/goEBP6uqqj6Qjw8/+/r6PvTzcz+enR0/p6amvtDPTz///v4+trU1vw==",
+      "vectorSha256": "992dbebd5d385d6cef23eb0c79eeb2791e03c23a5bc28e03ae46051d02cc8e79",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4b4c415371622075760e18345c22d5d3bfcaa832411cc0aac7bef9ce56e7bf25",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0554": {
+      "vector": "lJMTv6qpKb/X1tY+5+bmvvTzcz+urS2/mZiYPbu6ur6joqI+1NNTP5WUFL6Lioq+uLc3v7W0NL67urq+oaCgPOvq6j7083M/q6qqPurpab+Ihwe/g4KCPsrJST+HhoY+ycjIPd/e3r76+Xm/3dxcPtLRUT/Avz8/xcREPpWUFL6UkxO/qqkpv9fW1j7n5ua+9PNzP66tLb+ZmJg9u7q6vqOioj7U01M/lZQUvouKir64tze/tbQ0vru6ur6hoKA86+rqPvTzcz+rqqo+6ulpv4iHB7+DgoI+yslJP4eGhj7JyMg9397evvr5eb/d3Fw+0tFRP8C/Pz/FxEQ+lZQUvg==",
+      "vectorSha256": "526159a42d41106b8c71595f9ba557aead81ea6788cba5eb511ea5549b5a381f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "362bb546f9298951a8e96d5d24695182baf9aa0b3ca0e4a18c48039be8df986d",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0555": {
+      "vector": "kpERv9va2j7Qz0+/397ePufm5r7v7u4+2djYPeTjY7/c21s/qaioPbGwML2trCy+vr09P/n4+L3v7u6+np0dv6alJT+Ylxe/09LSvoyLC7+EgwO/pKMjP5aVFb+WlRW/rq0tP5mYmD2wry8/hYQEvrGwMD3s62u/iYiIva+urj6SkRG/29raPtDPT7/f3t4+5+bmvu/u7j7Z2Ng95ONjv9zbWz+pqKg9sbAwva2sLL6+vT0/+fj4ve/u7r6enR2/pqUlP5iXF7/T0tK+jIsLv4SDA7+koyM/lpUVv5aVFb+urS0/mZiYPbCvLz+FhAS+sbAwPezra7+JiIi9r66uPg==",
+      "vectorSha256": "93f689ff574a985ff9f0aebf8ea3e177d94cf944bfa05db5e0803ad3cb555838",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "37b618b746bb8d0eed8a7a6ade704431d2344b3a3ed13535d689d76f850a77ab",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0556": {
+      "vector": "rKsrv9HQUD3j4uI+2djYvdXUVD7s62u/gYCAO8vKyj78+3u/pKMjP5uamr7+/X0/lZQUvoGAgLvKyUk/zMtLP4qJCb/5+Pi9yMdHv9nY2D3z8vI+g4KCvqGgoDzh4OC8u7q6vqGgoLyZmJg9oaCgvPX0dL7i4WE/p6amvqyrK7+sqyu/0dBQPePi4j7Z2Ni91dRUPuzra7+BgIA7y8rKPvz7e7+koyM/m5qavv79fT+VlBS+gYCAu8rJST/My0s/iokJv/n4+L3Ix0e/2djYPfPy8j6DgoK+oaCgPOHg4Ly7urq+oaCgvJmYmD2hoKC89fR0vuLhYT+npqa+rKsrvw==",
+      "vectorSha256": "38c483ec3301640126580210ce79db0b9ee3a8c25b0d8160ee06a47561954c67",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2a86b8729a0a80b202d159fe6d7fe4e53b701c8dbc5f827c517d897d61f0562a",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0557": {
+      "vector": "3t1dv9bVVT/m5WW/7u1tv8rJST/z8vI+nJsbv6uqqj6npqY+5eRkPr++vr79/Hy+iokJv7a1NT+gnx+/6Odnv+zra7/JyMg9kpERv5+enr6qqSk/3dxcPoyLCz/9/Hw+2tlZv4GAgDvV1FQ+6ejovfTzc7+/vr4+wsFBP7GwML3e3V2/1tVVP+blZb/u7W2/yslJP/Py8j6cmxu/q6qqPqempj7l5GQ+v76+vv38fL6KiQm/trU1P6CfH7/o52e/7Otrv8nIyD2SkRG/n56evqqpKT/d3Fw+jIsLP/38fD7a2Vm/gYCAO9XUVD7p6Oi99PNzv7++vj7CwUE/sbAwvQ==",
+      "vectorSha256": "c622f635c1538364d705687363e1e6a829296b05a43b1d528523d2b5bbeff1a3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "11ea0d09e4bc32aaa99c50603bda300c0a8c3758d49bc59f13809a7106afe07a",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0558": {
+      "vector": "2NdXv+fm5r6pqKg98O9vP6GgoDympSU/4+LivpmYmD2EgwO/s7KyPoaFBT/x8HA9v76+vrq5OT/g318/+Pd3v+no6L3NzEy+np0dv46NDT/BwEA8+fj4veHg4Dzo52c/zMtLv87NTb+8uzs/qqkpP+zra7/f3t6+7+7uvpKRET/Y11e/5+bmvqmoqD3w728/oaCgPKalJT/j4uK+mZiYPYSDA7+zsrI+hoUFP/HwcD2/vr6+urk5P+DfXz/493e/6ejovc3MTL6enR2/jo0NP8HAQDz5+Pi94eDgPOjnZz/My0u/zs1Nv7y7Oz+qqSk/7Otrv9/e3r7v7u6+kpERPw==",
+      "vectorSha256": "b92891851486e8247373c0503764d866d608cfdb7777e98d6b4bcdec96a80e0a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "14468af782d247893eacc28750dcef04716631c6817083f31a19ddd40a4844c8",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0559": {
+      "vector": "s7Kyvr++vr7V1FQ+tLMzP9va2j6Lioq+yslJv9HQUL3t7Gw+AACAv56dHb/U01O/vLs7v/38fD7Ix0e/mpkZP/v6+j6EgwM/vr09P7Oysr7X1ta+2NdXP+Pi4r6ioSE/xsVFP+7tbb+zsrK+nZwcPo6NDT+9vDw+vLs7v6moqL2zsrK+v76+vtXUVD60szM/29raPouKir7KyUm/0dBQve3sbD4AAIC/np0dv9TTU7+8uzu//fx8PsjHR7+amRk/+/r6PoSDAz++vT0/s7KyvtfW1r7Y11c/4+LivqKhIT/GxUU/7u1tv7Oysr6dnBw+jo0NP728PD68uzu/qaiovQ==",
+      "vectorSha256": "175892bc1d2920a7d1d34995f64980d9004112bd298456ab98f404501cfa283a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "53509ad9b65d1b799d003116229f1cccbec1de534aeb47d0e2095393c6972275",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0560": {
+      "vector": "g4KCPuno6L3W1VU/8O9vP/r5eb/8+3u/6ejoPc/Ozr6NjAw+9vV1P7++vj6Hhoa+x8bGPpWUFD6UkxO/5uVlv7GwMD3Z2Ng9q6qqPry7O7+SkRE/2NdXP9zbW7+npqY+lpUVv8zLS7+2tTU/q6qqPsnIyL2ysTE/4uFhv+blZb+DgoI+6ejovdbVVT/w728/+vl5v/z7e7/p6Og9z87Ovo2MDD729XU/v76+PoeGhr7HxsY+lZQUPpSTE7/m5WW/sbAwPdnY2D2rqqo+vLs7v5KRET/Y11c/3Ntbv6empj6WlRW/zMtLv7a1NT+rqqo+ycjIvbKxMT/i4WG/5uVlvw==",
+      "vectorSha256": "605057cccbc3134860c204dc1dda64c844df3f4789c80d3669757b7b90b603e5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a071eaf703028e4c91faaf5eb192360d858daa22c8eb12a9351adaaa73d80f0d",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0561": {
+      "vector": "7Otrv52cHD6/vr6+jIsLv/X0dL6xsDC9nZwcvvr5eb/My0s/hYQEPqmoqD3X1ta+vr09P6Oioj6ysTG/tLMzv83MTD7Pzs4+1NNTP4mIiD2DgoI+1dRUvu/u7r61tDS+5ONjP9jXVz+5uLg9qaiovcPCwr6DgoI+2djYPePi4j7s62u/nZwcPr++vr6Miwu/9fR0vrGwML2dnBy++vl5v8zLSz+FhAQ+qaioPdfW1r6+vT0/o6KiPrKxMb+0szO/zcxMPs/Ozj7U01M/iYiIPYOCgj7V1FS+7+7uvrW0NL7k42M/2NdXP7m4uD2pqKi9w8LCvoOCgj7Z2Ng94+LiPg==",
+      "vectorSha256": "6074286975d8ffd157558a56ff40c87a967bc3315422c7185d0cf9b04cdd0092",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0a93503a617a6c03e5908a4adea8272699b3e988a0654469f1eb8b754fa08db8",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0562": {
+      "vector": "yMdHv8TDQ7/9/Hy+19bWvri3Nz+WlRW/7Otrv+vq6j6ioSE/0dBQvcfGxr7493e/ycjIPbOysr77+vo+urk5v5OSkj6Pjo6+oqEhP8PCwj7+/X0/gYCAO5KRET/f3t4+3t1dv4GAgLu3trY++/r6vqalJT+wry+/4N9fP6inJz/Ix0e/xMNDv/38fL7X1ta+uLc3P5aVFb/s62u/6+rqPqKhIT/R0FC9x8bGvvj3d7/JyMg9s7Kyvvv6+j66uTm/k5KSPo+Ojr6ioSE/w8LCPv79fT+BgIA7kpERP9/e3j7e3V2/gYCAu7e2tj77+vq+pqUlP7CvL7/g318/qKcnPw==",
+      "vectorSha256": "b624952ac7a7da3f30072159491c9b96457fdc1f7b5f28f2c72d95723460b610",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1c1e604adb350abad0794e048c53be23a45cd0b0fe80c8b7117fad41d228efd3",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0563": {
+      "vector": "kI8Pv4yLCz/j4uI+rq0tP/f29r6hoKA87exsvqmoqD3083M/2djYPc3MTD7f3t6+nZwcvtbVVb+5uLg9wL8/P/j3dz+hoKA85ONjv7++vr7g318/yMdHP/HwcD3T0tK+pKMjv4KBAT/Lyso+jYwMPv/+/r6/vr6+srExv5KRET+Qjw+/jIsLP+Pi4j6urS0/9/b2vqGgoDzt7Gy+qaioPfTzcz/Z2Ng9zcxMPt/e3r6dnBy+1tVVv7m4uD3Avz8/+Pd3P6GgoDzk42O/v76+vuDfXz/Ix0c/8fBwPdPS0r6koyO/goEBP8vKyj6NjAw+//7+vr++vr6ysTG/kpERPw==",
+      "vectorSha256": "68d1c327c09dd302a7f3b1bab53ca08695bdcd1ce10f5a2b5b3232308e4d8a35",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "38c5b8d64282628af98d99486c158bdffb820e50efe3874b2ec0b291405027c8",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0564": {
+      "vector": "wcBAvOTjY7+pqKi9j46OPsvKyj4AAIC/2djYPfHwcL2GhQW/urk5P7W0NL7z8vI+z87OPo2MDL6UkxM/urk5v7CvLz/Ix0c/8/LyvpmYmD3U01O/7Otrv+XkZL7GxUW/zs1Nv8HAQLzNzEw+pKMjP4KBAb/HxsY+sbAwvc3MTL7BwEC85ONjv6moqL2Pjo4+y8rKPgAAgL/Z2Ng98fBwvYaFBb+6uTk/tbQ0vvPy8j7Pzs4+jYwMvpSTEz+6uTm/sK8vP8jHRz/z8vK+mZiYPdTTU7/s62u/5eRkvsbFRb/OzU2/wcBAvM3MTD6koyM/goEBv8fGxj6xsDC9zcxMvg==",
+      "vectorSha256": "23ff2bfe6654d177ab04024a17a90ae1fa69c073224e4d869725e77c8438b22f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7e0e75a3b2008d783ddc69bcb36ec923d7e34389160a631d197e99d13fb17a66",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0565": {
+      "vector": "l5aWvru6uj6xsDC99vV1v8C/Pz+rqqo+qaioPc7NTT/083M/oqEhP8vKyr6KiQm/oqEhv6uqqj6Miws/hYQEPtDPT7+ysTG/sK8vv/Dvbz8AAIA/kZAQvdbVVT+gnx+/uLc3v8rJSb/V1FS+wL8/v+/u7r6gnx8/r66uvurpab+Xlpa+u7q6PrGwML329XW/wL8/P6uqqj6pqKg9zs1NP/Tzcz+ioSE/y8rKvoqJCb+ioSG/q6qqPoyLCz+FhAQ+0M9Pv7KxMb+wry+/8O9vPwAAgD+RkBC91tVVP6CfH7+4tze/yslJv9XUVL7Avz+/7+7uvqCfHz+vrq6+6ulpvw==",
+      "vectorSha256": "a5cb422bd9a48984e7492b749c638bbacbf97d245a1f5d2ed9a0b47efab1926c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5aae7a05dfaa8ae6f9d04d3b2faac590182728f7ff7bea30241b652044cf540b",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0566": {
+      "vector": "4N9fP5uamj6gnx+/u7q6PsbFRb+pqKi9oaCgvO7tbb+6uTm/urk5v4yLCz+urS0/tbQ0PpOSkr63tra+2djYvfHwcD3My0u/l5aWvvLxcb+DgoK++vl5v/n4+D3m5WU/0dBQPc3MTD79/Hy+6OdnP66tLT/R0FC9urk5v5ybGz/g318/m5qaPqCfH7+7uro+xsVFv6moqL2hoKC87u1tv7q5Ob+6uTm/jIsLP66tLT+1tDQ+k5KSvre2tr7Z2Ni98fBwPczLS7+Xlpa+8vFxv4OCgr76+Xm/+fj4PeblZT/R0FA9zcxMPv38fL7o52c/rq0tP9HQUL26uTm/nJsbPw==",
+      "vectorSha256": "ca413477cc101dcb07adc344a60019a634b5d64c11adc56e66cac697c29bd037",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "efa630ae1d757d092323c5d6965b5272871a5a075f038ff2869960f3d67923cd",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0567": {
+      "vector": "9/b2Pv79fT+Lioq+AACAP6qpKT/U01M/s7KyvvHwcD3S0VG/k5KSvsXERL7//v6+pKMjv6moqL2TkpK+jYwMvvv6+j7Ew0M/iokJv8bFRT/m5WW/lpUVP+DfXz+Miws/7+7uPoOCgj6Ihwc/hoUFP83MTL7FxEQ+n56evt3cXD739vY+/v19P4uKir4AAIA/qqkpP9TTUz+zsrK+8fBwPdLRUb+TkpK+xcREvv/+/r6koyO/qaiovZOSkr6NjAy++/r6PsTDQz+KiQm/xsVFP+blZb+WlRU/4N9fP4yLCz/v7u4+g4KCPoiHBz+GhQU/zcxMvsXERD6fnp6+3dxcPg==",
+      "vectorSha256": "0c07c53dafcb33d1f0bcdc4dd0dbd02017d947524a9efb37a5f7fe1bc7328971",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bdfe5dffd4e95387175b67402e755b6ebee13be20dcaefc5bba0c3c26698589b",
+      "updatedAt": "2025-09-20T22:27:41.536Z"
+    },
+    "j-0568": {
+      "vector": "mZiYPcTDQ7+UkxM/1dRUPqOior6SkRG/mJcXv4KBAb/29XU/6ejoPbe2tj6fnp4+wsFBP6KhIT+dnBy+/Pt7P4OCgr6urS0/lJMTP6Oioj6urS0/ycjIvdjXVz+OjQ2/0tFRv//+/j6koyM//fx8voeGhr6HhoY+9PNzP7m4uD2ZmJg9xMNDv5STEz/V1FQ+o6KivpKREb+Ylxe/goEBv/b1dT/p6Og9t7a2Pp+enj7CwUE/oqEhP52cHL78+3s/g4KCvq6tLT+UkxM/o6KiPq6tLT/JyMi92NdXP46NDb/S0VG///7+PqSjIz/9/Hy+h4aGvoeGhj7083M/ubi4PQ==",
+      "vectorSha256": "cc4514a1a9f2ce159fb5dd56dbd1aade3fc8f1bee223f861e32b8d0c7ce31dff",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "891ec99a5737343ffa8eada7e0d06cfd5fd6c9a8d673eb3917bfd1605ea1f98b",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0569": {
+      "vector": "iIcHv6uqqj7u7W2/zcxMvo2MDD6amRm/xMNDv6alJb/083O/pKMjv8zLS7+npqa+qqkpP5GQED2ZmJi9trU1P83MTL7s62u/rq0tP7q5OT+9vDw+9/b2Ptva2r6Lioo++vl5P/z7e7/p6Oi9xMNDv+7tbb/Y11e/uLc3P8jHRz+Ihwe/q6qqPu7tbb/NzEy+jYwMPpqZGb/Ew0O/pqUlv/Tzc7+koyO/zMtLv6empr6qqSk/kZAQPZmYmL22tTU/zcxMvuzra7+urS0/urk5P728PD739vY+29ravouKij76+Xk//Pt7v+no6L3Ew0O/7u1tv9jXV7+4tzc/yMdHPw==",
+      "vectorSha256": "ddf7b8540001bff60104abee6b05d4d2f1de47890bac0a64717c5d40a522d931",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3caa096691331e2d062e1a56d48476da660ad6dc97bd49a2fc02711e0914dbe3",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0570": {
+      "vector": "09LSvqinJ7+0szO/z87OvuXkZL6gnx+/vLs7P5eWlj7493e/nZwcPsTDQ7+trCw+rKsrvwAAgD+lpCQ+gYCAu6GgoDzIx0e/1tVVvwAAgD+KiQm/zMtLv/X0dL719HS+sbAwveLhYT+9vDy+qaioPc3MTL6SkRE/pqUlP7y7Oz/T0tK+qKcnv7SzM7/Pzs6+5eRkvqCfH7+8uzs/l5aWPvj3d7+dnBw+xMNDv62sLD6sqyu/AACAP6WkJD6BgIC7oaCgPMjHR7/W1VW/AACAP4qJCb/My0u/9fR0vvX0dL6xsDC94uFhP728PL6pqKg9zcxMvpKRET+mpSU/vLs7Pw==",
+      "vectorSha256": "7060e628d75395de5ca23bb8b5f15e839ba3bfba92095dc1a63d80e1c017d8c1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4b2c264c6330dda504931e952aff947f821c15ff3b1a61617af0688a66c8d2dd",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0571": {
+      "vector": "hYQEPvX0dL7x8HA9kI8PP5ybGz+Hhoa+m5qavtnY2L3q6Wk/s7KyvtXUVL6ysTE/nZwcPv/+/r75+Pg9lJMTv5mYmL2sqyu//Pt7P+rpab/Pzs4+wL8/v8TDQ7+trCy+x8bGPujnZ7+/vr4+sK8vv/f29j6Pjo6+hIMDv8fGxj6FhAQ+9fR0vvHwcD2Qjw8/nJsbP4eGhr6bmpq+2djYverpaT+zsrK+1dRUvrKxMT+dnBw+//7+vvn4+D2UkxO/mZiYvayrK7/8+3s/6ulpv8/Ozj7Avz+/xMNDv62sLL7HxsY+6Odnv7++vj6wry+/9/b2Po+Ojr6EgwO/x8bGPg==",
+      "vectorSha256": "5be619328f587ed26f2b701a257eee2a71a6787a32321fd68d9fbbff2596eb3f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "906187c7cd5e5972f45365d893408f36762afd0bb3201e6ab10caf28bd5c3eb1",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0572": {
+      "vector": "yslJP83MTD6rqqq+z87OPsXERD7DwsK+np0dP+LhYT/6+Xk/l5aWPtbVVb/JyMi9gYCAO6+urr7Ix0e/mJcXv9va2r6Ylxc/9vV1v/38fD7r6uq+9vV1v7e2tr7KyUm/9fR0Pt3cXL7v7u6+rKsrv66tLb+Qjw8/oaCgPK+urj7KyUk/zcxMPquqqr7Pzs4+xcREPsPCwr6enR0/4uFhP/r5eT+XlpY+1tVVv8nIyL2BgIA7r66uvsjHR7+Ylxe/29ravpiXFz/29XW//fx8Puvq6r729XW/t7a2vsrJSb/19HQ+3dxcvu/u7r6sqyu/rq0tv5CPDz+hoKA8r66uPg==",
+      "vectorSha256": "44939da514c933efd5a347a1e4490b92d0e615a71246839fcbc3dddf97605669",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e49955b3984fcef0fca5157380541c3449cb059f4505521b9e64442a29c782ab",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0573": {
+      "vector": "oJ8fP4eGhr6Ylxc/qqkpv6WkJL75+Pi92djYPezra7+XlpY+iIcHP+3sbD7i4WG/l5aWPoWEBL6SkRE/5ONjP7y7Oz+zsrK+gYCAO728PL6Pjo4+rq0tP9TTU7/My0s/8fBwPcfGxj7GxUW/vLs7P5aVFT+FhAQ+vbw8vqGgoLygnx8/h4aGvpiXFz+qqSm/paQkvvn4+L3Z2Ng97Otrv5eWlj6Ihwc/7exsPuLhYb+XlpY+hYQEvpKRET/k42M/vLs7P7Oysr6BgIA7vbw8vo+Ojj6urS0/1NNTv8zLSz/x8HA9x8bGPsbFRb+8uzs/lpUVP4WEBD69vDy+oaCgvA==",
+      "vectorSha256": "d8c9191c739bb19ad8198f38ee2a03e7856c779563264e4d4e3b2facee7f65db",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cf5ecb2b6b708d0aa5c39d0fa56fc8f1dd538068a3d616e587b11dddca90687d",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0574": {
+      "vector": "3dxcvoKBAb/f3t4+6OdnP+vq6r6rqqq+xsVFv8LBQT+rqqq+h4aGPq6tLT/m5WU/09LSvsjHR7+urS0/4+LiPoOCgj6GhQU/o6KiPsrJST+5uLi90dBQvZuamr6Lioo+4N9fv6qpKb/BwEC8wL8/P9rZWb/9/Hy+8vFxP4aFBb/d3Fy+goEBv9/e3j7o52c/6+rqvquqqr7GxUW/wsFBP6uqqr6HhoY+rq0tP+blZT/T0tK+yMdHv66tLT/j4uI+g4KCPoaFBT+joqI+yslJP7m4uL3R0FC9m5qavouKij7g31+/qqkpv8HAQLzAvz8/2tlZv/38fL7y8XE/hoUFvw==",
+      "vectorSha256": "a6a80f351cf15fde2d7b5d00fade7db52b2badab49acd82a9b15cad6624c55a9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "643fb7f345551de055a1d6f24b1cd6b8a0c2a8e4747959a2102b7edf1360f83d",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0575": {
+      "vector": "3dxcPtXUVD7i4WG/rKsrv9nY2D3Pzs6+3dxcvtnY2D3i4WE/iYiIPaOior78+3u/m5qavsnIyD2Ylxe/o6Kivvj3dz+9vDw+wcBAPKOioj77+vq+1dRUPuPi4j6CgQE/vbw8vomIiD3t7Gy+397evo6NDb+0szM/yslJv8jHRz/d3Fw+1dRUPuLhYb+sqyu/2djYPc/Ozr7d3Fy+2djYPeLhYT+JiIg9o6Kivvz7e7+bmpq+ycjIPZiXF7+joqK++Pd3P728PD7BwEA8o6KiPvv6+r7V1FQ+4+LiPoKBAT+9vDy+iYiIPe3sbL7f3t6+jo0Nv7SzMz/KyUm/yMdHPw==",
+      "vectorSha256": "ba54705a50cc9cd39951a0c58e3a1e6bae76f5bd8e6ca4aeca09157e80ce5ade",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9b9a0f2a8d4c648df0885702598c3457fb9781a8419ab8c06888624839d91be3",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0576": {
+      "vector": "2NdXv8rJSb+JiIi929raPvb1dT+6uTk/0tFRP56dHb/9/Hw+mZiYvdPS0r6CgQE/9PNzv/79fb+Ylxe/4uFhP8jHR7+amRk//fx8Pt/e3j6trCy+m5qaPsjHR7+joqK+s7Kyvufm5r6lpCS+w8LCvqmoqD23tra+ycjIvbKxMT/Y11e/yslJv4mIiL3b2to+9vV1P7q5OT/S0VE/np0dv/38fD6ZmJi909LSvoKBAT/083O//v19v5iXF7/i4WE/yMdHv5qZGT/9/Hw+397ePq2sLL6bmpo+yMdHv6Oior6zsrK+5+bmvqWkJL7DwsK+qaioPbe2tr7JyMi9srExPw==",
+      "vectorSha256": "06e440905516f8ea5a606432ddf3eb8f1015fc2bf2d1b2fdb9154a447a5363cf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "141b77b6fadce8319f764bc0060134f01ccc9fb76aa61c5753466b4f8a5273d8",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0577": {
+      "vector": "tLMzv7++vr6Pjo6+pKMjv//+/r6Lioq++/r6vsLBQb+KiQk//Pt7P6alJb/5+Pg93t1dv4KBAb+XlpY+sK8vP//+/r7CwUG//Pt7P62sLL7Qz0+/paQkPtDPTz+npqY+mpkZP4qJCb/Ew0M/m5qaPpSTEz/19HS+//7+vt7dXT+0szO/v76+vo+Ojr6koyO///7+vouKir77+vq+wsFBv4qJCT/8+3s/pqUlv/n4+D3e3V2/goEBv5eWlj6wry8///7+vsLBQb/8+3s/rawsvtDPT7+lpCQ+0M9PP6empj6amRk/iokJv8TDQz+bmpo+lJMTP/X0dL7//v6+3t1dPw==",
+      "vectorSha256": "611c19001f8d2c55f131e9a4791ea4152a620b781612ca7ece68c91dafc113e1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "26505c2e405d411fc4fd2d8f113fa5d7401ffd6a1894e7a9cc3be1a6c96140ee",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0578": {
+      "vector": "09LSPqqpKb+WlRU/r66uvqempj7DwsK+v76+vs7NTb/s62s/4N9fP8nIyL3s62u/1dRUPu/u7r7n5ua+np0dv6+urr62tTU/urk5v/Dvbz/19HQ+mJcXv7SzMz/j4uK+tLMzP93cXL7Z2Ni97+7uvvDvbz+ioSG/5uVlP4SDAz/T0tI+qqkpv5aVFT+vrq6+p6amPsPCwr6/vr6+zs1Nv+zraz/g318/ycjIvezra7/V1FQ+7+7uvufm5r6enR2/r66uvra1NT+6uTm/8O9vP/X0dD6Ylxe/tLMzP+Pi4r60szM/3dxcvtnY2L3v7u6+8O9vP6KhIb/m5WU/hIMDPw==",
+      "vectorSha256": "9a91542646df9ee510f1671fa35a43df7b06152d1386584c81a71ffc4a22650d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b42bca54a94f5019f5ef730a9a44463154da23f79e34d947d9647244f72ff2c1",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0579": {
+      "vector": "mpkZv7W0NL75+Pi91NNTv83MTL7Y11e/lZQUvsbFRb/BwEA83t1dP5GQEL2amRk/q6qqvq+urr6koyM/4eDgvPr5eb/U01O/mZiYvd3cXL719HS+6+rqPpybGz/w728/pKMjP4iHBz+urS0/q6qqPv79fb+9vDy+xcREPq6tLb+amRm/tbQ0vvn4+L3U01O/zcxMvtjXV7+VlBS+xsVFv8HAQDze3V0/kZAQvZqZGT+rqqq+r66uvqSjIz/h4OC8+vl5v9TTU7+ZmJi93dxcvvX0dL7r6uo+nJsbP/Dvbz+koyM/iIcHP66tLT+rqqo+/v19v728PL7FxEQ+rq0tvw==",
+      "vectorSha256": "c17520105809842d9884c23c186908909f60f016511fcd2dd0fd5d651e5326af",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3369701666146d1d81ee7bcc5554d17c0316766461bacdf7d1c3d6aa01689829",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0580": {
+      "vector": "4+LiPtHQUL35+Pg9wcBAvPTzc7/e3V0/goEBP7CvLz+TkpI+19bWvo6NDb/l5GS+iokJv4uKij6FhAQ+9PNzv5GQED2TkpK+iIcHv+Hg4Dzo52e/4N9fP5GQEL24tzc/0tFRv5STE7+rqqq+ubi4vZ2cHD7Y11e/5ONjv4GAgLvj4uI+0dBQvfn4+D3BwEC89PNzv97dXT+CgQE/sK8vP5OSkj7X1ta+jo0Nv+XkZL6KiQm/i4qKPoWEBD7083O/kZAQPZOSkr6Ihwe/4eDgPOjnZ7/g318/kZAQvbi3Nz/S0VG/lJMTv6uqqr65uLi9nZwcPtjXV7/k42O/gYCAuw==",
+      "vectorSha256": "0e0e820dd404ea2331294b3093647f8516455110379b30d5f9c56191b85f2a50",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b8798f7e06eec0d7a44a39633ba29006845b3c830cef7bdb1736557493140e7f",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0581": {
+      "vector": "h4aGvvb1db+GhQU/kZAQvfv6+j7My0s/vr09P/79fT+5uLg99vV1v/X0dL61tDQ+lZQUPsjHR7+rqqq+vr09P9LRUT+enR0/3t1dP6SjIz+7uro+3t1dv8C/P7+cmxs/n56ePv79fT/p6Oi9pKMjP7W0NL7i4WE/oJ8fP5mYmD2Hhoa+9vV1v4aFBT+RkBC9+/r6PszLSz++vT0//v19P7m4uD329XW/9fR0vrW0ND6VlBQ+yMdHv6uqqr6+vT0/0tFRP56dHT/e3V0/pKMjP7u6uj7e3V2/wL8/v5ybGz+fnp4+/v19P+no6L2koyM/tbQ0vuLhYT+gnx8/mZiYPQ==",
+      "vectorSha256": "673bd5e9cdfcf90a9addef36fb984ec5e1258eeaed9dab6ae6557b40c532539d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5e05c27bbee5defe8b056196921c55dee8ceeed1ae1120cda7fe71d169f0cf89",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0582": {
+      "vector": "0dBQPYmIiL3FxES+p6amPo+Ojj6Lioo+jYwMPvLxcb+SkRG/srExP+3sbD62tTW/1tVVP87NTb/S0VE/vr09P8rJSb/9/Hy+7OtrP4mIiD2wry8/6ulpP4OCgj7T0tI+qaiovc7NTT/m5WW/vr09P9bVVT/29XU/n56ePvf29r7R0FA9iYiIvcXERL6npqY+j46OPouKij6NjAw+8vFxv5KREb+ysTE/7exsPra1Nb/W1VU/zs1Nv9LRUT++vT0/yslJv/38fL7s62s/iYiIPbCvLz/q6Wk/g4KCPtPS0j6pqKi9zs1NP+blZb++vT0/1tVVP/b1dT+fnp4+9/b2vg==",
+      "vectorSha256": "c4ae0ce3882e40d1266e2d10e10e56bdb6e4a1da685bc95bc7c6592595d45afe",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "867767a9a3a2910737d89d25ea19e8de1b60f588d7f4a0b475e60ddeeafaa742",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0583": {
+      "vector": "0tFRP/Lxcb/y8XG/g4KCvsvKyj739va+g4KCvtbVVT+Qjw+/zMtLP5KREb///v4+6ulpv9DPT7+sqyu/9fR0Puzraz/19HQ+/fx8vv79fT+npqa+uLc3v/v6+j7s62s/kZAQPby7Oz/Hxsa+8/Lyvq+urr6ysTG//v19vwAAgL/S0VE/8vFxv/Lxcb+DgoK+y8rKPvf29r6DgoK+1tVVP5CPD7/My0s/kpERv//+/j7q6Wm/0M9Pv6yrK7/19HQ+7OtrP/X0dD79/Hy+/v19P6empr64tze/+/r6Puzraz+RkBA9vLs7P8fGxr7z8vK+r66uvrKxMb/+/X2/AACAvw==",
+      "vectorSha256": "8dfcca57a9e5f0d95e79240128c5e79f578e631f0e69508676644de0211558d1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e807075fb2425fea38e537bf0b182a9ef59e60fe5624bef584dd4e4354270100",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0584": {
+      "vector": "h4aGvre2tr4AAIA/9fR0PtnY2L3Pzs6+o6KiPv79fb/r6uo+wsFBP+DfXz+OjQ0/sbAwPd7dXT/Qz08/rq0tv/Tzc7+lpCS++fj4PdzbWz/Avz8/+fj4PeDfXz/b2tq+ycjIPYaFBT+Ihwe/p6amPsjHR7+fnp6+z87OPvb1db+Hhoa+t7a2vgAAgD/19HQ+2djYvc/Ozr6joqI+/v19v+vq6j7CwUE/4N9fP46NDT+xsDA93t1dP9DPTz+urS2/9PNzv6WkJL75+Pg93NtbP8C/Pz/5+Pg94N9fP9va2r7JyMg9hoUFP4iHB7+npqY+yMdHv5+enr7Pzs4+9vV1vw==",
+      "vectorSha256": "477cf45d3fff8254f6d6b1e9f6ede0274f51c8184bce04bde971b6fcf938237f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5e52ff9e724ca801bae0efc685eee729066b8feddf8fef498cc23ca91c58b305",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0585": {
+      "vector": "2tlZP6GgoDzt7Gy+trU1P7++vj7j4uI+sbAwvf38fD78+3u/0M9PP8nIyL3l5GS+1dRUPqOioj6lpCQ+2NdXP5qZGb+qqSk/rKsrP5OSkj6KiQm/v76+vr69Pb+dnBw+1tVVv/Py8r7g31+/7+7uvu/u7r67urq+sK8vv8/Ozj7a2Vk/oaCgPO3sbL62tTU/v76+PuPi4j6xsDC9/fx8Pvz7e7/Qz08/ycjIveXkZL7V1FQ+o6KiPqWkJD7Y11c/mpkZv6qpKT+sqys/k5KSPoqJCb+/vr6+vr09v52cHD7W1VW/8/LyvuDfX7/v7u6+7+7uvru6ur6wry+/z87OPg==",
+      "vectorSha256": "035d88c2eae7f22d86ee6d38a608b03aac6ae37b7d05870a0304f523e7f1c73f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ec8262daafb87a9f02e773639aa894eb33d4d5a43b50219315431044445128b3",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0586": {
+      "vector": "/v19v/b1db/w728/oaCgPIWEBL64tze/sK8vv5iXFz8AAIC/9PNzv4qJCT+xsDA92tlZP6GgoLz//v4+z87OvoaFBb+ioSE/mZiYPZaVFT/9/Hw+yMdHP4KBAb+1tDQ+mZiYPbSzM7+NjAw+0dBQvdDPT7+vrq4+yslJP+blZT/+/X2/9vV1v/Dvbz+hoKA8hYQEvri3N7+wry+/mJcXPwAAgL/083O/iokJP7GwMD3a2Vk/oaCgvP/+/j7Pzs6+hoUFv6KhIT+ZmJg9lpUVP/38fD7Ix0c/goEBv7W0ND6ZmJg9tLMzv42MDD7R0FC90M9Pv6+urj7KyUk/5uVlPw==",
+      "vectorSha256": "090d6d2bdc407eb5251305623bd3fd175e865ec7f71f3cc84046d5c399b7d567",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0105f7826f2428cb0006c485ec7dbf4c3dd089ca9fe33f968926917918abe4f2",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0587": {
+      "vector": "3dxcPuTjYz/19HQ+pqUlP+blZb/W1VU/2NdXv4GAgLurqqo+yslJP6moqL3NzEw+29raPvn4+L3Lysq+nJsbv62sLL63tra+6ulpv+LhYb+FhAS+wcBAvMrJSb+vrq4+n56evqKhIT/083O/lJMTP5+enj6koyM/xcREvp6dHb/d3Fw+5ONjP/X0dD6mpSU/5uVlv9bVVT/Y11e/gYCAu6uqqj7KyUk/qaiovc3MTD7b2to++fj4vcvKyr6cmxu/rawsvre2tr7q6Wm/4uFhv4WEBL7BwEC8yslJv6+urj6fnp6+oqEhP/Tzc7+UkxM/n56ePqSjIz/FxES+np0dvw==",
+      "vectorSha256": "8e6b563080a9770a1d772052f80cb61bbd52f10199c589b5721ac069c9adbc8c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9bf19ed20dea147faae47599b6704d326a520b0f6f7e1bab58d006c9a7d16731",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0588": {
+      "vector": "2tlZv+jnZ7+wry8/8fBwPcTDQz+Pjo4+yslJP8HAQDympSU//fx8PpGQED3r6uo+29ravuno6D3Z2Ni93t1dv8/Ozj6DgoI+5uVlv9XUVL7m5WW/jYwMPpSTE7/X1tY+mJcXP7SzMz+zsrI+2tlZv+LhYT8AAIC/7+7uPtfW1j7a2Vm/6Odnv7CvLz/x8HA9xMNDP4+Ojj7KyUk/wcBAPKalJT/9/Hw+kZAQPevq6j7b2tq+6ejoPdnY2L3e3V2/z87OPoOCgj7m5WW/1dRUvublZb+NjAw+lJMTv9fW1j6Ylxc/tLMzP7Oysj7a2Vm/4uFhPwAAgL/v7u4+19bWPg==",
+      "vectorSha256": "a580a49fff2fb676f2062642b278c3a50ebbabf1b0d5463afaa2478ae3460550",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "130cd787e1a3e481d29f84ba498e7211b3a00d650d9136b5cbd9ac13f000bbb5",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0589": {
+      "vector": "5eRkPp2cHL7Avz8/zMtLv4iHB7/j4uK+k5KSvp2cHL7u7W2/09LSvomIiL2Miws/rKsrv6qpKT/5+Pi9tLMzP/X0dL7V1FS+pqUlv8zLS7+ZmJi9q6qqvquqqj7S0VG/rawsPvv6+j6lpCQ+4N9fv/Dvb7/y8XG/mZiYvaempr7l5GQ+nZwcvsC/Pz/My0u/iIcHv+Pi4r6TkpK+nZwcvu7tbb/T0tK+iYiIvYyLCz+sqyu/qqkpP/n4+L20szM/9fR0vtXUVL6mpSW/zMtLv5mYmL2rqqq+q6qqPtLRUb+trCw++/r6PqWkJD7g31+/8O9vv/Lxcb+ZmJi9p6amvg==",
+      "vectorSha256": "49b6f1994c80cd3a8c33573791284228fc26e27972033a3e9e3ce7fb94d7ce83",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9c6cdf1a3c475b6c094b77c52ad470d961652d1a7655aa1795be941008077656",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0590": {
+      "vector": "xsVFv6alJb/l5GQ+y8rKPpKREb/r6uq+0dBQPZiXF7+CgQE/+Pd3v97dXT+4tzc/j46OPvv6+r6xsDC9q6qqvvv6+r64tze//Pt7v6Oioj7p6Oi9h4aGPtDPTz/Hxsa+//7+PoaFBT+5uLg97u1tv+/u7j739va+3NtbP9DPT7/GxUW/pqUlv+XkZD7Lyso+kpERv+vq6r7R0FA9mJcXv4KBAT/493e/3t1dP7i3Nz+Pjo4++/r6vrGwML2rqqq++/r6vri3N7/8+3u/o6KiPuno6L2HhoY+0M9PP8fGxr7//v4+hoUFP7m4uD3u7W2/7+7uPvf29r7c21s/0M9Pvw==",
+      "vectorSha256": "4b1daacc937332845e6a84c1bbe5d414e85eee2c3648fe375d9f83c7bca38399",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1d2d9cb237458634c004eedba3417a55412402a871a1e74ebfc28b09bb42ed18",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0591": {
+      "vector": "q6qqPuDfXz+lpCS+hIMDP+rpab+JiIg9kZAQPbSzMz/w72+/7exsPo+Ojr79/Hy+uLc3v97dXT+1tDQ+5+bmvsC/P7/083O/tbQ0vublZT/W1VU/jYwMPrKxMT/s62u/t7a2PoqJCT/a2Vm/sbAwvcbFRT+TkpI+i4qKPvDvbz+rqqo+4N9fP6WkJL6EgwM/6ulpv4mIiD2RkBA9tLMzP/Dvb7/t7Gw+j46Ovv38fL64tze/3t1dP7W0ND7n5ua+wL8/v/Tzc7+1tDS+5uVlP9bVVT+NjAw+srExP+zra7+3trY+iokJP9rZWb+xsDC9xsVFP5OSkj6Lioo+8O9vPw==",
+      "vectorSha256": "086bfa923690c68af9031a690c21a500dc575d7dbf3f4e0323b7ffe7142f66ae",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "aaef6bc10b8884d9089d5c6024ee9646200669f2ea91d80aadc4137ae2a4a2f7",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0592": {
+      "vector": "3t1dv9XUVL7KyUk/v76+Ptva2r7OzU0/iIcHP4yLC7+wry8/7u1tv+no6D26uTk/iIcHP+blZT+FhAQ+qKcnP/Dvb7/493c/gYCAO8LBQT+UkxM/wsFBv8vKyr6bmpo+0tFRv9bVVb+3trY++fj4Pby7O7/s62u/vbw8PoyLCz/e3V2/1dRUvsrJST+/vr4+29ravs7NTT+Ihwc/jIsLv7CvLz/u7W2/6ejoPbq5OT+Ihwc/5uVlP4WEBD6opyc/8O9vv/j3dz+BgIA7wsFBP5STEz/CwUG/y8rKvpuamj7S0VG/1tVVv7e2tj75+Pg9vLs7v+zra7+9vDw+jIsLPw==",
+      "vectorSha256": "f1452b12992abbc6d85a3d5cbb3e3da69356d9384abcd461bad40a741d68a36b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1165e4af49e6c33ad7098edcc3f290d308fb80e0c91f4da61715ad8f220a97c5",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0593": {
+      "vector": "oaCgvISDA7/c21u/6+rqPpOSkr6rqqo+oJ8fP5GQEL3Qz0+/jo0NP/Lxcb/f3t6+rawsvpybG7+/vr4+9PNzP4eGhj7Ix0e/mZiYPc/Ozj6TkpI+kZAQvYqJCT+EgwO/trU1P5qZGb/493e/9fR0PpiXFz/39va+3t1dv+blZT+hoKC8hIMDv9zbW7/r6uo+k5KSvquqqj6gnx8/kZAQvdDPT7+OjQ0/8vFxv9/e3r6trCy+nJsbv7++vj7083M/h4aGPsjHR7+ZmJg9z87OPpOSkj6RkBC9iokJP4SDA7+2tTU/mpkZv/j3d7/19HQ+mJcXP/f29r7e3V2/5uVlPw==",
+      "vectorSha256": "998b5b0d6baaaeaad0b4785395ddf89072b21db9011db59d13b1a6e6c3a7bab2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7d3e12ba5baacf7b18c607486a32aff9a11c89b3a47bc43eda33049ecb4211f2",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0594": {
+      "vector": "x8bGPoeGhj6xsDA9x8bGvpybGz+sqys/3dxcPtzbWz/t7Gw+h4aGvp2cHL6joqK+lZQUvs7NTb/19HS+lZQUvvX0dD6FhAS+yMdHP9fW1r75+Pg9tbQ0PoOCgr7Ew0M/+fj4vZeWlr6Xlpa+mpkZP/b1db/i4WE/AACAP7GwMD3HxsY+h4aGPrGwMD3Hxsa+nJsbP6yrKz/d3Fw+3NtbP+3sbD6Hhoa+nZwcvqOior6VlBS+zs1Nv/X0dL6VlBS+9fR0PoWEBL7Ix0c/19bWvvn4+D21tDQ+g4KCvsTDQz/5+Pi9l5aWvpeWlr6amRk/9vV1v+LhYT8AAIA/sbAwPQ==",
+      "vectorSha256": "d583c13201f6a0f08c5be61d36b0fd455406f3b30daa432cab1b7939fa9c1dfa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b1a1854ecdd59bed9d5e6c576d19616d9e6fe34a8f965fe1705a5acc05f0ff85",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0595": {
+      "vector": "uLc3P8zLSz+Lioq+2djYPYeGhr6XlpY+pqUlv5qZGb/U01M/397ePuHg4DyysTG/wcBAvNva2r6vrq6+hoUFv7CvL7/Qz08/jYwMvtzbW7/39va+7+7uPpOSkj6zsrI+vr09v8TDQ7+3trY+n56ePpqZGT+wry8/qKcnv+/u7j64tzc/zMtLP4uKir7Z2Ng9h4aGvpeWlj6mpSW/mpkZv9TTUz/f3t4+4eDgPLKxMb/BwEC829ravq+urr6GhQW/sK8vv9DPTz+NjAy+3Ntbv/f29r7v7u4+k5KSPrOysj6+vT2/xMNDv7e2tj6fnp4+mpkZP7CvLz+opye/7+7uPg==",
+      "vectorSha256": "6ac8028d91bc27dd1897d1aece4809bd1c51df0c6a2d8304aa5900eec37f2325",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dbe55d8d5ea52d33e9b783277e49543d28e76e1242bba4ac211eada7ccd72cbb",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0596": {
+      "vector": "9/b2Pvj3dz+Lioq+zcxMvoiHB7/s62u/n56ePsPCwj7b2to+j46OPo+Ojj6wry+/k5KSvr28PL7d3Fw+19bWvtjXVz+wry+/5ONjv7GwMD25uLg9uLc3P7i3N7+4tze/5+bmvpCPD7+npqY+rKsrP8LBQT+CgQE/0tFRP6inJz/39vY++Pd3P4uKir7NzEy+iIcHv+zra7+fnp4+w8LCPtva2j6Pjo4+j46OPrCvL7+TkpK+vbw8vt3cXD7X1ta+2NdXP7CvL7/k42O/sbAwPbm4uD24tzc/uLc3v7i3N7/n5ua+kI8Pv6empj6sqys/wsFBP4KBAT/S0VE/qKcnPw==",
+      "vectorSha256": "7f50b82101e6989fe3b6fe27cd483c77b6b717e3e68a6db5113bea8a6bb7ada5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bdfb5d663c0aa7b0b6a3a3285b689b4aeb280e858bdb24244638a9d5e0c0e8d3",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0597": {
+      "vector": "+vl5P5iXFz+2tTW/9vV1P8nIyL2lpCS+iokJP9PS0r7o52c/6ulpP7CvLz/Z2Ni9lpUVv8TDQ7/Y11c/p6amvuno6D3Z2Ni9oJ8fv9/e3r62tTU/0tFRv8HAQLzBwEC8iIcHv8XERL7Qz08/pqUlP+LhYT+1tDS+uLc3v6+urr76+Xk/mJcXP7a1Nb/29XU/ycjIvaWkJL6KiQk/09LSvujnZz/q6Wk/sK8vP9nY2L2WlRW/xMNDv9jXVz+npqa+6ejoPdnY2L2gnx+/397evra1NT/S0VG/wcBAvMHAQLyIhwe/xcREvtDPTz+mpSU/4uFhP7W0NL64tze/r66uvg==",
+      "vectorSha256": "752248561cc0943e1d6372f7cb53c5c4a98a187591b095c6098c44bb5f38e486",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fccb25fa736bc44bf3f4d772351eeb568e723048da177e7e3c67e7d2f0692454",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0598": {
+      "vector": "x8bGPqinJz+Lioq+zMtLv+/u7r7S0VE/1tVVP9nY2L0AAIC/n56ePqmoqL2pqKg9pKMjP4SDAz/i4WE/oaCgPJSTEz/HxsY+4eDgvOvq6j7V1FQ+2djYPYOCgj79/Hw+6ulpP4qJCT+0szM/4+LiPrKxMb/y8XE/8fBwPdnY2L3HxsY+qKcnP4uKir7My0u/7+7uvtLRUT/W1VU/2djYvQAAgL+fnp4+qaiovamoqD2koyM/hIMDP+LhYT+hoKA8lJMTP8fGxj7h4OC86+rqPtXUVD7Z2Ng9g4KCPv38fD7q6Wk/iokJP7SzMz/j4uI+srExv/LxcT/x8HA92djYvQ==",
+      "vectorSha256": "f17db82ba7513d488172846d9dbbd36324ac19c3ef539a4264f6abaea12d6701",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b1d35d1a44e8ea7200a7758ad1c1f082c9b17cba9a8da09ff4c4d9b827f88772",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0599": {
+      "vector": "+vl5P5OSkr7x8HA9jIsLP6SjIz/Pzs6+hIMDv+3sbD6Ihwc/m5qaPsC/Pz+koyM/jIsLP5GQEL3r6uo+4uFhv83MTL6VlBQ+vbw8vqKhIT/Hxsa+/Pt7P/HwcD24tzc/6+rqPvr5eb/29XW/AACAP/Dvbz+6uTk/h4aGPsbFRb/6+Xk/k5KSvvHwcD2Miws/pKMjP8/Ozr6EgwO/7exsPoiHBz+bmpo+wL8/P6SjIz+Miws/kZAQvevq6j7i4WG/zcxMvpWUFD69vDy+oqEhP8fGxr78+3s/8fBwPbi3Nz/r6uo++vl5v/b1db8AAIA/8O9vP7q5OT+HhoY+xsVFvw==",
+      "vectorSha256": "6d7e625c3ea2c5e29202867df01a53dfd53a0e67fe560f62800f1f037aa4d9d5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fc5b87c5d14c3e9dc3a6dfd1c57bba0f669268d04efd87dbba0305fff7dca11d",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0600": {
+      "vector": "g4KCPvv6+r6JiIi9srExP728PD6urS2/kI8PP5CPD7/e3V0/vr09v5KREb+Ylxe//v19P/38fL6Qjw8/p6amPuno6D27urq+p6amPr++vr6npqa+19bWvsC/Pz+4tze/0tFRP87NTT+pqKi9m5qaPu7tbT+XlpY+lpUVP8zLS7+DgoI++/r6vomIiL2ysTE/vbw8Pq6tLb+Qjw8/kI8Pv97dXT++vT2/kpERv5iXF7/+/X0//fx8vpCPDz+npqY+6ejoPbu6ur6npqY+v76+vqempr7X1ta+wL8/P7i3N7/S0VE/zs1NP6moqL2bmpo+7u1tP5eWlj6WlRU/zMtLvw==",
+      "vectorSha256": "32e9e15eedbf6cdb7e176441f913d55602f18991fba96808865a17f969f2be9a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a04177d89729c738ee213734fe60c7a98e51a950564adf24e8e675a6f6a5ca1a",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0601": {
+      "vector": "8vFxP7y7Oz+NjAy+4eDgPO7tbT+mpSU/3dxcPo+Ojj7Avz+/8vFxP+/u7j6JiIg9h4aGvvHwcD3p6Oi9nJsbv4aFBT+FhAQ+ycjIPb69PT/NzEy+t7a2PublZb+mpSU/vr09v9PS0j7n5ua+s7KyvoOCgj7DwsK+zcxMPtnY2L3y8XE/vLs7P42MDL7h4OA87u1tP6alJT/d3Fw+j46OPsC/P7/y8XE/7+7uPomIiD2Hhoa+8fBwPeno6L2cmxu/hoUFP4WEBD7JyMg9vr09P83MTL63trY+5uVlv6alJT++vT2/09LSPufm5r6zsrK+g4KCPsPCwr7NzEw+2djYvQ==",
+      "vectorSha256": "33c94b64d13c36de493345089b998cb9ac2a79a846d47069e9e2f6bf03d4a59f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f8dd6e83f6d29ba320f8bb885e877132c2908cde66ad0dd221b44653a04f9972",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0602": {
+      "vector": "3t1dP769Pb///v4+iYiIvfv6+j6cmxs/mZiYPYSDAz+4tzc/2NdXP46NDT+fnp4+t7a2vouKir78+3u/np0dP/38fL7r6uo+8O9vP4qJCT+hoKA8pqUlv+zra7/e3V0/ubi4Pb++vr66uTm/6Odnv7u6uj7v7u4+7Otrv4GAgLve3V0/vr09v//+/j6JiIi9+/r6PpybGz+ZmJg9hIMDP7i3Nz/Y11c/jo0NP5+enj63tra+i4qKvvz7e7+enR0//fx8vuvq6j7w728/iokJP6GgoDympSW/7Otrv97dXT+5uLg9v76+vrq5Ob/o52e/u7q6Pu/u7j7s62u/gYCAuw==",
+      "vectorSha256": "96fe4bd2575cd83eec8382708875ebe72be73f59968c908163ab024d1c627a57",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ee21bf77becd89c1dbebc6a7525d02ce60baf7c4822d0aee8b50230caebb0a7f",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0603": {
+      "vector": "qaiovZiXFz/h4OA819bWPpiXF7/o52c/tbQ0vqWkJD6OjQ2/1tVVP8LBQT+ioSG/pqUlv9jXVz+XlpY+6+rqPtfW1r7S0VG/kI8Pv/f29j6rqqo+3dxcvpybGz+amRk/4uFhP769PT+sqyu/6ulpv9bVVT/y8XG/xMNDv7GwML2pqKi9mJcXP+Hg4DzX1tY+mJcXv+jnZz+1tDS+paQkPo6NDb/W1VU/wsFBP6KhIb+mpSW/2NdXP5eWlj7r6uo+19bWvtLRUb+Qjw+/9/b2Pquqqj7d3Fy+nJsbP5qZGT/i4WE/vr09P6yrK7/q6Wm/1tVVP/Lxcb/Ew0O/sbAwvQ==",
+      "vectorSha256": "ed1ad13a8156b020abb0d9be8c3d4d9949a5c254c12d484400704203517686db",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "75cb83b534f3699439eae02f2deba5ba4a1738bdaa64cdccf0de2a0bea071e7a",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0604": {
+      "vector": "h4aGvsfGxj7U01M/0dBQvZqZGT+wry+/6ulpP6GgoDz083O/AACAP6GgoLz19HS+1dRUPszLSz/d3Fw+vr09v7i3Nz/e3V2/hIMDv6Oioj6Ylxe/jo0NP4+Ojj60szM/rq0tP4yLC7+amRm/xMNDP56dHb+Ylxc/i4qKvri3N7+Hhoa+x8bGPtTTUz/R0FC9mpkZP7CvL7/q6Wk/oaCgPPTzc78AAIA/oaCgvPX0dL7V1FQ+zMtLP93cXD6+vT2/uLc3P97dXb+EgwO/o6KiPpiXF7+OjQ0/j46OPrSzMz+urS0/jIsLv5qZGb/Ew0M/np0dv5iXFz+Lioq+uLc3vw==",
+      "vectorSha256": "584562f8e6f0bbd607d611830c02fb1721e6cd1f3d62ab7e6e270ee0082a5164",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5eb1e979cc28f48206ff7d619ae59b21db113ea834c6a3d9d63a33e131cb5d24",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0605": {
+      "vector": "pqUlv9HQUL2XlpY+qaioPeHg4Lzq6Wm/3Ntbv9zbWz+5uLi9wsFBv6alJb+vrq4+8fBwva6tLT/7+vo+sK8vP5OSkr6fnp4+1tVVv/r5eb/Ix0c//Pt7v9rZWT+ysTG/6Odnv6WkJL75+Pi99PNzP9va2r6JiIg96ulpv4uKir6mpSW/0dBQvZeWlj6pqKg94eDgvOrpab/c21u/3NtbP7m4uL3CwUG/pqUlv6+urj7x8HC9rq0tP/v6+j6wry8/k5KSvp+enj7W1VW/+vl5v8jHRz/8+3u/2tlZP7KxMb/o52e/paQkvvn4+L3083M/29ravomIiD3q6Wm/i4qKvg==",
+      "vectorSha256": "bf8fe47effa0734daeb5906cac33d2e82edb305e9d4668f6748c1240b223149a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2d79a58a7c0b12ed741f2dab78d6bed75ba71503e302ec270c6b70f949880b5d",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0606": {
+      "vector": "oaCgPPX0dL6OjQ2/vr09P6alJb+Lioq+oaCgvJOSkr7083M/4N9fv+no6D2trCy++fj4vcfGxr7r6uq+vLs7P5CPD7+enR2/5ONjP6SjI7/GxUW/oqEhv8fGxr76+Xk/3dxcvuvq6r6lpCQ+jIsLP4KBAT+Qjw8/3t1dv/Lxcb+hoKA89fR0vo6NDb++vT0/pqUlv4uKir6hoKC8k5KSvvTzcz/g31+/6ejoPa2sLL75+Pi9x8bGvuvq6r68uzs/kI8Pv56dHb/k42M/pKMjv8bFRb+ioSG/x8bGvvr5eT/d3Fy+6+rqvqWkJD6Miws/goEBP5CPDz/e3V2/8vFxvw==",
+      "vectorSha256": "766384139d44ebef4a378414516ca2aa3393e1efa4ab7e334cc7010aac090030",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "826139de2d5d7d5bf9108e6a704e45dd3831f12e1d2f4efc644594c5c0c71107",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0607": {
+      "vector": "kpERP5eWlj7DwsK+s7KyPtrZWT/V1FQ+o6KiPsnIyL25uLi98fBwvYyLCz/p6Og9y8rKvr28PL6sqyu/3t1dP8TDQ7/CwUG/g4KCPp2cHL6qqSm/6ulpP4qJCT/p6Og9qaiovYmIiL3My0u/8O9vv9jXV78AAIA/2NdXv769PT+SkRE/l5aWPsPCwr6zsrI+2tlZP9XUVD6joqI+ycjIvbm4uL3x8HC9jIsLP+no6D3Lysq+vbw8vqyrK7/e3V0/xMNDv8LBQb+DgoI+nZwcvqqpKb/q6Wk/iokJP+no6D2pqKi9iYiIvczLS7/w72+/2NdXvwAAgD/Y11e/vr09Pw==",
+      "vectorSha256": "6f17d5c00b3ef681f1b7b359056ab7ba5ff608f0a5d0aff979c9c421f48bd7ce",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c8a54facec9aa8737478c58e4d682aee1e1fa06c2bf4c48e75771a0814ff14de",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0608": {
+      "vector": "s7KyvrGwMD2koyM/5+bmvtDPTz/T0tK+r66uPuLhYb+Miwu/09LSvqWkJD7y8XG/ubi4vd/e3j7Ix0c/goEBv83MTL6DgoK+4+LiPqOior7p6Oi9rawsPoKBAb+ioSE/g4KCvuHg4LyEgwO/8vFxv8C/Pz+/vr4+7OtrP9TTUz+zsrK+sbAwPaSjIz/n5ua+0M9PP9PS0r6vrq4+4uFhv4yLC7/T0tK+paQkPvLxcb+5uLi9397ePsjHRz+CgQG/zcxMvoOCgr7j4uI+o6Kivuno6L2trCw+goEBv6KhIT+DgoK+4eDgvISDA7/y8XG/wL8/P7++vj7s62s/1NNTPw==",
+      "vectorSha256": "376d398ddf3e6f7a156aefc024b178c11ff385f7072edc099608fe403692d993",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5385d146e74bab0f3a4b940774b7e33f665fb85771953fd05f7c3e07dfaff5e9",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0609": {
+      "vector": "kI8Pv8XERD6CgQG/+vl5v+blZT/Pzs6+8vFxv52cHD7o52e/1tVVP7q5Ob/Qz0+/gYCAO5ybGz/k42O/m5qavra1Nb///v6+wcBAPMHAQLz//v6+xcREvvPy8r7g31+/h4aGPpqZGb/493e/hYQEvtLRUT/u7W2/8O9vP//+/j6Qjw+/xcREPoKBAb/6+Xm/5uVlP8/Ozr7y8XG/nZwcPujnZ7/W1VU/urk5v9DPT7+BgIA7nJsbP+TjY7+bmpq+trU1v//+/r7BwEA8wcBAvP/+/r7FxES+8/LyvuDfX7+HhoY+mpkZv/j3d7+FhAS+0tFRP+7tbb/w728///7+Pg==",
+      "vectorSha256": "dabb9515a934a4c2000bbaf23cf8129fd88bc66e5b0b1162b309e894b78b4721",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "38983f03f24c07930cea231880cd0e592540817e40674310a133046fe809f7bf",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0610": {
+      "vector": "6Odnv769Pb+sqys/hYQEvqKhIb/5+Pi94N9fP7u6uj7y8XE/mJcXv/r5eT+5uLg9iokJv4SDA7+Ihwc/pqUlv7i3Nz/d3Fw+mJcXP6empr6SkRG/gYCAu4GAgDuXlpa+3t1dP6SjIz/x8HC9oaCgPLq5Ob/s62s/397ePq6tLb/o52e/vr09v6yrKz+FhAS+oqEhv/n4+L3g318/u7q6PvLxcT+Ylxe/+vl5P7m4uD2KiQm/hIMDv4iHBz+mpSW/uLc3P93cXD6Ylxc/p6amvpKREb+BgIC7gYCAO5eWlr7e3V0/pKMjP/HwcL2hoKA8urk5v+zraz/f3t4+rq0tvw==",
+      "vectorSha256": "6e84077c3576d3681a9bf7ec2260ceea95b0fe9e25ce05283ddccd894f9a0550",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0c21d56f2f70efaef834fc8b3b3ec32ddb9bcb56377f805aeed1788223f5b729",
+      "updatedAt": "2025-09-20T22:27:41.537Z"
+    },
+    "j-0611": {
+      "vector": "rq0tP+vq6j75+Pi98O9vv97dXT+KiQm/5+bmvtzbWz/j4uI+lJMTv6qpKb+8uzs/tLMzv5iXFz/OzU0/2NdXP/38fD7Z2Ni98O9vP6SjI7/u7W2/6ejoPZybGz/9/Hw+3dxcvo6NDT+SkRE/09LSPo+Ojj61tDQ+2djYPfX0dD6urS0/6+rqPvn4+L3w72+/3t1dP4qJCb/n5ua+3NtbP+Pi4j6UkxO/qqkpv7y7Oz+0szO/mJcXP87NTT/Y11c//fx8PtnY2L3w728/pKMjv+7tbb/p6Og9nJsbP/38fD7d3Fy+jo0NP5KRET/T0tI+j46OPrW0ND7Z2Ng99fR0Pg==",
+      "vectorSha256": "ff55d9c2757ddc08d06909aa172e693fa03d7062b30fad1543629da3ad4d62b8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d6ba7008ee3b46edb8362bdd26cbe6eb9f72f72e098ecd9f64c6c8b4a3968d9e",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0612": {
+      "vector": "mpkZv/HwcD2BgIA70dBQvby7O7+Ylxc/tLMzP+LhYb+TkpK+iIcHv56dHb+FhAS+h4aGPpqZGb+trCw+vr09P9XUVD7h4OA89PNzP+Pi4r7Pzs4+3dxcPv/+/r6TkpI+gYCAO/Dvb7+Lioq+v76+PqalJb/p6Og9rawsPuTjYz+amRm/8fBwPYGAgDvR0FC9vLs7v5iXFz+0szM/4uFhv5OSkr6Ihwe/np0dv4WEBL6HhoY+mpkZv62sLD6+vT0/1dRUPuHg4Dz083M/4+Livs/Ozj7d3Fw+//7+vpOSkj6BgIA78O9vv4uKir6/vr4+pqUlv+no6D2trCw+5ONjPw==",
+      "vectorSha256": "f0b3a5ae0c13796609ad20d9232f73e138ad9cd205651e9e9e1159247f761075",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3387807922cbd90f5b3c316fa13395de9a83f947b39b40a480085daf2d8e95f1",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0613": {
+      "vector": "4uFhP+DfX7/R0FA9AACAv4eGhj6FhAS+hIMDP6GgoDy7uro+xMNDv8C/Pz/FxEQ+goEBv+blZT/Avz+/k5KSPu7tbT+rqqq+kpERP6qpKb/V1FS+/fx8voOCgj7f3t4+sK8vP+zraz/Ew0O/3t1dv7y7Oz/39vY+gYCAO8PCwj7i4WE/4N9fv9HQUD0AAIC/h4aGPoWEBL6EgwM/oaCgPLu6uj7Ew0O/wL8/P8XERD6CgQG/5uVlP8C/P7+TkpI+7u1tP6uqqr6SkRE/qqkpv9XUVL79/Hy+g4KCPt/e3j6wry8/7OtrP8TDQ7/e3V2/vLs7P/f29j6BgIA7w8LCPg==",
+      "vectorSha256": "540592c9144117cd0891f81df1e51c8cb32e6366f0e1e4126243c03db77b3173",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f0108600a16fc182ae1edf983ff220a4f655c82b6560a0b7d7f51e11ddbd80b0",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0614": {
+      "vector": "trU1v4+Ojj64tzc/i4qKPouKir7h4OC8p6amPo+Ojj7t7Gy+29ravuPi4j6EgwO/rq0tP+XkZD7i4WG/+vl5P7++vj77+vo+5eRkPurpaT/p6Oi9uLc3P4KBAT+WlRW/ycjIvdTTU7++vT2/2djYPdzbWz/Ix0c/2tlZv8PCwj62tTW/j46OPri3Nz+Lioo+i4qKvuHg4LynpqY+j46OPu3sbL7b2tq+4+LiPoSDA7+urS0/5eRkPuLhYb/6+Xk/v76+Pvv6+j7l5GQ+6ulpP+no6L24tzc/goEBP5aVFb/JyMi91NNTv769Pb/Z2Ng93NtbP8jHRz/a2Vm/w8LCPg==",
+      "vectorSha256": "c6ce2a9e5bce13840673f46dbfba5104cc4af29f1a10d11627b11651614b5349",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "25a3dba25d7ca9a36249b83ed69c0ffcafbe9cf471dbc0357316218dede313b0",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0615": {
+      "vector": "pqUlv6SjIz+wry+/w8LCvoqJCT+4tze/rawsvsHAQLyPjo6+pKMjv728PD7My0s/zMtLv5WUFL6gnx+/zs1NP6alJT/9/Hy+vr09v8bFRb/My0u/iYiIvQAAgD/R0FC9oJ8fP7CvLz/NzEw+qaioPfLxcT/493c/n56evsrJST+mpSW/pKMjP7CvL7/DwsK+iokJP7i3N7+trCy+wcBAvI+Ojr6koyO/vbw8PszLSz/My0u/lZQUvqCfH7/OzU0/pqUlP/38fL6+vT2/xsVFv8zLS7+JiIi9AACAP9HQUL2gnx8/sK8vP83MTD6pqKg98vFxP/j3dz+fnp6+yslJPw==",
+      "vectorSha256": "fecf95a71aefda5d8f6eab0c01f54d08d5ab06700c05c72a5d4d127c296a3297",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2dd1284fc4246a7e5c2e97e51a6d30e6d260211d1a77ff79cfd7998af8fb58e4",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0616": {
+      "vector": "v76+vsHAQLyfnp4+goEBP9nY2D2xsDA9j46OPs3MTD6npqY+tbQ0vpmYmD3DwsI+rKsrP+zra7+VlBQ+rawsvvDvbz/X1tY+v76+PuDfXz+BgIA7wcBAvL69PT+bmpo+2djYvaOioj6Pjo4+3dxcvvPy8r7GxUW/9/b2vvLxcT+/vr6+wcBAvJ+enj6CgQE/2djYPbGwMD2Pjo4+zcxMPqempj61tDS+mZiYPcPCwj6sqys/7Otrv5WUFD6trCy+8O9vP9fW1j6/vr4+4N9fP4GAgDvBwEC8vr09P5uamj7Z2Ni9o6KiPo+Ojj7d3Fy+8/LyvsbFRb/39va+8vFxPw==",
+      "vectorSha256": "2453a4d7c4d752dacaf051ff6ad83ae14c61700864e2649d6c8be7e9ec44ade7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "507ea7c08d85a399a96989b0d50a926af7b5afef807edea672a8a364431d42f8",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0617": {
+      "vector": "jo0NP5STE7/5+Pi9p6amvquqqj69vDy+8fBwvQAAgL+KiQm/3t1dP4yLCz/W1VW/rq0tP4+Ojj7r6uq+4+LivoKBAT+7urq++vl5P87NTT+2tTU/hIMDP66tLb/BwEC87exsPtzbW7+Miws/mJcXP+3sbL7h4OC8xMNDv7e2tr6OjQ0/lJMTv/n4+L2npqa+q6qqPr28PL7x8HC9AACAv4qJCb/e3V0/jIsLP9bVVb+urS0/j46OPuvq6r7j4uK+goEBP7u6ur76+Xk/zs1NP7a1NT+EgwM/rq0tv8HAQLzt7Gw+3Ntbv4yLCz+Ylxc/7exsvuHg4LzEw0O/t7a2vg==",
+      "vectorSha256": "368f5fb7ab7432b13bcc0df29ad1646ada62cc217e8ea5a5b9c24c45a2bfa1d3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c6367056aa6878003beec515d6a34547c051fce6dac1297e9d12c5cb627c1e52",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0618": {
+      "vector": "pqUlv5ybGz/Hxsa+m5qavsXERL6urS0/srExP5+enj6DgoK+l5aWPrm4uD2wry8//Pt7P/b1db+xsDA9+/r6PqinJ7+VlBS+7exsPs7NTT/OzU0/l5aWvvHwcL3e3V2//fx8vp+enj6pqKg9lpUVP/f29r7t7Gw+gYCAO4uKij6mpSW/nJsbP8fGxr6bmpq+xcREvq6tLT+ysTE/n56ePoOCgr6XlpY+ubi4PbCvLz/8+3s/9vV1v7GwMD37+vo+qKcnv5WUFL7t7Gw+zs1NP87NTT+Xlpa+8fBwvd7dXb/9/Hy+n56ePqmoqD2WlRU/9/b2vu3sbD6BgIA7i4qKPg==",
+      "vectorSha256": "b0a7a78db464b704fa7c403e072ba260dc1bf958934d8371168527beec003a2a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2dcd4e5967d6d8a75fa58bd7fd0585be2c6d9de6e65a781160a78aca429d80a2",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0619": {
+      "vector": "o6KiPt3cXL6ioSG/5eRkPpSTEz/W1VU/vbw8vpqZGb/Qz0+/6ulpP8C/Pz+XlpY+n56evgAAgL+ysTG/9/b2vvn4+L2RkBC9ubi4vZqZGb+qqSk/q6qqvvf29j6GhQW/+Pd3v7SzM7/39va+zMtLP+/u7r6dnBy+4N9fv8HAQDyjoqI+3dxcvqKhIb/l5GQ+lJMTP9bVVT+9vDy+mpkZv9DPT7/q6Wk/wL8/P5eWlj6fnp6+AACAv7KxMb/39va++fj4vZGQEL25uLi9mpkZv6qpKT+rqqq+9/b2PoaFBb/493e/tLMzv/f29r7My0s/7+7uvp2cHL7g31+/wcBAPA==",
+      "vectorSha256": "393e4c3457a5c6e926ccad60a6e316a90b18916ab9c8005f6aacfbf5a17a59b4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a8642f9cc9ea683318f4dfa558002742707b7433d455bd3d042642e5446c1081",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0620": {
+      "vector": "mJcXP7y7O7/GxUW/tbQ0Pv38fD7+/X2/q6qqPt7dXb/T0tI+7OtrP5OSkj6trCw+09LSPpiXFz/l5GQ+urk5v728PD6DgoK+7+7uvq2sLD6JiIi9vr09P56dHb+enR0/q6qqvsXERD6GhQU/8fBwvYGAgDuwry+/w8LCPpaVFb+Ylxc/vLs7v8bFRb+1tDQ+/fx8Pv79fb+rqqo+3t1dv9PS0j7s62s/k5KSPq2sLD7T0tI+mJcXP+XkZD66uTm/vbw8PoOCgr7v7u6+rawsPomIiL2+vT0/np0dv56dHT+rqqq+xcREPoaFBT/x8HC9gYCAO7CvL7/DwsI+lpUVvw==",
+      "vectorSha256": "f6367cc347282692413ce5723765946e0d08c61427b38f6c7cc9722143f20a79",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cb221d969f01aa11b4f5a495b4cb9c23975f449577de31ce5598c2788028b035",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0621": {
+      "vector": "zcxMPsHAQDyIhwe/0tFRv52cHL7Avz+/2djYvcfGxr7u7W0/5ONjv769PT/b2to+2djYPby7O7+cmxs/y8rKPs3MTD63trY+g4KCPt3cXD7OzU0/qaiovbu6ur7c21s/y8rKvrSzM7/a2Vm/7Otrv9va2r7Ix0e/iokJv//+/j7NzEw+wcBAPIiHB7/S0VG/nZwcvsC/P7/Z2Ni9x8bGvu7tbT/k42O/vr09P9va2j7Z2Ng9vLs7v5ybGz/Lyso+zcxMPre2tj6DgoI+3dxcPs7NTT+pqKi9u7q6vtzbWz/Lysq+tLMzv9rZWb/s62u/29ravsjHR7+KiQm///7+Pg==",
+      "vectorSha256": "e60a956c7250c89b7f747b2a59f685ff6b7cbc47d321f6da251b9071cd7e6436",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "99813c176c20724ef60edeb68d22cdb299ada09be67551ed4d26130a491c3bbf",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0622": {
+      "vector": "tLMzP4qJCT+3tra+oaCgPKalJT+SkRG///7+Pr69PT/R0FC9pKMjP6SjIz+HhoY+5uVlv5KRET+ZmJi9oqEhP6CfHz+6uTk/zMtLv8TDQ7+Ihwc/jIsLv7u6ur7+/X2/lJMTvwAAgD/493e/i4qKPrm4uD3NzEy+tbQ0vpaVFb+0szM/iokJP7e2tr6hoKA8pqUlP5KREb///v4+vr09P9HQUL2koyM/pKMjP4eGhj7m5WW/kpERP5mYmL2ioSE/oJ8fP7q5OT/My0u/xMNDv4iHBz+Miwu/u7q6vv79fb+UkxO/AACAP/j3d7+Lioo+ubi4Pc3MTL61tDS+lpUVvw==",
+      "vectorSha256": "9720846710c1b6cf57aa93ac4632f7ad91a340fc8e251998a6436c42c813edf4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d9c45282d237bfde79d1d1a10dc876d0cfdc1a1ec33a510136ff04a28b666935",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0623": {
+      "vector": "s7KyPvv6+j7c21u/29ravsvKyj6NjAw+//7+vre2tr6vrq6+hoUFv/j3dz/f3t6+4+LiPr28PD63trY+5uVlv8rJST+3tra+tLMzv62sLD6Ylxe/2djYPbe2tr69vDy+8fBwPYKBAb/6+Xk/n56ePvLxcb+Pjo6+8/Lyvre2tj6zsrI++/r6PtzbW7/b2tq+y8rKPo2MDD7//v6+t7a2vq+urr6GhQW/+Pd3P9/e3r7j4uI+vbw8Pre2tj7m5WW/yslJP7e2tr60szO/rawsPpiXF7/Z2Ng9t7a2vr28PL7x8HA9goEBv/r5eT+fnp4+8vFxv4+Ojr7z8vK+t7a2Pg==",
+      "vectorSha256": "e9524ab0466a600c204728d8829b365159aac83ab13465e45764d180722057e2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "acbe1249b2914052543dfb48b897ad0de4522695348d5268873ffca7075c43ad",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0624": {
+      "vector": "xcREPquqqj4AAIC/tLMzP+TjYz+KiQm/paQkvuvq6r6lpCS+np0dv/b1dT/n5uY+nJsbv97dXb+FhAS+rq0tv9fW1j6trCy+5ONjP6CfHz+Lioo+m5qavq+urj7n5ua+lJMTP4GAgLuqqSk/+/r6vvTzcz+SkRE/y8rKvvPy8j7FxEQ+q6qqPgAAgL+0szM/5ONjP4qJCb+lpCS+6+rqvqWkJL6enR2/9vV1P+fm5j6cmxu/3t1dv4WEBL6urS2/19bWPq2sLL7k42M/oJ8fP4uKij6bmpq+r66uPufm5r6UkxM/gYCAu6qpKT/7+vq+9PNzP5KRET/Lysq+8/LyPg==",
+      "vectorSha256": "6f0b575810b6d978099ab9c7bc58763c5f2f37e6612f9f2fa8cc2705116bfb40",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "98aa00d9f13b6b456b31fab932116f29b56af1cfa259ab46c97fd441f9c84dbc",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0625": {
+      "vector": "rawsvvj3d7+4tzc/5uVlP+TjY7/z8vK+wcBAPJybGz/d3Fw+p6amPoKBAT/Ix0e/vLs7P5iXFz/k42O/8fBwPZ2cHL7k42M/l5aWvszLS7+Pjo6+rawsPpqZGb+Miws/4uFhP4WEBL65uLi9yslJP9XUVL7S0VG/+fj4vYyLC7+trCy++Pd3v7i3Nz/m5WU/5ONjv/Py8r7BwEA8nJsbP93cXD6npqY+goEBP8jHR7+8uzs/mJcXP+TjY7/x8HA9nZwcvuTjYz+Xlpa+zMtLv4+Ojr6trCw+mpkZv4yLCz/i4WE/hYQEvrm4uL3KyUk/1dRUvtLRUb/5+Pi9jIsLvw==",
+      "vectorSha256": "4368eec9aa12a37447b114b418dd0fb33fe0e614b39a8fdc4a89456e978af3bb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6a04dbf20e4381cd9ba9c01cddcb0e876cf15a1a5c9533c5f06f74e46517703a",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0626": {
+      "vector": "iYiIPefm5r6fnp6+5eRkvqGgoDzm5WW/4eDgvKempj7h4OC8rq0tv5CPD7/Lysq+yMdHv6SjIz+lpCQ+8/LyvtzbWz/HxsY+qqkpv/79fT+Miws/wL8/v5WUFD6fnp4+np0dv/Tzcz/KyUk/h4aGvpGQED3w728/1NNTP9HQUD2JiIg95+bmvp+enr7l5GS+oaCgPOblZb/h4OC8p6amPuHg4LyurS2/kI8Pv8vKyr7Ix0e/pKMjP6WkJD7z8vK+3NtbP8fGxj6qqSm//v19P4yLCz/Avz+/lZQUPp+enj6enR2/9PNzP8rJST+Hhoa+kZAQPfDvbz/U01M/0dBQPQ==",
+      "vectorSha256": "968828b2538adaefd03f35a49ca93903fbb09a239f606f6d43d97f820931a124",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "88465863820d7ca97c29384d1cd19443edb12bfec52092a731f9e45e84f7e986",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0627": {
+      "vector": "rq0tv9LRUb+wry8/8O9vv8nIyD3f3t6++Pd3P4yLCz/p6Oi9pKMjv/HwcD2wry+/wL8/v769PT/JyMg9k5KSvrCvLz+dnBy+k5KSPru6uj75+Pg91NNTP7CvLz+hoKA8vbw8vsLBQT+VlBQ+sK8vP9LRUb/JyMg9goEBP7m4uL2urS2/0tFRv7CvLz/w72+/ycjIPd/e3r7493c/jIsLP+no6L2koyO/8fBwPbCvL7/Avz+/vr09P8nIyD2TkpK+sK8vP52cHL6TkpI+u7q6Pvn4+D3U01M/sK8vP6GgoDy9vDy+wsFBP5WUFD6wry8/0tFRv8nIyD2CgQE/ubi4vQ==",
+      "vectorSha256": "c2517ccfdc4210b22bc2a137d3fb1dc722f7c0e06e857ab3250971e81eb59b75",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2917d7088c48fbc5712e872820de8c5bd76ca4ae8fe9d78268e092d7178cc074",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0628": {
+      "vector": "9vV1P/38fD7+/X2/zs1Nv+7tbb/p6Oi9q6qqvoeGhr7t7Gw+9PNzP6KhIT/5+Pi91dRUPpqZGb/j4uK+zs1Nv83MTL7t7Gw+7+7uPqCfHz/x8HA9+Pd3v6inJ7+NjAy+hYQEvqKhIT+Pjo4+5+bmvtrZWb/Y11e/nJsbv6CfH7/29XU//fx8Pv79fb/OzU2/7u1tv+no6L2rqqq+h4aGvu3sbD7083M/oqEhP/n4+L3V1FQ+mpkZv+Pi4r7OzU2/zcxMvu3sbD7v7u4+oJ8fP/HwcD3493e/qKcnv42MDL6FhAS+oqEhP4+Ojj7n5ua+2tlZv9jXV7+cmxu/oJ8fvw==",
+      "vectorSha256": "d782bb35a870da609b52b5675fe9ba47085212f8abc90203aab4613b8b5a898f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fa9f01190971555e9df9d0709a334719669dbbcf87042c6e6fd0a34613143230",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0629": {
+      "vector": "pKMjv4aFBb///v4+i4qKPrW0ND7Lysq+yMdHv4uKij6amRk//v19P/LxcT8AAIA/vLs7v+LhYb/Avz+/vbw8vu/u7j6TkpK+AACAP8vKyj65uLi9v76+PvDvbz8AAIA/pKMjv6KhIb+8uzs/nZwcPqKhIb/k42O/wL8/v/r5eT+koyO/hoUFv//+/j6Lioo+tbQ0PsvKyr7Ix0e/i4qKPpqZGT/+/X0/8vFxPwAAgD+8uzu/4uFhv8C/P7+9vDy+7+7uPpOSkr4AAIA/y8rKPrm4uL2/vr4+8O9vPwAAgD+koyO/oqEhv7y7Oz+dnBw+oqEhv+TjY7/Avz+/+vl5Pw==",
+      "vectorSha256": "185944da2d0f1b3d899c775b5d64fcbcb0c90577db3578a028afb33a3863ff65",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2e3dbfa2964d1ca2ccfef8ff220f2068bb5bffb274aff7ff2e2fdd932f0e20fc",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0630": {
+      "vector": "w8LCPuXkZL7Y11c/xcREvsTDQz+enR0/u7q6vvr5eb+UkxO/oaCgPAAAgL+FhAQ+rKsrP/z7e7/8+3u/wsFBv/Lxcb+BgIC7v76+PsrJSb+ZmJg9qqkpv+rpaT/U01M/3dxcvgAAgD+amRk//Pt7P5WUFD7R0FA91dRUvpqZGb/DwsI+5eRkvtjXVz/FxES+xMNDP56dHT+7urq++vl5v5STE7+hoKA8AACAv4WEBD6sqys//Pt7v/z7e7/CwUG/8vFxv4GAgLu/vr4+yslJv5mYmD2qqSm/6ulpP9TTUz/d3Fy+AACAP5qZGT/8+3s/lZQUPtHQUD3V1FS+mpkZvw==",
+      "vectorSha256": "1d51b605f9261a789ea470c717811165e7bab724abf047dfe7a268ba5607e9a5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b063eb67e1ce510336820090d502021f077faf1b892bf4e964ffccfd92866533",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0631": {
+      "vector": "tLMzP6uqqj7W1VU//Pt7P5eWlr7FxEQ+5eRkvurpaT+amRk/x8bGvtjXV7+WlRU/qqkpP728PD7Avz8/lpUVP9HQUD2joqK+2djYPdjXVz+koyO/yslJP5GQED2ioSG/5uVlv/HwcL2KiQm/1dRUvq6tLb+Miwu/w8LCPtPS0j60szM/q6qqPtbVVT/8+3s/l5aWvsXERD7l5GS+6ulpP5qZGT/Hxsa+2NdXv5aVFT+qqSk/vbw8PsC/Pz+WlRU/0dBQPaOior7Z2Ng92NdXP6SjI7/KyUk/kZAQPaKhIb/m5WW/8fBwvYqJCb/V1FS+rq0tv4yLC7/DwsI+09LSPg==",
+      "vectorSha256": "457d9097a0eb3ee39868861ebb19acea027bd8be186bde4011b33eaa95f888c3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d9aaeafd5a9863f4cc4e14cad497dfca86578deb2ee4842f0d783b65293ab0b4",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0632": {
+      "vector": "4+LivuHg4LyUkxM/kI8Pv4aFBb+Hhoa+k5KSvp6dHb/u7W2/kI8PP4qJCT/Lyso+k5KSPpmYmD3CwUE/397ePr69PT+dnBy+2tlZP9TTU7/Y11c/3dxcPoSDA7/y8XG/w8LCPujnZ7/r6uo+trU1P8/Ozr7U01M/hYQEPuXkZD7j4uK+4eDgvJSTEz+Qjw+/hoUFv4eGhr6TkpK+np0dv+7tbb+Qjw8/iokJP8vKyj6TkpI+mZiYPcLBQT/f3t4+vr09P52cHL7a2Vk/1NNTv9jXVz/d3Fw+hIMDv/Lxcb/DwsI+6Odnv+vq6j62tTU/z87OvtTTUz+FhAQ+5eRkPg==",
+      "vectorSha256": "9cefa36ce838aba21e4ed360b7ffc87a1f1e13ef961fb3a36a593bd3045b1e18",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "477cc9383d5e5b3109c7c4b2a489e0b7de6cec16eb9b3e07b00cbada4ce9909c",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0633": {
+      "vector": "vLs7v+TjY7+7urq+wcBAPJKRET/o52e/nJsbP8XERD7i4WG/xsVFP+TjY7+0szM/y8rKPo6NDb+KiQm/o6Kivtva2j7FxES+1dRUvtLRUb+mpSU/yMdHP/38fD7y8XG/jo0NP4mIiL2VlBQ+7Otrv9LRUb+NjAy+6ulpv6Oioj68uzu/5ONjv7u6ur7BwEA8kpERP+jnZ7+cmxs/xcREPuLhYb/GxUU/5ONjv7SzMz/Lyso+jo0Nv4qJCb+joqK+29raPsXERL7V1FS+0tFRv6alJT/Ix0c//fx8PvLxcb+OjQ0/iYiIvZWUFD7s62u/0tFRv42MDL7q6Wm/o6KiPg==",
+      "vectorSha256": "af18485fb293c3d19334f03242e625593e5b289cb36a67253b1cd65a27209c59",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "220e5181c80ccd980fe20ed9b2393b57b6676517d2e39f07c677920a176e0ba8",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0634": {
+      "vector": "tbQ0vrGwMD3s62u/8O9vv+XkZL6Miwu/y8rKPre2tj67uro+0tFRv9DPTz+cmxs/yslJP7CvL7+KiQk/nZwcPtzbW7+UkxM/nJsbP9zbW7+Lioq+zcxMPrCvLz/j4uI+0tFRv93cXL7a2Vk/wsFBv/Tzcz+4tze/uLc3P/LxcT+1tDS+sbAwPezra7/w72+/5eRkvoyLC7/Lyso+t7a2Pru6uj7S0VG/0M9PP5ybGz/KyUk/sK8vv4qJCT+dnBw+3Ntbv5STEz+cmxs/3Ntbv4uKir7NzEw+sK8vP+Pi4j7S0VG/3dxcvtrZWT/CwUG/9PNzP7i3N7+4tzc/8vFxPw==",
+      "vectorSha256": "294f7f78a215ffa2ca9f0da44d40d710dd566fff7b00773253d62435e9532d53",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "69850a08633ab2adae17e7cde428c49312c9cd125d99d7b81764ec1ff924dbf8",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0635": {
+      "vector": "pqUlP/f29j7e3V2/r66uPujnZ7/Lysq+rKsrP7KxMb+SkRG/0dBQPaKhIb/FxES+tbQ0PrGwML2amRk/kZAQPdrZWb++vT0/1dRUPsXERD7e3V2/oqEhv+fm5r61tDS+hIMDv/Tzc7+7urq+397ePqinJz+amRk/9/b2Pvj3d7+mpSU/9/b2Pt7dXb+vrq4+6Odnv8vKyr6sqys/srExv5KREb/R0FA9oqEhv8XERL61tDQ+sbAwvZqZGT+RkBA92tlZv769PT/V1FQ+xcREPt7dXb+ioSG/5+bmvrW0NL6EgwO/9PNzv7u6ur7f3t4+qKcnP5qZGT/39vY++Pd3vw==",
+      "vectorSha256": "c89c54f7b3c13eab18bfd977bf3c8682517e089268287d99a31dc77e58a084f4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d2bd11ab0c4dd52737862f67967acc8413de9a98112f46693e0651b7d3ccbd04",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0636": {
+      "vector": "oqEhP6yrK7/FxES+2tlZP8HAQLyIhwe/h4aGvtrZWT/U01M/4eDgPOfm5j7f3t6+h4aGvuno6L3Qz0+/vbw8PvTzcz/i4WG/tbQ0vv38fD7c21u/pKMjP9rZWT/CwUE/n56evvDvbz/m5WW/AACAP7CvLz+1tDS+3NtbP6SjIz+ioSE/rKsrv8XERL7a2Vk/wcBAvIiHB7+Hhoa+2tlZP9TTUz/h4OA85+bmPt/e3r6Hhoa+6ejovdDPT7+9vDw+9PNzP+LhYb+1tDS+/fx8PtzbW7+koyM/2tlZP8LBQT+fnp6+8O9vP+blZb8AAIA/sK8vP7W0NL7c21s/pKMjPw==",
+      "vectorSha256": "983e706241cc499fa64f8e3e0da2e0e4364ceb884397c6f98e70107fb46c14c5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d02a67ec7e3c5eece983b9485e711897f90f699f12d1ece058f70dffd769edd1",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0637": {
+      "vector": "rKsrP8XERD7GxUU/ycjIvcbFRT+NjAw+2djYvfb1dT+vrq4+19bWvri3Nz+/vr6+3dxcvqyrK7/l5GS+oqEhv/z7ez+TkpI+xcREvqempj7f3t4+0M9Pv5+enr6opyc/1NNTP6yrKz+hoKC8t7a2PszLS7+VlBQ+//7+vt7dXb+sqys/xcREPsbFRT/JyMi9xsVFP42MDD7Z2Ni99vV1P6+urj7X1ta+uLc3P7++vr7d3Fy+rKsrv+XkZL6ioSG//Pt7P5OSkj7FxES+p6amPt/e3j7Qz0+/n56evqinJz/U01M/rKsrP6GgoLy3trY+zMtLv5WUFD7//v6+3t1dvw==",
+      "vectorSha256": "9ab90421acaf15f5cff2c1980b90362694172f7b5d25b8bbd357093f418c12aa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d598e273e29172faab4adb50642a632ffda467a9b71858d3e9d57dad1a924011",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0638": {
+      "vector": "trU1v4KBAb/FxEQ+vr09v4WEBL6urS2/gYCAu4uKij7U01O/+Pd3P7a1NT/S0VG/xsVFv9LRUT+KiQk/pqUlv9DPTz/BwEC8kI8Pv9PS0r7n5uY+s7KyPvb1dT/S0VE/zcxMPvb1dT/Avz+/3NtbP728PD6amRm/rq0tP4yLCz+2tTW/goEBv8XERD6+vT2/hYQEvq6tLb+BgIC7i4qKPtTTU7/493c/trU1P9LRUb/GxUW/0tFRP4qJCT+mpSW/0M9PP8HAQLyQjw+/09LSvufm5j6zsrI+9vV1P9LRUT/NzEw+9vV1P8C/P7/c21s/vbw8PpqZGb+urS0/jIsLPw==",
+      "vectorSha256": "970cba365d63c5ede4d53f1859529d890214c49ba6b6a8679ae8bf88996723a1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "253f98216f297fa216fbda171de8c42de77e384bb9acfae899fa20ed9733d6c5",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0639": {
+      "vector": "7u1tv97dXT/Lyso+vbw8PqGgoLzd3Fy+3dxcvqempr7HxsY+h4aGvtPS0j6Ylxc/j46OPvf29j7n5uY+7OtrP9zbW7/X1ta+oqEhP6inJz/f3t4+h4aGPtfW1r6wry8/goEBPwAAgD/KyUm/j46OPpaVFT/Pzs6+ycjIvdLRUT/u7W2/3t1dP8vKyj69vDw+oaCgvN3cXL7d3Fy+p6amvsfGxj6Hhoa+09LSPpiXFz+Pjo4+9/b2Pufm5j7s62s/3Ntbv9fW1r6ioSE/qKcnP9/e3j6HhoY+19bWvrCvLz+CgQE/AACAP8rJSb+Pjo4+lpUVP8/Ozr7JyMi90tFRPw==",
+      "vectorSha256": "c6a3f64a07da7c2bdcf8be5a3e6fefa5ae422fa7189a9bcf40da0eef77588bcc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "09eeb2977d646456b15eb4cba3bdb9f5124ad0d3b7a14ad7c0ff1ba3ca4c73e8",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0640": {
+      "vector": "iYiIPdnY2L2Miwu/9fR0PoKBAT/7+vo+iYiIPbGwML36+Xk/iYiIvc7NTT+dnBy+u7q6Pvr5eT++vT2/t7a2Pr28PD6DgoI+3NtbP4yLCz/Z2Ni99vV1P6uqqr7JyMi9/Pt7P8fGxr6dnBy+uLc3P52cHL7e3V0/7Otrv+Hg4LyJiIg92djYvYyLC7/19HQ+goEBP/v6+j6JiIg9sbAwvfr5eT+JiIi9zs1NP52cHL67uro++vl5P769Pb+3trY+vbw8PoOCgj7c21s/jIsLP9nY2L329XU/q6qqvsnIyL38+3s/x8bGvp2cHL64tzc/nZwcvt7dXT/s62u/4eDgvA==",
+      "vectorSha256": "e6283b92a390fa35e0d06a0b5be54c41ead50f47fe7d4f9903c8eca350acf79f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "88723a9ec0be887afc77e66caefc21ad97a0edc572fa5573fd4e6cdb6cee0a7c",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0641": {
+      "vector": "mpkZP9jXV7/FxEQ+2NdXv5STE7/Ix0e/rq0tv7SzM7+trCw+rawsPqCfHz+Miwu/9PNzv5eWlj77+vo+urk5P9va2j62tTW/qqkpP+LhYT/h4OA8//7+PvPy8j7Hxsa+1NNTP93cXL7y8XG/5uVlv+TjY7/8+3u/lJMTv8XERD6amRk/2NdXv8XERD7Y11e/lJMTv8jHR7+urS2/tLMzv62sLD6trCw+oJ8fP4yLC7/083O/l5aWPvv6+j66uTk/29raPra1Nb+qqSk/4uFhP+Hg4Dz//v4+8/LyPsfGxr7U01M/3dxcvvLxcb/m5WW/5ONjv/z7e7+UkxO/xcREPg==",
+      "vectorSha256": "8b823d30c993d24341e33ccbfc4a4ae23caf7914fc01e6d8741e0bb6c2442651",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cc149814361c29269595cf3a06a5bedcb625d4f083bfbc4ee964070d0e023698",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0642": {
+      "vector": "pqUlv4qJCb+7uro+mJcXP9TTUz+Pjo4+09LSvs/Ozj6ZmJg9hIMDv7q5Ob/Qz08/7OtrP6CfH7/19HQ+lpUVv8vKyj7h4OA8iokJv/HwcD3S0VE/jo0NP4aFBb+ioSE/goEBP4GAgDuZmJi9ubi4PbSzM7/W1VU/7exsPpOSkj6mpSW/iokJv7u6uj6Ylxc/1NNTP4+Ojj7T0tK+z87OPpmYmD2EgwO/urk5v9DPTz/s62s/oJ8fv/X0dD6WlRW/y8rKPuHg4DyKiQm/8fBwPdLRUT+OjQ0/hoUFv6KhIT+CgQE/gYCAO5mYmL25uLg9tLMzv9bVVT/t7Gw+k5KSPg==",
+      "vectorSha256": "f5a41cd5c2b797f553839653cd1d5e3484e415aa9fa2d41b404219c6f8decefc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2d3baecbe9a34bb3893e23e7f5309e35b2833b87e8c63dd0c080768b26ea9da4",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0643": {
+      "vector": "iIcHP7KxMT+ioSE/m5qaPt3cXL7k42M/9vV1v6CfHz+RkBC9vr09v5uamr6BgIC70tFRP6qpKT+ioSG/397evqCfHz/GxUW/5+bmvpaVFb/V1FS+1tVVP6qpKb+DgoK+7u1tv8nIyL3b2to+29ravtLRUT+cmxs/8vFxP4GAgLuIhwc/srExP6KhIT+bmpo+3dxcvuTjYz/29XW/oJ8fP5GQEL2+vT2/m5qavoGAgLvS0VE/qqkpP6KhIb/f3t6+oJ8fP8bFRb/n5ua+lpUVv9XUVL7W1VU/qqkpv4OCgr7u7W2/ycjIvdva2j7b2tq+0tFRP5ybGz/y8XE/gYCAuw==",
+      "vectorSha256": "033439a22e3d5c513b7b6bad2548ad2bf108b23c96ca5f51ddbb2621e2546ea1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c3d8d0a664f105cf7b21597fe8d42f48cf1d463565ea2b5f0973b649e8cdf87f",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0644": {
+      "vector": "wsFBP6GgoDzJyMi91dRUPsC/P7+DgoK+jo0NP5+enr60szO/8vFxv5aVFb+2tTW/1tVVP4yLC7+vrq4+pKMjP/v6+r7j4uI+AACAP/j3d7+/vr4+9/b2vvb1dT/T0tK+8vFxv4KBAb/q6Wk/o6KivqmoqL2fnp6+1NNTP6KhIb/CwUE/oaCgPMnIyL3V1FQ+wL8/v4OCgr6OjQ0/n56evrSzM7/y8XG/lpUVv7a1Nb/W1VU/jIsLv6+urj6koyM/+/r6vuPi4j4AAIA/+Pd3v7++vj739va+9vV1P9PS0r7y8XG/goEBv+rpaT+joqK+qaiovZ+enr7U01M/oqEhvw==",
+      "vectorSha256": "d791f6dc7f1b7e22f6abac0b2edaf6efd08f5a9e53e4c3da3bce431a71a13462",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e082739a205fc65826073525ea3aabd141b8ff04af42fa4b073ff4577558e92f",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0645": {
+      "vector": "6+rqvtnY2D2dnBy+np0dv4mIiD3o52c/3NtbP8jHR7+6uTm/3t1dP6qpKb+NjAy+2NdXP//+/r7s62s/3Ntbv/b1db+pqKg929raPoWEBD7CwUG/5+bmPri3N7+amRk/6ejovejnZz/n5uY+xsVFv+DfXz/19HQ+rq0tP8XERL7r6uq+2djYPZ2cHL6enR2/iYiIPejnZz/c21s/yMdHv7q5Ob/e3V0/qqkpv42MDL7Y11c///7+vuzraz/c21u/9vV1v6moqD3b2to+hYQEPsLBQb/n5uY+uLc3v5qZGT/p6Oi96OdnP+fm5j7GxUW/4N9fP/X0dD6urS0/xcREvg==",
+      "vectorSha256": "62c47195e74fbf1486fc67809beb03645b3cf842a62799d9af5d96bd52002baa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "458d6c3188f3ed1c23ee2b6eeb40f512058ab6901fb924cc71f3b91def9ed667",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0646": {
+      "vector": "vLs7v728PL6fnp4+hIMDv4WEBL6Lioq+jo0Nv4WEBD6qqSk/tLMzv6CfHz+/vr6+lpUVP4+Ojj7Pzs4+2NdXv5WUFL7R0FC9tbQ0PtLRUT/q6Wm/6ulpv+rpaT/Y11c/z87OPquqqr6EgwO/6ejovby7O7/Avz+/vr09P5aVFT+8uzu/vbw8vp+enj6EgwO/hYQEvouKir6OjQ2/hYQEPqqpKT+0szO/oJ8fP7++vr6WlRU/j46OPs/Ozj7Y11e/lZQUvtHQUL21tDQ+0tFRP+rpab/q6Wm/6ulpP9jXVz/Pzs4+q6qqvoSDA7/p6Oi9vLs7v8C/P7++vT0/lpUVPw==",
+      "vectorSha256": "d5b00aa741bc49934d7d94db5b105238fccec61a39955e5aac660bedf7b42d0f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2268a73e6f5d3990d426cf50caa3b3146d7996e80b0bf4ebb3553e712220deca",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0647": {
+      "vector": "tLMzP8LBQT+lpCQ+8vFxP9nY2L22tTW/p6amvurpab+EgwO/19bWvpeWlj7JyMi9+/r6PtTTU7/b2to+kI8PP83MTL7y8XG/hIMDv+rpaT/JyMi90dBQPYaFBb+ioSE/3t1dP/Tzcz+7urq+gYCAu/j3dz+8uzs/srExP7KxMT+0szM/wsFBP6WkJD7y8XE/2djYvba1Nb+npqa+6ulpv4SDA7/X1ta+l5aWPsnIyL37+vo+1NNTv9va2j6Qjw8/zcxMvvLxcb+EgwO/6ulpP8nIyL3R0FA9hoUFv6KhIT/e3V0/9PNzP7u6ur6BgIC7+Pd3P7y7Oz+ysTE/srExPw==",
+      "vectorSha256": "0436ba22ff21a54052d2d93951121c720b2217f878b368b26858f66f719d5c87",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d9e094f87225560b3e4aa573be16b6c766073ef473863dd0eef9517ffbddd8d8",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0648": {
+      "vector": "trU1P6CfHz+OjQ2/qKcnv8zLSz/Avz+/z87OvpaVFb+1tDS+i4qKvry7Oz+cmxu/goEBP9PS0r6UkxM/pKMjP5uamr7r6uq+9/b2vqinJ7/n5uY+0M9PP4yLCz/6+Xm/vbw8PpKREb/KyUm/9vV1P9/e3j64tzc/vLs7P8PCwr62tTU/oJ8fP46NDb+opye/zMtLP8C/P7/Pzs6+lpUVv7W0NL6Lioq+vLs7P5ybG7+CgQE/09LSvpSTEz+koyM/m5qavuvq6r739va+qKcnv+fm5j7Qz08/jIsLP/r5eb+9vDw+kpERv8rJSb/29XU/397ePri3Nz+8uzs/w8LCvg==",
+      "vectorSha256": "dd4448abdf0aedf28c124cd30a1d56aeae7862201a59bcc37be7482c04f9ffb9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dacf392ce5204c35695ddd32c04bc9d15945422cb9e7c50397371bfab7dbdd4f",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0649": {
+      "vector": "g4KCvo2MDD6joqI+vbw8PomIiL2sqyu/o6KiPtnY2D2cmxu/q6qqvtPS0j4AAIA/+/r6Pv/+/j6DgoK+/v19P8bFRT/s62u/6ulpv83MTD6enR0/oaCgPNrZWb+enR0/5eRkPtfW1r7X1ta+np0dP//+/j79/Hy+7exsPvv6+r6DgoK+jYwMPqOioj69vDw+iYiIvayrK7+joqI+2djYPZybG7+rqqq+09LSPgAAgD/7+vo+//7+PoOCgr7+/X0/xsVFP+zra7/q6Wm/zcxMPp6dHT+hoKA82tlZv56dHT/l5GQ+19bWvtfW1r6enR0///7+Pv38fL7t7Gw++/r6vg==",
+      "vectorSha256": "2915d6e519f11cfd9aaed01e7c483d9135c67b76070ea87e8b230e62bd78025d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5f91a897772aa88d3255b4ffbebf5ffee20a0b99ce8213ce9c4a4acebf609d41",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0650": {
+      "vector": "oqEhP6Oior719HQ+1tVVP/j3dz+opyc/mZiYPcvKyj69vDw+lZQUPt3cXL6JiIi9zMtLP8PCwr7j4uK+zs1Nv+blZT+Ylxe/6ulpv769Pb+GhQU/pqUlv+zra7+zsrK+jo0NP5aVFT+3tra++vl5P+XkZL77+vo+nZwcvoGAgLuioSE/o6KivvX0dD7W1VU/+Pd3P6inJz+ZmJg9y8rKPr28PD6VlBQ+3dxcvomIiL3My0s/w8LCvuPi4r7OzU2/5uVlP5iXF7/q6Wm/vr09v4aFBT+mpSW/7Otrv7Oysr6OjQ0/lpUVP7e2tr76+Xk/5eRkvvv6+j6dnBy+gYCAuw==",
+      "vectorSha256": "0539744a0372d241b7f6a90ecad140a05aa3479d372577cd87b4510413d87370",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d0579eeafbd389b297926477e54f4719f2340b21c22d0a53c6ca52fc63be6c7f",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0651": {
+      "vector": "8/LyvoqJCT/29XW/oqEhv6WkJD7493e/8fBwvaempr6bmpq+g4KCPqWkJD6/vr6+mJcXP769Pb+trCy+lpUVP7y7Oz/493c/iIcHP/j3d7+OjQ0/oJ8fP+7tbb/5+Pg9yslJP6inJz+dnBw+qqkpP8/Ozr7Ix0c/8vFxv7W0NL7z8vK+iokJP/b1db+ioSG/paQkPvj3d7/x8HC9p6amvpuamr6DgoI+paQkPr++vr6Ylxc/vr09v62sLL6WlRU/vLs7P/j3dz+Ihwc/+Pd3v46NDT+gnx8/7u1tv/n4+D3KyUk/qKcnP52cHD6qqSk/z87OvsjHRz/y8XG/tbQ0vg==",
+      "vectorSha256": "59a3b83451dd606a6ace322eca9cb5add34c982b1af5842ffd50cc23139fdc42",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "43c4052f9404785659a09450cb216acaddfbc304c6cf098fe4d393d44ce30769",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0652": {
+      "vector": "j46OvublZT+KiQk/5eRkvqGgoDyJiIi9k5KSPry7O7/19HQ+l5aWPq6tLT/s62u/rq0tv7q5OT+zsrI+iYiIvff29r6EgwO/xMNDP6qpKT+joqI+rKsrP7KxMT/a2Vk/p6amPtXUVL7Qz0+/xcREvvDvb7/8+3u/+/r6vp2cHL6Pjo6+5uVlP4qJCT/l5GS+oaCgPImIiL2TkpI+vLs7v/X0dD6XlpY+rq0tP+zra7+urS2/urk5P7Oysj6JiIi99/b2voSDA7/Ew0M/qqkpP6Oioj6sqys/srExP9rZWT+npqY+1dRUvtDPT7/FxES+8O9vv/z7e7/7+vq+nZwcvg==",
+      "vectorSha256": "e484cacfaa7b2b92331d44d8bd5d0f5e7d6edc51d495bd4a9680c267ce70063a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5cf2c4638277a4229ea5d60a29dcac77423ee1d4a8d5d8eca96518670802416c",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0653": {
+      "vector": "3t1dP8/Ozr6zsrI+uLc3v+/u7j7p6Oi9nJsbv8jHR7/R0FC91tVVv8jHRz+xsDC9jYwMPoyLC7+joqK+h4aGvpuamj7FxES++fj4Pfj3d7+Pjo4+j46OvszLSz/V1FS+5ONjv769Pb+JiIi91NNTP7Oysj6VlBS+//7+Po+Ojj7e3V0/z87OvrOysj64tze/7+7uPuno6L2cmxu/yMdHv9HQUL3W1VW/yMdHP7GwML2NjAw+jIsLv6Oior6Hhoa+m5qaPsXERL75+Pg9+Pd3v4+Ojj6Pjo6+zMtLP9XUVL7k42O/vr09v4mIiL3U01M/s7KyPpWUFL7//v4+j46OPg==",
+      "vectorSha256": "fe33fb6b20a5ef4c9293801c9ccc9773ee81ebe7c8ee40d0ef549776fcd11edc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ee4cac24bb71321c7915e37a913a575ea6678f04a35ce5650e2177e9ac6dbfa3",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0654": {
+      "vector": "lpUVP8rJSb/b2tq+nJsbv+no6L39/Hw++Pd3P5GQEL3o52e/mpkZP5aVFb/T0tI+mJcXP8/Ozr6ZmJi97OtrP+XkZD6gnx8/iokJv8nIyD329XU/z87OPrm4uD3Ew0O/p6amvtXUVD6wry8/j46OPsvKyr6trCw+x8bGPtjXV7+WlRU/yslJv9va2r6cmxu/6ejovf38fD7493c/kZAQvejnZ7+amRk/lpUVv9PS0j6Ylxc/z87OvpmYmL3s62s/5eRkPqCfHz+KiQm/ycjIPfb1dT/Pzs4+ubi4PcTDQ7+npqa+1dRUPrCvLz+Pjo4+y8rKvq2sLD7HxsY+2NdXvw==",
+      "vectorSha256": "44ad2c9aa9c46601c624eb543fbe6f76c66ea99b173e6b50f2b6d1037e5a87e1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ca1b4932719ffb7b0ccc35b4cb4c76f59ccf3b8cfab38b1e569ad7a34d95b114",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0655": {
+      "vector": "gYCAO/HwcL2Qjw+/rawsvoyLC7+fnp4+0dBQvZeWlj62tTW/oaCgPJuamj7HxsY+m5qavqKhIb+OjQ0/wsFBP6GgoDzEw0M//fx8vomIiD0AAIC/09LSPo+Ojr6+vT0/7OtrvwAAgD+amRk/397ePtfW1j7493c/nJsbv769Pb+BgIA78fBwvZCPD7+trCy+jIsLv5+enj7R0FC9l5aWPra1Nb+hoKA8m5qaPsfGxj6bmpq+oqEhv46NDT/CwUE/oaCgPMTDQz/9/Hy+iYiIPQAAgL/T0tI+j46Ovr69PT/s62u/AACAP5qZGT/f3t4+19bWPvj3dz+cmxu/vr09vw==",
+      "vectorSha256": "4558f437ebabbbb228d51d671e7dc2b2f20c9f98055d2ff818b89878d8fe1bb2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8078386a3aa779a52582a6b1592fc6e082e1608800b45cde0affccb7b5fb3221",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0656": {
+      "vector": "3t1dP9rZWb/T0tK+hoUFv+XkZL6npqa+y8rKvqOior7Z2Ng9vLs7P4GAgDvV1FS+paQkvtnY2L3JyMg9urk5v9/e3j6trCy+gYCAu728PL6fnp6+pqUlv56dHb/a2Vm/t7a2Pru6uj6hoKA8s7KyPurpaT/5+Pg9rKsrP4OCgr7e3V0/2tlZv9PS0r6GhQW/5eRkvqempr7Lysq+o6KivtnY2D28uzs/gYCAO9XUVL6lpCS+2djYvcnIyD26uTm/397ePq2sLL6BgIC7vbw8vp+enr6mpSW/np0dv9rZWb+3trY+u7q6PqGgoDyzsrI+6ulpP/n4+D2sqys/g4KCvg==",
+      "vectorSha256": "46c37e6d873326ff1af3840ce763610de740ad63a3ec9aaa47c0923f6806ec42",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ee134b3d63564d578ddd80656b728c23b76a7f68582d3113adae82acf48fd55f",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0657": {
+      "vector": "p6amvp2cHD7S0VE/zcxMPrq5Ob/s62s/8O9vv5STE7+WlRU/sK8vP/LxcT+wry+/urk5P+7tbT/29XU///7+PqOioj7q6Wk/pKMjv4uKir6+vT2/wsFBP9jXVz/HxsY+mpkZv8bFRT/n5ua+lpUVv/r5eb+Ylxc/lZQUPtLRUb+npqa+nZwcPtLRUT/NzEw+urk5v+zraz/w72+/lJMTv5aVFT+wry8/8vFxP7CvL7+6uTk/7u1tP/b1dT///v4+o6KiPurpaT+koyO/i4qKvr69Pb/CwUE/2NdXP8fGxj6amRm/xsVFP+fm5r6WlRW/+vl5v5iXFz+VlBQ+0tFRvw==",
+      "vectorSha256": "b67cdc0b3f531768733288d3613f5c394ea6091cadc70681d0fa33afc37b8534",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5693e89923f50836cad7f828dcf6fabfa8f42e5d21e0ebb133e2463503cb9217",
+      "updatedAt": "2025-09-20T22:27:41.538Z"
+    },
+    "j-0658": {
+      "vector": "vbw8vrGwML2Pjo6+lpUVP4GAgDuVlBQ+iIcHv/Tzc7/X1tY+xcREvuXkZD63trY+vLs7v/HwcD3083M/lJMTP9jXVz/n5uY+nJsbv//+/r7t7Gy+p6amvuzra7+7uro+vLs7P/Tzcz+FhAQ+5uVlv7Oysj719HS+1NNTP5CPD7+9vDy+sbAwvY+Ojr6WlRU/gYCAO5WUFD6Ihwe/9PNzv9fW1j7FxES+5eRkPre2tj68uzu/8fBwPfTzcz+UkxM/2NdXP+fm5j6cmxu///7+vu3sbL6npqa+7Otrv7u6uj68uzs/9PNzP4WEBD7m5WW/s7KyPvX0dL7U01M/kI8Pvw==",
+      "vectorSha256": "3b95a2a7a95a07c979165862ae7f80bb7d9518040e282e86bd9933e72f9ba826",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "687a5cca80923c06b5679cad2287f9c9ebb9324062560aaeddf9900dac61e938",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0659": {
+      "vector": "+Pd3P6alJT+2tTW/xcREvtLRUT/Ix0c/6ejoPeTjY7+4tze/+fj4vY6NDT/z8vK+tLMzP9rZWT+4tze/jIsLv+fm5j7T0tI+g4KCPvj3dz+/vr6+jYwMvvz7e7/u7W2/5ONjv6yrK7/g318/xsVFP6inJz/Qz08/hIMDP9zbW7/493c/pqUlP7a1Nb/FxES+0tFRP8jHRz/p6Og95ONjv7i3N7/5+Pi9jo0NP/Py8r60szM/2tlZP7i3N7+Miwu/5+bmPtPS0j6DgoI++Pd3P7++vr6NjAy+/Pt7v+7tbb/k42O/rKsrv+DfXz/GxUU/qKcnP9DPTz+EgwM/3Ntbvw==",
+      "vectorSha256": "615d6b89a436f9b4d725386636324b530b7d1322f94601d3fd1c8b7e4149c2d3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fbd22567e8e38e0e2470c643d9ec243ab9b4a0fb506e02090e2aefe2d3e7c112",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0660": {
+      "vector": "4uFhP87NTT/u7W0/ubi4vQAAgD/R0FA9trU1P/Dvb7/OzU0/7exsvublZb/l5GQ+i4qKPufm5j7DwsI+j46OvqqpKb/GxUU/mZiYPbq5Ob+3trY+urk5P/f29r6zsrI+oqEhv8TDQz+bmpo+kI8Pv9TTUz/u7W2/iIcHv7CvLz/i4WE/zs1NP+7tbT+5uLi9AACAP9HQUD22tTU/8O9vv87NTT/t7Gy+5uVlv+XkZD6Lioo+5+bmPsPCwj6Pjo6+qqkpv8bFRT+ZmJg9urk5v7e2tj66uTk/9/b2vrOysj6ioSG/xMNDP5uamj6Qjw+/1NNTP+7tbb+Ihwe/sK8vPw==",
+      "vectorSha256": "79a34c3c25adc10cb876419418bf519eb67466eba0005d09c173d4286cdca90e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f0e6f674ff86da08e6620d9ca2b9b05c2be28923addc42ac2fe1a638e9093cd7",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0661": {
+      "vector": "paQkPtHQUD2SkRE/wcBAvNHQUL2NjAy+0tFRv9jXV7/y8XG/g4KCvry7Oz+npqY+1dRUPrOysj6trCy+x8bGvru6uj6Ylxc/+/r6PoSDA7/+/X0/hIMDv+no6L3v7u6+zs1NP/X0dD6Xlpa+zMtLP7++vr7Qz08/v76+Pri3Nz+lpCQ+0dBQPZKRET/BwEC80dBQvY2MDL7S0VG/2NdXv/Lxcb+DgoK+vLs7P6empj7V1FQ+s7KyPq2sLL7Hxsa+u7q6PpiXFz/7+vo+hIMDv/79fT+EgwO/6ejove/u7r7OzU0/9fR0PpeWlr7My0s/v76+vtDPTz+/vr4+uLc3Pw==",
+      "vectorSha256": "37a7d6ed824b85b30537541e992bfbe4d7ecad940a79a6adafb6829a49afd677",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9486c87e796e1714075fdda99aac6a4eaecbbe3efe3e7144e69e5ae550e7afdb",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0662": {
+      "vector": "vLs7P+XkZD6urS2/n56ePoyLC7/j4uI+v76+vs3MTD7w72+/sK8vv8LBQb+rqqo+ycjIPYuKir7083O/oqEhv+vq6r4AAIC/zs1NP+XkZL68uzs/xMNDP9bVVb/y8XG/h4aGPsfGxj7Qz0+//Pt7PwAAgD/6+Xm/hYQEPpOSkj68uzs/5eRkPq6tLb+fnp4+jIsLv+Pi4j6/vr6+zcxMPvDvb7+wry+/wsFBv6uqqj7JyMg9i4qKvvTzc7+ioSG/6+rqvgAAgL/OzU0/5eRkvry7Oz/Ew0M/1tVVv/Lxcb+HhoY+x8bGPtDPT7/8+3s/AACAP/r5eb+FhAQ+k5KSPg==",
+      "vectorSha256": "41aba9743f5c9981705a5781c0f3462f3312f9f7e172c6cd24600869f91040bc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dd9c29a73ab8509908281faa8c5d062f4500e663dde11507a1b118fdff0390a4",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0663": {
+      "vector": "ycjIveblZb/KyUk/s7KyvuXkZL7b2tq+pqUlv/Dvbz+gnx8/np0dP5ybG7/GxUW/xcREvpeWlr6DgoI+9fR0vuDfXz/y8XE/paQkvrSzMz/l5GS+hoUFv9va2r7U01O/3dxcvrOysr6TkpK+wcBAvODfXz/X1ta+9vV1P93cXL7JyMi95uVlv8rJST+zsrK+5eRkvtva2r6mpSW/8O9vP6CfHz+enR0/nJsbv8bFRb/FxES+l5aWvoOCgj719HS+4N9fP/LxcT+lpCS+tLMzP+XkZL6GhQW/29ravtTTU7/d3Fy+s7KyvpOSkr7BwEC84N9fP9fW1r729XU/3dxcvg==",
+      "vectorSha256": "9ed7d3e75ac8aa9e0b7bca20c91ac3d9d74404ff33da9b4d2b2619443f117969",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "730de45363492df7cfce321d675aa061eff86bd9633d491664535b7eef4afa64",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0664": {
+      "vector": "w8LCPurpab/y8XE/i4qKvqalJT/493e/goEBv/n4+L3Qz0+/9fR0vszLSz+lpCS+/v19P66tLT/g31+/lJMTP56dHT+9vDw++/r6Pra1Nb+rqqq+7u1tP6CfHz+bmpo+vLs7P9PS0j7f3t4+nZwcPvr5eT/n5uY+6OdnP7u6ur7DwsI+6ulpv/LxcT+Lioq+pqUlP/j3d7+CgQG/+fj4vdDPT7/19HS+zMtLP6WkJL7+/X0/rq0tP+DfX7+UkxM/np0dP728PD77+vo+trU1v6uqqr7u7W0/oJ8fP5uamj68uzs/09LSPt/e3j6dnBw++vl5P+fm5j7o52c/u7q6vg==",
+      "vectorSha256": "fe78761a454cd185aa617728015df535359941d7a71cb18584eb803b167593eb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b00bf85dd2043f701861e56bfed610c9ce97be2555f6cfa6ddb4b793fcb9f351",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0665": {
+      "vector": "kZAQvba1Nb/a2Vm/kI8PP7y7Oz+EgwM/wcBAvJOSkj7W1VU/hIMDv6CfH7/Avz8/8fBwPQAAgL+dnBw+trU1P4WEBL7p6Oi9+vl5v5mYmL2NjAw+u7q6PpqZGb+ioSE/j46OPpeWlr7FxES+gYCAu93cXL7FxEQ+mpkZP5mYmD2RkBC9trU1v9rZWb+Qjw8/vLs7P4SDAz/BwEC8k5KSPtbVVT+EgwO/oJ8fv8C/Pz/x8HA9AACAv52cHD62tTU/hYQEvuno6L36+Xm/mZiYvY2MDD67uro+mpkZv6KhIT+Pjo4+l5aWvsXERL6BgIC73dxcvsXERD6amRk/mZiYPQ==",
+      "vectorSha256": "818eed9c28cc16f42aa327f8856e0f1deb3e68030139a2b3399cfa3c89ef53e0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7b2513c7ddc17ea4ea3e30df870093da6f71037691ae33d0a35a677f6498cc89",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0666": {
+      "vector": "srExv9TTU7/S0VE/6OdnP+DfXz+wry8/7u1tv8XERD6Ylxe/yMdHP6yrKz+zsrK+rKsrP6inJz+opyc/srExP+3sbL65uLi9xsVFv83MTD6SkRE/8vFxP4iHBz/e3V0/kI8Pv/Py8r7CwUE/nJsbv97dXT+Qjw8/z87OvrKxMb+ysTG/1NNTv9LRUT/o52c/4N9fP7CvLz/u7W2/xcREPpiXF7/Ix0c/rKsrP7Oysr6sqys/qKcnP6inJz+ysTE/7exsvrm4uL3GxUW/zcxMPpKRET/y8XE/iIcHP97dXT+Qjw+/8/LyvsLBQT+cmxu/3t1dP5CPDz/Pzs6+srExvw==",
+      "vectorSha256": "ad04b454062dbee096de800ee2319b727e8459bf288921d60c4323353f8ae63e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2716e8f3efd7099834e3d553d5d3d3d862741d99c8f8c3ee3843e032eec74c27",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0667": {
+      "vector": "xsVFv7a1Nb+DgoI+k5KSPrCvL7+mpSW/nJsbP6WkJL67urq+9/b2Pv79fb/d3Fw++/r6vu3sbD6Qjw8/4uFhP5aVFb/s62s/+/r6vrW0ND7e3V0/lpUVv8bFRb+pqKi92NdXP8rJSb/Y11c/mZiYvaWkJD7w728/hYQEvvPy8j7GxUW/trU1v4OCgj6TkpI+sK8vv6alJb+cmxs/paQkvru6ur739vY+/v19v93cXD77+vq+7exsPpCPDz/i4WE/lpUVv+zraz/7+vq+tbQ0Pt7dXT+WlRW/xsVFv6moqL3Y11c/yslJv9jXVz+ZmJi9paQkPvDvbz+FhAS+8/LyPg==",
+      "vectorSha256": "f84eaf1f5dbe3b0221082a5eb47b92ea5b0163bd4b2eef36bf0af800266971df",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1d25a0a4282dcd6b51bd019b419dc7f035f54196ee351d75eb1beb7694f76fbc",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0668": {
+      "vector": "oqEhP+fm5r6XlpY+7+7uvpmYmD3Ix0e/3NtbP/f29r6JiIi9vLs7P/z7ez/KyUm/1tVVP6qpKT/j4uK+l5aWvuzra7/y8XG/gYCAO8vKyr7JyMi9kZAQPdTTUz+ioSE/uLc3v8rJST+ioSG/2NdXv6uqqj6enR2/iIcHv8jHR7+ioSE/5+bmvpeWlj7v7u6+mZiYPcjHR7/c21s/9/b2vomIiL28uzs//Pt7P8rJSb/W1VU/qqkpP+Pi4r6Xlpa+7Otrv/Lxcb+BgIA7y8rKvsnIyL2RkBA91NNTP6KhIT+4tze/yslJP6KhIb/Y11e/q6qqPp6dHb+Ihwe/yMdHvw==",
+      "vectorSha256": "24122ec57a8846449c08dfa83008878ceaa5ad02ed55ce9d0674057386a4ed36",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d046a544891ced4277ddfd1bead4475a0a07804d7384e9d024e42f14aa313c1c",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0669": {
+      "vector": "np0dP+fm5r78+3s//Pt7v52cHD7Ew0O/x8bGPuDfXz+ZmJg9oqEhP+/u7r7e3V2/6ulpv8C/Pz/5+Pg97Otrv/v6+r6trCy+0dBQPdbVVb++vT2/4+LiPoKBAb/l5GQ+j46OPtva2j6opye/np0dP4GAgLudnBw+vLs7P4+Ojj6enR0/5+bmvvz7ez/8+3u/nZwcPsTDQ7/HxsY+4N9fP5mYmD2ioSE/7+7uvt7dXb/q6Wm/wL8/P/n4+D3s62u/+/r6vq2sLL7R0FA91tVVv769Pb/j4uI+goEBv+XkZD6Pjo4+29raPqinJ7+enR0/gYCAu52cHD68uzs/j46OPg==",
+      "vectorSha256": "96616afeb447bf4395bb76a8f9764d727029d64b0c965ce6d2e50d2357579e75",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ce46fd02931eb1ef89d044110bdf8f0a416a861521b83f9ca3b62cce7f93dda3",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0671": {
+      "vector": "h4aGvtva2r7a2Vk/oJ8fP5iXF7/c21u/9fR0PtjXVz+lpCQ+2tlZP/Dvbz+5uLg9kI8PP769Pb+Ihwc/+Pd3P+no6D2ysTG/gYCAO7q5OT/r6uo+7u1tv7i3N7+hoKC8/Pt7v/v6+j7Z2Ni9v76+vqyrK7+pqKg9x8bGvoiHB7+Hhoa+29ravtrZWT+gnx8/mJcXv9zbW7/19HQ+2NdXP6WkJD7a2Vk/8O9vP7m4uD2Qjw8/vr09v4iHBz/493c/6ejoPbKxMb+BgIA7urk5P+vq6j7u7W2/uLc3v6GgoLz8+3u/+/r6PtnY2L2/vr6+rKsrv6moqD3Hxsa+iIcHvw==",
+      "vectorSha256": "1e7f837e06b13b600b84deeb8530cf9a52ba410bbf93d02c1441294f9b508b1d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5e49eccf34129eeb94ecf78bc721c3fb8e2780dcba09247d02be72502a8a4e3c",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0672": {
+      "vector": "hYQEvtHQUD2zsrK+i4qKvvf29r4AAIA/6+rqPqWkJD7x8HC9u7q6vurpaT/i4WG/6ejovfDvb7+3tra+xMNDP5eWlj7My0s/397ePrm4uD3q6Wk/+Pd3P5GQED3+/X2/5uVlP7e2tr7j4uI++fj4veDfXz+RkBA9yslJP8rJST+FhAS+0dBQPbOysr6Lioq+9/b2vgAAgD/r6uo+paQkPvHwcL27urq+6ulpP+LhYb/p6Oi98O9vv7e2tr7Ew0M/l5aWPszLSz/f3t4+ubi4PerpaT/493c/kZAQPf79fb/m5WU/t7a2vuPi4j75+Pi94N9fP5GQED3KyUk/yslJPw==",
+      "vectorSha256": "960ec5cd87c943a2d3cea17221705a32d4a2a2cc38762929be90ba78c2d08f02",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6f86535d42ffba947851f40f710852e1a5e5b78bf4fb8401f252b870ef84e4e4",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0673": {
+      "vector": "2tlZv9TTU7+Lioo+q6qqvr69Pb/j4uI+j46OvrW0NL60szO/7OtrP+LhYb+xsDA9mZiYPfPy8j6trCy+l5aWPo2MDD6urS0/9vV1P7m4uL27uro+np0dP+LhYb/z8vI+zMtLP56dHT/Pzs6+m5qaPv38fD6dnBy+xsVFv/X0dD7a2Vm/1NNTv4uKij6rqqq+vr09v+Pi4j6Pjo6+tbQ0vrSzM7/s62s/4uFhv7GwMD2ZmJg98/LyPq2sLL6XlpY+jYwMPq6tLT/29XU/ubi4vbu6uj6enR0/4uFhv/Py8j7My0s/np0dP8/Ozr6bmpo+/fx8Pp2cHL7GxUW/9fR0Pg==",
+      "vectorSha256": "5bd34f2d519a1cced202000ae0cea1f5f657b71f124e7a34fd5c46dcf43c0f64",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1316a25521b85c6926f50f8589bc6aa591d6fa74aece0fbce5ce4ca69f6c1d9e",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0675": {
+      "vector": "4eDgPL++vj7o52e/wL8/P6Oioj6Ihwc/19bWvtTTU7/s62s/iIcHP769Pb/My0s/6ejovYWEBL62tTW/nZwcPrW0ND7Ix0e/7OtrP5ybG7/V1FS+lpUVv/79fT+9vDy+np0dv6inJ7/x8HA9wsFBv/LxcT+vrq6+3dxcvuvq6j7h4OA8v76+PujnZ7/Avz8/o6KiPoiHBz/X1ta+1NNTv+zraz+Ihwc/vr09v8zLSz/p6Oi9hYQEvra1Nb+dnBw+tbQ0PsjHR7/s62s/nJsbv9XUVL6WlRW//v19P728PL6enR2/qKcnv/HwcD3CwUG/8vFxP6+urr7d3Fy+6+rqPg==",
+      "vectorSha256": "c78887789cfa03d7d4bcb98cb7ab9f4375e0345259c850d46ff0106d4a39778c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "83af0cdfa8c34a16f5c321e5716f2593961cf5326535fe68312c871ff85464ba",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0676": {
+      "vector": "iYiIPcfGxj6Miws/7exsvpeWlr6fnp6+7exsvpCPD7+zsrK+wcBAvK6tLb/Pzs6+6ulpv8C/Pz/g318///7+Pr++vj7Qz0+/h4aGPrq5OT/j4uI+m5qaPurpab/29XW/5ONjP9LRUT+fnp6+jYwMvqWkJL7FxES+m5qaPry7O7+JiIg9x8bGPoyLCz/t7Gy+l5aWvp+enr7t7Gy+kI8Pv7Oysr7BwEC8rq0tv8/Ozr7q6Wm/wL8/P+DfXz///v4+v76+PtDPT7+HhoY+urk5P+Pi4j6bmpo+6ulpv/b1db/k42M/0tFRP5+enr6NjAy+paQkvsXERL6bmpo+vLs7vw==",
+      "vectorSha256": "27198bae1fddfb77437f193a3d9052035a0acd5504b3ae405045588e711cfe3e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "88b1c5625a586238537e294c0bdfefbfaf18a1dcb8a60b05f1e8586e6b67a622",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0677": {
+      "vector": "oqEhv4GAgLvV1FS+rKsrP+zra7+hoKC80dBQvff29r7b2tq++/r6vqmoqL3KyUk/hoUFv62sLL6gnx8/2NdXv8vKyr6xsDA9/fx8PuDfX7/q6Wm/hoUFP+DfXz/u7W2/vbw8voGAgDuMiws/9PNzP//+/r7w72+/8/LyPsTDQ7+ioSG/gYCAu9XUVL6sqys/7Otrv6GgoLzR0FC99/b2vtva2r77+vq+qaiovcrJST+GhQW/rawsvqCfHz/Y11e/y8rKvrGwMD39/Hw+4N9fv+rpab+GhQU/4N9fP+7tbb+9vDy+gYCAO4yLCz/083M///7+vvDvb7/z8vI+xMNDvw==",
+      "vectorSha256": "78d5ec9bf0f33b6d5c06135054713e88f666406b19da1814af747022217cc84e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2f7f65d50a7d7942494175e43d6acf144d859f100bc2ef096880c5f94008bc1e",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0678": {
+      "vector": "6+rqPsPCwj7Pzs6+zMtLv+LhYT/W1VW/x8bGvpCPDz+CgQE/iokJv7KxMb/NzEw+397ePuPi4j7b2to+lpUVP8jHR7/NzEy+0tFRv8vKyr7Hxsa+n56ePujnZ7/n5ua+lJMTv9XUVD7j4uI+np0dP52cHD6Xlpa+p6amPtHQUD3r6uo+w8LCPs/Ozr7My0u/4uFhP9bVVb/Hxsa+kI8PP4KBAT+KiQm/srExv83MTD7f3t4+4+LiPtva2j6WlRU/yMdHv83MTL7S0VG/y8rKvsfGxr6fnp4+6Odnv+fm5r6UkxO/1dRUPuPi4j6enR0/nZwcPpeWlr6npqY+0dBQPQ==",
+      "vectorSha256": "206921a33a8ae8e378d695e360a712a4c8f1718107bfbfbf9698d461177c85bc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bab04c1af0154ec7c03b2799b7b8b6ca1c66174d4ea70c46369ab8ce935aa986",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0679": {
+      "vector": "5+bmvoKBAb///v6+jo0NP7i3Nz/t7Gw+r66uPp+enr7n5uY+/fx8PpGQED2Miws/tLMzv6SjI7/Ix0c/np0dv9jXVz/x8HA9tLMzv8rJSb+Qjw8/jIsLv+LhYb+Ylxe/trU1v+zraz/b2tq+3t1dv8HAQDzw72+/zs1NP9XUVL7n5ua+goEBv//+/r6OjQ0/uLc3P+3sbD6vrq4+n56evufm5j79/Hw+kZAQPYyLCz+0szO/pKMjv8jHRz+enR2/2NdXP/HwcD20szO/yslJv5CPDz+Miwu/4uFhv5iXF7+2tTW/7OtrP9va2r7e3V2/wcBAPPDvb7/OzU0/1dRUvg==",
+      "vectorSha256": "2c1be0b80967dd4e216875ee319762adebbc543a863c3c485423bc3a5383e67a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "463f40c6db9dab58b99f84c5262ee331eb87261bc73a0f3425f549118108e665",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0680": {
+      "vector": "AACAv93cXL6Ylxe/3NtbP5+enr6SkRE/mJcXv7u6ur6enR2/ubi4va+urj7R0FA9uLc3v6GgoLzBwEA82NdXP4KBAT+koyM/nJsbP/79fT+SkRE/l5aWvqqpKT+WlRU/19bWvpqZGb/z8vI+zMtLv+3sbL7BwEA8pKMjv66tLb8AAIC/3dxcvpiXF7/c21s/n56evpKRET+Ylxe/u7q6vp6dHb+5uLi9r66uPtHQUD24tze/oaCgvMHAQDzY11c/goEBP6SjIz+cmxs//v19P5KRET+Xlpa+qqkpP5aVFT/X1ta+mpkZv/Py8j7My0u/7exsvsHAQDykoyO/rq0tvw==",
+      "vectorSha256": "f3af3eb9262b9d0df31ac5a54dcfbffefd1717210eeaab16eb0489361e6bb11c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "006434ed58c834513174ab86247d81ebc0d1cdfec85ad4ca4a33bc1a62812e29",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0681": {
+      "vector": "urk5v/j3dz/493c/7+7uvre2tr7Ew0O/np0dv+jnZ7/R0FA9w8LCvvb1db/R0FA9hIMDv+TjYz+XlpY+7+7uvpGQED2xsDC9tLMzP+/u7j6koyO/iokJv4eGhr7e3V0/rawsvqalJT+xsDC9trU1P9va2j6Pjo4+397evtva2j66uTm/+Pd3P/j3dz/v7u6+t7a2vsTDQ7+enR2/6Odnv9HQUD3DwsK+9vV1v9HQUD2EgwO/5ONjP5eWlj7v7u6+kZAQPbGwML20szM/7+7uPqSjI7+KiQm/h4aGvt7dXT+trCy+pqUlP7GwML22tTU/29raPo+Ojj7f3t6+29raPg==",
+      "vectorSha256": "f225ca2e044b267aa125476a3f160b9e12823fe6e0a69a989b0033bb27be0874",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "23fbfb44521e310c864f05863ef1a544847ad9bb2e3b5eee6ad27adab6a348b6",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0682": {
+      "vector": "r66uvvn4+L2FhAS+ubi4vdPS0j77+vq+oqEhP5GQED2opye/1dRUvpmYmL2cmxu/i4qKvuzra7/T0tK+kpERv7i3N7+lpCS+xMNDv+LhYT+vrq4+hYQEPvb1dT+joqK+//7+vsXERL7NzEw+i4qKPoyLC7+enR0/8vFxv9zbWz+vrq6++fj4vYWEBL65uLi909LSPvv6+r6ioSE/kZAQPainJ7/V1FS+mZiYvZybG7+Lioq+7Otrv9PS0r6SkRG/uLc3v6WkJL7Ew0O/4uFhP6+urj6FhAQ+9vV1P6Oior7//v6+xcREvs3MTD6Lioo+jIsLv56dHT/y8XG/3NtbPw==",
+      "vectorSha256": "f3ae73628c55f474baf86791965799bc69ddf180cc804c950ea89e3c25f5148e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "54706f74b441d0842c6576325d0a4b37246b1ef0ab90fa57406799a23ace07ed",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0683": {
+      "vector": "v76+vsvKyr6sqys/9/b2vqKhIb+enR0/4+LiPv38fL7V1FQ+AACAP4KBAT/FxEQ+hIMDP5eWlj77+vq+7Otrv7W0NL7t7Gy+np0dP+LhYT/e3V2/hoUFv7a1Nb+dnBw+19bWvoOCgj7n5ua+o6Kivu3sbL7p6Oi92tlZv+zra7+/vr6+y8rKvqyrKz/39va+oqEhv56dHT/j4uI+/fx8vtXUVD4AAIA/goEBP8XERD6EgwM/l5aWPvv6+r7s62u/tbQ0vu3sbL6enR0/4uFhP97dXb+GhQW/trU1v52cHD7X1ta+g4KCPufm5r6joqK+7exsvuno6L3a2Vm/7Otrvw==",
+      "vectorSha256": "fee92f731e0c9c56d0dfb669e55f3c3d3f04d58ccdd4a10b7480bef38258b4d2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "504dd5422fceb8609affc098c1a5410a6962cef0113d25934aa046576271130a",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0684": {
+      "vector": "oaCgvI6NDT/X1ta++/r6vsLBQT+0szO/qqkpv7KxMb+TkpI+1dRUvpiXFz/t7Gy+m5qavsfGxj60szM/zMtLv9LRUb+lpCS+0tFRP5OSkj7d3Fw+19bWPq+urr7My0u/nZwcvt/e3r7KyUm/xsVFv9nY2D2HhoY+rawsvurpab+hoKC8jo0NP9fW1r77+vq+wsFBP7SzM7+qqSm/srExv5OSkj7V1FS+mJcXP+3sbL6bmpq+x8bGPrSzMz/My0u/0tFRv6WkJL7S0VE/k5KSPt3cXD7X1tY+r66uvszLS7+dnBy+397evsrJSb/GxUW/2djYPYeGhj6trCy+6ulpvw==",
+      "vectorSha256": "ccd7c9f4f6fab7698f26a620bb25e81111731f2bed8ef7c0177091dc084125e3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7dc64a41e0262b27a465cb6259b1d91a176be8a49bb5541a6c481b1d8da16a0b",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0685": {
+      "vector": "qKcnv/79fb/g31+/7+7uPuLhYb+ZmJi9l5aWPv79fT+qqSk/vr09P9jXVz+1tDS+rKsrv5aVFT///v4+l5aWvpSTEz/e3V2/sbAwvd7dXT/6+Xm/7OtrP7m4uD2NjAw+v76+PoOCgr7b2tq+nJsbP62sLD6JiIg9srExv5CPD7+opye//v19v+DfX7/v7u4+4uFhv5mYmL2XlpY+/v19P6qpKT++vT0/2NdXP7W0NL6sqyu/lpUVP//+/j6Xlpa+lJMTP97dXb+xsDC93t1dP/r5eb/s62s/ubi4PY2MDD6/vr4+g4KCvtva2r6cmxs/rawsPomIiD2ysTG/kI8Pvw==",
+      "vectorSha256": "f64ad0fd54074d4b1ef6d4f3b8199bd18db62423688d689a5a22c73954c784ba",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2c0110bb0f76a5fed4deeb692acabf5ac9117aee03f58b91af5f49cd95882738",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0686": {
+      "vector": "sK8vv9zbW7/Ew0M/l5aWvp2cHL6trCw+hIMDv4SDA7/JyMg9pqUlP42MDL6Pjo6+lZQUPuXkZL7p6Og9vLs7P+jnZz+xsDC94eDgvM3MTL77+vo+5uVlP7GwMD3Lyso+h4aGPpWUFL6KiQm/zs1NP8/Ozj7BwEC8zs1Nv6empr6wry+/3Ntbv8TDQz+Xlpa+nZwcvq2sLD6EgwO/hIMDv8nIyD2mpSU/jYwMvo+Ojr6VlBQ+5eRkvuno6D28uzs/6OdnP7GwML3h4OC8zcxMvvv6+j7m5WU/sbAwPcvKyj6HhoY+lZQUvoqJCb/OzU0/z87OPsHAQLzOzU2/p6amvg==",
+      "vectorSha256": "8a694b825ffbfe5578c6240abc0f52185c9626b20ead4edcb5e43dd0a055e290",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2812e15a6c953e3e8cd26e5c92638eddf37a7c66bef285b2a16d3be6b37e1956",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0687": {
+      "vector": "urk5P9XUVD6BgIC71tVVP/Dvb7+Xlpa+0M9PP87NTT+urS0/zcxMvoWEBL719HS+q6qqPqSjI7/OzU0/m5qavtXUVD6Xlpa+n56ePtzbWz/r6uo+vLs7P/79fT+BgIA7xcREPv38fL62tTW/qqkpv6GgoLzf3t6+mJcXP7a1Nb+6uTk/1dRUPoGAgLvW1VU/8O9vv5eWlr7Qz08/zs1NP66tLT/NzEy+hYQEvvX0dL6rqqo+pKMjv87NTT+bmpq+1dRUPpeWlr6fnp4+3NtbP+vq6j68uzs//v19P4GAgDvFxEQ+/fx8vra1Nb+qqSm/oaCgvN/e3r6Ylxc/trU1vw==",
+      "vectorSha256": "afeb9981e762426c597fda96372136b84fa0a69f4c960c261277c588c4ba683a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dc9a7fea085ae7e6d6666f61aa2ee6599a5aa7edbaddfe809860252b7d48cb25",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0688": {
+      "vector": "6ulpv6inJz+VlBS+kpERv+TjYz/Hxsa+0M9Pv9/e3j7Avz8/jIsLP7GwML2wry+/u7q6vomIiL3v7u6+trU1P+fm5j6rqqq+1dRUvpmYmD3h4OC8rKsrP8nIyD2JiIi9gYCAO8TDQz/S0VG/oqEhP46NDT+qqSm/5+bmPtXUVL7q6Wm/qKcnP5WUFL6SkRG/5ONjP8fGxr7Qz0+/397ePsC/Pz+Miws/sbAwvbCvL7+7urq+iYiIve/u7r62tTU/5+bmPquqqr7V1FS+mZiYPeHg4Lysqys/ycjIPYmIiL2BgIA7xMNDP9LRUb+ioSE/jo0NP6qpKb/n5uY+1dRUvg==",
+      "vectorSha256": "aa9b90186f16b311a3568f1bb998dd4db5b9c6cc9cafca2bcae87b4f2db2bdb5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0bd36d37f14e18b7dfc57a28517744dab95565897cd58c7780e117d0c62bb965",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0689": {
+      "vector": "mpkZv5aVFb+sqyu/8vFxv/n4+L3NzEy+rq0tP5KREb+dnBy+8/LyvvX0dD7q6Wm/lJMTv+rpaT+DgoI+//7+vpmYmL3My0s/0dBQvf/+/j7DwsK+m5qaPoSDAz/v7u4+tLMzP9zbWz/Z2Ng9v76+vquqqr7a2Vm/k5KSPvHwcD2amRm/lpUVv6yrK7/y8XG/+fj4vc3MTL6urS0/kpERv52cHL7z8vK+9fR0Purpab+UkxO/6ulpP4OCgj7//v6+mZiYvczLSz/R0FC9//7+PsPCwr6bmpo+hIMDP+/u7j60szM/3NtbP9nY2D2/vr6+q6qqvtrZWb+TkpI+8fBwPQ==",
+      "vectorSha256": "a079381fb55474c0def999023f569c12dc4eedf316f6b9e16d5dcb1e87980916",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "33352a077066d6376c439e0b36f4a04076e579bf4fa6c1bbd9ed8d505513a487",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0690": {
+      "vector": "kpERv97dXb+lpCQ+5uVlv8nIyL37+vq+0M9Pv728PL7w728/iokJP8jHR7/s62u/j46OPvDvb7/w72+/19bWPqWkJD65uLg9hYQEPsvKyj6bmpo+qKcnP6Oioj63trY+3NtbP/r5eT/t7Gw+gYCAO4GAgLvY11c/mpkZP5STE7+SkRG/3t1dv6WkJD7m5WW/ycjIvfv6+r7Qz0+/vbw8vvDvbz+KiQk/yMdHv+zra7+Pjo4+8O9vv/Dvb7/X1tY+paQkPrm4uD2FhAQ+y8rKPpuamj6opyc/o6KiPre2tj7c21s/+vl5P+3sbD6BgIA7gYCAu9jXVz+amRk/lJMTvw==",
+      "vectorSha256": "16400df9d408970176d1460de588a63be874f131b98ee501a4a30cca9d49c8b1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3711940d73411868f7c41c0aa30808b5948b90b2a6d3a8adedfc9d807febcc36",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0691": {
+      "vector": "yMdHP/r5eb+8uzs/lpUVP//+/r6+vT0/yMdHv8LBQT/Qz0+/lJMTv8PCwj6xsDC92djYvczLS7+trCy+pqUlv5OSkj7m5WU/lZQUvs/Ozr7n5ua+5uVlP4yLC7/My0u/0tFRP5aVFT+SkRG/8O9vP5GQED3T0tI+6Odnv5KRET/Ix0c/+vl5v7y7Oz+WlRU///7+vr69PT/Ix0e/wsFBP9DPT7+UkxO/w8LCPrGwML3Z2Ni9zMtLv62sLL6mpSW/k5KSPublZT+VlBS+z87Ovufm5r7m5WU/jIsLv8zLS7/S0VE/lpUVP5KREb/w728/kZAQPdPS0j7o52e/kpERPw==",
+      "vectorSha256": "3f4a180775f52eb33cc772208bc657e94810a54ac96df77eb7315cce2fea5c37",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e303ddca40de1ce01836b07a721a6a2da4f26d4c46f23a1ae8ca37f784b40cc8",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0692": {
+      "vector": "lpUVP4mIiD2HhoY+3dxcvqOior6TkpI+rq0tv8vKyj7f3t6+qKcnP5qZGT/+/X0/srExv4+Ojr6wry8/hoUFP8/Ozj6Qjw+/vLs7P9fW1j7//v4+hoUFP7a1Nb/a2Vk/hYQEvvDvbz/083M//v19v/b1dT/DwsI+tLMzP9TTUz+WlRU/iYiIPYeGhj7d3Fy+o6KivpOSkj6urS2/y8rKPt/e3r6opyc/mpkZP/79fT+ysTG/j46OvrCvLz+GhQU/z87OPpCPD7+8uzs/19bWPv/+/j6GhQU/trU1v9rZWT+FhAS+8O9vP/Tzcz/+/X2/9vV1P8PCwj60szM/1NNTPw==",
+      "vectorSha256": "06e065af012d19e13b97c9e6a84ba70828b0969b75e5140a9e9b7122ae697b7e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ca88a16457a429b248d3ccfe275cd7c2b338ddb5bfc225ec6ff7f901fab0d9e9",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0693": {
+      "vector": "+fj4vcXERD7q6Wk/8/LyPszLSz/Qz0+/7Otrv93cXL6CgQG/8/LyPu7tbT/g31+/trU1P97dXb/39va+9/b2Pvf29j6rqqo+urk5v4iHBz+trCw+wL8/P+DfXz/a2Vm/9fR0vuzraz/o52e/+fj4Pf/+/j6UkxO/qKcnP7SzMz/5+Pi9xcREPurpaT/z8vI+zMtLP9DPT7/s62u/3dxcvoKBAb/z8vI+7u1tP+DfX7+2tTU/3t1dv/f29r739vY+9/b2Pquqqj66uTm/iIcHP62sLD7Avz8/4N9fP9rZWb/19HS+7OtrP+jnZ7/5+Pg9//7+PpSTE7+opyc/tLMzPw==",
+      "vectorSha256": "89bbaa4a694fc637e43a2ef46cd5247b2140cbe6c2279443c08f176de90c3567",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7098f4bce5180a643fbcf610da1142bdbdaa23c395dfef1361f50c8fbf36d3d9",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0694": {
+      "vector": "8/LyPrW0ND7p6Oi9g4KCvvz7e7+vrq4+8vFxvwAAgD+/vr6+jo0NP5uamr7Y11e/ycjIvcrJST+Ihwe/ubi4Pba1Nb+WlRU/rawsPvTzcz+7uro+i4qKPpOSkj6Ihwe/p6amPuLhYT+sqys/ycjIPbq5Ob/k42M/iokJv+7tbb/z8vI+tbQ0Puno6L2DgoK+/Pt7v6+urj7y8XG/AACAP7++vr6OjQ0/m5qavtjXV7/JyMi9yslJP4iHB7+5uLg9trU1v5aVFT+trCw+9PNzP7u6uj6Lioo+k5KSPoiHB7+npqY+4uFhP6yrKz/JyMg9urk5v+TjYz+KiQm/7u1tvw==",
+      "vectorSha256": "6ca5c315e2ee5a4543d450db965e5441655025ba675ef53a9b712d6e3cc63ed0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bc96715f02ab07ff50c6591473e43c8b25ca95f9aea2a43ca9f0d58c23f13b09",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0695": {
+      "vector": "lJMTP/LxcT+Pjo6+tbQ0Purpab+UkxM/+Pd3P5GQEL2HhoY+sK8vv9rZWT+wry+/tbQ0voiHB7/29XU/5+bmvoeGhr7CwUG/6ulpv/r5eT/8+3u/6ejovZ+enr7T0tK+hYQEvtbVVT/Y11c/oqEhP4SDAz+Ylxc/paQkPuTjY7+UkxM/8vFxP4+Ojr61tDQ+6ulpv5STEz/493c/kZAQvYeGhj6wry+/2tlZP7CvL7+1tDS+iIcHv/b1dT/n5ua+h4aGvsLBQb/q6Wm/+vl5P/z7e7/p6Oi9n56evtPS0r6FhAS+1tVVP9jXVz+ioSE/hIMDP5iXFz+lpCQ+5ONjvw==",
+      "vectorSha256": "1d4bf88f30ee969a330cd44daff3b9ae70cadd95e8d75ca7a7aed3102f0a7961",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c9f85c960bc9fb7ba128ec28693cfa465e1f0bfc0271584b6feaebd0c1cb940e",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0696": {
+      "vector": "xsVFv8nIyL339vY+nJsbv6Oior719HQ+i4qKPpSTEz/6+Xm/tbQ0vtXUVL7NzEy+7u1tP4GAgLvr6uo+9PNzv5GQEL3//v4+jYwMvu3sbL7x8HC9wcBAvNTTUz/W1VU/iYiIPayrKz/Y11e/qqkpP4eGhj7t7Gw+wcBAvPPy8j7GxUW/ycjIvff29j6cmxu/o6KivvX0dD6Lioo+lJMTP/r5eb+1tDS+1dRUvs3MTL7u7W0/gYCAu+vq6j7083O/kZAQvf/+/j6NjAy+7exsvvHwcL3BwEC81NNTP9bVVT+JiIg9rKsrP9jXV7+qqSk/h4aGPu3sbD7BwEC88/LyPg==",
+      "vectorSha256": "867fddfea668fee59b27ea25d81d5212deec8612d2442353aac6e80481faa229",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1d73bd32579ea2c903696566f67fba067bbf6e62787ee9ea88d514d4a19d7ebc",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0697": {
+      "vector": "4uFhP8LBQT+opyc/g4KCPvTzcz8AAIA/397evoeGhr7BwEC8iYiIPZiXF7/t7Gy+kZAQPQAAgL/KyUm/wcBAvIeGhr7Lyso++fj4vdPS0r6EgwO//fx8vpWUFL7p6Oi9goEBv+vq6r6joqI+tLMzP5qZGT/HxsY+pqUlP9zbWz/i4WE/wsFBP6inJz+DgoI+9PNzPwAAgD/f3t6+h4aGvsHAQLyJiIg9mJcXv+3sbL6RkBA9AACAv8rJSb/BwEC8h4aGvsvKyj75+Pi909LSvoSDA7/9/Hy+lZQUvuno6L2CgQG/6+rqvqOioj60szM/mpkZP8fGxj6mpSU/3NtbPw==",
+      "vectorSha256": "8a215b3ee63996ddab2a32ee01dc2b98582e8b5354bea9673b8f9edbd5b97c9e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f0e0d3a0f9ff485e7e88346284001b7e5eb2704b3e606d713f45a8d9ccb1d2ed",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0698": {
+      "vector": "jYwMvufm5j6WlRW/oqEhP/79fb/Avz+/hIMDvwAAgD+ioSG/wsFBP5mYmL2amRk/n56ePp+enj6EgwM/6ejoveTjYz+JiIi9yslJv4KBAb/Lysq+zMtLv+/u7r7n5uY+p6amPqmoqL3n5uY+m5qaPqKhIT+BgIC7z87OPq+urr6NjAy+5+bmPpaVFb+ioSE//v19v8C/P7+EgwO/AACAP6KhIb/CwUE/mZiYvZqZGT+fnp4+n56ePoSDAz/p6Oi95ONjP4mIiL3KyUm/goEBv8vKyr7My0u/7+7uvufm5j6npqY+qaiovefm5j6bmpo+oqEhP4GAgLvPzs4+r66uvg==",
+      "vectorSha256": "d72a6640f4967051839194179082c4e285e190797d71a1b48e0fd213bbaccaf9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6eb935d001203eff2fe076cca7a7c171f1771b3f4d1a44b9a975b9a6d07fb354",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0700": {
+      "vector": "pqUlv/38fD6opyc/ycjIPfTzcz+Lioq+gYCAO6WkJD7S0VG/iYiIvQAAgD/Lyso+5ONjP9va2j6koyO/yMdHv+Pi4j69vDw+pKMjP7CvL7+Qjw8/mpkZv4uKir7Qz08/6ejoPfr5eb+Ihwe/+Pd3v+TjY7+FhAS+g4KCPrGwML2mpSW//fx8PqinJz/JyMg99PNzP4uKir6BgIA7paQkPtLRUb+JiIi9AACAP8vKyj7k42M/29raPqSjI7/Ix0e/4+LiPr28PD6koyM/sK8vv5CPDz+amRm/i4qKvtDPTz/p6Og9+vl5v4iHB7/493e/5ONjv4WEBL6DgoI+sbAwvQ==",
+      "vectorSha256": "acd18cf8a952bff98d4105a57fedb891cfbd8d0014c270677160781573abb29a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2d9fd38cf95d80941777ffb2f1b62e1cb897d128c7335de78e033c040e6fa07a",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0701": {
+      "vector": "u7q6vra1Nb/6+Xm/xMNDP52cHD6mpSW/pqUlv8fGxj729XW//v19v9DPT7+1tDS+mpkZv8fGxr7r6uq+nJsbP9/e3j7KyUm/trU1P6qpKT+9vDw+u7q6Po6NDT/9/Hy+rawsPoaFBT/v7u4+1NNTP+LhYb+UkxM/4uFhv/n4+D27urq+trU1v/r5eb/Ew0M/nZwcPqalJb+mpSW/x8bGPvb1db/+/X2/0M9Pv7W0NL6amRm/x8bGvuvq6r6cmxs/397ePsrJSb+2tTU/qqkpP728PD67uro+jo0NP/38fL6trCw+hoUFP+/u7j7U01M/4uFhv5STEz/i4WG/+fj4PQ==",
+      "vectorSha256": "625b57da04ccdd9e0a618206ac276c4d915bcc94b15466055ca83dd129959ea5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "512503e1932d2db105011869334e45cdb71bdad497aec66095c2bbe90fc90f8f",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0702": {
+      "vector": "xMNDv8vKyj64tzc/rq0tP8PCwr7OzU2/nZwcvtTTU7/KyUm/3dxcvujnZz+7uro+goEBP7y7Oz/n5ua+9vV1v9fW1j6DgoK+jo0Nv9fW1j6KiQm/19bWvpCPD7+HhoY+6ulpP6uqqj7GxUW/yslJP/n4+L3i4WE/9vV1P9LRUb/Ew0O/y8rKPri3Nz+urS0/w8LCvs7NTb+dnBy+1NNTv8rJSb/d3Fy+6OdnP7u6uj6CgQE/vLs7P+fm5r729XW/19bWPoOCgr6OjQ2/19bWPoqJCb/X1ta+kI8Pv4eGhj7q6Wk/q6qqPsbFRb/KyUk/+fj4veLhYT/29XU/0tFRvw==",
+      "vectorSha256": "6028e16ad4ac474b8c3339a03c5b7a1d167a52dd387800ed4b8d827638126be1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1eb2dbd64f196c161b64f3aec0dd4605b55f39b53b4a38a1f4aa1de470f0fa17",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0703": {
+      "vector": "yMdHv/z7ez/Y11e/hIMDP9va2j7v7u6+i4qKPoWEBD7s62u/3NtbP6KhIT/U01M/z87Ovre2tr6Qjw+/yMdHP/79fT+SkRE/lpUVv/X0dL63tra+zcxMvsC/Pz/S0VE/k5KSvs3MTL7y8XE/yMdHP/Dvb7+1tDS+n56evtrZWb/Ix0e//Pt7P9jXV7+EgwM/29raPu/u7r6Lioo+hYQEPuzra7/c21s/oqEhP9TTUz/Pzs6+t7a2vpCPD7/Ix0c//v19P5KRET+WlRW/9fR0vre2tr7NzEy+wL8/P9LRUT+TkpK+zcxMvvLxcT/Ix0c/8O9vv7W0NL6fnp6+2tlZvw==",
+      "vectorSha256": "79f2b002f15692045c94f186152d462fda8ae0080e6311d3bf8d325cd7ca7470",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1cfd14c1b644a2900aedd0e94c5238e3fec835615266dfe85b66f8e308695813",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0704": {
+      "vector": "8/LyPqinJz/+/X2/9vV1v+TjY7/U01O/7u1tv769PT+EgwM/3dxcPq2sLD7n5uY+sbAwPeno6D3u7W2/t7a2PtnY2L3f3t4+goEBv/z7ez+vrq4+1tVVv+XkZD6rqqq+uLc3v/v6+r7KyUm/xsVFv4uKij6joqI+/Pt7P6GgoDzz8vI+qKcnP/79fb/29XW/5ONjv9TTU7/u7W2/vr09P4SDAz/d3Fw+rawsPufm5j6xsDA96ejoPe7tbb+3trY+2djYvd/e3j6CgQG//Pt7P6+urj7W1VW/5eRkPquqqr64tze/+/r6vsrJSb/GxUW/i4qKPqOioj78+3s/oaCgPA==",
+      "vectorSha256": "26ac40f89d2aa93b8a6201d5596ad3ca74508aa8c7262d85dcc3e203ad1e5998",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bcd301050e1609dec19b95b9858e09ad72b73ffdab159c5524411b1da2a8fd82",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0705": {
+      "vector": "1NNTP+XkZL6OjQ0/qKcnv9TTU7/8+3s/rKsrv8fGxj7h4OA8nJsbP6KhIb/i4WE//v19v6GgoDzAvz+/tLMzv42MDD7c21u/x8bGPtnY2D2JiIi99vV1P62sLL65uLi9/v19P+Hg4LyysTG/oaCgPLW0NL6Ylxe/nJsbP9fW1j7U01M/5eRkvo6NDT+opye/1NNTv/z7ez+sqyu/x8bGPuHg4Dycmxs/oqEhv+LhYT/+/X2/oaCgPMC/P7+0szO/jYwMPtzbW7/HxsY+2djYPYmIiL329XU/rawsvrm4uL3+/X0/4eDgvLKxMb+hoKA8tbQ0vpiXF7+cmxs/19bWPg==",
+      "vectorSha256": "c7920ca23923709b3b41a892075c984e0b385d5bd4855945a4e9b6c98964b999",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e963c62c16fd2ab183cd2ff0018220269112b18d77fa6a74fe7c27826934cdb5",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0706": {
+      "vector": "kI8PP8bFRb+pqKg98vFxv6alJT/19HQ+np0dv769Pb+joqI+u7q6Pr28PD7n5ua+4+LiPrW0ND7DwsK++/r6vpSTEz/7+vq+4uFhP9PS0r6rqqo+nJsbP+no6L3Lyso+trU1P8/Ozj739vY++/r6vqGgoLzr6uq+6ulpP5uamr6Qjw8/xsVFv6moqD3y8XG/pqUlP/X0dD6enR2/vr09v6Oioj67uro+vbw8Pufm5r7j4uI+tbQ0PsPCwr77+vq+lJMTP/v6+r7i4WE/09LSvquqqj6cmxs/6ejovcvKyj62tTU/z87OPvf29j77+vq+oaCgvOvq6r7q6Wk/m5qavg==",
+      "vectorSha256": "ed7d6f243d69bed63ef80e6fa7a4f746d5417cf14f9e4d36f6341cb034fb4212",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c71d8a07d29e3121a8ae9746b8964f41c941f04baacd71b2dab3bd417d45f459",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0707": {
+      "vector": "//7+vtXUVL7My0u/0tFRv+blZb+Lioo+6Odnv4qJCb/NzEw+jYwMPoOCgj7p6Oi9lpUVv4KBAb+3tra+p6amvqOior7V1FS+/Pt7v62sLL7Y11c/0tFRP6Oior7u7W0/qqkpv7GwML3u7W2/iIcHP5mYmL2zsrK+0tFRP+LhYb///v6+1dRUvszLS7/S0VG/5uVlv4uKij7o52e/iokJv83MTD6NjAw+g4KCPuno6L2WlRW/goEBv7e2tr6npqa+o6KivtXUVL78+3u/rawsvtjXVz/S0VE/o6Kivu7tbT+qqSm/sbAwve7tbb+Ihwc/mZiYvbOysr7S0VE/4uFhvw==",
+      "vectorSha256": "40b213540a85e3022107155ee8315ace74be726d82e656343c89ff205f5ecc20",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "40651a170da20c3b9991a071353f52565765026aebe857f62b7a09c37653e80f",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0708": {
+      "vector": "h4aGPsHAQLzx8HA9qqkpv/z7e7/9/Hy+//7+voOCgr729XW/3dxcPvn4+L2rqqq+wsFBv/Tzcz/r6uq+rKsrP5eWlj729XW/qKcnP8rJSb+0szM/0M9PP5uamr7FxEQ+9/b2Pufm5r7j4uK+paQkvvX0dL6GhQW/gYCAO8rJST+HhoY+wcBAvPHwcD2qqSm//Pt7v/38fL7//v6+g4KCvvb1db/d3Fw++fj4vauqqr7CwUG/9PNzP+vq6r6sqys/l5aWPvb1db+opyc/yslJv7SzMz/Qz08/m5qavsXERD739vY+5+bmvuPi4r6lpCS+9fR0voaFBb+BgIA7yslJPw==",
+      "vectorSha256": "d5463ae65694985206f490ec34b44e0f19707c35b81a93142bc6b00133aca09a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a17e872b0260405f059b70551ff945d5a505d31bd9e75998bd46476b613d80e4",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0709": {
+      "vector": "6ejoPcTDQz+WlRU/8vFxv5OSkj6FhAS+6ulpv6SjI7+8uzs/AACAP4aFBT+dnBw+8fBwvbGwMD2urS0/1tVVP8PCwr6ZmJi9/Pt7v4iHBz/s62s/lZQUvqWkJD6WlRU/jYwMPre2tj7Avz+/qaiovd7dXT/GxUU/1dRUvqmoqL3p6Og9xMNDP5aVFT/y8XG/k5KSPoWEBL7q6Wm/pKMjv7y7Oz8AAIA/hoUFP52cHD7x8HC9sbAwPa6tLT/W1VU/w8LCvpmYmL38+3u/iIcHP+zraz+VlBS+paQkPpaVFT+NjAw+t7a2PsC/P7+pqKi93t1dP8bFRT/V1FS+qaiovQ==",
+      "vectorSha256": "067eaeadadf540dbeceb68d0d71aad10eb65f037b1f015cb1e9e342a5c03d3ea",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8ee1ca07a46f0b2eddffc2937885d6ea4f7602c3f56d94ca91ad2075eee26575",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0710": {
+      "vector": "srExv6SjIz/d3Fw+ubi4vfTzc7+FhAS+wsFBP/Tzcz/y8XG//fx8vs3MTD6/vr6+vLs7v5aVFb/39vY++vl5P5iXFz/OzU2/paQkPo2MDD7GxUU/+fj4Perpab/g318/sbAwPd7dXT/Lyso+mpkZv9PS0r62tTW/8vFxP8TDQ7+ysTG/pKMjP93cXD65uLi99PNzv4WEBL7CwUE/9PNzP/Lxcb/9/Hy+zcxMPr++vr68uzu/lpUVv/f29j76+Xk/mJcXP87NTb+lpCQ+jYwMPsbFRT/5+Pg96ulpv+DfXz+xsDA93t1dP8vKyj6amRm/09LSvra1Nb/y8XE/xMNDvw==",
+      "vectorSha256": "71cc883cd21a52f15abe4eb4f049df3da8a8eaffd9d85ae4b269fba78c53459a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "27d19b74066fe0f9076099502235bdfccb199491e28f0bef85eeb2334b25f81e",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0711": {
+      "vector": "9vV1P+DfX7/29XW//v19v7a1Nb/j4uI++fj4PaOioj64tze/trU1v6yrKz+2tTW/rq0tP+vq6r7U01O/j46OvvTzc7+lpCS+t7a2vouKij6ysTG/m5qaPpSTEz+sqyu/jo0Nv8vKyr6joqI+goEBv56dHb+WlRU/k5KSvt3cXD729XU/4N9fv/b1db/+/X2/trU1v+Pi4j75+Pg9o6KiPri3N7+2tTW/rKsrP7a1Nb+urS0/6+rqvtTTU7+Pjo6+9PNzv6WkJL63tra+i4qKPrKxMb+bmpo+lJMTP6yrK7+OjQ2/y8rKvqOioj6CgQG/np0dv5aVFT+TkpK+3dxcPg==",
+      "vectorSha256": "019d52fd7f6a2d1c40c00252577ac21977af68e011f86fe9f2fad1f856be44a9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fa10050125b88fa82425d525d645165c066b52a227a6c92a394da83f31ca5b9b",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0712": {
+      "vector": "oaCgPPv6+j6xsDC9vr09v/Tzcz+npqa+xsVFv9zbWz+3tra+5eRkPqempr78+3s/7u1tP4qJCT/j4uI+7u1tP8PCwj6WlRW/9vV1P9jXVz+trCy+rawsvtXUVL7My0s/ycjIvamoqL3x8HA9zMtLv+vq6r76+Xm/7u1tP+DfXz+hoKA8+/r6PrGwML2+vT2/9PNzP6empr7GxUW/3NtbP7e2tr7l5GQ+p6amvvz7ez/u7W0/iokJP+Pi4j7u7W0/w8LCPpaVFb/29XU/2NdXP62sLL6trCy+1dRUvszLSz/JyMi9qaiovfHwcD3My0u/6+rqvvr5eb/u7W0/4N9fPw==",
+      "vectorSha256": "6ee6f598116c983946549c66bb2a310d480b8df91f0ec59ef6234feba4a82948",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "82be7a21f9561ded529c56fdf6c4b8f6b035faeb6a6a65e57375871a4503f6ef",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0713": {
+      "vector": "n56evtLRUb/U01O/mZiYvbGwML3p6Oi93dxcPu7tbT/Ew0M/397evsjHRz+GhQW/9vV1v7a1Nb+BgIA7vbw8vq+urj7S0VG/oaCgvOXkZL62tTW//v19P4SDA7+npqa+srExP/X0dL64tzc/l5aWPpmYmL3v7u4+m5qaPt3cXL6fnp6+0tFRv9TTU7+ZmJi9sbAwveno6L3d3Fw+7u1tP8TDQz/f3t6+yMdHP4aFBb/29XW/trU1v4GAgDu9vDy+r66uPtLRUb+hoKC85eRkvra1Nb/+/X0/hIMDv6empr6ysTE/9fR0vri3Nz+XlpY+mZiYve/u7j6bmpo+3dxcvg==",
+      "vectorSha256": "ce22a74f7de009212a6012f832203e1d15d57616f4f3207023e900c4268eff1b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "581716767a719bf6e148e33d05258068ab177d6325fe3e56d861dba576bba664",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0714": {
+      "vector": "lpUVv/Dvb7+GhQW/r66uvpaVFb/19HQ+oJ8fv/n4+D3w728/4eDgvNfW1j7083O/7exsPuXkZL61tDS+q6qqPvn4+L29vDy+397evqmoqL2KiQm//v19P7KxMb+hoKA8paQkvpOSkj729XW/mpkZv/v6+r7d3Fw+goEBv+XkZL6WlRW/8O9vv4aFBb+vrq6+lpUVv/X0dD6gnx+/+fj4PfDvbz/h4OC819bWPvTzc7/t7Gw+5eRkvrW0NL6rqqo++fj4vb28PL7f3t6+qaiovYqJCb/+/X0/srExv6GgoDylpCS+k5KSPvb1db+amRm/+/r6vt3cXD6CgQG/5eRkvg==",
+      "vectorSha256": "1cbe540f86f963a496b71ca0e41e1e1f62603fbcaae66bbabebd0fc0858cece8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "35083d54359e308ff77cb5069d6369aa706848753bfe27826ba40533419b3f63",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0717": {
+      "vector": "vr09P8nIyL2zsrI+0dBQveDfX7+gnx8/6OdnP87NTb/x8HA9rq0tv4OCgr6ZmJg9m5qavtHQUD2zsrI+sbAwPY6NDb+mpSW/zMtLv9XUVD6RkBC99PNzP4+Ojr6zsrK+6ejoPcPCwr6RkBC93NtbP9zbW7/j4uK+jo0Nv87NTT++vT0/ycjIvbOysj7R0FC94N9fv6CfHz/o52c/zs1Nv/HwcD2urS2/g4KCvpmYmD2bmpq+0dBQPbOysj6xsDA9jo0Nv6alJb/My0u/1dRUPpGQEL3083M/j46OvrOysr7p6Og9w8LCvpGQEL3c21s/3Ntbv+Pi4r6OjQ2/zs1NPw==",
+      "vectorSha256": "11b62431a07341bf42249771a70dc5b0eab5bb341cc9e9a1ac7d340348459dd7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "de73ac7910cff31987295f895986ac85392d1a9a7bf95c538e4f7bed124739e6",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0718": {
+      "vector": "6+rqvs3MTL7r6uq++Pd3P6empr6npqa+kpERv9LRUT/DwsK+1NNTP5ybGz+qqSk//Pt7P4uKij6UkxO/4uFhv42MDL7OzU2/kI8Pv6alJT/Avz+/lZQUPqOioj7T0tI+7+7uPqOioj6Qjw8/gYCAu6SjIz+3tra+wsFBP+3sbD7r6uq+zcxMvuvq6r7493c/p6amvqempr6SkRG/0tFRP8PCwr7U01M/nJsbP6qpKT/8+3s/i4qKPpSTE7/i4WG/jYwMvs7NTb+Qjw+/pqUlP8C/P7+VlBQ+o6KiPtPS0j7v7u4+o6KiPpCPDz+BgIC7pKMjP7e2tr7CwUE/7exsPg==",
+      "vectorSha256": "ab7306f36f77462b4158ae173856fcaa0804017410d19325c2b2dd8cacb108f3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "456645fb565637e84fe9cdd4fda2360f6e1938d22092a8b4bba8c77fd152e09d",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0719": {
+      "vector": "oaCgvJOSkr7U01O/t7a2vqOioj6sqyu/h4aGvrq5OT/i4WE/9PNzP9bVVT+gnx8/3Ntbv9TTUz+EgwM/+/r6Puno6D3S0VG/jo0NP8zLSz+Miws/zMtLP7Oysr6wry+/r66uvoOCgr6Qjw8/nJsbv+Pi4r6vrq6+5eRkvqyrKz+hoKC8k5KSvtTTU7+3tra+o6KiPqyrK7+Hhoa+urk5P+LhYT/083M/1tVVP6CfHz/c21u/1NNTP4SDAz/7+vo+6ejoPdLRUb+OjQ0/zMtLP4yLCz/My0s/s7KyvrCvL7+vrq6+g4KCvpCPDz+cmxu/4+Livq+urr7l5GS+rKsrPw==",
+      "vectorSha256": "5edccd434030b9979ad618c8651e99de17ad5db6e228216839a3d5ec9539def1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7d5b1652a82a5edcf0f9eacf12e9c1be8e17c6e5c5e55328545fc732475463d5",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0720": {
+      "vector": "xsVFv7Oysr6UkxM/qqkpv5ybGz+0szM/vbw8vvX0dD6Miws/i4qKvsLBQb/5+Pg9k5KSvtXUVL7NzEw+3t1dP6empr6gnx8/gYCAO5+enr6Miwu/urk5v6alJT/f3t4+9fR0vqempj6fnp4+kpERv6moqL2KiQm/8O9vv4uKir7GxUW/s7KyvpSTEz+qqSm/nJsbP7SzMz+9vDy+9fR0PoyLCz+Lioq+wsFBv/n4+D2TkpK+1dRUvs3MTD7e3V0/p6amvqCfHz+BgIA7n56evoyLC7+6uTm/pqUlP9/e3j719HS+p6amPp+enj6SkRG/qaiovYqJCb/w72+/i4qKvg==",
+      "vectorSha256": "1d2d685a23d8dea217e1c6c4761f0996a1e90f876e9f76c28d4e220ba9aaddd7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1d53c92bcdd9689ec55d1f8f5b6599ee56cf80583a23d2b761a9a737753b085d",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0721": {
+      "vector": "iokJv/79fT/KyUk/8O9vP/38fL719HQ+y8rKPvj3dz/r6uq+tbQ0PqmoqD2qqSm/uLc3v7u6ur78+3u/t7a2vpSTE7/39vY+t7a2vv79fT/j4uK+x8bGPvv6+j6ysTG//v19P46NDb/R0FA93dxcvtPS0j6OjQ2/urk5v+/u7r6KiQm//v19P8rJST/w728//fx8vvX0dD7Lyso++Pd3P+vq6r61tDQ+qaioPaqpKb+4tze/u7q6vvz7e7+3tra+lJMTv/f29j63tra+/v19P+Pi4r7HxsY++/r6PrKxMb/+/X0/jo0Nv9HQUD3d3Fy+09LSPo6NDb+6uTm/7+7uvg==",
+      "vectorSha256": "40473571bbf4b9bc89abfd64dc1f0d2a6c566caa45fff717cdc3f828cc7cd77b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3bfee4f7609eb2fb45968a2b2451025236bd52fe47b1be27fe398664b4392344",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0722": {
+      "vector": "vLs7v6KhIb/m5WU/4eDgPNXUVL7s62s/3dxcPqSjIz+Lioo+7OtrP5+enr7S0VG/z87OvpqZGb/i4WG/iIcHv9bVVb/Pzs6+xsVFv/j3d7/X1ta+2djYvbq5OT+qqSm/9fR0PuHg4DzS0VG/4+LiPsvKyr7q6Wm/trU1P769Pb+8uzu/oqEhv+blZT/h4OA81dRUvuzraz/d3Fw+pKMjP4uKij7s62s/n56evtLRUb/Pzs6+mpkZv+LhYb+Ihwe/1tVVv8/Ozr7GxUW/+Pd3v9fW1r7Z2Ni9urk5P6qpKb/19HQ+4eDgPNLRUb/j4uI+y8rKvurpab+2tTU/vr09vw==",
+      "vectorSha256": "8a8c1a5fdbc40e9293bd5bf054b9f299775ba14051b5d4733cbe1e772798b22d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "222ff28365f59bd1a2f558174c330f3c154c1d044a72dc2b9e8317b84d0bda21",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0723": {
+      "vector": "zcxMPpmYmD22tTU/2NdXP8fGxj7p6Og9/v19v4GAgDv//v6+wsFBv+3sbD6Hhoa+9vV1P5KRET/FxEQ+trU1P62sLD7Ix0c/m5qaPoeGhj6trCy+iYiIPbSzM7/29XW/xMNDP8C/P7/9/Hy+jo0Nv9fW1r6sqys/7+7uvszLS7/NzEw+mZiYPba1NT/Y11c/x8bGPuno6D3+/X2/gYCAO//+/r7CwUG/7exsPoeGhr729XU/kpERP8XERD62tTU/rawsPsjHRz+bmpo+h4aGPq2sLL6JiIg9tLMzv/b1db/Ew0M/wL8/v/38fL6OjQ2/19bWvqyrKz/v7u6+zMtLvw==",
+      "vectorSha256": "68bbe4ab1c903d14dc7e549440c57c9d324a85cb5c0d87586b80a0ce6668c98a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9989daebb18e0180401f9d5efac898da95e3a6a16a882605e12060394ad5441a",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0724": {
+      "vector": "k5KSPri3Nz+cmxu/tLMzP/j3dz/h4OC8+/r6Po+Ojr7w728/7OtrP93cXL7Pzs4+lZQUPpKRET/9/Hy+kpERv/Tzcz/h4OA8AACAv8C/P7+Qjw8/zcxMPpmYmD2dnBw+u7q6vq2sLL739vY+/fx8Pquqqj7j4uK+r66uvtnY2L2TkpI+uLc3P5ybG7+0szM/+Pd3P+Hg4Lz7+vo+j46OvvDvbz/s62s/3dxcvs/Ozj6VlBQ+kpERP/38fL6SkRG/9PNzP+Hg4DwAAIC/wL8/v5CPDz/NzEw+mZiYPZ2cHD67urq+rawsvvf29j79/Hw+q6qqPuPi4r6vrq6+2djYvQ==",
+      "vectorSha256": "8651fec03f67d6a6fa90f7240a34d9c3e7b970807babd2b24ba0f979b1e8adbd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a4db32d9fb7cbe5cf7f564b392c86037f9830020c7998993516abd9faa475472",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0725": {
+      "vector": "/v19v+3sbD7//v4+pqUlv+rpab+koyO/jIsLP9LRUb+XlpY+8fBwPeno6D2Ihwe/397ePsTDQz+Ihwe/+Pd3P//+/j7a2Vm/j46Ovru6uj6RkBA97Otrv8PCwj7n5ua+z87OvvLxcb+opye/yslJP+7tbT+opye/r66uPo2MDL7+/X2/7exsPv/+/j6mpSW/6ulpv6SjI7+Miws/0tFRv5eWlj7x8HA96ejoPYiHB7/f3t4+xMNDP4iHB7/493c///7+PtrZWb+Pjo6+u7q6PpGQED3s62u/w8LCPufm5r7Pzs6+8vFxv6inJ7/KyUk/7u1tP6inJ7+vrq4+jYwMvg==",
+      "vectorSha256": "88884e420ec9079f7de8bc7cfe3a71cffa6452ffb94bbd6ce3c713890f3b4f4a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "019dbf2d0b2ec517a5878e3cb7e13cfbbf135cae840ab0464c072ce4f62cab6e",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0726": {
+      "vector": "hoUFP7i3Nz/29XU/5uVlP6WkJL6Ihwe/nJsbv5CPDz/c21s/397evuLhYb/V1FS+2NdXv/X0dD7y8XE/AACAP6SjIz+UkxO/iIcHv8HAQLybmpq+lJMTP8vKyj6Lioq+3dxcPu3sbL6dnBw+1NNTP7y7O7+zsrK+np0dv8bFRT+GhQU/uLc3P/b1dT/m5WU/paQkvoiHB7+cmxu/kI8PP9zbWz/f3t6+4uFhv9XUVL7Y11e/9fR0PvLxcT8AAIA/pKMjP5STE7+Ihwe/wcBAvJuamr6UkxM/y8rKPouKir7d3Fw+7exsvp2cHD7U01M/vLs7v7Oysr6enR2/xsVFPw==",
+      "vectorSha256": "e00189d1f4cee50635f7e0e1c89db7725e93653d247a44056e156986edf29a36",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c2dbfaf26b3c32c7ed480f65149ef8ffd1363c7e59c9b25d9b6293e9225331e2",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0727": {
+      "vector": "4uFhP5STEz/l5GQ+k5KSPoOCgr6Lioo+7OtrP7m4uD0AAIC/ubi4PeDfX7++vT2/ycjIPZWUFL6opye/v76+vsrJSb+amRm/g4KCvvX0dD6npqa+tLMzP6empr6gnx8/5ONjv9rZWT/DwsK+sbAwvdnY2L2koyO/6+rqvrGwMD3i4WE/lJMTP+XkZD6TkpI+g4KCvouKij7s62s/ubi4PQAAgL+5uLg94N9fv769Pb/JyMg9lZQUvqinJ7+/vr6+yslJv5qZGb+DgoK+9fR0Pqempr60szM/p6amvqCfHz/k42O/2tlZP8PCwr6xsDC92djYvaSjI7/r6uq+sbAwPQ==",
+      "vectorSha256": "9adc57a849d8927c57fd4d07bd3cdced7c38d1aefaa73ab6f085855b6dc9d886",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f0c99ca45fa2f58b008b10218c6d2c501b335f9e56d956cf0eec4f7a722e4585",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0728": {
+      "vector": "wcBAvOjnZ7/x8HC91dRUPvj3d7/39va+5uVlP+Hg4LyHhoY+i4qKvq+urr7FxEQ+7Otrv9nY2L28uzs/2NdXv+vq6r6Pjo4+2djYvZKREb+cmxu/4eDgvNfW1j6sqys/vbw8vurpaT/p6Og9iYiIvZuamj7i4WE/+/r6vvz7ez/BwEC86Odnv/HwcL3V1FQ++Pd3v/f29r7m5WU/4eDgvIeGhj6Lioq+r66uvsXERD7s62u/2djYvby7Oz/Y11e/6+rqvo+Ojj7Z2Ni9kpERv5ybG7/h4OC819bWPqyrKz+9vDy+6ulpP+no6D2JiIi9m5qaPuLhYT/7+vq+/Pt7Pw==",
+      "vectorSha256": "41dc96a592d541859970c6f013e46167a15535935231fd71f349841808ee5c43",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7e0c789a0442f27ca15d54980a72dd1445a37237327cb5d568f48e77a6f041fd",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0729": {
+      "vector": "4eDgPPLxcT/V1FQ+lZQUPrGwML3z8vK+AACAv8C/Pz/c21u/+fj4vayrK7+/vr6+4eDgPIyLC7/Pzs4++Pd3P/j3d7/U01M/ubi4vcC/Pz/Ew0M/3t1dP6uqqr76+Xm/5ONjv/79fb/d3Fy+kpERv9bVVb+UkxM/gYCAu4OCgr7h4OA88vFxP9XUVD6VlBQ+sbAwvfPy8r4AAIC/wL8/P9zbW7/5+Pi9rKsrv7++vr7h4OA8jIsLv8/Ozj7493c/+Pd3v9TTUz+5uLi9wL8/P8TDQz/e3V0/q6qqvvr5eb/k42O//v19v93cXL6SkRG/1tVVv5STEz+BgIC7g4KCvg==",
+      "vectorSha256": "6a2eaf11770497fe37e356d698dbf05c5b6555fa4b1718667bc1ec1fa394a381",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "83f89a927a4300df12702a50833ab3fb04e974dfe1ee55030e01643715c97f5f",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0730": {
+      "vector": "wsFBv8jHR7/z8vI+vbw8PsjHRz/KyUk/k5KSPuTjYz/My0u/9PNzv5OSkj6+vT2/j46OPvf29r7s62s/oqEhP7GwML2UkxM/g4KCvtDPTz+Xlpa+srExv/v6+j6FhAQ+/fx8PuPi4j7v7u6+u7q6PuPi4j6OjQ0/7+7uvqSjIz/CwUG/yMdHv/Py8j69vDw+yMdHP8rJST+TkpI+5ONjP8zLS7/083O/k5KSPr69Pb+Pjo4+9/b2vuzraz+ioSE/sbAwvZSTEz+DgoK+0M9PP5eWlr6ysTG/+/r6PoWEBD79/Hw+4+LiPu/u7r67uro+4+LiPo6NDT/v7u6+pKMjPw==",
+      "vectorSha256": "3cf329c80d7426686731b91b610461f5447cec7ae235380b0014a742d2cda381",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1f1cbc97e3e4a4f11a06a421a342f5d07ac95fe75a27be909fb844aeb8c644d1",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0731": {
+      "vector": "wL8/P9HQUD3w728/sbAwvbCvLz+3trY+1dRUvp6dHT/u7W0/19bWvoGAgDvw728/tbQ0PuPi4j6VlBQ+m5qaPs/Ozj6xsDC9+fj4PdXUVL6xsDA9z87Ovp+enr6ZmJi9vLs7v8jHR78AAIC/7Otrv7a1NT/h4OA8urk5P9HQUD3Avz8/0dBQPfDvbz+xsDC9sK8vP7e2tj7V1FS+np0dP+7tbT/X1ta+gYCAO/Dvbz+1tDQ+4+LiPpWUFD6bmpo+z87OPrGwML35+Pg91dRUvrGwMD3Pzs6+n56evpmYmL28uzu/yMdHvwAAgL/s62u/trU1P+Hg4Dy6uTk/0dBQPQ==",
+      "vectorSha256": "ce454efa75ca3a5d96ad78f79340e5f9dc192116c55c96a0d535a73e6ac2490d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "df86f77ad7ad65cef64a80f796b892a6b37a8f65854c5876221c000ada83dc86",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0732": {
+      "vector": "qaioPfHwcL20szO/pqUlv4SDAz+Lioo+vr09v9HQUL3Z2Ng9t7a2vszLSz/OzU2/7exsPt/e3r76+Xm/goEBP4+Ojr6VlBQ+7exsPvb1db/u7W0/ycjIvZ2cHL6BgIC7mJcXv6moqL2urS0/kpERv/HwcL3b2to+rKsrv//+/j6pqKg98fBwvbSzM7+mpSW/hIMDP4uKij6+vT2/0dBQvdnY2D23tra+zMtLP87NTb/t7Gw+397evvr5eb+CgQE/j46OvpWUFD7t7Gw+9vV1v+7tbT/JyMi9nZwcvoGAgLuYlxe/qaiova6tLT+SkRG/8fBwvdva2j6sqyu///7+Pg==",
+      "vectorSha256": "152b204902d495079dd346b6cc6a1cb54b74df001d3759f6c13b418c96488c0f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8a78262dc1a221798d52e5199d4803c05c929d05f6736c7f3475d63778b62abf",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0733": {
+      "vector": "r66uPoiHBz+FhAQ+1NNTP9TTU7+cmxs/iokJP9va2j7FxEQ+8fBwvYiHB7+cmxu/2NdXv97dXb/m5WW/zs1NP8rJSb/FxEQ+09LSvvv6+r6xsDA9t7a2vu/u7j6NjAw+7exsvuHg4DyKiQm/29ravuzra7/U01M/kZAQvdjXVz+vrq4+iIcHP4WEBD7U01M/1NNTv5ybGz+KiQk/29raPsXERD7x8HC9iIcHv5ybG7/Y11e/3t1dv+blZb/OzU0/yslJv8XERD7T0tK++/r6vrGwMD23tra+7+7uPo2MDD7t7Gy+4eDgPIqJCb/b2tq+7Otrv9TTUz+RkBC92NdXPw==",
+      "vectorSha256": "baacb9bbc2ff861af9ed7e92f66d4d1f35a77bce393fa9ce194cd436dba8ebc4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "abc390e916cdc4b698783c3214110de61b984b418552bb9162833b490ae97beb",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0734": {
+      "vector": "jo0NP4yLC7/19HS+5ONjv5GQED2+vT0/9PNzP//+/r7j4uI+uLc3P8nIyL3DwsK+xMNDv4+Ojr7R0FC9/v19P/Dvbz/u7W0/hYQEvo+Ojj7S0VG/zs1Nv9va2r7x8HC99/b2vs/Ozj69vDy+xMNDP6WkJD7h4OC8vLs7v62sLD6OjQ0/jIsLv/X0dL7k42O/kZAQPb69PT/083M///7+vuPi4j64tzc/ycjIvcPCwr7Ew0O/j46OvtHQUL3+/X0/8O9vP+7tbT+FhAS+j46OPtLRUb/OzU2/29ravvHwcL339va+z87OPr28PL7Ew0M/paQkPuHg4Ly8uzu/rawsPg==",
+      "vectorSha256": "8f6c06d184cfb5f89db4de054d1145210f38cbd2f801f360fd0cea7ba2e4f32e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c63a610e84def940b8db734f1e5c79fef7f66fa31719497842b368e1947c2295",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0735": {
+      "vector": "zs1NP+rpab+joqI+jIsLv5GQED2hoKC85uVlP9XUVL6mpSW/6ejoPa+urj6FhAS+rq0tv5mYmD2OjQ2/0tFRv8vKyr6OjQ2/n56evpSTE7+3trY+mJcXv+XkZD7p6Oi9sK8vv//+/j6Qjw8/xcREPpiXF7/KyUk/2NdXP/f29r7OzU0/6ulpv6Oioj6Miwu/kZAQPaGgoLzm5WU/1dRUvqalJb/p6Og9r66uPoWEBL6urS2/mZiYPY6NDb/S0VG/y8rKvo6NDb+fnp6+lJMTv7e2tj6Ylxe/5eRkPuno6L2wry+///7+PpCPDz/FxEQ+mJcXv8rJST/Y11c/9/b2vg==",
+      "vectorSha256": "ee458728223954badbe8e4987c702d393cef50e790117386069d3b4822d44811",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e60ba83a847df2652d8eab6f298939174d395836ad349c7128bfc79834e4eb42",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0736": {
+      "vector": "4N9fv+DfX7/Lysq+u7q6vtDPTz/Ix0c/kI8Pv5GQEL2qqSm/9fR0vqmoqL2Lioq+xcREvt3cXL6GhQU/lJMTv5+enj7t7Gw+tbQ0vvPy8j7b2to+zMtLP46NDb/m5WU/9fR0Ptva2j6GhQW/paQkvtfW1j6NjAy+n56ePouKir7g31+/4N9fv8vKyr67urq+0M9PP8jHRz+Qjw+/kZAQvaqpKb/19HS+qaiovYuKir7FxES+3dxcvoaFBT+UkxO/n56ePu3sbD61tDS+8/LyPtva2j7My0s/jo0Nv+blZT/19HQ+29raPoaFBb+lpCS+19bWPo2MDL6fnp4+i4qKvg==",
+      "vectorSha256": "717bd5a138ed05c63c4aec70b3e25302bdbfa7051bda19a4317fc568072dd877",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "10104d51e7e3387b2b61755d6764c236a79d69bcb6e539f29eb63d6bb56ea75d",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0737": {
+      "vector": "rKsrv9fW1j719HS+9/b2vtbVVT/Z2Ni96ulpv9HQUL3r6uq++Pd3v5eWlj7m5WU/m5qavuLhYb+fnp4+/v19P+vq6r6fnp4+r66uvqqpKT8AAIA/kpERv9zbW7/JyMi9rKsrv7y7Oz+hoKA8o6KiPqOioj7g318/sbAwPZOSkr6sqyu/19bWPvX0dL739va+1tVVP9nY2L3q6Wm/0dBQvevq6r7493e/l5aWPublZT+bmpq+4uFhv5+enj7+/X0/6+rqvp+enj6vrq6+qqkpPwAAgD+SkRG/3Ntbv8nIyL2sqyu/vLs7P6GgoDyjoqI+o6KiPuDfXz+xsDA9k5KSvg==",
+      "vectorSha256": "45de56d1fcbe9575d1ac9872c732f220c13b21e80e769dcd87ac57c3c47c4d9e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2ab56142ea720b794504a5f2590fa7fe45a754d4ff3712732add82a8a8ef855b",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0740": {
+      "vector": "3t1dv7i3Nz+fnp6+j46OvpmYmL35+Pi9/Pt7P7CvLz/KyUk/paQkvqCfHz+JiIg9/Pt7v+DfX7+Ylxe/8/LyvujnZz+VlBQ+wsFBv+/u7j7v7u4+r66uPvr5eT+vrq4+7+7uPr++vj7g318/k5KSvtbVVb+wry8/rq0tv8rJSb/e3V2/uLc3P5+enr6Pjo6+mZiYvfn4+L38+3s/sK8vP8rJST+lpCS+oJ8fP4mIiD38+3u/4N9fv5iXF7/z8vK+6OdnP5WUFD7CwUG/7+7uPu/u7j6vrq4++vl5P6+urj7v7u4+v76+PuDfXz+TkpK+1tVVv7CvLz+urS2/yslJvw==",
+      "vectorSha256": "8c2edcbf9aafc681e7cd3fe6b2bc6f0abe7c5107c519e472666919b1495cf3de",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "11db585c7670fdd7e46bcf8802103443f3921fbbbbabfcabbbafef5b15d7291b",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0741": {
+      "vector": "3Ntbv9/e3j7V1FS+7u1tv5eWlr7Y11c/m5qaPrSzM7/DwsI+7u1tP/38fL7o52e/xsVFP7Oysr6Miws/tLMzP5aVFT/Ew0O/6ejovcfGxj66uTm/u7q6PpCPDz/HxsY+oJ8fP+fm5r7Hxsa+urk5P62sLL6npqY+1tVVP+/u7j7c21u/397ePtXUVL7u7W2/l5aWvtjXVz+bmpo+tLMzv8PCwj7u7W0//fx8vujnZ7/GxUU/s7KyvoyLCz+0szM/lpUVP8TDQ7/p6Oi9x8bGPrq5Ob+7uro+kI8PP8fGxj6gnx8/5+bmvsfGxr66uTk/rawsvqempj7W1VU/7+7uPg==",
+      "vectorSha256": "fc08dcf9c4255f861c4176ae5a7c6a5f3d56aefd3bddfcafc6be51dfba77028c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "12b765095aeba626b0f6600ce253c5d9ca1e71b123aec7b1cf464edc6aa9eabb",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0742": {
+      "vector": "0tFRv/r5eT+CgQG/+Pd3P4uKir7c21s/jIsLv+fm5r68uzu/oJ8fP4eGhj7w728/7u1tv6CfH7+wry8/nJsbP5WUFL6wry8/l5aWvvX0dL7a2Vm/2djYPfb1db+Ihwc/yMdHP6inJ7+DgoI+lZQUPpGQED2urS2/jo0NP7++vj7S0VG/+vl5P4KBAb/493c/i4qKvtzbWz+Miwu/5+bmvry7O7+gnx8/h4aGPvDvbz/u7W2/oJ8fv7CvLz+cmxs/lZQUvrCvLz+Xlpa+9fR0vtrZWb/Z2Ng99vV1v4iHBz/Ix0c/qKcnv4OCgj6VlBQ+kZAQPa6tLb+OjQ0/v76+Pg==",
+      "vectorSha256": "426d408ec300c6f9b6a867b159e5b69fdb0bd4bd1c6e37e57085e6f556caf46b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "17fc3ffb5ded3a4622cfa1f70930d7cd6dd75a61138d05c3e32ca0928429c6af",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0744": {
+      "vector": "urk5P4GAgDuKiQk/vbw8PqqpKb+hoKC8zs1NP6Oioj6trCy+/Pt7v/j3dz+Miwu/kZAQvff29j6GhQW/ubi4vd/e3r6Lioq+pqUlv4qJCb+RkBC9jYwMPtrZWb+vrq6+//7+PqSjIz/493e/urk5P/n4+D3Qz08/vbw8vtfW1j66uTk/gYCAO4qJCT+9vDw+qqkpv6GgoLzOzU0/o6KiPq2sLL78+3u/+Pd3P4yLC7+RkBC99/b2PoaFBb+5uLi9397evouKir6mpSW/iokJv5GQEL2NjAw+2tlZv6+urr7//v4+pKMjP/j3d7+6uTk/+fj4PdDPTz+9vDy+19bWPg==",
+      "vectorSha256": "1e0d4ccfb65da4f49a599f2c0b4b6f8c664dec5d7586d96f44b739136e484f6e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dc80c4972b7de6a86a02fb3a7bbd3d74485d2d3b7b911354bfd104dc8fe768b5",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0746": {
+      "vector": "sK8vP8/Ozr6wry8/4eDgPKSjI7/My0u/8fBwPeHg4DzCwUG/trU1v769Pb+Miwu/09LSPtva2r7+/X0/2tlZv7CvLz/f3t4++Pd3v9zbWz/S0VG/9PNzP9/e3r7DwsI++Pd3v+LhYb/w72+/+fj4PY2MDD6enR0/t7a2vu3sbL6wry8/z87OvrCvLz/h4OA8pKMjv8zLS7/x8HA94eDgPMLBQb+2tTW/vr09v4yLC7/T0tI+29ravv79fT/a2Vm/sK8vP9/e3j7493e/3NtbP9LRUb/083M/397evsPCwj7493e/4uFhv/Dvb7/5+Pg9jYwMPp6dHT+3tra+7exsvg==",
+      "vectorSha256": "9f5706e7884758d97b891f28a526c8e468312cbc3199464507d86df80dd9ea19",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d74cd7832e1a87831f25213ab449fe13d7b704ed17f948b0040f088f91ce5262",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0747": {
+      "vector": "oaCgPJqZGT/Avz8/qqkpv6CfH7/Y11e/9/b2vq6tLT/g318/hIMDv8HAQLz083O/+Pd3P93cXD6CgQG/1NNTv5CPDz/l5GS+x8bGPuPi4j6rqqo+tbQ0PtnY2L23trY+19bWvrOysr7S0VE/0tFRv7u6ur7v7u4+5uVlP728PL6hoKA8mpkZP8C/Pz+qqSm/oJ8fv9jXV7/39va+rq0tP+DfXz+EgwO/wcBAvPTzc7/493c/3dxcPoKBAb/U01O/kI8PP+XkZL7HxsY+4+LiPquqqj61tDQ+2djYvbe2tj7X1ta+s7KyvtLRUT/S0VG/u7q6vu/u7j7m5WU/vbw8vg==",
+      "vectorSha256": "63817c89cbe242a464fa4519bef3073be2c8b8ec595ea19d2ccbb001a4e1401c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "82ccdf2b301442d6ef3e7e06fb9b3f16c763b1b8aa9672ad4a53e81751bbf268",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0748": {
+      "vector": "2djYPbCvL7/x8HC919bWvru6ur7p6Og9kZAQPaWkJD729XW/rawsPru6ur729XU/7+7uvuLhYT+9vDy+29ravsLBQb/g318/oqEhP+7tbT/FxEQ+/fx8vvb1db+rqqo+x8bGPpCPD7+GhQU/xMNDP5GQED2GhQW/1dRUPo+Ojr7Z2Ng9sK8vv/HwcL3X1ta+u7q6vuno6D2RkBA9paQkPvb1db+trCw+u7q6vvb1dT/v7u6+4uFhP728PL7b2tq+wsFBv+DfXz+ioSE/7u1tP8XERD79/Hy+9vV1v6uqqj7HxsY+kI8Pv4aFBT/Ew0M/kZAQPYaFBb/V1FQ+j46Ovg==",
+      "vectorSha256": "71d0f21761f927ebcfabc0be57551f18fe6c4986be10910826ea2545185cac4e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8d28784a518e8494059551fa44f068491fefd0f6986005aab138c2e1843d9a5c",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0749": {
+      "vector": "zcxMvublZb+ioSG/8vFxv+3sbD6WlRW/n56evq+urr7w728/iokJP4GAgLv8+3u/9vV1P9va2r6Qjw8/uLc3P4KBAb/CwUE/kpERv8/Ozr7//v4+n56ePqKhIT/R0FC9yMdHP5eWlr6ioSG/7+7uPo+Ojj6DgoK+paQkvtTTUz/NzEy+5uVlv6KhIb/y8XG/7exsPpaVFb+fnp6+r66uvvDvbz+KiQk/gYCAu/z7e7/29XU/29ravpCPDz+4tzc/goEBv8LBQT+SkRG/z87Ovv/+/j6fnp4+oqEhP9HQUL3Ix0c/l5aWvqKhIb/v7u4+j46OPoOCgr6lpCS+1NNTPw==",
+      "vectorSha256": "1b194a306cf5d30b4b3cb00bff365833421f276d10c0e078147d585dd67db333",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "660d2f079d355854f7c47f02fa49c7db3fe0374cbfa7d079e35a2fbba35f6be9",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0750": {
+      "vector": "wcBAvOLhYT+enR0/s7Kyvvz7ez/19HQ+/v19v4yLC7/DwsK+tbQ0PrCvLz/BwEA8vbw8PuHg4Lzd3Fy+iIcHv+3sbD6OjQ0/paQkPt3cXL6opyc/oaCgvK+urr6amRm/z87OPq2sLD729XU/t7a2PqCfHz/BwEC8urk5v8fGxr7BwEC84uFhP56dHT+zsrK+/Pt7P/X0dD7+/X2/jIsLv8PCwr61tDQ+sK8vP8HAQDy9vDw+4eDgvN3cXL6Ihwe/7exsPo6NDT+lpCQ+3dxcvqinJz+hoKC8r66uvpqZGb/Pzs4+rawsPvb1dT+3trY+oJ8fP8HAQLy6uTm/x8bGvg==",
+      "vectorSha256": "a5c28b9b810f31b3a2ab2079486d1ca5c90545e17f9d02744cd7b095583666c1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7ef0ce53fd9e013a4f96d781977c643c9dc69464d37d5433b395faadcf7e234e",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0751": {
+      "vector": "mZiYPYmIiD2JiIi9r66uvvn4+L24tze/n56evouKij6vrq4+0dBQvbu6ur6qqSm/vr09v66tLT+GhQW/m5qavpqZGT+gnx+/3dxcvoWEBL7n5ua+09LSPsC/Pz/Hxsa+09LSPoyLCz/Qz08/nJsbP6SjIz/X1tY+s7KyPqKhIT+ZmJg9iYiIPYmIiL2vrq6++fj4vbi3N7+fnp6+i4qKPq+urj7R0FC9u7q6vqqpKb++vT2/rq0tP4aFBb+bmpq+mpkZP6CfH7/d3Fy+hYQEvufm5r7T0tI+wL8/P8fGxr7T0tI+jIsLP9DPTz+cmxs/pKMjP9fW1j6zsrI+oqEhPw==",
+      "vectorSha256": "dcd17e5c1b70b94156a2f1396fa9ae6568c9a62042d9c2c65fa8cde69c89b9e1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "89887754702458a2ab79512b21d63d59cc30646f46b4df4eb4c5e7cdd1b5acd0",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0752": {
+      "vector": "n56evry7Oz+KiQk/8O9vP9PS0r6GhQU/0tFRv7GwML2koyO/09LSvomIiL2hoKC80tFRv7q5Ob+4tzc/vr09v6WkJL6Lioo+5eRkvpWUFD6Hhoa+0dBQPevq6j6xsDA9AACAv7SzMz+enR0/+Pd3v4+Ojj7a2Vk/jYwMvoaFBT+fnp6+vLs7P4qJCT/w728/09LSvoaFBT/S0VG/sbAwvaSjI7/T0tK+iYiIvaGgoLzS0VG/urk5v7i3Nz++vT2/paQkvouKij7l5GS+lZQUPoeGhr7R0FA96+rqPrGwMD0AAIC/tLMzP56dHT/493e/j46OPtrZWT+NjAy+hoUFPw==",
+      "vectorSha256": "e91754f5a92e99f5fb1cab3d73bde1250d409f0971227038eea68e9bc85f7a87",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "58ddc4f74bc2177a2e4b777d1723db216ba263925e86ba8500d9ce04a3ec6ec2",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0753": {
+      "vector": "trU1P9XUVL4AAIC/l5aWPt3cXD62tTW/oaCgPNjXVz+Ihwe/+vl5P6uqqj7u7W0/3NtbP8XERD7x8HC9w8LCPqalJb+BgIA74+LiPuXkZD6KiQk/9/b2PpSTE7/Ix0e/oaCgvIGAgLvNzEw+v76+Ptva2r6EgwO/+fj4PZ2cHL62tTU/1dRUvgAAgL+XlpY+3dxcPra1Nb+hoKA82NdXP4iHB7/6+Xk/q6qqPu7tbT/c21s/xcREPvHwcL3DwsI+pqUlv4GAgDvj4uI+5eRkPoqJCT/39vY+lJMTv8jHR7+hoKC8gYCAu83MTD6/vr4+29ravoSDA7/5+Pg9nZwcvg==",
+      "vectorSha256": "c2c729a08cac7d71441c86edc7537dae724841040826c82da195954f617769ec",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "da6500a59b2582eb3cfcaaf6ed9878b02d80b89cc4bd361c7d7f99af493e8f6c",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0754": {
+      "vector": "qaioPZaVFb/i4WG/29ravomIiL2BgIC7hYQEPsHAQLzr6uq+8/LyvvLxcb/r6uo+kI8PP/79fT+1tDQ+urk5P7W0ND7w728/3t1dv4yLC7/Y11e/9PNzP6+urr7y8XG/tbQ0vsfGxj7x8HC92NdXP5qZGT+zsrI+goEBP6qpKb+pqKg9lpUVv+LhYb/b2tq+iYiIvYGAgLuFhAQ+wcBAvOvq6r7z8vK+8vFxv+vq6j6Qjw8//v19P7W0ND66uTk/tbQ0PvDvbz/e3V2/jIsLv9jXV7/083M/r66uvvLxcb+1tDS+x8bGPvHwcL3Y11c/mpkZP7Oysj6CgQE/qqkpvw==",
+      "vectorSha256": "2f8f64d5d81344da3250df2120b636d954f86d0eff62a6c35141ac8edeb41cbc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8a350f49777f907e454307bac7fe96dc96f7113a14f9540769b178ebccacc02b",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0755": {
+      "vector": "+/r6vr++vr6rqqq+n56ePr++vj7Y11e/sK8vv6Oioj6CgQE/6+rqPvf29j6OjQ0/srExv+vq6r6GhQU/oJ8fP7CvLz+ioSG//Pt7v6qpKT+dnBw+mJcXP9nY2L3o52e/jo0Nv+Pi4j6dnBy+j46OPpGQEL2dnBw+j46OPtzbW7/7+vq+v76+vquqqr6fnp4+v76+PtjXV7+wry+/o6KiPoKBAT/r6uo+9/b2Po6NDT+ysTG/6+rqvoaFBT+gnx8/sK8vP6KhIb/8+3u/qqkpP52cHD6Ylxc/2djYvejnZ7+OjQ2/4+LiPp2cHL6Pjo4+kZAQvZ2cHD6Pjo4+3Ntbvw==",
+      "vectorSha256": "9f44ebbb4a7df429f40630bebb0e054990593227b7e449accfb16e9f5eee5419",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "415055a7af1428a8c0babdc62745c2cfd72f02d493cb720c39b86ca37b93a312",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0756": {
+      "vector": "xsVFP4qJCb/S0VG/2NdXv6Oior78+3u/yMdHP4KBAT+Pjo6+9vV1v728PD7n5uY+oaCgPOLhYT/Qz0+/oJ8fP/z7e7+mpSU/09LSvoaFBb/BwEC80tFRv9LRUb/X1ta+6OdnP5aVFT+/vr6+lJMTP9zbW7/i4WE/wL8/v9LRUb/GxUU/iokJv9LRUb/Y11e/o6Kivvz7e7/Ix0c/goEBP4+Ojr729XW/vbw8Pufm5j6hoKA84uFhP9DPT7+gnx8//Pt7v6alJT/T0tK+hoUFv8HAQLzS0VG/0tFRv9fW1r7o52c/lpUVP7++vr6UkxM/3Ntbv+LhYT/Avz+/0tFRvw==",
+      "vectorSha256": "b3e2cd858ed47899b76400ea22d428531a435f4602d3958c5d1898d7ba7a61ce",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e23b17145702e3c05c0597b982f018cf02d24b3d7e17174af3ca50c912f02017",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0757": {
+      "vector": "29ravpSTEz/y8XE/0tFRv83MTL6xsDA9iIcHv+Pi4r6sqyu/+fj4vd/e3r7Z2Ng94uFhP5iXFz+JiIi94eDgPKSjIz+opye/mpkZv+no6L2gnx+/+fj4PYuKij69vDw+pKMjP6moqL3x8HC95uVlP8PCwj7FxES+/fx8vqWkJL7b2tq+lJMTP/LxcT/S0VG/zcxMvrGwMD2Ihwe/4+LivqyrK7/5+Pi9397evtnY2D3i4WE/mJcXP4mIiL3h4OA8pKMjP6inJ7+amRm/6ejovaCfH7/5+Pg9i4qKPr28PD6koyM/qaiovfHwcL3m5WU/w8LCPsXERL79/Hy+paQkvg==",
+      "vectorSha256": "72b0b40757dba10bc62f7577a98151ec121d90b41325e3c143e9dc1c21552591",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "49c9f81766853c472a70488df0cb7783d12c3371308fa297d17578f2b067606b",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0758": {
+      "vector": "1tVVP6SjIz/9/Hy+hIMDv8HAQLyioSG/paQkPvDvbz/8+3u/uLc3v/z7e7/d3Fw+tLMzv5mYmL2Miws/397evszLSz/FxEQ+7Otrv9va2j6vrq6+ubi4vamoqL3o52e/iokJv6moqL3m5WW/rq0tv62sLL77+vq+lZQUPvb1db/W1VU/pKMjP/38fL6EgwO/wcBAvKKhIb+lpCQ+8O9vP/z7e7+4tze//Pt7v93cXD60szO/mZiYvYyLCz/f3t6+zMtLP8XERD7s62u/29raPq+urr65uLi9qaiovejnZ7+KiQm/qaioveblZb+urS2/rawsvvv6+r6VlBQ+9vV1vw==",
+      "vectorSha256": "e9808823ef5750330cc12b0e4cc3a285b7c9ae0df911a654caf5b1d29d02d1ba",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ead1603e7e2f94f70224029b2676c548e5980ab65474750c3b750d296a419205",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0759": {
+      "vector": "xMNDP6+urr6WlRW/mZiYvZmYmL23tra+7+7uPpOSkr7u7W2/xMNDv5qZGT/l5GQ+wL8/P7m4uD3HxsY+jo0NP/Tzc7/f3t6+9PNzP9/e3r7c21u/iYiIPby7Oz/T0tK+lpUVP7++vr7FxEQ+5eRkvpybGz+4tze/o6KivqOior7Ew0M/r66uvpaVFb+ZmJi9mZiYvbe2tr7v7u4+k5KSvu7tbb/Ew0O/mpkZP+XkZD7Avz8/ubi4PcfGxj6OjQ0/9PNzv9/e3r7083M/397evtzbW7+JiIg9vLs7P9PS0r6WlRU/v76+vsXERD7l5GS+nJsbP7i3N7+joqK+o6Kivg==",
+      "vectorSha256": "75243deea0336711e7faf4d59f658b4b8fde3dd71802cad0538aa2659c2ca6e4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e15435767652bb5b091ecc9cdf8bb1c60648f9481288dd4bca509863cd245757",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0760": {
+      "vector": "mJcXP93cXL7Ew0M/z87OvszLSz+urS0/5+bmvpaVFb+vrq6++/r6vo2MDD7KyUk/mZiYvfr5eb/6+Xk/+vl5P8vKyj7BwEA8u7q6PqOior6DgoI+1tVVP7++vr63tra+m5qavsvKyr6TkpK+oaCgPIKBAb/493e/mZiYvczLSz+Ylxc/3dxcvsTDQz/Pzs6+zMtLP66tLT/n5ua+lpUVv6+urr77+vq+jYwMPsrJST+ZmJi9+vl5v/r5eT/6+Xk/y8rKPsHAQDy7uro+o6KivoOCgj7W1VU/v76+vre2tr6bmpq+y8rKvpOSkr6hoKA8goEBv/j3d7+ZmJi9zMtLPw==",
+      "vectorSha256": "369b03ad6df7fe0462e807f587a36f57187fd771cc4ea53a38f9da4c0ec6bf54",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cb64e14ce5d64635544191e47603fcfcb281ae57a0ea5052594d5b823f0476e5",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0761": {
+      "vector": "goEBv9DPTz+3trY+goEBv769Pb+3tra+4eDgvIWEBL739vY+9vV1P7y7Oz+6uTm/6+rqvvX0dL7FxES+4uFhP9zbW7/6+Xk/w8LCPtTTUz+ioSE/zcxMvuPi4r4AAIA/7OtrP7a1NT/083O/29ravv/+/j78+3s/jYwMvvPy8j6CgQG/0M9PP7e2tj6CgQG/vr09v7e2tr7h4OC8hYQEvvf29j729XU/vLs7P7q5Ob/r6uq+9fR0vsXERL7i4WE/3Ntbv/r5eT/DwsI+1NNTP6KhIT/NzEy+4+LivgAAgD/s62s/trU1P/Tzc7/b2tq+//7+Pvz7ez+NjAy+8/LyPg==",
+      "vectorSha256": "92cea857f776627c5d4180f6927763a4860b978c2632eb56317e8ba1bebf4ac8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3fe7ad3f21527c6fbdfadd23456167f012fcb0e9d06647fff5da0649bffd6ebc",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0762": {
+      "vector": "lZQUPru6uj6+vT0/trU1P5WUFL6opyc/5uVlP9HQUD2FhAQ+qKcnv/Tzc7+JiIi9/fx8vo6NDb/8+3u/trU1v/Tzc7+NjAy+rKsrP4iHB7+OjQ0/6ulpv7CvL7/39vY++fj4vdrZWT+cmxs//v19P9TTU7+ysTE/qKcnP+zra7+VlBQ+u7q6Pr69PT+2tTU/lZQUvqinJz/m5WU/0dBQPYWEBD6opye/9PNzv4mIiL39/Hy+jo0Nv/z7e7+2tTW/9PNzv42MDL6sqys/iIcHv46NDT/q6Wm/sK8vv/f29j75+Pi92tlZP5ybGz/+/X0/1NNTv7KxMT+opyc/7Otrvw==",
+      "vectorSha256": "04d42033488ef59cdb876c49317921b51b49dc041bfbaa582dee621ad5bfeb13",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "92aededa6dd3f286902c067760390225066ed53cc60b28bd70eccdfe16d8d30a",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0763": {
+      "vector": "4+LiPqmoqL20szO/trU1P+DfX7+Xlpa+qqkpP+Pi4j7u7W0/hoUFP6inJz/u7W0/yslJv5GQEL3c21u/q6qqvtva2j7R0FA9yMdHP9va2j7Ew0O/i4qKPvHwcL2Ihwc/5uVlv+zraz/GxUU/tbQ0PrCvLz/d3Fy+hYQEPsC/P7/j4uI+qaiovbSzM7+2tTU/4N9fv5eWlr6qqSk/4+LiPu7tbT+GhQU/qKcnP+7tbT/KyUm/kZAQvdzbW7+rqqq+29raPtHQUD3Ix0c/29raPsTDQ7+Lioo+8fBwvYiHBz/m5WW/7OtrP8bFRT+1tDQ+sK8vP93cXL6FhAQ+wL8/vw==",
+      "vectorSha256": "a6e05807e0bb9300f6dac494e0b46304346f866ecef9544ae86df87c50653fb8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b87526da105ad4b8f6c2d3f61b7b1255b686e3b61ea278c30df5e296d7649020",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0764": {
+      "vector": "qKcnP9rZWT/5+Pg9qaioPdfW1r7//v4+q6qqPpSTEz+ysTG/qKcnv4mIiL3z8vK+pKMjP6Oioj6ysTE/5+bmvqyrKz/GxUW/8vFxP4qJCb+koyM/7OtrP7y7Oz+VlBS+7+7uPra1NT+BgIC77OtrP6KhIT/m5WW/5+bmPs/Ozj6opyc/2tlZP/n4+D2pqKg919bWvv/+/j6rqqo+lJMTP7KxMb+opye/iYiIvfPy8r6koyM/o6KiPrKxMT/n5ua+rKsrP8bFRb/y8XE/iokJv6SjIz/s62s/vLs7P5WUFL7v7u4+trU1P4GAgLvs62s/oqEhP+blZb/n5uY+z87OPg==",
+      "vectorSha256": "320ee9de96c90e96c52cf79c0733fa63e08a39312bbe039349f0d8b48693e434",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d3ec8f8a4abfaac9272c7743d1a8d846d51df83bd1f5dd6dbbda7ff5d00db9b3",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0765": {
+      "vector": "7exsPsnIyL3w72+/6ulpP/X0dL7FxES+mpkZP6moqD3DwsK+7Otrv8HAQLzV1FS++/r6vr69PT+DgoK+AACAv//+/j6ysTE/hoUFv6KhIb+3tra+u7q6vv79fb/a2Vm/lJMTP//+/r6ysTG/kpERv/b1db+ysTG/4N9fP+7tbT/t7Gw+ycjIvfDvb7/q6Wk/9fR0vsXERL6amRk/qaioPcPCwr7s62u/wcBAvNXUVL77+vq+vr09P4OCgr4AAIC///7+PrKxMT+GhQW/oqEhv7e2tr67urq+/v19v9rZWb+UkxM///7+vrKxMb+SkRG/9vV1v7KxMb/g318/7u1tPw==",
+      "vectorSha256": "4ad4c466c85146c7f1df6a96842cb250552ecd94e2ff3268fe6480aa720f6628",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9d7308f46167cc8a4f0a7e6541de5f00bfd83d2f52510113c94027370527eff6",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0766": {
+      "vector": "7Otrv9nY2D3+/X2/wsFBv9PS0r6ioSE/7OtrP4GAgLvl5GQ+y8rKvpOSkr7k42O/jYwMPu/u7j7R0FA9m5qavsTDQz/W1VU/4eDgPPX0dD7493c/r66uvtbVVb+zsrK+pqUlv+blZT/+/X2/nZwcvpaVFb+Lioq+6Odnv9PS0r7s62u/2djYPf79fb/CwUG/09LSvqKhIT/s62s/gYCAu+XkZD7Lysq+k5KSvuTjY7+NjAw+7+7uPtHQUD2bmpq+xMNDP9bVVT/h4OA89fR0Pvj3dz+vrq6+1tVVv7Oysr6mpSW/5uVlP/79fb+dnBy+lpUVv4uKir7o52e/09LSvg==",
+      "vectorSha256": "2cbc1802d26ca10582cdd585ef1de96b1f37b8e9fdf1afa6aa85103395bb49e1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0a8d011f4bd0f57f9c4d5b0e91bb8659e1ea839efb5415532df2016c355d0c4b",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0767": {
+      "vector": "j46OPvPy8r69vDy+3NtbP8PCwr7Qz08/zcxMPpOSkr7083M/p6amvv38fD7//v4+8fBwvYiHB7+WlRW//v19v83MTD6sqys/ycjIPamoqD37+vq+qKcnv9/e3r7f3t4+vr09v+rpab/5+Pg97OtrP7GwMD2Pjo6+397ePq+urj6Pjo4+8/Lyvr28PL7c21s/w8LCvtDPTz/NzEw+k5KSvvTzcz+npqa+/fx8Pv/+/j7x8HC9iIcHv5aVFb/+/X2/zcxMPqyrKz/JyMg9qaioPfv6+r6opye/397evt/e3j6+vT2/6ulpv/n4+D3s62s/sbAwPY+Ojr7f3t4+r66uPg==",
+      "vectorSha256": "2d78dde195c4a14da1dc54a87a6de7331c3378b4826c0f78de37b3ffff4aa5fc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a34368ed4fe7995bf9569fbf783c350199d58c8a412c48b7210b8ff5855cb7ab",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0768": {
+      "vector": "AACAv9PS0r7R0FA9tLMzP7GwMD3a2Vm/4uFhv769PT+OjQ2/kpERP7++vr6TkpI+wcBAvJCPD7/z8vI+1dRUvq+urr62tTW/np0dv8vKyj7KyUm/2djYvZqZGT///v4++fj4PdzbWz+zsrI+09LSPqmoqD2urS2/7Otrv6yrKz8AAIC/09LSvtHQUD20szM/sbAwPdrZWb/i4WG/vr09P46NDb+SkRE/v76+vpOSkj7BwEC8kI8Pv/Py8j7V1FS+r66uvra1Nb+enR2/y8rKPsrJSb/Z2Ni9mpkZP//+/j75+Pg93NtbP7Oysj7T0tI+qaioPa6tLb/s62u/rKsrPw==",
+      "vectorSha256": "cd3dc3d67b52beb649400bc80d95cb2cc0e1f656673f84e61c6374c3d81aec17",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "004b86d985130fde39c850a47e38bc65542531b21b72ccbf8fedacb48a290ad5",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0769": {
+      "vector": "3Ntbv97dXb+joqK+oJ8fP5uamr6enR2/4eDgPLW0NL6+vT0/+/r6voeGhj6RkBC9rKsrv52cHD7Z2Ng9t7a2vt/e3r719HS+srExP5aVFb/V1FS+9PNzP5CPDz+joqI+6ejoPZCPDz/m5WU/qaioPf/+/j6qqSk/o6KiPoyLCz/c21u/3t1dv6Oior6gnx8/m5qavp6dHb/h4OA8tbQ0vr69PT/7+vq+h4aGPpGQEL2sqyu/nZwcPtnY2D23tra+397evvX0dL6ysTE/lpUVv9XUVL7083M/kI8PP6Oioj7p6Og9kI8PP+blZT+pqKg9//7+PqqpKT+joqI+jIsLPw==",
+      "vectorSha256": "f1c33caaf47a81e69a2a621e11008dca86ddcef6e42305a69e852033163b0143",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "121157cf59318369de41a17b2a938d524861d83565f9c7a88ec7f28abfd4a8c5",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0770": {
+      "vector": "7Otrv9HQUD3p6Og9hIMDP+TjYz+BgIC7s7KyPtDPT7/c21u/hIMDP+TjY7+DgoI+tLMzv4qJCT/NzEy++/r6vqinJz/9/Hw+tbQ0vvr5eb/+/X0/9fR0vpuamj6cmxu/vLs7P4iHBz+dnBw+4uFhP/b1db+xsDC9pKMjP7q5OT/s62u/0dBQPeno6D2EgwM/5ONjP4GAgLuzsrI+0M9Pv9zbW7+EgwM/5ONjv4OCgj60szO/iokJP83MTL77+vq+qKcnP/38fD61tDS++vl5v/79fT/19HS+m5qaPpybG7+8uzs/iIcHP52cHD7i4WE/9vV1v7GwML2koyM/urk5Pw==",
+      "vectorSha256": "9491bed5afbaf7854de146c23e10bce1dccbfed858337ffe35d7582b6b5e49ea",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0a868ec1f17fac1812c10ea026c46641d39f6903fe61a632ddc393f0057ad1dc",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0771": {
+      "vector": "u7q6vpCPD7+pqKg9i4qKPuPi4j6gnx+/1NNTv+DfX7+qqSm/zs1Nv+blZT/h4OC8srExP/X0dL60szM/0tFRP8fGxj6JiIi9h4aGvp2cHD6Pjo4+4uFhP9nY2L3Qz08/3dxcPublZT+enR0/jIsLP/Dvb7/g318/hYQEvoiHBz+7urq+kI8Pv6moqD2Lioo+4+LiPqCfH7/U01O/4N9fv6qpKb/OzU2/5uVlP+Hg4LyysTE/9fR0vrSzMz/S0VE/x8bGPomIiL2Hhoa+nZwcPo+Ojj7i4WE/2djYvdDPTz/d3Fw+5uVlP56dHT+Miws/8O9vv+DfXz+FhAS+iIcHPw==",
+      "vectorSha256": "89397a803e63205d027f4b44e078694b7381cc362bd64900ff93f53fa097bf35",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "51388aa2b83016102b19f27cd861d9e8b1775e93a3f072e79bf2cec508ef6fc3",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0772": {
+      "vector": "6ulpv5+enr6cmxu/8fBwPZ6dHT/y8XG/qqkpv/Tzc7/v7u4+/Pt7P5aVFb+BgIA7+vl5v+no6L2RkBA9l5aWPpuamj7V1FQ+AACAv5STEz/8+3u/kpERv+/u7j7//v4+4+Livt3cXL6Xlpa+g4KCPublZT+joqK+sbAwvfPy8j7q6Wm/n56evpybG7/x8HA9np0dP/Lxcb+qqSm/9PNzv+/u7j78+3s/lpUVv4GAgDv6+Xm/6ejovZGQED2XlpY+m5qaPtXUVD4AAIC/lJMTP/z7e7+SkRG/7+7uPv/+/j7j4uK+3dxcvpeWlr6DgoI+5uVlP6Oior6xsDC98/LyPg==",
+      "vectorSha256": "47b321685e259837408acf6877f8a7db513556ae73d7202847511b6989aac56f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0b583287ce072b06bbfd3580037184a5a69a00c90237bbbf47645aa0f2577abc",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0773": {
+      "vector": "qaioPba1Nb+Pjo6+k5KSvpiXF7/X1ta+kZAQvb28PL6cmxu/oaCgvN3cXD7Ix0c/zcxMvu/u7j6KiQm/lZQUvtrZWT/p6Og9/fx8vqinJz+fnp4+qaioPf79fb/w72+/v76+PsjHR7/Pzs4+wL8/P8/Ozj6Lioo+x8bGvv38fD6pqKg9trU1v4+Ojr6TkpK+mJcXv9fW1r6RkBC9vbw8vpybG7+hoKC83dxcPsjHRz/NzEy+7+7uPoqJCb+VlBS+2tlZP+no6D39/Hy+qKcnP5+enj6pqKg9/v19v/Dvb7+/vr4+yMdHv8/Ozj7Avz8/z87OPouKij7Hxsa+/fx8Pg==",
+      "vectorSha256": "1fcf4cb189849b935d580ade4beff244a9cff8eb91cec6d18054977ffc384ede",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8a255c5b344a7b68327d9be366bb3b6dec8e60d3a78a0108af1cb3dfb3a24e9f",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0774": {
+      "vector": "vr09v4OCgj66uTk/t7a2PrSzMz/W1VW/q6qqvqinJ7+DgoK+z87Ovru6uj75+Pg919bWPp+enj7t7Gy+1tVVP8jHRz+DgoK+vbw8vqSjI7/r6uq+8vFxv+DfX7/l5GQ+wsFBv6qpKT+DgoK+paQkPsjHRz+fnp4+xMNDP7u6ur6+vT2/g4KCPrq5OT+3trY+tLMzP9bVVb+rqqq+qKcnv4OCgr7Pzs6+u7q6Pvn4+D3X1tY+n56ePu3sbL7W1VU/yMdHP4OCgr69vDy+pKMjv+vq6r7y8XG/4N9fv+XkZD7CwUG/qqkpP4OCgr6lpCQ+yMdHP5+enj7Ew0M/u7q6vg==",
+      "vectorSha256": "8dc30dea2fa889b00d41eab2bd41e1c6ecd58240b23b4f0c428d122d8e93e28a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "21a0dcadd915552c5f4cae8fb5a762eae35f682e4507109c1fd45f94e3a7e151",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0775": {
+      "vector": "p6amvo2MDL7Y11c/lJMTv4mIiD2EgwO/j46OvvX0dD6EgwO/9/b2PtDPTz/W1VW/iokJP5uamj7Avz+/9/b2vqqpKb+urS2/3Ntbv7e2tr7j4uK+h4aGPqalJb+Qjw+/9PNzP/r5eb++vT0/jYwMPvPy8j7Avz+/3dxcPs3MTL6npqa+jYwMvtjXVz+UkxO/iYiIPYSDA7+Pjo6+9fR0PoSDA7/39vY+0M9PP9bVVb+KiQk/m5qaPsC/P7/39va+qqkpv66tLb/c21u/t7a2vuPi4r6HhoY+pqUlv5CPD7/083M/+vl5v769PT+NjAw+8/LyPsC/P7/d3Fw+zcxMvg==",
+      "vectorSha256": "1d80fcb7ca3bd49679022c67812e4d6a15ef460d4893649f2c0074975d8c03ca",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "566eeb36883e5c9e3ebde715c4a620422b29125247a12d38f903de91bc209b66",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0776": {
+      "vector": "1NNTv7u6ur62tTU/5uVlP4KBAT+ysTE/h4aGPpGQED2UkxO/yslJv5GQED2lpCQ+n56ePpCPDz+joqK+y8rKPuDfX7/W1VW/y8rKPpiXF7+Lioo+3NtbP9va2r7JyMg9mpkZv6+urr6VlBQ+h4aGPtbVVb/v7u6+iokJv5eWlj7U01O/u7q6vra1NT/m5WU/goEBP7KxMT+HhoY+kZAQPZSTE7/KyUm/kZAQPaWkJD6fnp4+kI8PP6Oior7Lyso+4N9fv9bVVb/Lyso+mJcXv4uKij7c21s/29ravsnIyD2amRm/r66uvpWUFD6HhoY+1tVVv+/u7r6KiQm/l5aWPg==",
+      "vectorSha256": "e458299b0fe81176fd1e0a2953da736703756a4a61667de59785995dae5f68d5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1651daf2c0d8a184361b8494a7c757b21015b234a2ed498c335492a115443ba5",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0777": {
+      "vector": "09LSPpCPD7+WlRU/3dxcPsPCwr7Ix0c/lJMTv9XUVL7Ew0O/ycjIvd3cXD6sqyu/iYiIvaSjI7/h4OC86ejovYqJCb/R0FC99/b2vpeWlj7Z2Ng9vLs7P/n4+L2vrq6+y8rKPt7dXb+koyO/5uVlv4OCgj7Avz+/0M9PP5iXFz/T0tI+kI8Pv5aVFT/d3Fw+w8LCvsjHRz+UkxO/1dRUvsTDQ7/JyMi93dxcPqyrK7+JiIi9pKMjv+Hg4Lzp6Oi9iokJv9HQUL339va+l5aWPtnY2D28uzs/+fj4va+urr7Lyso+3t1dv6SjI7/m5WW/g4KCPsC/P7/Qz08/mJcXPw==",
+      "vectorSha256": "d39130d5b340e2d626d7356f5aa988a549b279af6c668fc6c949fdd4c636cd9e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b438ca9b4fe336651e739b2a772e7c713b7942a58ddd7054b2112e0da020e7cb",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0778": {
+      "vector": "iokJP5qZGT+Ylxc/5eRkvqmoqL22tTU/0tFRP4WEBD6vrq6+8O9vP52cHL7Avz8/6ejova2sLD7GxUU/u7q6vq2sLD4AAIC/wL8/v+DfX7+Ihwc/oqEhP5iXF7/a2Vk/mJcXP8TDQ7+zsrK+r66uPpeWlj7DwsK+s7KyPuLhYb+KiQk/mpkZP5iXFz/l5GS+qaiovba1NT/S0VE/hYQEPq+urr7w728/nZwcvsC/Pz/p6Oi9rawsPsbFRT+7urq+rawsPgAAgL/Avz+/4N9fv4iHBz+ioSE/mJcXv9rZWT+Ylxc/xMNDv7Oysr6vrq4+l5aWPsPCwr6zsrI+4uFhvw==",
+      "vectorSha256": "4333a9f81b691ae5934e9bfd51bc161165bc4811065a2b2f13ab3f405e08915e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c4cccb6375dae89054f76cdf7195e25195002010c3d034eccb1e53aba54fac0f",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0779": {
+      "vector": "hoUFv7CvL7+GhQW/4eDgvLa1NT+RkBA9srExv5GQED2zsrI+l5aWvr++vj69vDw+mJcXv6uqqr6NjAy+5uVlP9fW1r6fnp4+s7Kyvr69Pb+BgIA7y8rKPuDfXz/19HS+s7KyPuDfXz/GxUW/t7a2vsfGxj6npqa+0tFRP8/Ozj6GhQW/sK8vv4aFBb/h4OC8trU1P5GQED2ysTG/kZAQPbOysj6Xlpa+v76+Pr28PD6Ylxe/q6qqvo2MDL7m5WU/19bWvp+enj6zsrK+vr09v4GAgDvLyso+4N9fP/X0dL6zsrI+4N9fP8bFRb+3tra+x8bGPqempr7S0VE/z87OPg==",
+      "vectorSha256": "48b36fde78d2f0991588d429013032d54ea1f6eada22f6271dc6d070ebc7ef27",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3d283d7cda842784ac5aaf9734556ef24aa7532180b2ef61acef1d52b156e8b3",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0780": {
+      "vector": "qqkpv4yLCz/V1FS+pqUlP/j3d7/l5GQ+xMNDv4aFBT+joqI+9fR0PqSjI7/T0tK+kpERP4iHBz/u7W0/g4KCvpGQEL3Qz08/lpUVv4uKir6Ylxc/5eRkPoOCgr6enR2/vr09P+no6L3KyUm/q6qqvvTzc7+rqqo+7exsPr++vr6qqSm/jIsLP9XUVL6mpSU/+Pd3v+XkZD7Ew0O/hoUFP6Oioj719HQ+pKMjv9PS0r6SkRE/iIcHP+7tbT+DgoK+kZAQvdDPTz+WlRW/i4qKvpiXFz/l5GQ+g4KCvp6dHb++vT0/6ejovcrJSb+rqqq+9PNzv6uqqj7t7Gw+v76+vg==",
+      "vectorSha256": "faa64b2a2b9f2f57921de54b9f9efd42ff713ed9580fce2d32a7d0aa545a86ea",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2bc565d2049c1ec2a89e2e4bc8c3f65f7be7355dcb9c5f31de711b5506aa9d50",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0781": {
+      "vector": "4+LiPsnIyD2koyM/zs1NP769Pb/X1tY+/Pt7v/Tzc7/Hxsa+z87OvqWkJD63tra+ycjIvYqJCT/t7Gw+rq0tP6Oioj7g31+/l5aWvvTzcz+lpCS++fj4PY2MDD7g31+/8fBwPbi3N7/y8XE//v19P+7tbT+hoKA8u7q6PrSzM7/j4uI+ycjIPaSjIz/OzU0/vr09v9fW1j78+3u/9PNzv8fGxr7Pzs6+paQkPre2tr7JyMi9iokJP+3sbD6urS0/o6KiPuDfX7+Xlpa+9PNzP6WkJL75+Pg9jYwMPuDfX7/x8HA9uLc3v/LxcT/+/X0/7u1tP6GgoDy7uro+tLMzvw==",
+      "vectorSha256": "5c918cd07f307ea8167f6e3c5ad61c5a116bf4c92cb2d7ab2e9ea02d9056e320",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b88cd1e621b502064e4c945273c49dd6a8105af96b8f91108724f8fef682ae26",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0782": {
+      "vector": "sbAwPZqZGb/Ew0M/mJcXP9DPT7/19HS+/fx8PoOCgr6fnp6+iYiIva6tLT+Qjw+/zs1Nv9nY2L24tze/w8LCPpGQEL3Y11e/9fR0vquqqj6ysTG/t7a2PtDPTz+GhQW/hYQEvrSzM7+npqY+gYCAu7a1NT+urS2/4+LiPufm5r6xsDA9mpkZv8TDQz+Ylxc/0M9Pv/X0dL79/Hw+g4KCvp+enr6JiIi9rq0tP5CPD7/OzU2/2djYvbi3N7/DwsI+kZAQvdjXV7/19HS+q6qqPrKxMb+3trY+0M9PP4aFBb+FhAS+tLMzv6empj6BgIC7trU1P66tLb/j4uI+5+bmvg==",
+      "vectorSha256": "ba606466997a78f09d311588300767cc92e3fa2cc6005268affaebbe774fbcac",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8533e1cb18619f5f5877d638197224b07b1461aa27ade73d6f26a97fda29b846",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0783": {
+      "vector": "hIMDv5mYmL2KiQk/3dxcvvr5eT8AAIC/29ravsXERD7z8vK+qKcnv9HQUD3GxUW//Pt7v4eGhj6pqKi9vbw8Pu/u7r6FhAQ+t7a2PqCfHz/7+vo+kpERP4WEBD7OzU0/8/LyPvz7ez/S0VE/hoUFv/LxcT/6+Xk/lpUVP4KBAT+EgwO/mZiYvYqJCT/d3Fy++vl5PwAAgL/b2tq+xcREPvPy8r6opye/0dBQPcbFRb/8+3u/h4aGPqmoqL29vDw+7+7uvoWEBD63trY+oJ8fP/v6+j6SkRE/hYQEPs7NTT/z8vI+/Pt7P9LRUT+GhQW/8vFxP/r5eT+WlRU/goEBPw==",
+      "vectorSha256": "71bedaa4e1965bba667b583a184d77f5994134366fc9c93699b383a1f43cb787",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3e76c464fc004998432c861d02a175974490adcfbec890e6bcfde83df8fccac0",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0784": {
+      "vector": "+Pd3v7m4uD29vDy++vl5P8zLSz/e3V0/r66uvqinJ7+FhAS+6OdnP+jnZz/My0s/+/r6PpKREb+amRm/oaCgPI+Ojr6xsDC9/fx8Pt/e3r6+vT2/wsFBP9DPTz+fnp4+lJMTv/79fT+GhQU/8fBwvfLxcb+/vr6+s7KyvqGgoDz493e/ubi4Pb28PL76+Xk/zMtLP97dXT+vrq6+qKcnv4WEBL7o52c/6OdnP8zLSz/7+vo+kpERv5qZGb+hoKA8j46OvrGwML39/Hw+397evr69Pb/CwUE/0M9PP5+enj6UkxO//v19P4aFBT/x8HC98vFxv7++vr6zsrK+oaCgPA==",
+      "vectorSha256": "b924468ff10d0a2c6423093ea54b0770f87d1d0c9e20917246faadaed268e8e3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "048b68fce5ee542c6ff3f3e5be3733825c7a9f4821e0e7a736fec27807505382",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0785": {
+      "vector": "rawsvvLxcb/o52c/1dRUPri3Nz+ZmJg99/b2PrOysj7v7u6+6ejoPZeWlr7a2Vm/5uVlP4OCgj6zsrK+3dxcPqempr6zsrK+sK8vP9LRUT/c21u/gYCAO+XkZD7Y11c//Pt7v6uqqj7Ew0M/rawsvo+Ojr7Lysq+xsVFP/38fL6trCy+8vFxv+jnZz/V1FQ+uLc3P5mYmD339vY+s7KyPu/u7r7p6Og9l5aWvtrZWb/m5WU/g4KCPrOysr7d3Fw+p6amvrOysr6wry8/0tFRP9zbW7+BgIA75eRkPtjXVz/8+3u/q6qqPsTDQz+trCy+j46OvsvKyr7GxUU//fx8vg==",
+      "vectorSha256": "142d39012a1b7f1b677af3f3f2fd413bf208563387e06a0004fc237d93e23256",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6a07f39adb89bdac448e5a13f2a0539b5653d7e812809ceb02aae16a5c4de260",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0786": {
+      "vector": "mpkZP+Hg4LzT0tI+k5KSvszLS7+BgIA7xcREPo6NDb+VlBS+rq0tv5aVFT+0szO/9vV1P/Py8j76+Xm/zs1Nv7a1Nb/6+Xm/0tFRP8XERL6/vr4+yMdHv4GAgLu8uzs/5uVlv7++vj6Ihwc/09LSvs3MTL7r6uo+lJMTP8nIyL2amRk/4eDgvNPS0j6TkpK+zMtLv4GAgDvFxEQ+jo0Nv5WUFL6urS2/lpUVP7SzM7/29XU/8/LyPvr5eb/OzU2/trU1v/r5eb/S0VE/xcREvr++vj7Ix0e/gYCAu7y7Oz/m5WW/v76+PoiHBz/T0tK+zcxMvuvq6j6UkxM/ycjIvQ==",
+      "vectorSha256": "e1586eb478619044815cd3e80c46523d9bca6e0a8484e01381bb62937d727ae9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cc7cb45b1a8098396d29ca26fabc03192503e867af1c7fdd0dafc34b66bac973",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0787": {
+      "vector": "3dxcvsXERL7z8vK+mJcXP8fGxj719HS+yslJv7GwMD2Ihwc/zs1NP8vKyr77+vo++vl5P6empj61tDQ+6OdnP9fW1r7Ix0e/o6KivtrZWb/GxUW/5+bmPr++vr6qqSm/2NdXv62sLL6JiIi9rawsPrm4uD2fnp6+qqkpP6alJT/d3Fy+xcREvvPy8r6Ylxc/x8bGPvX0dL7KyUm/sbAwPYiHBz/OzU0/y8rKvvv6+j76+Xk/p6amPrW0ND7o52c/19bWvsjHR7+joqK+2tlZv8bFRb/n5uY+v76+vqqpKb/Y11e/rawsvomIiL2trCw+ubi4PZ+enr6qqSk/pqUlPw==",
+      "vectorSha256": "2772c6f875062dc2128cd7f3cf817a806e221e459aa89b7b59fa69718c4eb5ef",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "646743cbb1611b85c3e64dbefca996f34a1c57131db9502b146a77958b58d4d2",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0788": {
+      "vector": "zMtLv728PD6FhAQ+6ejoPYaFBT+6uTk/397evoaFBb+6uTk/u7q6PqqpKb+/vr6++/r6Po2MDD7p6Og9x8bGPt7dXb/+/X0/3Ntbv87NTT+joqK+19bWvp+enr6rqqo+lpUVP+jnZ7/29XW/9fR0PoiHB7///v6+i4qKPuPi4j7My0u/vbw8PoWEBD7p6Og9hoUFP7q5OT/f3t6+hoUFv7q5OT+7uro+qqkpv7++vr77+vo+jYwMPuno6D3HxsY+3t1dv/79fT/c21u/zs1NP6Oior7X1ta+n56evquqqj6WlRU/6Odnv/b1db/19HQ+iIcHv//+/r6Lioo+4+LiPg==",
+      "vectorSha256": "f760e25a494ffbd0a6f10bc83e38befa8300ee3a3c74ddbebb12cc854fd54e05",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1a97908ec2dc483ddcae2b50be918eb111fe12e6574a58aaca0c059e3c40a2b8",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0789": {
+      "vector": "sK8vP+rpab/t7Gw+5ONjP9jXV7/NzEy+8O9vP6SjI7/Ew0O//fx8voSDA7+8uzs/vbw8Ppuamr75+Pg9pKMjv4aFBb/m5WW/hYQEvtva2r7Y11c/vr09v/Dvb7+EgwM/7+7uvoqJCT++vT2/hoUFv+XkZL7U01O/6ejovfLxcT+wry8/6ulpv+3sbD7k42M/2NdXv83MTL7w728/pKMjv8TDQ7/9/Hy+hIMDv7y7Oz+9vDw+m5qavvn4+D2koyO/hoUFv+blZb+FhAS+29ravtjXVz++vT2/8O9vv4SDAz/v7u6+iokJP769Pb+GhQW/5eRkvtTTU7/p6Oi98vFxPw==",
+      "vectorSha256": "b15a277c1b875f3a15b29be18ca4d564e1f3d80a468d67b24bfce7569db342f1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d70b9df11466f72e1e603edd97598f2e3d0d6f49eb2108c144c4213d631671f8",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0791": {
+      "vector": "iIcHP+LhYb+Qjw8/7+7uPtzbW7+trCy+vLs7v6uqqj7y8XG/5uVlP+3sbL7h4OC8i4qKPtzbWz/X1tY+v76+PpiXF7/Z2Ni93dxcPoqJCT/HxsY+goEBP+rpaT/Ew0M/7exsPsPCwr6zsrI+j46OvuPi4r6BgIA7j46Ovvz7e7+Ihwc/4uFhv5CPDz/v7u4+3Ntbv62sLL68uzu/q6qqPvLxcb/m5WU/7exsvuHg4LyLioo+3NtbP9fW1j6/vr4+mJcXv9nY2L3d3Fw+iokJP8fGxj6CgQE/6ulpP8TDQz/t7Gw+w8LCvrOysj6Pjo6+4+LivoGAgDuPjo6+/Pt7vw==",
+      "vectorSha256": "a6d3b8499ec29be37a3cfb3d0320fd4d5b548d59ac0e266e7a04c82faddbd06c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c30fc7bb126a22aa07f2627ca2edb5af34729bc4b1c0f4e19d4fac5c47805c02",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0792": {
+      "vector": "/Pt7v5+enr6wry8/vbw8vvLxcT+JiIi9vbw8vo6NDT/g31+/sK8vv8HAQDz083O/vr09v/z7e7+0szM/09LSvoGAgDuCgQE/wsFBv46NDT/083O/1NNTP6empj6opye/AACAP7a1NT/Ix0e/5uVlP/v6+j6JiIi909LSPry7Oz/8+3u/n56evrCvLz+9vDy+8vFxP4mIiL29vDy+jo0NP+DfX7+wry+/wcBAPPTzc7++vT2//Pt7v7SzMz/T0tK+gYCAO4KBAT/CwUG/jo0NP/Tzc7/U01M/p6amPqinJ78AAIA/trU1P8jHR7/m5WU/+/r6PomIiL3T0tI+vLs7Pw==",
+      "vectorSha256": "789e91590cd86447de0f2e75cb3cba6b45962d2ba32190576cae8a4171991e3f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0258d768f87768c6102881062102d94b80c01fc606e9a92cffda1cf2be77b4dd",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0793": {
+      "vector": "mpkZv5mYmD25uLi9tbQ0vvj3d7+joqK+iYiIPdbVVb+2tTW/oqEhP+DfX7/z8vK+rq0tv+fm5j6sqys/19bWvqinJ7+UkxO/+vl5P5KRET+ZmJg97exsPo2MDD6gnx8/5+bmvtDPTz+Ylxe/2NdXv66tLb/l5GS+hYQEvufm5r6amRm/mZiYPbm4uL21tDS++Pd3v6Oior6JiIg91tVVv7a1Nb+ioSE/4N9fv/Py8r6urS2/5+bmPqyrKz/X1ta+qKcnv5STE7/6+Xk/kpERP5mYmD3t7Gw+jYwMPqCfHz/n5ua+0M9PP5iXF7/Y11e/rq0tv+XkZL6FhAS+5+bmvg==",
+      "vectorSha256": "3d2812c391f4e00e97299f864dc8326231affde97cd5483184f45e8ac062c24c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "338974690457881525d0104329b9d54a2c36fcc8899d91cf46e7341429636f46",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0794": {
+      "vector": "q6qqvqCfHz+Ihwe/lpUVv4uKij6urS0/mJcXP+XkZL7KyUm/iIcHv/Py8j7NzEy+u7q6PoWEBD6TkpI+nZwcPvX0dL7i4WG//fx8vt7dXb+0szO/+vl5v6Oior63tra+4eDgPPX0dL7y8XG/g4KCvvz7ez+qqSm/nJsbv/Tzc7+rqqq+oJ8fP4iHB7+WlRW/i4qKPq6tLT+Ylxc/5eRkvsrJSb+Ihwe/8/LyPs3MTL67uro+hYQEPpOSkj6dnBw+9fR0vuLhYb/9/Hy+3t1dv7SzM7/6+Xm/o6Kivre2tr7h4OA89fR0vvLxcb+DgoK+/Pt7P6qpKb+cmxu/9PNzvw==",
+      "vectorSha256": "b6534d298abaee0013896ddac08c9e8650dec091c9972f7dadbb504fda1086d1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "55cf3c35a2d6cb631b3cbc66ae90a493610f6011260357528361075ffd2b3206",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0795": {
+      "vector": "xsVFv5KRET/NzEy+oJ8fv7u6ur6Ylxe/4N9fv8C/P7/JyMi9rawsPoeGhr6FhAS+wL8/v6Oioj7n5ua+kI8PP5uamr6npqY+jIsLv728PD7OzU0/8fBwPZybGz+/vr6+8fBwPZCPDz/z8vI+i4qKvv/+/j7a2Vm/np0dP5eWlr7GxUW/kpERP83MTL6gnx+/u7q6vpiXF7/g31+/wL8/v8nIyL2trCw+h4aGvoWEBL7Avz+/o6KiPufm5r6Qjw8/m5qavqempj6Miwu/vbw8Ps7NTT/x8HA9nJsbP7++vr7x8HA9kI8PP/Py8j6Lioq+//7+PtrZWb+enR0/l5aWvg==",
+      "vectorSha256": "850a522f453c50ed5d027cda7e134658719ed172aab5aa4cee49878a117a6a8c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1dc866305134102073955e6f20a846c759a93a97e687cd5087c7bc5dbf13ce5a",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0796": {
+      "vector": "vLs7P8LBQb+zsrK+tLMzP4iHB7/m5WU/v76+PszLSz/c21u/paQkPsvKyr7BwEA8lJMTP8zLS7/Ix0e/2NdXP9rZWT+JiIi9mJcXP8/Ozr6WlRW/397ePuLhYb+NjAw+qqkpv6moqL2lpCQ+qqkpv5iXF7/b2tq+ubi4Pc/Ozj68uzs/wsFBv7Oysr60szM/iIcHv+blZT+/vr4+zMtLP9zbW7+lpCQ+y8rKvsHAQDyUkxM/zMtLv8jHR7/Y11c/2tlZP4mIiL2Ylxc/z87OvpaVFb/f3t4+4uFhv42MDD6qqSm/qaiovaWkJD6qqSm/mJcXv9va2r65uLg9z87OPg==",
+      "vectorSha256": "c78486e5bc34962b8c776c3ba8e5812996c9cb685749c7b30d5c3bad4b140ac9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dd1f53d93cf2afe512944d81c91a1cebec77cb4c35b70f912b75942b34498bb3",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0797": {
+      "vector": "lZQUPv38fD6lpCQ+wL8/v66tLT/i4WG/m5qaPtjXV7/5+Pi9x8bGvs/Ozr78+3s/09LSvuzraz+amRk//fx8Pqempj7R0FC9hIMDv/X0dD6Ylxe/j46OvpaVFb/n5ua+8O9vv/z7e7/x8HA9xMNDP/z7e7+4tzc/3NtbP5OSkr6VlBQ+/fx8PqWkJD7Avz+/rq0tP+LhYb+bmpo+2NdXv/n4+L3Hxsa+z87Ovvz7ez/T0tK+7OtrP5qZGT/9/Hw+p6amPtHQUL2EgwO/9fR0PpiXF7+Pjo6+lpUVv+fm5r7w72+//Pt7v/HwcD3Ew0M//Pt7v7i3Nz/c21s/k5KSvg==",
+      "vectorSha256": "b20d7e2b4d0be1d51546b771f25d0ab290ddb33a6db032883c6c16f58b32911d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "929f9420d60fa614704e4cfd4bf5cc9fa9793e9e345c3546080287e102dbed5b",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0798": {
+      "vector": "4+LiPpWUFL6gnx8/zs1Nv6uqqj7v7u6++vl5P4aFBT+/vr4+yslJP4uKir7Lyso+o6KivoSDA7+TkpI+vbw8Pp2cHD6UkxO/7+7uvsvKyj78+3u/397evoKBAT/T0tI+wcBAPKuqqr7Qz0+/rKsrv/Lxcb/7+vq+xMNDv8HAQDzj4uI+lZQUvqCfHz/OzU2/q6qqPu/u7r76+Xk/hoUFP7++vj7KyUk/i4qKvsvKyj6joqK+hIMDv5OSkj69vDw+nZwcPpSTE7/v7u6+y8rKPvz7e7/f3t6+goEBP9PS0j7BwEA8q6qqvtDPT7+sqyu/8vFxv/v6+r7Ew0O/wcBAPA==",
+      "vectorSha256": "451313fa9f54bb6aaf1ed4e16932bbc846692b12fc155ce06298aed5f8d9a146",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b86dcf19aa44fcc2afe45db2573ea497933644b20248c0b48155182a07411e81",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0800": {
+      "vector": "5ONjv6qpKT+Miws/kpERP/f29r75+Pi9wL8/v9va2r7f3t4+oJ8fP4iHBz+gnx8/xcREPpmYmD2lpCQ+ycjIvd3cXL729XW/g4KCvpqZGT+sqys/v76+vsHAQDzj4uK+xMNDv4iHBz+wry+/l5aWPpGQEL3V1FQ+i4qKvpeWlr7k42O/qqkpP4yLCz+SkRE/9/b2vvn4+L3Avz+/29ravt/e3j6gnx8/iIcHP6CfHz/FxEQ+mZiYPaWkJD7JyMi93dxcvvb1db+DgoK+mpkZP6yrKz+/vr6+wcBAPOPi4r7Ew0O/iIcHP7CvL7+XlpY+kZAQvdXUVD6Lioq+l5aWvg==",
+      "vectorSha256": "bc5fdc7e898bf28c4fb746859150b5344a902fddb6af15bf59925a9c61350b3a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0ed4c5c842702049b7cfc3cf9889947364055fccd55081471ec328a57b9a5d5a",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0801": {
+      "vector": "k5KSPu/u7r7Lysq+rawsPvj3dz/My0u/0tFRP/v6+r719HQ+mJcXv4yLC7+ysTE/l5aWPuDfXz+enR2/iIcHP8fGxr7j4uK+l5aWPtzbW7/T0tI+o6KiPs/Ozr7k42M/yslJv42MDL7R0FA90dBQvbSzM7/R0FA9jo0Nv+Pi4j6TkpI+7+7uvsvKyr6trCw++Pd3P8zLS7/S0VE/+/r6vvX0dD6Ylxe/jIsLv7KxMT+XlpY+4N9fP56dHb+Ihwc/x8bGvuPi4r6XlpY+3Ntbv9PS0j6joqI+z87OvuTjYz/KyUm/jYwMvtHQUD3R0FC9tLMzv9HQUD2OjQ2/4+LiPg==",
+      "vectorSha256": "640ac1d6c175d1a0775ec909e31211449976799ae5e7d955303f199775ee0ada",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a4444d95fb1ae8419e343ad8a5ef31c34e47a512b4a84cf11b6e8679268639b8",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0802": {
+      "vector": "h4aGPgAAgL/39va+09LSvqWkJD7My0u/g4KCvrq5OT+mpSU/sK8vP9DPT7/083O/oqEhP7KxMb+2tTU/ycjIPbSzMz/39va+0M9PP5qZGT+/vr4+8O9vv6yrK7+bmpq+tbQ0PoyLCz/a2Vm/r66uPqempr6GhQW/9vV1P/v6+j6HhoY+AACAv/f29r7T0tK+paQkPszLS7+DgoK+urk5P6alJT+wry8/0M9Pv/Tzc7+ioSE/srExv7a1NT/JyMg9tLMzP/f29r7Qz08/mpkZP7++vj7w72+/rKsrv5uamr61tDQ+jIsLP9rZWb+vrq4+p6amvoaFBb/29XU/+/r6Pg==",
+      "vectorSha256": "52162787fb154545bce6cc61bc12ee36117c52c6136f45def58ee76621f56009",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a100424b941a5fdcd2d71806d027da8cd942e7ccaf082a5996c513ab563dfabe",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0803": {
+      "vector": "yslJv+Pi4r7j4uK+k5KSvoaFBb+9vDy+uLc3P5iXFz/29XW/AACAv6empr6opyc/srExv4iHB7+8uzs/jIsLv728PL61tDS+5+bmPtHQUD2Pjo4+uLc3P8jHRz+amRm/2NdXv9bVVb/h4OA8uLc3P62sLD7U01M/k5KSvv/+/j7KyUm/4+LivuPi4r6TkpK+hoUFv728PL64tzc/mJcXP/b1db8AAIC/p6amvqinJz+ysTG/iIcHv7y7Oz+Miwu/vbw8vrW0NL7n5uY+0dBQPY+Ojj64tzc/yMdHP5qZGb/Y11e/1tVVv+Hg4Dy4tzc/rawsPtTTUz+TkpK+//7+Pg==",
+      "vectorSha256": "3eaf37500fbdb517835349ad5f67d866d9930853b9e9fb21d9fa809fb1005d17",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1b47475b3d68dbcb050056d3273cdd3a6869b986a3dbe333141583db95e95bbf",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0804": {
+      "vector": "hYQEvpeWlr68uzu/3NtbP87NTT/T0tK+mZiYPY2MDD7g318/0dBQPe7tbb/c21s/0M9PP7W0NL6BgIC7vbw8vouKir6Ylxc/sK8vv9XUVL79/Hw+srExv8PCwr6xsDA9kZAQPeDfX7/OzU0/8fBwvb69Pb/n5ua+t7a2vt7dXb+FhAS+l5aWvry7O7/c21s/zs1NP9PS0r6ZmJg9jYwMPuDfXz/R0FA97u1tv9zbWz/Qz08/tbQ0voGAgLu9vDy+i4qKvpiXFz+wry+/1dRUvv38fD6ysTG/w8LCvrGwMD2RkBA94N9fv87NTT/x8HC9vr09v+fm5r63tra+3t1dvw==",
+      "vectorSha256": "3b41bfc6a56a26eb6e828a7e49736d35f03305a3cbf40bd56bddf2e07cad4724",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6f5a22ede64b8991ef8609ede7697f685dcb28659f274f858410e67821465211",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0805": {
+      "vector": "t7a2PrSzMz+lpCS+6+rqvt7dXb/x8HA98vFxv+no6D2Qjw+/0dBQvfr5eb+4tze/7u1tv8XERL6ioSG/oJ8fP+TjYz+Qjw+/9PNzP/z7ez+pqKg9yslJP4WEBD6Lioq+6ulpv+blZb/5+Pi9o6KivvTzcz/083M/0M9Pv/Py8r63trY+tLMzP6WkJL7r6uq+3t1dv/HwcD3y8XG/6ejoPZCPD7/R0FC9+vl5v7i3N7/u7W2/xcREvqKhIb+gnx8/5ONjP5CPD7/083M//Pt7P6moqD3KyUk/hYQEPouKir7q6Wm/5uVlv/n4+L2joqK+9PNzP/Tzcz/Qz0+/8/Lyvg==",
+      "vectorSha256": "43414da1c258ce9f9d935940ad5063268d9b52033c73ec4026057ca40749c21a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "add96b451187078e3879032409672fcff138f9fd8ae4905d0b0d7057f9f91843",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0807": {
+      "vector": "lZQUPrSzMz+enR2/8O9vv5eWlj739va+paQkvv/+/j6joqI+7exsvr28PD7o52e/rawsvtnY2D2trCw+jo0NP62sLD7Z2Ni96+rqPqOior7R0FA9yMdHP6qpKb+xsDC9lJMTP8bFRT+1tDQ+tbQ0vpOSkr7Pzs6+sK8vv7m4uD2VlBQ+tLMzP56dHb/w72+/l5aWPvf29r6lpCS+//7+PqOioj7t7Gy+vbw8PujnZ7+trCy+2djYPa2sLD6OjQ0/rawsPtnY2L3r6uo+o6KivtHQUD3Ix0c/qqkpv7GwML2UkxM/xsVFP7W0ND61tDS+k5KSvs/Ozr6wry+/ubi4PQ==",
+      "vectorSha256": "e30d7de7a9a509ef3c80fa33c9f11908468e1f83de1991e9bff1acdb31e9dc3f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "92d93108a5426bbfa862970c6a8d95c69572ba5786e32b7ac9e296695b4c288b",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0808": {
+      "vector": "hIMDP8PCwj7u7W2/2NdXP/z7e7/s62u/2NdXv66tLT/083O/r66uvsfGxj7W1VW//fx8Pt/e3j6qqSm/x8bGPgAAgL+sqyu//fx8vuLhYT+trCw+y8rKvpeWlj6RkBC95+bmvgAAgL+3trY+wsFBv+3sbL7FxES+nZwcvpGQED2EgwM/w8LCPu7tbb/Y11c//Pt7v+zra7/Y11e/rq0tP/Tzc7+vrq6+x8bGPtbVVb/9/Hw+397ePqqpKb/HxsY+AACAv6yrK7/9/Hy+4uFhP62sLD7Lysq+l5aWPpGQEL3n5ua+AACAv7e2tj7CwUG/7exsvsXERL6dnBy+kZAQPQ==",
+      "vectorSha256": "c4d9d18f9c9e258c4197ffceb53b15de28101ce32bb12f678af48c51a1f0d83c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c1b009eb020a14d60654b1159fb72bb1002a60f0954da57b4600ad1f62676c84",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0810": {
+      "vector": "AACAP7m4uL2opye/0M9PP/HwcL3v7u6+4uFhP7y7O7+pqKi97exsPoWEBL7083O/j46OvuXkZL7d3Fw+oqEhv9LRUb8AAIC/ycjIvYKBAT+6uTk/7+7uPsPCwr6FhAS+0M9Pv6moqL2NjAw+qaiove/u7j6+vT0/1NNTv7KxMT8AAIA/ubi4vainJ7/Qz08/8fBwve/u7r7i4WE/vLs7v6moqL3t7Gw+hYQEvvTzc7+Pjo6+5eRkvt3cXD6ioSG/0tFRvwAAgL/JyMi9goEBP7q5OT/v7u4+w8LCvoWEBL7Qz0+/qaiovY2MDD6pqKi97+7uPr69PT/U01O/srExPw==",
+      "vectorSha256": "da32261017a13f91f0eb14038cee54cb844da342454ea6389381a539def5504a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ff742ce77844f022759d6f065c639b2f170073c0dcbb4f6f18759175bbde16d8",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0812": {
+      "vector": "+/r6vvv6+j7y8XE/2tlZv9jXV7+zsrK+tbQ0vpaVFT/x8HC9xcREvu3sbD7g31+/lJMTv6qpKb/T0tI+7OtrP+no6D3t7Gw+sbAwvf/+/j7V1FS+j46OvqqpKb+trCy+k5KSPuPi4r6EgwO/s7KyvuPi4r6wry8/5ONjP/z7ez/7+vq++/r6PvLxcT/a2Vm/2NdXv7Oysr61tDS+lpUVP/HwcL3FxES+7exsPuDfX7+UkxO/qqkpv9PS0j7s62s/6ejoPe3sbD6xsDC9//7+PtXUVL6Pjo6+qqkpv62sLL6TkpI+4+LivoSDA7+zsrK+4+LivrCvLz/k42M//Pt7Pw==",
+      "vectorSha256": "cb652c1a58432880807c19192f20880677605ee8081dcc9fd4b196f162a36422",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "41bef813145369ca78679d10362bb4f58e9d7abf655c2b6aa4473e5347d7f1fd",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0813": {
+      "vector": "yMdHv/79fb/l5GS+sbAwPYaFBb/7+vq+hoUFP5qZGT/CwUG//fx8vsC/Pz+pqKg91dRUvs/Ozr6wry8/8/LyPru6ur7+/X0/srExv7W0ND7d3Fw+wsFBv93cXL7S0VE//Pt7v4aFBb+Miwu/rKsrP52cHL7q6Wm/xcREPoWEBD7Ix0e//v19v+XkZL6xsDA9hoUFv/v6+r6GhQU/mpkZP8LBQb/9/Hy+wL8/P6moqD3V1FS+z87OvrCvLz/z8vI+u7q6vv79fT+ysTG/tbQ0Pt3cXD7CwUG/3dxcvtLRUT/8+3u/hoUFv4yLC7+sqys/nZwcvurpab/FxEQ+hYQEPg==",
+      "vectorSha256": "4e17727065e2ac6eaeefd6dd06be65aff46f8c18208e530f11ffdccf74349bb4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1c0163853d41c2cc1f60df8a654cd7bc51fe27969b1f64e8023d3ad56c0b9890",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0814": {
+      "vector": "19bWPrKxMT/x8HC9paQkvtLRUT+trCw+wsFBP7GwML3l5GS+z87OvoeGhr7t7Gy+vLs7v8vKyj6DgoK+s7KyPu7tbb+ysTE/y8rKPv38fD7v7u4+y8rKPuLhYT/j4uK+oJ8fP+fm5r6OjQ2/0dBQPcLBQb/h4OA8wcBAPPTzcz/X1tY+srExP/HwcL2lpCS+0tFRP62sLD7CwUE/sbAwveXkZL7Pzs6+h4aGvu3sbL68uzu/y8rKPoOCgr6zsrI+7u1tv7KxMT/Lyso+/fx8Pu/u7j7Lyso+4uFhP+Pi4r6gnx8/5+bmvo6NDb/R0FA9wsFBv+Hg4DzBwEA89PNzPw==",
+      "vectorSha256": "bf2f7302c429257e99ca7ff6195006509dd1fdb3c3fa6f37479d3e925faa13f8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b5d8786be895e07a634c5e6222b25fac09d8b29fbbb2f047cf4639861f8381f9",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0816": {
+      "vector": "n56evp6dHT/v7u4+1dRUvqGgoDzEw0M/oqEhP8bFRT/BwEA8x8bGvgAAgL/Ew0M/w8LCvqSjI7/R0FC9+Pd3v4aFBT/j4uK+nZwcvv38fL6dnBw+1dRUPuvq6r6bmpq+19bWPtDPTz+vrq6+8O9vv7a1Nb+ioSG/+vl5v7y7O7+fnp6+np0dP+/u7j7V1FS+oaCgPMTDQz+ioSE/xsVFP8HAQDzHxsa+AACAv8TDQz/DwsK+pKMjv9HQUL3493e/hoUFP+Pi4r6dnBy+/fx8vp2cHD7V1FQ+6+rqvpuamr7X1tY+0M9PP6+urr7w72+/trU1v6KhIb/6+Xm/vLs7vw==",
+      "vectorSha256": "9e2a1283088a8f3133e9e8afa50933d057c7f423086ddb243b1aeee7066530f4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "58cebb6582e1d0e2814e00e14f2e7904c2476c60939a4559b5e75408252f0322",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0817": {
+      "vector": "5+bmPq+urr6KiQm/wcBAPImIiL2opyc/kZAQPaOioj7V1FQ+7+7uvu/u7r7NzEy+uLc3P9bVVb/+/X2/yMdHP/79fT/a2Vk/s7KyPoSDAz/493e/wsFBP6Oioj6joqK+yMdHv9TTU7/19HS+7+7uPuXkZL6ysTE/jo0Nv7u6uj7n5uY+r66uvoqJCb/BwEA8iYiIvainJz+RkBA9o6KiPtXUVD7v7u6+7+7uvs3MTL64tzc/1tVVv/79fb/Ix0c//v19P9rZWT+zsrI+hIMDP/j3d7/CwUE/o6KiPqOior7Ix0e/1NNTv/X0dL7v7u4+5eRkvrKxMT+OjQ2/u7q6Pg==",
+      "vectorSha256": "972021b10551f0b4a82800cc5d5a43189e4c551144b39d86e2a9073a22593b0c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b9543b8177d384a89a444466db1501e3feecacc104e0a8571c1661bb63d839ae",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0819": {
+      "vector": "sK8vv9TTU7/JyMg95eRkPpqZGT+ZmJi9tLMzP6yrKz/w72+/9vV1P7i3N7+9vDw+iokJP769PT/V1FQ+oaCgPLKxMT/HxsY+np0dP56dHT/My0u/zcxMPuvq6j7NzEy+vr09v93cXD7c21u/+/r6vublZT+OjQ2/1dRUvu/u7j6wry+/1NNTv8nIyD3l5GQ+mpkZP5mYmL20szM/rKsrP/Dvb7/29XU/uLc3v728PD6KiQk/vr09P9XUVD6hoKA8srExP8fGxj6enR0/np0dP8zLS7/NzEw+6+rqPs3MTL6+vT2/3dxcPtzbW7/7+vq+5uVlP46NDb/V1FS+7+7uPg==",
+      "vectorSha256": "268caeee53df9bd4fed8a5e306812113ff3f62f7e75757eead2e12bcdd182c55",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "28168c9ccc76d9d508fa2497c4de9a82d8b1cece1a99ba66219b1241f23965bb",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0820": {
+      "vector": "wsFBP7KxMT/GxUU/vr09P8HAQDzDwsI+2tlZv9nY2D329XU/8O9vP4eGhr6mpSW/vr09P4SDA7+XlpY+pKMjP/b1dT+SkRE/srExP83MTD6Ihwc/6Odnv9rZWT+trCw+5uVlv8XERD7Hxsa++/r6vpqZGT/NzEw+iYiIPbKxMT/CwUE/srExP8bFRT++vT0/wcBAPMPCwj7a2Vm/2djYPfb1dT/w728/h4aGvqalJb++vT0/hIMDv5eWlj6koyM/9vV1P5KRET+ysTE/zcxMPoiHBz/o52e/2tlZP62sLD7m5WW/xcREPsfGxr77+vq+mpkZP83MTD6JiIg9srExPw==",
+      "vectorSha256": "20aea8c4aab0571c71fe228ac52e0dc3a7bee8e7e03f85cf1589584a5a40842e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e0d8e2de81b0138dfaf75e2dde3ea5d1fac8d899c30cec950d984e41cc9988d8",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0821": {
+      "vector": "goEBv97dXT/Ix0e/y8rKvvHwcD25uLi9iIcHv+LhYT/s62u/iYiIPfv6+j6qqSm/yslJv4mIiD29vDw+uLc3P7a1Nb/DwsK+l5aWvqalJb/i4WE/09LSPp6dHT+bmpq+goEBv9nY2D3GxUU/3dxcPujnZ7+xsDA97+7uvvz7ez+CgQG/3t1dP8jHR7/Lysq+8fBwPbm4uL2Ihwe/4uFhP+zra7+JiIg9+/r6PqqpKb/KyUm/iYiIPb28PD64tzc/trU1v8PCwr6Xlpa+pqUlv+LhYT/T0tI+np0dP5uamr6CgQG/2djYPcbFRT/d3Fw+6Odnv7GwMD3v7u6+/Pt7Pw==",
+      "vectorSha256": "7f7cd2ffb9285564ea6c51633b2f1f24ea1701327fe1c3dcf7a036ee3c9c78e5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3fee1c4d87743cf00a88be2b1b8897db254f5a2df0b4ce593f8de29b0c8544fd",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0822": {
+      "vector": "x8bGvoiHBz/w72+/xMNDv9TTU7+WlRU/19bWPoWEBD7c21u/oJ8fv6inJz/h4OA8zs1Nv46NDb+Miws/goEBP7GwMD3r6uq+yslJP6+urj6urS2/397evp+enr6mpSU/sbAwvcLBQT/+/X2/mJcXP+7tbT+amRm/9fR0voaFBT/Hxsa+iIcHP/Dvb7/Ew0O/1NNTv5aVFT/X1tY+hYQEPtzbW7+gnx+/qKcnP+Hg4DzOzU2/jo0Nv4yLCz+CgQE/sbAwPevq6r7KyUk/r66uPq6tLb/f3t6+n56evqalJT+xsDC9wsFBP/79fb+Ylxc/7u1tP5qZGb/19HS+hoUFPw==",
+      "vectorSha256": "17c3437a53fbb6bcba5436824ea71d9d4d476d64fbbb95f8638bd29e52d77313",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4ec3081e16cab5901230d3831939c5c08545e4ab294858d27ae001cbf63361c2",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0823": {
+      "vector": "goEBP4uKij7DwsK+hIMDv/n4+L2RkBC9np0dP8/Ozr6+vT2/m5qaPuDfX7+0szO/09LSPvn4+D27urq+zMtLP5mYmL3v7u4+y8rKvoyLC7+urS2/k5KSPp6dHb/s62u/rq0tP5qZGb/t7Gy+oJ8fv7GwMD3Ew0M/oJ8fP7m4uD2CgQE/i4qKPsPCwr6EgwO/+fj4vZGQEL2enR0/z87Ovr69Pb+bmpo+4N9fv7SzM7/T0tI++fj4Pbu6ur7My0s/mZiYve/u7j7Lysq+jIsLv66tLb+TkpI+np0dv+zra7+urS0/mpkZv+3sbL6gnx+/sbAwPcTDQz+gnx8/ubi4PQ==",
+      "vectorSha256": "ca4265a089ed46de8d04c9a4c7c8457baedec069afba07a5ff98d50db00082e6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c0a24f3e707bce4c21a61026b48f51e576bb4d3a29a4310ad633623085e1cf8b",
+      "updatedAt": "2025-09-20T22:27:41.542Z"
+    },
+    "j-0824": {
+      "vector": "h4aGvu/u7j7R0FA9qKcnP7SzMz+XlpY+xcREPrq5OT+JiIg9kZAQvZCPD7+gnx+/xcREPuPi4r7l5GQ+6ulpP/38fL7u7W0/oJ8fP7e2tr6JiIg97Otrv8fGxj7NzEw+h4aGvtnY2L2EgwM/o6Kivvv6+r6JiIi9qKcnP5KRET+Hhoa+7+7uPtHQUD2opyc/tLMzP5eWlj7FxEQ+urk5P4mIiD2RkBC9kI8Pv6CfH7/FxEQ+4+LivuXkZD7q6Wk//fx8vu7tbT+gnx8/t7a2vomIiD3s62u/x8bGPs3MTD6Hhoa+2djYvYSDAz+joqK++/r6vomIiL2opyc/kpERPw==",
+      "vectorSha256": "6064ac780d3080ec5e6d56a929f805aec2846b62fcebc1123ab35c188cef1c3a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5ebb86d3d9a598dc887b383098479cf460f6cf52880ab1995e72c1574177d3c8",
+      "updatedAt": "2025-09-20T22:27:41.543Z"
+    },
+    "j-0825": {
+      "vector": "nJsbv4WEBD69vDy+7u1tv/v6+r6lpCS+7u1tv4eGhr75+Pi9mpkZP+XkZL7Y11e//v19v8fGxr6ioSE/lZQUPtDPT7/GxUU/qqkpv46NDb+fnp6+3NtbP6GgoLyysTE/y8rKPvHwcL3U01M/yslJP7++vj6Ylxc/mpkZv93cXD6cmxu/hYQEPr28PL7u7W2/+/r6vqWkJL7u7W2/h4aGvvn4+L2amRk/5eRkvtjXV7/+/X2/x8bGvqKhIT+VlBQ+0M9Pv8bFRT+qqSm/jo0Nv5+enr7c21s/oaCgvLKxMT/Lyso+8fBwvdTTUz/KyUk/v76+PpiXFz+amRm/3dxcPg==",
+      "vectorSha256": "4606a8ddcb4bc27254be1dae8b12745ddfc5106b47c10bfaaf50212a3a19f2fe",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "32906809416b095e70cc6314014ed09218e22b3958ed7dd8b278e9e4afcb339b",
+      "updatedAt": "2025-09-20T22:27:41.543Z"
+    },
+    "j-0826": {
+      "vector": "4eDgvJqZGT+Ylxc/z87Ovs/Ozr6qqSk/xMNDv9va2j6NjAw+mpkZP6SjI7+8uzu/k5KSvqmoqD2npqY+/v19P8bFRb/v7u6+iYiIPZGQED35+Pi9jo0NP6+urj6zsrI+6Odnv7y7Oz/19HQ+397ePqOioj6JiIi9/fx8Pp6dHT/h4OC8mpkZP5iXFz/Pzs6+z87OvqqpKT/Ew0O/29raPo2MDD6amRk/pKMjv7y7O7+TkpK+qaioPaempj7+/X0/xsVFv+/u7r6JiIg9kZAQPfn4+L2OjQ0/r66uPrOysj7o52e/vLs7P/X0dD7f3t4+o6KiPomIiL39/Hw+np0dPw==",
+      "vectorSha256": "1cfb177a38b1c952e11f5b436309c2e9dd40a60ca073a8e6d5195531ce47321d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7ccccb4c4cd41eb691cc2e225b8aa9fe1d44888470c6abac0cdd9eb7a8779fce",
+      "updatedAt": "2025-09-20T22:27:41.543Z"
+    },
+    "j-0827": {
+      "vector": "g4KCPry7Oz/w72+/np0dP5WUFD7Ew0O/urk5v+fm5r6SkRE/iIcHP9TTUz+RkBC9x8bGvq+urr79/Hy+7exsPr++vj7+/X2/+vl5PwAAgD/r6uo+9PNzv7q5OT/b2tq+y8rKvtva2j4AAIA/trU1P52cHD6enR0/8O9vv+vq6r6DgoI+vLs7P/Dvb7+enR0/lZQUPsTDQ7+6uTm/5+bmvpKRET+Ihwc/1NNTP5GQEL3Hxsa+r66uvv38fL7t7Gw+v76+Pv79fb/6+Xk/AACAP+vq6j7083O/urk5P9va2r7Lysq+29raPgAAgD+2tTU/nZwcPp6dHT/w72+/6+rqvg==",
+      "vectorSha256": "9c8d45c3600b988dfe00e0445a3238fc0f91bd914e457061fdc3988ff4d58caa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a0dd08ce921e2346c8c3e97b4e54609daf01fcffba06dc494db6ffda93ce0845",
+      "updatedAt": "2025-09-20T22:27:41.543Z"
+    },
+    "j-0828": {
+      "vector": "8fBwPe/u7j6JiIg98O9vP4qJCT/o52e/397ePqWkJD7Ix0c/lZQUvpmYmL2trCw+jIsLv+LhYb/Qz0+/8vFxP4WEBL6bmpq+oqEhv83MTD6opyc/srExP/Lxcb+koyO/9fR0Pri3Nz+BgIA74N9fP6uqqr7k42O/yMdHv+3sbD7x8HA97+7uPomIiD3w728/iokJP+jnZ7/f3t4+paQkPsjHRz+VlBS+mZiYva2sLD6Miwu/4uFhv9DPT7/y8XE/hYQEvpuamr6ioSG/zcxMPqinJz+ysTE/8vFxv6SjI7/19HQ+uLc3P4GAgDvg318/q6qqvuTjY7/Ix0e/7exsPg==",
+      "vectorSha256": "150330a049a39ed7dff8a137e0c2e547c08ae4b59107a816b0ae618e492be986",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "87bb88f7c40cb794e36d76953a0f18f86f592f99d3d8072e9edb80ef550e1c9d",
+      "updatedAt": "2025-09-20T22:27:41.543Z"
+    },
+    "j-0829": {
+      "vector": "AACAP5WUFL78+3s/oqEhv8/Ozj6qqSm/8/LyPpCPDz+FhAS+8fBwPaalJb/Y11c/oaCgPPn4+L3KyUm/v76+Po2MDD719HS+l5aWvujnZz+sqys/6OdnP9bVVb+WlRW/397evqCfHz/7+vq+mpkZP5CPD7+Ylxe/oJ8fv+7tbT8AAIA/lZQUvvz7ez+ioSG/z87OPqqpKb/z8vI+kI8PP4WEBL7x8HA9pqUlv9jXVz+hoKA8+fj4vcrJSb+/vr4+jYwMPvX0dL6Xlpa+6OdnP6yrKz/o52c/1tVVv5aVFb/f3t6+oJ8fP/v6+r6amRk/kI8Pv5iXF7+gnx+/7u1tPw==",
+      "vectorSha256": "b883bbee276581208cae3136f1d7d90374898e38adb3397124c0304843dfb681",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ff6dfd2fb32bbcc76f872deb82701baf91615af3d5f3153548cf41cc383430f6",
+      "updatedAt": "2025-09-20T22:27:41.543Z"
+    }
+  }
+}

--- a/data/jokes-manifest.json
+++ b/data/jokes-manifest.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "generatedAt": "2025-09-20T20:02:25.932Z",
-    "total": 828,
+    "generatedAt": "2025-09-20T22:24:08.680Z",
+    "total": 812,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",
     "fields": [
@@ -26,9 +26,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7a6569132384e0bf4e388a4ae653d93a3c29105458b3aeba17f12d868f630c89",
-        "updatedAt": "2025-09-20T19:49:57.654Z"
+        "model": "fake-64",
+        "vectorSha256": "25b86de4c565923a74dad51665c058978d64569fc9756382cc64afe996a9145f",
+        "updatedAt": "2025-09-20T22:27:41.489Z"
       }
     },
     "j-0002": {
@@ -47,9 +47,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cc2fe578a55131f02ae6f7a961e098ccb641a3f5922ad07c9d5ff7a533223981",
-        "updatedAt": "2025-09-20T19:49:57.658Z"
+        "model": "fake-64",
+        "vectorSha256": "f9c3aaf90bda00a0ae4a59aa2c43a27be08bb8449dbd166db08076cb95f8f228",
+        "updatedAt": "2025-09-20T22:27:41.490Z"
       }
     },
     "j-0003": {
@@ -68,9 +68,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "882312e302105f4fc4c3b14af88ffe03227d153f69f5d315991ed584002da344",
-        "updatedAt": "2025-09-20T19:49:57.660Z"
+        "model": "fake-64",
+        "vectorSha256": "7f3b64634f4ec96d01bbbe924821a8bebbb3a11488788254ed95c732b8117ac5",
+        "updatedAt": "2025-09-20T22:27:41.490Z"
       }
     },
     "j-0004": {
@@ -89,9 +89,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a56c10779bec02f2e3bc81932a8ad7582c0d26f37f5bccbfeee7c2b6839b6950",
-        "updatedAt": "2025-09-20T19:49:57.661Z"
+        "model": "fake-64",
+        "vectorSha256": "cd4fe6d19b8e33e13821833a98624ba8d4cb0092237c044fa39ff0380dcef2ab",
+        "updatedAt": "2025-09-20T22:27:41.490Z"
       }
     },
     "j-0005": {
@@ -110,9 +110,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7844d804252082d7655c4fc0ecbbafa3f16da23bb80f1b3eeb08ae64acd149d4",
-        "updatedAt": "2025-09-20T19:49:57.661Z"
+        "model": "fake-64",
+        "vectorSha256": "6e8db44805f0b978a4f10547988ead1ff28cfe70fd8452ef17caf041d52d4748",
+        "updatedAt": "2025-09-20T22:27:41.490Z"
       }
     },
     "j-0006": {
@@ -131,9 +131,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7973b3dc4d0aa38274fb5f1b167b1a7c5e8f2f05da84eb51b351342893a4c9b0",
-        "updatedAt": "2025-09-20T19:49:57.662Z"
+        "model": "fake-64",
+        "vectorSha256": "bafcaadbb32c7dea8f5fe49fac318bac2a5802cadf566b1a1052b034c4a7f719",
+        "updatedAt": "2025-09-20T22:27:41.493Z"
       }
     },
     "j-0007": {
@@ -152,9 +152,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "664f2919b3b96c2c7fe9c00164611addab8d2bd4b6677325da254cf11bd74069",
-        "updatedAt": "2025-09-20T19:49:57.662Z"
+        "model": "fake-64",
+        "vectorSha256": "eea9312a5b2d80911c5d3d75d86dbe8d1dee0a551e560da6afbc4667e609c8cc",
+        "updatedAt": "2025-09-20T22:27:41.493Z"
       }
     },
     "j-0008": {
@@ -173,9 +173,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bf45be17adae7715b8a9637ca6bb799208dce27b112244e762f80f6168226919",
-        "updatedAt": "2025-09-20T19:49:57.662Z"
+        "model": "fake-64",
+        "vectorSha256": "a1b967b8a5fbe6b3e01203969edaf8480a22dbb2f921a2e42f4ceba36f9afca0",
+        "updatedAt": "2025-09-20T22:27:41.493Z"
       }
     },
     "j-0009": {
@@ -194,9 +194,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "46bb4d6cfd249d2db34b8ad7393b3458d14160460bb5fd13a6c6d7041c33c799",
-        "updatedAt": "2025-09-20T19:49:58.061Z"
+        "model": "fake-64",
+        "vectorSha256": "5532e4d3bf3901aa9142ca81bf0f752b0777f9684e50cc5a34033dc9be1a220d",
+        "updatedAt": "2025-09-20T22:27:41.494Z"
       }
     },
     "j-0010": {
@@ -215,9 +215,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ae190d5b6456ce22c12790055bbb869ff382bb899e09ae373e7cec00d7e1127e",
-        "updatedAt": "2025-09-20T19:49:58.062Z"
+        "model": "fake-64",
+        "vectorSha256": "72394f7f2264a0c00ce5467d0bbf725ee60b520f353ba2953537b6b0eca98d4f",
+        "updatedAt": "2025-09-20T22:27:41.494Z"
       }
     },
     "j-0011": {
@@ -236,9 +236,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0d397887a0cd38f8a5d8aeff2021559da305c5ee10b103cad8e6f653536a76d6",
-        "updatedAt": "2025-09-20T19:49:58.062Z"
+        "model": "fake-64",
+        "vectorSha256": "328b69e0e2499f45ac6355895b299f77ef15044e8e31d48334e6615b6cfbde37",
+        "updatedAt": "2025-09-20T22:27:41.494Z"
       }
     },
     "j-0012": {
@@ -257,9 +257,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "770d4b7076c80a1975f2c5758e04ae1d4fbd5661b05375190eb5e5c10bcf137b",
-        "updatedAt": "2025-09-20T19:49:58.062Z"
+        "model": "fake-64",
+        "vectorSha256": "83e2bb316bac6ee6509aa367d74049fd3697a0222e961c648690fcd224542e60",
+        "updatedAt": "2025-09-20T22:27:41.495Z"
       }
     },
     "j-0013": {
@@ -278,9 +278,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a0193a0e0a481458b84e2f682a41c5e59d53fbc4446416fee73721e2e5c84842",
-        "updatedAt": "2025-09-20T19:49:58.062Z"
+        "model": "fake-64",
+        "vectorSha256": "1e5f9cb43801a8f26454b402a02780d5b1ec029a0b2b2878b7491ac1afa6720e",
+        "updatedAt": "2025-09-20T22:27:41.495Z"
       }
     },
     "j-0014": {
@@ -299,9 +299,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "24432ccab3b743bf7d3cbe16a3bfd3d971ffda3792d6dae63784e007d12e4e15",
-        "updatedAt": "2025-09-20T19:49:58.064Z"
+        "model": "fake-64",
+        "vectorSha256": "f1874e031b502bd23dca64a09df15b68a75b6de8ce07e31a22b3182ccc019d28",
+        "updatedAt": "2025-09-20T22:27:41.495Z"
       }
     },
     "j-0015": {
@@ -320,9 +320,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1238a87fc5e932d08838a590ba1f63f8457fdaa0bd93fed6bd1e274697963f1e",
-        "updatedAt": "2025-09-20T19:49:58.064Z"
+        "model": "fake-64",
+        "vectorSha256": "77f7b4a9a3a7f02d5456250fa0be4c868114193b4592af90a8f2909b9ac24f29",
+        "updatedAt": "2025-09-20T22:27:41.496Z"
       }
     },
     "j-0016": {
@@ -341,9 +341,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "44867c2e26181fd85b21210c90d9198ff2058dc350b2d789ef5bb117412dc45e",
-        "updatedAt": "2025-09-20T19:49:58.064Z"
+        "model": "fake-64",
+        "vectorSha256": "33ba9c2c30bb60eefd519ccab01cdd1d3d00fec21c72e2026a4165634e1a1d59",
+        "updatedAt": "2025-09-20T22:27:41.496Z"
       }
     },
     "j-0017": {
@@ -362,9 +362,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "49f7624042185047b9fcf364c1773df85036d52fd23eb11d64f4f03055d3432f",
-        "updatedAt": "2025-09-20T19:49:58.462Z"
+        "model": "fake-64",
+        "vectorSha256": "d03339ea030c8973824102b563a3aa7f5b0663c4a2e0a7492b62c847de752523",
+        "updatedAt": "2025-09-20T22:27:41.497Z"
       }
     },
     "j-0018": {
@@ -383,9 +383,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b2d12ce96bffc7dc0c48e80923e6de9e90b3a865e0d7670dbd9a9a689e6c4dbe",
-        "updatedAt": "2025-09-20T19:49:58.462Z"
+        "model": "fake-64",
+        "vectorSha256": "db4adc12e700bd2baedc029b5fa5a5ea2f6f4cdee72100226ee45e65640a2c99",
+        "updatedAt": "2025-09-20T22:27:41.497Z"
       }
     },
     "j-0019": {
@@ -404,9 +404,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "08bde09c5bdeea788fd65e40fe16a152133328eb49125a8f8effafb7005ae0d8",
-        "updatedAt": "2025-09-20T19:49:58.462Z"
+        "model": "fake-64",
+        "vectorSha256": "57f3255d209d39254da6626c4be04bc318d947f4b4ede6a9ea52edd8970c2993",
+        "updatedAt": "2025-09-20T22:27:41.497Z"
       }
     },
     "j-0020": {
@@ -425,9 +425,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "522f1f0c0c4f213b598136cc783733bb3a7f5f78226a65ad39383bc8baf51a6a",
-        "updatedAt": "2025-09-20T19:49:58.462Z"
+        "model": "fake-64",
+        "vectorSha256": "78199a06c9407eb98a56e13a1d37408ef45300916854034d58069ba0a6dd11a6",
+        "updatedAt": "2025-09-20T22:27:41.497Z"
       }
     },
     "j-0021": {
@@ -446,9 +446,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eae80d06dbf75c5dd913d27dfa8ce231482746490463def8f5908d9e1ef01db8",
-        "updatedAt": "2025-09-20T19:49:58.462Z"
+        "model": "fake-64",
+        "vectorSha256": "dcecebb6afb12ccd251fc6efbd40fff2621a83c4c701bc2b4567637a563b6225",
+        "updatedAt": "2025-09-20T22:27:41.497Z"
       }
     },
     "j-0022": {
@@ -467,9 +467,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b714fa4506a37ac25a77f6d034d58e72570d500bea8778776b729d843793106f",
-        "updatedAt": "2025-09-20T19:49:58.462Z"
+        "model": "fake-64",
+        "vectorSha256": "cc29949b6702904605b95c56277282ab8feb98b9cf938ac6c36c002f14b14a73",
+        "updatedAt": "2025-09-20T22:27:41.497Z"
       }
     },
     "j-0023": {
@@ -488,9 +488,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "88d0c28db5b6853b7325047cca0bdccbe6cad591612f3ef9f202ece511a82272",
-        "updatedAt": "2025-09-20T19:49:58.462Z"
+        "model": "fake-64",
+        "vectorSha256": "604b8a7c6f3a7ecc70e28aa544566edf57d1ab0fd0b8c2f698327f2cd9dc3fa8",
+        "updatedAt": "2025-09-20T22:27:41.498Z"
       }
     },
     "j-0024": {
@@ -509,9 +509,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bd7e8114cf8bc059a102e19373f66dd1a00f93bda716625d58b18ce25ae8d865",
-        "updatedAt": "2025-09-20T19:49:58.462Z"
+        "model": "fake-64",
+        "vectorSha256": "8d3e180a373278bbb02c7f7988f159dc1d84e89247eed21e725d2e1e6a76c756",
+        "updatedAt": "2025-09-20T22:27:41.498Z"
       }
     },
     "j-0025": {
@@ -530,9 +530,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "067930084e75183dad54363c1acf81269c2d9c476cd3703a8899881abef0dfca",
-        "updatedAt": "2025-09-20T19:49:58.865Z"
+        "model": "fake-64",
+        "vectorSha256": "a02d87ac60d2d2430ee8a01cbb6309caf401ee34d247d0a59be61135f051e77e",
+        "updatedAt": "2025-09-20T22:27:41.498Z"
       }
     },
     "j-0026": {
@@ -551,9 +551,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "436a7ebd3815271df372a82f235b259a98f442184fbf8ca2a19d6537f359d1f7",
-        "updatedAt": "2025-09-20T19:49:58.865Z"
+        "model": "fake-64",
+        "vectorSha256": "8de9da55ff9b1b8210ec09d7f136a96a5f17c2ee116b114835fa5bb6bd564907",
+        "updatedAt": "2025-09-20T22:27:41.498Z"
       }
     },
     "j-0027": {
@@ -572,9 +572,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ccdb9293135446f0c78bb98db8482e0ac670fee1989138f09eade4638fa5da6f",
-        "updatedAt": "2025-09-20T19:49:58.865Z"
+        "model": "fake-64",
+        "vectorSha256": "2f89efe3479b2d1b0a174c5d21fe0110b0917e70c11554a55a6c9e9aa4bafc0f",
+        "updatedAt": "2025-09-20T22:27:41.498Z"
       }
     },
     "j-0028": {
@@ -593,9 +593,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cee7c0385a64c6d3a8c7b1c14a2b92738706b6a7e38ad97dbc03f80e308c4c77",
-        "updatedAt": "2025-09-20T19:49:58.865Z"
+        "model": "fake-64",
+        "vectorSha256": "87c7495f55b2b4de4d94a7957b2f7f080cd6e39d4f2a070e9e0a5c8a2553e9ee",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0029": {
@@ -614,9 +614,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "973a86b3b6dc1abb32366209a3f87702de707f405ab08071dd14b5408e0191cc",
-        "updatedAt": "2025-09-20T19:49:58.865Z"
+        "model": "fake-64",
+        "vectorSha256": "5486edaf47edeada0c32b1c7fa477db40d3ad46d793e7ed5cb25330596cb20fb",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0030": {
@@ -635,9 +635,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a3a1d74cb160b20db4992f5ab7dca2dc48f53f446dafefe87d6c417eb0d1abb4",
-        "updatedAt": "2025-09-20T19:49:58.865Z"
+        "model": "fake-64",
+        "vectorSha256": "8bf2b9f1ab8d26cfad3d03ddc3eb253036fe8d092ec0935be6aedb1a717f5264",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0031": {
@@ -656,9 +656,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f8a15ac7f6deddf300873d9157bb64242ed1b2af9823518afab9bd302f7546aa",
-        "updatedAt": "2025-09-20T19:49:58.865Z"
+        "model": "fake-64",
+        "vectorSha256": "8cb2dcb442ceb1df29a7ce0651a0dc24142c671c1e33ea7a722d6970dd8ccf19",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0032": {
@@ -677,9 +677,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "69425458e70d90037c54616d335898a64fdb94837b1ec8695e86767f7b6a4be9",
-        "updatedAt": "2025-09-20T19:49:58.866Z"
+        "model": "fake-64",
+        "vectorSha256": "ab6b630a2e174685c28fe9fa5fdcc5eba99020e4cb07ca27c0e38521f632562e",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0033": {
@@ -698,9 +698,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5d1a4ff336cd2f3b7cc8bdb4e8a6474ae77555fb7ffad5fd9a5cd0f99d553151",
-        "updatedAt": "2025-09-20T19:49:59.371Z"
+        "model": "fake-64",
+        "vectorSha256": "b477ebb1af6e0bfd929f8af2bac397e5e3ee163c905a3805af1388b247d010f2",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0034": {
@@ -719,9 +719,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "143e752e802795c0ffea027949f0cd59706277ef28c08216d6764539bf7dfb65",
-        "updatedAt": "2025-09-20T19:49:59.371Z"
+        "model": "fake-64",
+        "vectorSha256": "1c75a59e9f7c9137cf59e2d6b27c47a18e7ca24ad42b06328c5d17a9e38e9435",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0035": {
@@ -740,9 +740,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "672f468bdaef0e8e668da3b195f7be4d3481f668764305617dd4c2eb2aabed4f",
-        "updatedAt": "2025-09-20T19:49:59.371Z"
+        "model": "fake-64",
+        "vectorSha256": "2fb858b518802a3ef6f4f7727bc77e06506f3641692004f62a9f8f5e077a09f9",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0036": {
@@ -761,9 +761,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eb6d97055c834c81c1879c04517925d08b4eeafbd6dc9425b5289e1f92d24d4e",
-        "updatedAt": "2025-09-20T19:49:59.371Z"
+        "model": "fake-64",
+        "vectorSha256": "f8305ba0cfd05cdff565cdc9c94550d17fc2311161cdad16166428b766357412",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0037": {
@@ -782,9 +782,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d5f4545a38282b4c7432650fa3399ddc89e09358493131734ace6a8ce4058270",
-        "updatedAt": "2025-09-20T19:49:59.371Z"
+        "model": "fake-64",
+        "vectorSha256": "d89d120b7208d377a322e7e04b8a5f4affebb78c53015f4cd4c3b936187fd03c",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0038": {
@@ -803,9 +803,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ae831831e24324c992bc111f3f3f526391f753c8d291b456846a4841cfe73dfe",
-        "updatedAt": "2025-09-20T19:49:59.371Z"
+        "model": "fake-64",
+        "vectorSha256": "79b94998ecf727786c1182b3ad0bc06bcd455f31f78d1fe48b4e8d5f7031991e",
+        "updatedAt": "2025-09-20T22:27:41.499Z"
       }
     },
     "j-0039": {
@@ -824,9 +824,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7896618d8bd5b4a1f4f1bd012f98d626c8602234c4481064d4708ce199f90146",
-        "updatedAt": "2025-09-20T19:49:59.371Z"
+        "model": "fake-64",
+        "vectorSha256": "ee857bfd51b1abd54028408898dca3c54d1f93b07242cee3b790117a12905663",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0040": {
@@ -845,9 +845,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a775325df732ced3b185ef009eb1d3f749d65e14f04ad47c386b69a2629ea13f",
-        "updatedAt": "2025-09-20T19:49:59.371Z"
+        "model": "fake-64",
+        "vectorSha256": "4b6fdfa9e6742943fdc46d4adfc0ae1fec9d415e835d291cc59b22b9167fd85b",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0041": {
@@ -866,9 +866,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6f58f57b6c5b7d9544667ba78a28680d047cd4a95c6e7ec374fc76936ccfb04e",
-        "updatedAt": "2025-09-20T19:49:59.757Z"
+        "model": "fake-64",
+        "vectorSha256": "987fc45997e28cde266e7e7b74d4022636497193ddcf424029766091dbbe2a79",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0042": {
@@ -887,9 +887,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4c278f48918ad813ce31f016384ecaf684171622ce802afda82aad04f14dfbbb",
-        "updatedAt": "2025-09-20T19:49:59.757Z"
+        "model": "fake-64",
+        "vectorSha256": "a43cc37deebb7e4340b308e811721a8e99e1946964acd9177758a44053994aeb",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0043": {
@@ -908,9 +908,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c14095ac9e338608f8191fbf1814205ff8cf3021f631372c06b0679bba6400a5",
-        "updatedAt": "2025-09-20T19:49:59.757Z"
+        "model": "fake-64",
+        "vectorSha256": "4ed1ee698a217b3244fcb5f3dff153c82ebecc76a5170d717b39bb817c55ab3d",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0044": {
@@ -929,9 +929,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "078627b8fd666c164572daaa0fcae8d36da78e1a6632844cbd474d014550e159",
-        "updatedAt": "2025-09-20T19:49:59.757Z"
+        "model": "fake-64",
+        "vectorSha256": "a529dbe58783005b575b6c567a1776ab2342124a9c26c34e3494e8379a8b8c5e",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0045": {
@@ -950,9 +950,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "07b75b2e90f15281571c006cdf90590b80244b584760094c247b2d553dd80bd9",
-        "updatedAt": "2025-09-20T19:49:59.758Z"
+        "model": "fake-64",
+        "vectorSha256": "efb0846b3aaff20a546e8822194ef569294dce407210da5eda8d43b5853818e8",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0046": {
@@ -971,9 +971,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ab8bd38e68ba5b84817f939210e4f78ea1c00ffa018acb098d7978628403dc0b",
-        "updatedAt": "2025-09-20T19:49:59.758Z"
+        "model": "fake-64",
+        "vectorSha256": "9120ce1d1ee284e487c9e4e25717767749c26e6a3e45e27cf71abf19febadda2",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0047": {
@@ -992,9 +992,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eb2a295e873556c86d91610bb7d1182db9237b56f5e8d2008234b982365c7e55",
-        "updatedAt": "2025-09-20T19:49:59.758Z"
+        "model": "fake-64",
+        "vectorSha256": "0d6e0f34d507116e7fa8be6e4a5b8ab8d1c6ec9d6e47c5fd3a3c40bf74cbdffd",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0048": {
@@ -1013,9 +1013,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ace2e20c2f9dc0996641ec6d92c41fecaa8d31520d2e27ccf8dcbcce9e3614d8",
-        "updatedAt": "2025-09-20T19:49:59.758Z"
+        "model": "fake-64",
+        "vectorSha256": "3d1c290f214f2ba98728df04296e5c11fe66fff0bd7f6d4e23b3d0b879c6a5e8",
+        "updatedAt": "2025-09-20T22:27:41.500Z"
       }
     },
     "j-0049": {
@@ -1034,9 +1034,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "770514838016eb4421e10d7c306549b260242bff4a5a5438b64a244117a1476a",
-        "updatedAt": "2025-09-20T19:50:00.203Z"
+        "model": "fake-64",
+        "vectorSha256": "5e27f04ebe5f331e861ccf684e731d762f0a8d9038498a1928711a3192093e16",
+        "updatedAt": "2025-09-20T22:27:41.501Z"
       }
     },
     "j-0050": {
@@ -1055,9 +1055,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0d4c693c69170d5436ca85192dab73da22e23d3c7ef9eaee00ada14c7f278026",
-        "updatedAt": "2025-09-20T19:50:00.203Z"
+        "model": "fake-64",
+        "vectorSha256": "392521a85568e6979a29b10b06394dd65f25f9b1c4848bc7fec2b1d3ecf3a301",
+        "updatedAt": "2025-09-20T22:27:41.501Z"
       }
     },
     "j-0051": {
@@ -1076,9 +1076,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "08badc08a6e21de17b929092a8ae94151ada16306bf31ae3e48f18954ab2da7a",
-        "updatedAt": "2025-09-20T19:50:00.203Z"
+        "model": "fake-64",
+        "vectorSha256": "c1df035b526b8f19c0fdf628e80377345f404881e0142f11ff1e0599b3bec6f1",
+        "updatedAt": "2025-09-20T22:27:41.501Z"
       }
     },
     "j-0052": {
@@ -1097,9 +1097,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5f670e52e08c76b2c45bd4c0e7fc142bfcd3ffcde54330845f7d2558ee4b025d",
-        "updatedAt": "2025-09-20T19:50:00.203Z"
+        "model": "fake-64",
+        "vectorSha256": "567d7f6e0e2dd89e056caa837019e7e2d0a35b0bbc5db62ef878c171f241041d",
+        "updatedAt": "2025-09-20T22:27:41.501Z"
       }
     },
     "j-0053": {
@@ -1118,9 +1118,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9082bde6311348cced028fffe34547d23594e2e45ac3cbff46820de87b20b5e6",
-        "updatedAt": "2025-09-20T19:50:00.203Z"
+        "model": "fake-64",
+        "vectorSha256": "268dac40eca24aaf06a03ab2c8f8e96a301669c06bcdd911613d64a6fbb1c132",
+        "updatedAt": "2025-09-20T22:27:41.501Z"
       }
     },
     "j-0054": {
@@ -1139,9 +1139,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0f42edc9dd2684c979a1961ced71f8c83356fe5930d85b37f1ab43922cd0a532",
-        "updatedAt": "2025-09-20T19:50:00.203Z"
+        "model": "fake-64",
+        "vectorSha256": "4f17d4f905d5b8bd6da85f9c2315ad6dafaaf43787d6a9f374380a49d495a04f",
+        "updatedAt": "2025-09-20T22:27:41.501Z"
       }
     },
     "j-0055": {
@@ -1160,9 +1160,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "25982540228d5e9902a49684e26793572b4eb1958baf0eac80dba24169bf57ce",
-        "updatedAt": "2025-09-20T19:50:00.204Z"
+        "model": "fake-64",
+        "vectorSha256": "dcf4ceef2984a5bc22825596fea39c96a12f6a8b5a01fcd80e259841156f4512",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0056": {
@@ -1181,9 +1181,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8450e28f42c248580618ad218f7a95b48559cfe099a83be6cd27adab2594ceb6",
-        "updatedAt": "2025-09-20T19:50:00.204Z"
+        "model": "fake-64",
+        "vectorSha256": "91aa1cab7507aae72ec32a004d42aa4bb15cbd69890fa71807007a9da16add4b",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0057": {
@@ -1202,9 +1202,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "771f075b5b08ba127e9280385a1bdd9b214a5e5a183c0555594f0fc3205fd33e",
-        "updatedAt": "2025-09-20T19:50:00.645Z"
+        "model": "fake-64",
+        "vectorSha256": "cd6d2c454197192f7d31ba481861da8c26108d70983fdd248e8e30027e7630ad",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0058": {
@@ -1223,9 +1223,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b0a2e0191599163a60a212ba23a86506ae695e2376acfcf79448b6453dea4029",
-        "updatedAt": "2025-09-20T19:50:00.645Z"
+        "model": "fake-64",
+        "vectorSha256": "4116e31caab79ff5014ce09c9af5d7a5a68281ddc0d729055a785da823137cf9",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0059": {
@@ -1244,9 +1244,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "18a153e44882c7e54eebb645d88643fcb82658245e03eec01844de45a57b8626",
-        "updatedAt": "2025-09-20T19:50:00.645Z"
+        "model": "fake-64",
+        "vectorSha256": "4ccd6fb2b611054aab8ea4ffa7ec38707ff30a8532f47cb57a4b826a1a45c38f",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0060": {
@@ -1265,9 +1265,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "30f48c5e04fd06bcaf1d22abd6d87659a6cb1d19f1e47e4ae97cb770bf06d47c",
-        "updatedAt": "2025-09-20T19:50:00.645Z"
+        "model": "fake-64",
+        "vectorSha256": "7fd334733fd963c87ecc24803f1484daf786356c3f0b2d44df5745c8464b25cf",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0061": {
@@ -1286,9 +1286,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1e3053b590b207311aaca758aef378cf8a9e6e741711ea1cd9b615f93c0c9733",
-        "updatedAt": "2025-09-20T19:50:00.645Z"
+        "model": "fake-64",
+        "vectorSha256": "e72d9264f4cff287b0e41feb891eb1571a8182769b52ff432da80f6814d2deae",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0062": {
@@ -1307,9 +1307,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "65eb6a78d0be3ceec90ebef0995cfeddf39377fe9190888d95db40b65bfcd7d6",
-        "updatedAt": "2025-09-20T19:50:00.646Z"
+        "model": "fake-64",
+        "vectorSha256": "94554a7484518d84094c9761036d3c78b4e4faf81595872f789ade42b0233eb7",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0063": {
@@ -1328,9 +1328,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7cdf7f384913d7dcddeebe2a777370f5ac59347b3a27dc17d2ca37bb5a94a8b8",
-        "updatedAt": "2025-09-20T19:50:00.646Z"
+        "model": "fake-64",
+        "vectorSha256": "98953d64b91fb392abfe50288e22a4ede664a8b703469f9fc997a21303e9a40a",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0064": {
@@ -1349,9 +1349,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5d974947e436417b9f128b4bbd6fc2cd615cda2f4330a0116113f6692136092c",
-        "updatedAt": "2025-09-20T19:50:00.646Z"
+        "model": "fake-64",
+        "vectorSha256": "8fa5beb887b23d44310271cc3e358a6e06a5c5a93205753f76b570077d66de68",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0065": {
@@ -1370,9 +1370,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a9b9f6b7c77309e78871ca79b602c308c052f1e7e68d13d83b970f51a6e44ae5",
-        "updatedAt": "2025-09-20T19:50:01.034Z"
+        "model": "fake-64",
+        "vectorSha256": "b12d378928f5972740dd29e9c753325281db532e22a984f1c705d6810de76718",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0066": {
@@ -1391,9 +1391,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5f05f1ad112eba5bf77a339067f11e2ba1f7e2ab5fa45673d0a567c84e2f8269",
-        "updatedAt": "2025-09-20T19:50:01.034Z"
+        "model": "fake-64",
+        "vectorSha256": "a6e647b2bce12e2fcad9b80fe2ddd73ec65fdc87b40204f30f175b03bd946b0d",
+        "updatedAt": "2025-09-20T22:27:41.505Z"
       }
     },
     "j-0067": {
@@ -1412,9 +1412,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "10d59cc0222996aa513fcc635293b41aa4781b1ba0df85605ea80ce3ddd644c0",
-        "updatedAt": "2025-09-20T19:50:01.034Z"
+        "model": "fake-64",
+        "vectorSha256": "8ce368b4ab02fe5c00598c3968ddbcb82f5e9401251f98e28acc44c043875739",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0068": {
@@ -1433,9 +1433,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "407ab0f998712b343a00c573eb8797f215d8f26882163bb3b6631a59d891e366",
-        "updatedAt": "2025-09-20T19:50:01.035Z"
+        "model": "fake-64",
+        "vectorSha256": "60bc2fd0a609ef1d789244266d82f4015d69248f5e743a2cb2b0ddc946bdf3a1",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0069": {
@@ -1454,9 +1454,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e643a48fcf0df3248070e5749952b98b955ed9387ca1a8f9fac09dba9181b1c7",
-        "updatedAt": "2025-09-20T19:50:01.035Z"
+        "model": "fake-64",
+        "vectorSha256": "3676a6c330b5c23db66ab67490143fbe55d5f3a53d105dfde26fe897f41014b8",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0070": {
@@ -1475,9 +1475,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5c96684bbeaebd22dd7ef8120a80f48bc1bd6606967e60de80c361015a9f971a",
-        "updatedAt": "2025-09-20T19:50:01.035Z"
+        "model": "fake-64",
+        "vectorSha256": "ad9f1cc967c5def3df57569f0812c28fa3f03b13014408d3ece32ee5bab54761",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0071": {
@@ -1496,9 +1496,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4b19105024c21b84cbba82c5763c115d4a176675863f9c628742e3e24a2b68ee",
-        "updatedAt": "2025-09-20T19:50:01.035Z"
+        "model": "fake-64",
+        "vectorSha256": "2f30752ddf0839c10d5e998968a8175dd354010aec1dc875413b049d85d6caf7",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0072": {
@@ -1517,9 +1517,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d5c141ddf9bbab605500a2aa31bf58f9615d4a1fb941064f325a72e63916968f",
-        "updatedAt": "2025-09-20T19:50:01.035Z"
+        "model": "fake-64",
+        "vectorSha256": "fc8db06713846ca6e56854ec53b220a8ee7b4f016492a2db230dd7a8bdf1bf78",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0073": {
@@ -1538,9 +1538,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "717fb178e0e0a585d6788125844d423bcf626363d0b767f327d22bf9b8003a52",
-        "updatedAt": "2025-09-20T19:50:01.400Z"
+        "model": "fake-64",
+        "vectorSha256": "f5ac33a50154fbfb0fe774727c3d02ded46d0e13d2469715cc2a21324042cbb9",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0074": {
@@ -1559,9 +1559,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0f465f536c1e3c0ed1d76926186442d14da68d2830d737b4a80f070e008789ef",
-        "updatedAt": "2025-09-20T19:50:01.400Z"
+        "model": "fake-64",
+        "vectorSha256": "a4c95f70c90231f6ea783704048455fa78503fc2b1efc80363f20d95fd1f5817",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0075": {
@@ -1580,9 +1580,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4eb16d39bb090c52ecef889e847ebc5dc051ef2bff37342449b05bceac61d778",
-        "updatedAt": "2025-09-20T19:50:01.400Z"
+        "model": "fake-64",
+        "vectorSha256": "3aeb71a62d2d36eaf6856e773eb824f836ee4401be0e5293980822892405dadb",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0076": {
@@ -1601,9 +1601,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "95d940ba0d21205c1ee2a6697b14af7bc483ea833c1fe8df03c65b5f3bacbf42",
-        "updatedAt": "2025-09-20T19:50:01.400Z"
+        "model": "fake-64",
+        "vectorSha256": "a13d450a1f9a01c52c5bd5b9c22de570207fe0e7f0257e6069e1b2c6ec86b39d",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0077": {
@@ -1622,9 +1622,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ab7425c3b710e6b8fd82d5fec145a405c0f29640000b47363b1524d44b37fcd1",
-        "updatedAt": "2025-09-20T19:50:01.400Z"
+        "model": "fake-64",
+        "vectorSha256": "4fa72edaffbd31421ece1a5dcd3f49302b0304683a9ece753d7c5df717160c61",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0078": {
@@ -1643,9 +1643,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "04bae064021ac4cf96e9c6288113bb630c8fe3716a59dc3037449318053de4d1",
-        "updatedAt": "2025-09-20T19:50:01.400Z"
+        "model": "fake-64",
+        "vectorSha256": "d98d02da93896fd4404c2fe860329de198c9e62fdc6939cf2ebee69f97a77d5f",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0079": {
@@ -1664,9 +1664,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b907a6a8c7c6c7ae02b5eedded5661387a674d706bae2cc73a272ad1373e725c",
-        "updatedAt": "2025-09-20T19:50:01.400Z"
+        "model": "fake-64",
+        "vectorSha256": "8bceb9acd92a9a8bf3dfa5bc20900513dbc57dfb4accf63c667f0f191cb15231",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0080": {
@@ -1685,9 +1685,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "47a2579e7006b6d17f849b5658418e7bcf9197470c547b443a2edfeab8a9a7a2",
-        "updatedAt": "2025-09-20T19:50:01.400Z"
+        "model": "fake-64",
+        "vectorSha256": "13cdef955c1af5fefc54400ca013061cb7ebf3dc84c5033ea6fef89aae3f3a4a",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0081": {
@@ -1706,9 +1706,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3eafcd45f10fffba83843cf7a32e4b392cef5e8adc8edab9f0cc1e765ce61451",
-        "updatedAt": "2025-09-20T19:50:01.741Z"
+        "model": "fake-64",
+        "vectorSha256": "ab90bbf2714e2fd502d2860793486acb6c574e246976102e197fe633ca1e79d4",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0082": {
@@ -1727,9 +1727,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "561e3bb2d082f0b262d04e38f2543a31738e8a09187f35589276b184be057357",
-        "updatedAt": "2025-09-20T19:50:01.742Z"
+        "model": "fake-64",
+        "vectorSha256": "0e7b8b2f7580dfa47cbf176116068b70f3b30ab6633c52fa0528c88ca42307f7",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0083": {
@@ -1748,9 +1748,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "98ad7c8ca64dec499e743a64c8b97a967ba4098c466b0dc5495ea59816c4a3b2",
-        "updatedAt": "2025-09-20T19:50:01.742Z"
+        "model": "fake-64",
+        "vectorSha256": "d123347d16191b3d4671a04eef84d20bf39124353ff7762c66b9b963890af75c",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0084": {
@@ -1769,9 +1769,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3a00e4e47f3f82689eea04eb9d2b3a7888b92ff49b88d27335b6f3ac642c8773",
-        "updatedAt": "2025-09-20T19:50:01.742Z"
+        "model": "fake-64",
+        "vectorSha256": "4d212e902a7030b32cbf560daf6c3de848fac1ccd71beffe8cefc8642500b75b",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0085": {
@@ -1790,9 +1790,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ad32b5fa11f5fb759184b62d7a11e296c0909d657f1b8df1a6a57b36ba4c45cb",
-        "updatedAt": "2025-09-20T19:50:01.742Z"
+        "model": "fake-64",
+        "vectorSha256": "d6008d5ca25846e94bed479dd8a18ce7275f7f6f49e289eb1ee1b66309b0c5a1",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0086": {
@@ -1811,9 +1811,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3b7a37812464bb2dd3db6c806a88d59b2a64dea91e7f3babda6daaf9ac554da7",
-        "updatedAt": "2025-09-20T19:50:01.742Z"
+        "model": "fake-64",
+        "vectorSha256": "30fa0075ff602a349611cca07105ccba985db566ccdc8dd71bef815947f4d978",
+        "updatedAt": "2025-09-20T22:27:41.506Z"
       }
     },
     "j-0087": {
@@ -1832,9 +1832,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a11262cdbba2097a8a0e3caeecd31a49dc61079f20b804ed79d3e9f36f77cdca",
-        "updatedAt": "2025-09-20T19:50:01.742Z"
+        "model": "fake-64",
+        "vectorSha256": "04d854d135b398a657fccd631472cb4391c006dd51a4cbf4da70859bb524d678",
+        "updatedAt": "2025-09-20T22:27:41.507Z"
       }
     },
     "j-0088": {
@@ -1853,9 +1853,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "47bd5e8f586bbbc420c9f14ca3d77beb255762ef6279e1fadebd1eaea1edc563",
-        "updatedAt": "2025-09-20T19:50:01.742Z"
+        "model": "fake-64",
+        "vectorSha256": "2cd32aa6c746ea26ec4083b43547372b78a3aef35643d1fe2775e7e0aeb41318",
+        "updatedAt": "2025-09-20T22:27:41.507Z"
       }
     },
     "j-0089": {
@@ -1874,9 +1874,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "07944e93ca9f81068b6880928bde70233373fbbc2916b5a0408484c50bac863b",
-        "updatedAt": "2025-09-20T19:50:02.121Z"
+        "model": "fake-64",
+        "vectorSha256": "e1da52d19ee7423d3b3cfb6d9cd9794a96c83cd1eb8a149d06d2988284f60977",
+        "updatedAt": "2025-09-20T22:27:41.507Z"
       }
     },
     "j-0090": {
@@ -1895,9 +1895,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c0acd5f97b24eb2af3c68b227749f38c6e0ed8cad14efa0679f0e320bb8365a3",
-        "updatedAt": "2025-09-20T19:50:02.121Z"
+        "model": "fake-64",
+        "vectorSha256": "a4a4768c94c06847f95067fb516b0bb428c095e4b747ed0b986ab832b48f54ab",
+        "updatedAt": "2025-09-20T22:27:41.507Z"
       }
     },
     "j-0091": {
@@ -1916,9 +1916,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fa081ef3702cf19507d96356bcd942427bb34bf07b916ae8b0afc1d1a15394e3",
-        "updatedAt": "2025-09-20T19:50:02.121Z"
+        "model": "fake-64",
+        "vectorSha256": "2fb80b7be94d2c6fa9da5931e65c84681f18dfbc0807232c2bc1b588dae5bb3d",
+        "updatedAt": "2025-09-20T22:27:41.507Z"
       }
     },
     "j-0092": {
@@ -1937,9 +1937,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "88843b32574cb654cfac30c42a5508a5f92f8abc7b636945dbb91cc2204314f5",
-        "updatedAt": "2025-09-20T19:50:02.121Z"
+        "model": "fake-64",
+        "vectorSha256": "206bde4edfbf2b37419f6b71fdaf2541fc0d60ebb2e8d6ab757c2018711493da",
+        "updatedAt": "2025-09-20T22:27:41.507Z"
       }
     },
     "j-0093": {
@@ -1958,9 +1958,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1a794b4a588aba2cb2cf87a614b56281da09581cd6144da81a5187896f2e986d",
-        "updatedAt": "2025-09-20T19:50:02.121Z"
+        "model": "fake-64",
+        "vectorSha256": "85addfa4f9561b8fd6b85103f36f1842fb47da8b06575d20b5900362b8fb35eb",
+        "updatedAt": "2025-09-20T22:27:41.507Z"
       }
     },
     "j-0094": {
@@ -1979,9 +1979,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1f3c62d42ed8535e1506772c32d741bdbcc2d197f6b1924949d1934788f81a22",
-        "updatedAt": "2025-09-20T19:50:02.121Z"
+        "model": "fake-64",
+        "vectorSha256": "c785bb970e215e868863d363fb64df6e06fa7817e649c55f957a32b2b9176ba4",
+        "updatedAt": "2025-09-20T22:27:41.507Z"
       }
     },
     "j-0095": {
@@ -2000,9 +2000,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "51e58a6e3f72e8ecced26794918024912e26eb7381b1aa1e3bcf6ae241282097",
-        "updatedAt": "2025-09-20T19:50:02.121Z"
+        "model": "fake-64",
+        "vectorSha256": "a02e04935743c147b5d5e867c63b1126c15708d4bcb2f1a180c245c25b4d342b",
+        "updatedAt": "2025-09-20T22:27:41.507Z"
       }
     },
     "j-0096": {
@@ -2021,9 +2021,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "107f9cc23bc8ce5e098527ea6bb4d9bae3c5be2751efc05912d9b671b4ea0ff3",
-        "updatedAt": "2025-09-20T19:50:02.121Z"
+        "model": "fake-64",
+        "vectorSha256": "450cc6b287b0c2ad3640abefcaedab112f43dfd73d524c6d46b5cf06f1b0f634",
+        "updatedAt": "2025-09-20T22:27:41.508Z"
       }
     },
     "j-0097": {
@@ -2042,9 +2042,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "86732db69c4063c78747e21784a676656790ccb13deed20afc9869be2439785f",
-        "updatedAt": "2025-09-20T19:50:02.481Z"
+        "model": "fake-64",
+        "vectorSha256": "72b4aaae731ce8257b19cb80aa3f9ca8e3111029e60e7b1f9d1af9350491ac05",
+        "updatedAt": "2025-09-20T22:27:41.508Z"
       }
     },
     "j-0098": {
@@ -2063,9 +2063,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d1deea29b807e34e7e698d85ca31c3c976151be8044db6cd8d7ed26eb9652d4d",
-        "updatedAt": "2025-09-20T19:50:02.482Z"
+        "model": "fake-64",
+        "vectorSha256": "07e466f6acf01319fa49242ff1331a8c28c8c1d78746c86ad6d646d83a54086d",
+        "updatedAt": "2025-09-20T22:27:41.508Z"
       }
     },
     "j-0099": {
@@ -2084,9 +2084,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4aa9e5804838d732680ad25e9641483a5d1857764e51229ce93b6dfa395f3348",
-        "updatedAt": "2025-09-20T19:50:02.482Z"
+        "model": "fake-64",
+        "vectorSha256": "4b81d605a0af6395a0de792ce873196b6d28304937c18edf17851b6ad377feac",
+        "updatedAt": "2025-09-20T22:27:41.508Z"
       }
     },
     "j-0100": {
@@ -2105,9 +2105,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fa870c24bb651f01ffa384bf2bed3a3cc574af33058eb9d9fa02657f081efefc",
-        "updatedAt": "2025-09-20T19:50:02.482Z"
+        "model": "fake-64",
+        "vectorSha256": "47719b926e61007f0cbcdef3323fa003ffbc410b496adf51a02b8362f390b0dd",
+        "updatedAt": "2025-09-20T22:27:41.508Z"
       }
     },
     "j-0101": {
@@ -2126,9 +2126,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aab5156c29027c48ec8100e14994789fc2884d46e1bc85ef69d63f3e76115dbf",
-        "updatedAt": "2025-09-20T19:50:02.482Z"
+        "model": "fake-64",
+        "vectorSha256": "b5528e59e784f7f5ce79d8e285cb4b0eb02d2ec379d048ab0cdc91110a75c58b",
+        "updatedAt": "2025-09-20T22:27:41.508Z"
       }
     },
     "j-0102": {
@@ -2147,9 +2147,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "28172981a6da5776a42033deed4bce36728457144be1c658c950dba23674bc47",
-        "updatedAt": "2025-09-20T19:50:02.482Z"
+        "model": "fake-64",
+        "vectorSha256": "1d9a7e9487b5631bb0ee88c1506e8329d6a958d82564f4710f997bdc7a506e7d",
+        "updatedAt": "2025-09-20T22:27:41.508Z"
       }
     },
     "j-0103": {
@@ -2168,9 +2168,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f97d57e0a917fa8092046b98daeea79b1735b808f080864feefabe0bb8c55f3b",
-        "updatedAt": "2025-09-20T19:50:02.482Z"
+        "model": "fake-64",
+        "vectorSha256": "e75e8caad6a07e320486b581b7fba5f3d83dfe8e449788be3e3a36f493cedb46",
+        "updatedAt": "2025-09-20T22:27:41.508Z"
       }
     },
     "j-0104": {
@@ -2189,9 +2189,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c84d4fa59c96d54fe4a805567fd285bcc125bf9dd140f6572de7cba115daedde",
-        "updatedAt": "2025-09-20T19:50:02.482Z"
+        "model": "fake-64",
+        "vectorSha256": "64b1bf031a5af11c0e1adcaa6a5c9c13855215b105176694d31f4364b8d5e3cf",
+        "updatedAt": "2025-09-20T22:27:41.508Z"
       }
     },
     "j-0105": {
@@ -2210,9 +2210,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1947d60794e5b43f58dd918b8d4e915cd1215a0b26aae9b0084719b1fc04fe43",
-        "updatedAt": "2025-09-20T19:50:02.787Z"
+        "model": "fake-64",
+        "vectorSha256": "d7cd59842677f0b8d18e36626baee0249341033462d0baa0581fcf405a447ff2",
+        "updatedAt": "2025-09-20T22:27:41.509Z"
       }
     },
     "j-0106": {
@@ -2231,9 +2231,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "62ff7381b8c46f4a1e241d325b8b6194e42a4cca0c0c0c7a4e9ff49be88aefdc",
-        "updatedAt": "2025-09-20T19:50:02.787Z"
+        "model": "fake-64",
+        "vectorSha256": "129d0f0101731b671067e7aed575fba66fd194c3e6adb873d593fa6c8bf5adb7",
+        "updatedAt": "2025-09-20T22:27:41.509Z"
       }
     },
     "j-0107": {
@@ -2252,9 +2252,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c6614aa568f16015b2fc0f16ac189f2e2335032317cfbfa69de08b1253381207",
-        "updatedAt": "2025-09-20T19:50:02.787Z"
+        "model": "fake-64",
+        "vectorSha256": "02e2cf317a751a093298311a7178e6e1b1c96351cfd01044bccc4a37d08132bb",
+        "updatedAt": "2025-09-20T22:27:41.509Z"
       }
     },
     "j-0108": {
@@ -2273,9 +2273,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "af86a7493e0846316bd875b2509a269fecbcab9ce9355fcbf9e87ae1580555d2",
-        "updatedAt": "2025-09-20T19:50:02.787Z"
+        "model": "fake-64",
+        "vectorSha256": "978b95b70bc4a3c67ffd27a9b99d3fda56250e6ecdabbd8e9e51ef12e8b0e985",
+        "updatedAt": "2025-09-20T22:27:41.509Z"
       }
     },
     "j-0109": {
@@ -2294,9 +2294,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2a00cedc4e4dae3040b35ccaea5bc09bab2322f6f57cfde578b63b20d76cb527",
-        "updatedAt": "2025-09-20T19:50:02.787Z"
+        "model": "fake-64",
+        "vectorSha256": "00b8295f99658088db5ec0f3308352809f8f7a5c81086ad1dd00b5c6ae586786",
+        "updatedAt": "2025-09-20T22:27:41.509Z"
       }
     },
     "j-0110": {
@@ -2315,9 +2315,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a9c8870b4a4072842b8729c3c55546f434d4a1948a0062f8b543e1a44f27db89",
-        "updatedAt": "2025-09-20T19:50:02.787Z"
+        "model": "fake-64",
+        "vectorSha256": "eab65d0a2509d8e92453860a3fb27e92745ede3ec90b55c18e43c50a546a2a07",
+        "updatedAt": "2025-09-20T22:27:41.509Z"
       }
     },
     "j-0111": {
@@ -2336,9 +2336,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fd923f43c183d7e18f586a20c17a0ff361c9609cf9267d2e25f229a074a4475c",
-        "updatedAt": "2025-09-20T19:50:02.787Z"
+        "model": "fake-64",
+        "vectorSha256": "cbe4d9489824f7df6e7bedb575d36017601cbf01ed8c99884d7da34b698f0c7c",
+        "updatedAt": "2025-09-20T22:27:41.509Z"
       }
     },
     "j-0112": {
@@ -2357,9 +2357,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f78e71ded329709359eb2d0e6325b11fb4963bf90839adbce66cbb8dcf758128",
-        "updatedAt": "2025-09-20T19:50:02.787Z"
+        "model": "fake-64",
+        "vectorSha256": "498df164102e3d47b6c370726d92f3cec2bad4e9441f2fbb0c0f901fa2071045",
+        "updatedAt": "2025-09-20T22:27:41.509Z"
       }
     },
     "j-0113": {
@@ -2378,9 +2378,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "402d79a61f9dd9690924614f3c68ef1ac2e27c4754e089632a4d1d6ce2ae1ff7",
-        "updatedAt": "2025-09-20T19:50:03.224Z"
+        "model": "fake-64",
+        "vectorSha256": "4adba64bf1e423f80948cf51b172f5b22255c3943bd8a2868e895009fe10b3c1",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0114": {
@@ -2399,9 +2399,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "da3ecc508ea6b268188d2b3e6a1c52f2f6c77317af466bcee43bbcfcbb843aa8",
-        "updatedAt": "2025-09-20T19:50:03.224Z"
+        "model": "fake-64",
+        "vectorSha256": "5a5dd3b22ecd925c99dd84a891c01c3e8b91444a6212eb37cf24607d9e8c9807",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0115": {
@@ -2420,9 +2420,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "02fa0adfdfc4755d17a65d64e1d89500b8368ebe3dedb3dc5f0e3b2fb4267160",
-        "updatedAt": "2025-09-20T19:50:03.224Z"
+        "model": "fake-64",
+        "vectorSha256": "07986ba64ebf6dbdff37ac710abd5ee2b1598319a774e96f7162704a988d8acf",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0116": {
@@ -2441,9 +2441,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d27e3b47ee6a9d68ca5adfc5c8d96be71078d1aff15cba58d064e1ef5be8a21b",
-        "updatedAt": "2025-09-20T19:50:03.224Z"
+        "model": "fake-64",
+        "vectorSha256": "d607f235c0b277a9a60f328b297aa0a459dbb05c9b9c96a4ecab715954d95780",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0117": {
@@ -2462,9 +2462,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "310d72d0c54dd78a977db871285beabf19414d9da81a3ec2c237964517c9476a",
-        "updatedAt": "2025-09-20T19:50:03.224Z"
+        "model": "fake-64",
+        "vectorSha256": "1406617e7b5e87212d0274427d3cdbced62315a2bc0ca97832946588a6f6138c",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0118": {
@@ -2483,9 +2483,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5fde4fcb12de78ef7d2f86ab6ceffbee9018ae1c6105772ad410343ebec50ecf",
-        "updatedAt": "2025-09-20T19:50:03.224Z"
+        "model": "fake-64",
+        "vectorSha256": "896e62352bb3d3366587b1bfcd338726766bb7f18b1113cc75c7dc2e1cd64f45",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0119": {
@@ -2504,9 +2504,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c8eb8446ae64db268fdec1d24e61cdeed58c77b26e0c6e4c40eb096ca22eb9bf",
-        "updatedAt": "2025-09-20T19:50:03.224Z"
+        "model": "fake-64",
+        "vectorSha256": "6d9fa590fc7e73dbf2f0130857159ee6c167a13802970a7eb06dd654f6d22b94",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0120": {
@@ -2525,9 +2525,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d0deebd55a0b24ee72d629c367307906e2f1791d8a4b5fc4fa3ccf42d606dd7e",
-        "updatedAt": "2025-09-20T19:50:03.224Z"
+        "model": "fake-64",
+        "vectorSha256": "4bdbaa493fed411608b05fc73143cb1d16c17f81e8a0c4461af88c41a554b3aa",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0121": {
@@ -2546,9 +2546,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2bf11d6e34c8ecd9c3cafd330619dcf292c102c413931e682d06abe88b33f9ef",
-        "updatedAt": "2025-09-20T19:50:03.617Z"
+        "model": "fake-64",
+        "vectorSha256": "fad623b119c4ba37ac34255b4fedc6628a2c88c7969d90e18d800c058bd4a158",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0122": {
@@ -2567,9 +2567,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6e0891704abda9dda5da3937fe0f4c7631be5e4613de4966c33a10737f21fbbb",
-        "updatedAt": "2025-09-20T19:50:03.617Z"
+        "model": "fake-64",
+        "vectorSha256": "29cbcfd54c24035c94d31b7c1e480fd60ccfc6109cdf5d5ac23c809302236b0f",
+        "updatedAt": "2025-09-20T22:27:41.510Z"
       }
     },
     "j-0123": {
@@ -2588,9 +2588,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f80f0f0d807e7025ebe8b12030750b5cadc542ea7f6ea56de50c4ee6a9d35af0",
-        "updatedAt": "2025-09-20T19:50:03.617Z"
+        "model": "fake-64",
+        "vectorSha256": "500fc9c9c9e7fc9a0037308abc2ea4aaa7996c8a613c33c21819725077ef82a8",
+        "updatedAt": "2025-09-20T22:27:41.511Z"
       }
     },
     "j-0124": {
@@ -2609,9 +2609,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7916201a87d34b604e7e4acf4b984bd50c8321cdd1afbfa126fa923d0f3942f0",
-        "updatedAt": "2025-09-20T19:50:03.617Z"
+        "model": "fake-64",
+        "vectorSha256": "aef6a4487cc107d4437b0672749cbae090329ae9b6c6cda94adae40f442cf59c",
+        "updatedAt": "2025-09-20T22:27:41.511Z"
       }
     },
     "j-0125": {
@@ -2630,9 +2630,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cc59418b6a5d52058809f3b620303ed7559286f91ee928dde17a999ae956ae0b",
-        "updatedAt": "2025-09-20T19:50:03.617Z"
+        "model": "fake-64",
+        "vectorSha256": "c87400e17957076b05defd9e2154122c4218971bdcdd535e220e5d027b3e2c5c",
+        "updatedAt": "2025-09-20T22:27:41.511Z"
       }
     },
     "j-0126": {
@@ -2651,9 +2651,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "472ed4c133512af9473164600a05a05a81197837df376df834c278f40f1dde22",
-        "updatedAt": "2025-09-20T19:50:03.617Z"
+        "model": "fake-64",
+        "vectorSha256": "6104503f919ac6d741a6f41e18386c62efebef022bba2a9f24ec6369fbfbd2d9",
+        "updatedAt": "2025-09-20T22:27:41.511Z"
       }
     },
     "j-0127": {
@@ -2672,9 +2672,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3098f98472d4f7d12d65ee46cf01dbbf6f225b04f5a9cc393455e5faf2b558e2",
-        "updatedAt": "2025-09-20T19:50:03.617Z"
+        "model": "fake-64",
+        "vectorSha256": "c640d094e1e9fdda299b60a868e9ae9dfa95afcd711a4a9530cc74e4c6f89cae",
+        "updatedAt": "2025-09-20T22:27:41.511Z"
       }
     },
     "j-0128": {
@@ -2693,9 +2693,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7af8ae6d9c099a6dd05f88d366badd1b0e77d22b265e187f145bbe4d66a0d331",
-        "updatedAt": "2025-09-20T19:50:03.618Z"
+        "model": "fake-64",
+        "vectorSha256": "69fbc30843d82f028c063c4d4ba247e188ff15f1cebacf2d0c14f2a800045994",
+        "updatedAt": "2025-09-20T22:27:41.511Z"
       }
     },
     "j-0129": {
@@ -2714,9 +2714,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ece8684fec32c1d95d5cf3abb0ceb21d78cb1a75fb832520fe56fb64b829e12e",
-        "updatedAt": "2025-09-20T19:50:03.985Z"
+        "model": "fake-64",
+        "vectorSha256": "9d038ae4aaee02051de03bd614b0b38e3e53aa4052d7636d1611d8e5d9e581f3",
+        "updatedAt": "2025-09-20T22:27:41.511Z"
       }
     },
     "j-0130": {
@@ -2735,9 +2735,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5c21dfbbf8d2d4aa68b6c398540f4042272a6b25c1ffeb718430af0a5c889e2b",
-        "updatedAt": "2025-09-20T19:50:03.985Z"
+        "model": "fake-64",
+        "vectorSha256": "18beefc2537fd926dd912912573871c55cadeeb86ebc0604cb889b34c459d0ec",
+        "updatedAt": "2025-09-20T22:27:41.511Z"
       }
     },
     "j-0131": {
@@ -2756,9 +2756,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "066bae634725b8355ea06ce768c344b0c6fdbf1cc059bcb26394e84fb1b81a34",
-        "updatedAt": "2025-09-20T19:50:03.985Z"
+        "model": "fake-64",
+        "vectorSha256": "b93977b8f571b663b8e0179a709bfa16113a38d0fdd74c9224acc13ae511f7b2",
+        "updatedAt": "2025-09-20T22:27:41.511Z"
       }
     },
     "j-0132": {
@@ -2777,9 +2777,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "386fcaec03c75a68121bf5287f1c17b74fa572420500a7fd3474f4431c2f6982",
-        "updatedAt": "2025-09-20T19:50:03.985Z"
+        "model": "fake-64",
+        "vectorSha256": "bb4ed5de24e451736046e0ea5bf6f61bb57a62ed8fa3070b64c2f78e1e2b8bec",
+        "updatedAt": "2025-09-20T22:27:41.512Z"
       }
     },
     "j-0133": {
@@ -2798,9 +2798,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "18172b6a67045b2b58cedd46f113a1490b6e3d562226538de04ab8ff6531b77f",
-        "updatedAt": "2025-09-20T19:50:03.985Z"
+        "model": "fake-64",
+        "vectorSha256": "ed8f23f9df2c00d8d0a9bc191028fa96c567c8c3f9539991ce7ce189d3c3d636",
+        "updatedAt": "2025-09-20T22:27:41.512Z"
       }
     },
     "j-0134": {
@@ -2819,9 +2819,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7507b6071c8273f9b0c05c5595b9672b889028981ddcdb51f428b5df765c2edb",
-        "updatedAt": "2025-09-20T19:50:03.985Z"
+        "model": "fake-64",
+        "vectorSha256": "6e024bbeed0efb05fa3cfe524b311ac94872d565d779c7e76852f7406f382ca0",
+        "updatedAt": "2025-09-20T22:27:41.512Z"
       }
     },
     "j-0135": {
@@ -2840,9 +2840,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "08fd09d5c11fef88e254436fa5de85902c4542c80d5ed8d27de5c6229a7cb444",
-        "updatedAt": "2025-09-20T19:50:03.985Z"
+        "model": "fake-64",
+        "vectorSha256": "6594a2d4df224aadc21f8780c6ebb20f47bdf8fa11187909a8dfa89ab525589a",
+        "updatedAt": "2025-09-20T22:27:41.512Z"
       }
     },
     "j-0136": {
@@ -2861,9 +2861,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "828638a19b271eed012b98e96766f053d299a3ca4cbf6c7484e0095f786b769d",
-        "updatedAt": "2025-09-20T19:50:03.985Z"
+        "model": "fake-64",
+        "vectorSha256": "82280c0dab48cf62dee2f9b37da679b7d1651485a659ceb0f09f81ceaabc190e",
+        "updatedAt": "2025-09-20T22:27:41.512Z"
       }
     },
     "j-0137": {
@@ -2882,9 +2882,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d68edecdc3fbe1618f0b84af14200c57999e87df814e468d164977aa498758f5",
-        "updatedAt": "2025-09-20T19:50:04.283Z"
+        "model": "fake-64",
+        "vectorSha256": "32990bccda2eba7ca98f318a322c090865a47cd840962a456d4a1290459008f0",
+        "updatedAt": "2025-09-20T22:27:41.512Z"
       }
     },
     "j-0138": {
@@ -2903,9 +2903,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c864b29bf96a29de7bae8220f4a42eb73e59513bb94123e631fdc1cff319c724",
-        "updatedAt": "2025-09-20T19:50:04.283Z"
+        "model": "fake-64",
+        "vectorSha256": "d15a1de51b6b3683ae5efd8902fbb497d89d35d82b4acd8bd1c8d39f7b745b17",
+        "updatedAt": "2025-09-20T22:27:41.512Z"
       }
     },
     "j-0139": {
@@ -2924,9 +2924,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "60836dffb979b359d0e8724ed001796faf14cba9e8afcb33b51238ce9255c177",
-        "updatedAt": "2025-09-20T19:50:04.283Z"
+        "model": "fake-64",
+        "vectorSha256": "77b1cb3bc62c4a686be26e3d88ec692bde808f309904d2906bdbbac32ef34ad4",
+        "updatedAt": "2025-09-20T22:27:41.512Z"
       }
     },
     "j-0140": {
@@ -2945,9 +2945,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4b24585f65e008ad6bb4780ece14efd686c567f5031f555b7164ff7e2402c80a",
-        "updatedAt": "2025-09-20T19:50:04.283Z"
+        "model": "fake-64",
+        "vectorSha256": "799730b7d12c7fea580b92a7067b5f55171d86a3532d0e2681c35ff0b31a3560",
+        "updatedAt": "2025-09-20T22:27:41.512Z"
       }
     },
     "j-0141": {
@@ -2966,9 +2966,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "844785a6d734d51e26adc490ee2cae8f02e1977e4cb9a7111da7ea44f560af7e",
-        "updatedAt": "2025-09-20T19:50:04.283Z"
+        "model": "fake-64",
+        "vectorSha256": "a78ea491000d834a5b9eed17ec38ebe540b6594893ac43aaa11ca63162219d35",
+        "updatedAt": "2025-09-20T22:27:41.513Z"
       }
     },
     "j-0142": {
@@ -2987,9 +2987,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b4506c7fc0c6cd8960c16dc09cef29200ee525123fd7a790fb93387242e482f7",
-        "updatedAt": "2025-09-20T19:50:04.284Z"
+        "model": "fake-64",
+        "vectorSha256": "2dc5061de9f63a555199ac32ffcb118e4449218e8d818da899b549e108dd774b",
+        "updatedAt": "2025-09-20T22:27:41.513Z"
       }
     },
     "j-0143": {
@@ -3008,9 +3008,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "827ffb62db3d632490d360561a6b0913420144fa267463143c85f3d545634bc4",
-        "updatedAt": "2025-09-20T19:50:04.284Z"
+        "model": "fake-64",
+        "vectorSha256": "15992d49e557759d6567fe8731fba9260f0ff10db7d77bd0f2ca30f6537efa47",
+        "updatedAt": "2025-09-20T22:27:41.513Z"
       }
     },
     "j-0144": {
@@ -3029,9 +3029,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "404c8c5f751686ed2a2700403f046f056018ae8f85d8ea700681d396da395315",
-        "updatedAt": "2025-09-20T19:50:04.284Z"
+        "model": "fake-64",
+        "vectorSha256": "e53c35b1de538326faf349a446d40fac3ae8a2d58a5625d3be56fe74ac54fc54",
+        "updatedAt": "2025-09-20T22:27:41.513Z"
       }
     },
     "j-0145": {
@@ -3050,9 +3050,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c16590c1890a4fe254e9e343f720269c52c25e27d10f7188005042803f44cef3",
-        "updatedAt": "2025-09-20T19:50:04.588Z"
+        "model": "fake-64",
+        "vectorSha256": "3c666f0d5712cce59342146b031a83a06ddb1c3711138c515d7fa1ba7a89ae9a",
+        "updatedAt": "2025-09-20T22:27:41.513Z"
       }
     },
     "j-0146": {
@@ -3071,9 +3071,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d6571748e6e3026ae66756b00c5b1453be51229a87986de26c72f74edfb5f94b",
-        "updatedAt": "2025-09-20T19:50:04.588Z"
+        "model": "fake-64",
+        "vectorSha256": "ec9b74bdbe895f2c309adf066751b90f35f46e050ab471c8f4003070b9acc895",
+        "updatedAt": "2025-09-20T22:27:41.513Z"
       }
     },
     "j-0147": {
@@ -3092,9 +3092,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "90005f44d3159b8396246f9ef1f1a123adc39a965f25c2bc133962b4af8feb69",
-        "updatedAt": "2025-09-20T19:50:04.588Z"
+        "model": "fake-64",
+        "vectorSha256": "b28191525220ca5ac6baa142799521a6201bae68136e09632d49955e9d5ff12a",
+        "updatedAt": "2025-09-20T22:27:41.513Z"
       }
     },
     "j-0148": {
@@ -3113,9 +3113,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "51890e2ee3e54d1cc2337617495e23ba6dbc809b7ad230dcbef9d63b841fcaab",
-        "updatedAt": "2025-09-20T19:50:04.588Z"
+        "model": "fake-64",
+        "vectorSha256": "c82387d436b21da50cfdd1d775b1ab489795ed007e4641b1bd78beda23b91ecd",
+        "updatedAt": "2025-09-20T22:27:41.513Z"
       }
     },
     "j-0149": {
@@ -3134,9 +3134,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e3849ba397d80d431a02b3d0ddfb6cc13dc0b3840ec574b27be7f40f19ac4954",
-        "updatedAt": "2025-09-20T19:50:04.588Z"
+        "model": "fake-64",
+        "vectorSha256": "b5893363db4b87c1ce0fc4c37d3660c1dfb227abdb0b4c650f980ea9aca20415",
+        "updatedAt": "2025-09-20T22:27:41.514Z"
       }
     },
     "j-0150": {
@@ -3155,9 +3155,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "788a4926119671de1d43ef17df615f7c99ae9f2ebb11d746c852ebfcddda2b11",
-        "updatedAt": "2025-09-20T19:50:04.588Z"
+        "model": "fake-64",
+        "vectorSha256": "c1d8888f9538f8026c166d4f0a32e22fb1cecb276e4088a96abac6f4280c4715",
+        "updatedAt": "2025-09-20T22:27:41.514Z"
       }
     },
     "j-0151": {
@@ -3176,9 +3176,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2cc64c59a0ffdb3d74967bd90e1ebaf154aaeb7c18aa34d0698840a99c877110",
-        "updatedAt": "2025-09-20T19:50:04.588Z"
+        "model": "fake-64",
+        "vectorSha256": "4b2aa0920b4339c20021653c2a3af7296f68cba7ceb3c2782aa3999a06b5b57e",
+        "updatedAt": "2025-09-20T22:27:41.514Z"
       }
     },
     "j-0152": {
@@ -3197,9 +3197,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0ef5693626ef0081a074292f8011c339d4c510d810abf530d60aa7733152bb1b",
-        "updatedAt": "2025-09-20T19:50:04.588Z"
+        "model": "fake-64",
+        "vectorSha256": "d052eb5330aac4ededb629ab103ffe87eab99540b17732212deb7741abe7f41c",
+        "updatedAt": "2025-09-20T22:27:41.514Z"
       }
     },
     "j-0153": {
@@ -3218,9 +3218,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "928ad85131a3ad69549960d1503e0f16de74b8b36eccd83c41399633c6c24e51",
-        "updatedAt": "2025-09-20T19:50:04.857Z"
+        "model": "fake-64",
+        "vectorSha256": "9ddbc19fdbe1cb8cdf728a69e4ac1dacd48a2700981e74c5e938e3298c9f2d41",
+        "updatedAt": "2025-09-20T22:27:41.514Z"
       }
     },
     "j-0154": {
@@ -3239,9 +3239,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dc646f70ad0eb8d1bb8eb53d3ec5243f4631f7b84da5d9aa6ceb980cdb9ba693",
-        "updatedAt": "2025-09-20T19:50:04.857Z"
+        "model": "fake-64",
+        "vectorSha256": "e13e27cf989bc2e67d7daf720cfc0d11ac8768d81c1cc7d4aa98b1ebe98e660a",
+        "updatedAt": "2025-09-20T22:27:41.514Z"
       }
     },
     "j-0155": {
@@ -3260,9 +3260,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ff019c37b1388f23b26b296fe69f114efc6825ddd6d83f266e3fd5f120b3010e",
-        "updatedAt": "2025-09-20T19:50:04.858Z"
+        "model": "fake-64",
+        "vectorSha256": "b00d65734732bb7a4c1308b83e43e36de4916bc5aa4bed703c95e9261717d576",
+        "updatedAt": "2025-09-20T22:27:41.514Z"
       }
     },
     "j-0156": {
@@ -3281,9 +3281,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c21c2812462cb30eb28e7380165d9e18d441a0c72863e079b07258e5738a1570",
-        "updatedAt": "2025-09-20T19:50:04.858Z"
+        "model": "fake-64",
+        "vectorSha256": "558c0f9f8b79927e9ae664dec52659250072f89f5f30aaa73f872467dd628889",
+        "updatedAt": "2025-09-20T22:27:41.514Z"
       }
     },
     "j-0157": {
@@ -3302,9 +3302,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "11e347c5bf5ac52ec6a3e04bb039b57de973dd88d265a4c661e89e580ceb23c7",
-        "updatedAt": "2025-09-20T19:50:04.858Z"
+        "model": "fake-64",
+        "vectorSha256": "249a03671cab61b8cb9434f393f15d989a536356f8efb54bbbbc4da118055fd6",
+        "updatedAt": "2025-09-20T22:27:41.515Z"
       }
     },
     "j-0158": {
@@ -3323,9 +3323,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "60923c86e769485a899ce3e34ed8b634bb93f73e26d01fcc5aea1e9d4e8aad34",
-        "updatedAt": "2025-09-20T19:50:04.858Z"
+        "model": "fake-64",
+        "vectorSha256": "10c1fe3e2038d825bd471ec90eca09be4308e531d15c7b5a12a43f9262ed9f74",
+        "updatedAt": "2025-09-20T22:27:41.515Z"
       }
     },
     "j-0159": {
@@ -3344,9 +3344,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "24600945a1858b0058a1d90f0a65f0480edcfc90df537092c441f8ee01d6cd3b",
-        "updatedAt": "2025-09-20T19:50:04.858Z"
+        "model": "fake-64",
+        "vectorSha256": "066a6e9b2df9ce5a43ee4154eec33991a01106de67b0ab95a4d50b5083d36ab1",
+        "updatedAt": "2025-09-20T22:27:41.515Z"
       }
     },
     "j-0160": {
@@ -3365,9 +3365,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "546831b2c9940267b417987c6158fe9eb346639e5c3507048e13c9775e5051b8",
-        "updatedAt": "2025-09-20T19:50:04.858Z"
+        "model": "fake-64",
+        "vectorSha256": "00b42caaef70380acb661b5bb254a96745211fcb667b12024e92a708debd4393",
+        "updatedAt": "2025-09-20T22:27:41.515Z"
       }
     },
     "j-0161": {
@@ -3386,9 +3386,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8ecf7dba34e73efaaf646ee75e8426e78b87d23f35686c73f004bed86e7883d1",
-        "updatedAt": "2025-09-20T19:50:05.257Z"
+        "model": "fake-64",
+        "vectorSha256": "7f015a87c799b86208f1fb14da4c4b48f4e8566f7b45effac8f40e2162c52669",
+        "updatedAt": "2025-09-20T22:27:41.515Z"
       }
     },
     "j-0162": {
@@ -3407,9 +3407,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e8710f47d6f74450246431935e617aa050c864226e053a70387db86eedd6939a",
-        "updatedAt": "2025-09-20T19:50:05.257Z"
+        "model": "fake-64",
+        "vectorSha256": "c41f90452f3b7303787e450dccbe107b434dffb79886a613766b556add61b92a",
+        "updatedAt": "2025-09-20T22:27:41.515Z"
       }
     },
     "j-0163": {
@@ -3428,9 +3428,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "25e86022403eb3dc6ee9899981c979f7443428ee7a200773f3de7c97cd408675",
-        "updatedAt": "2025-09-20T19:50:05.257Z"
+        "model": "fake-64",
+        "vectorSha256": "774662625a6bc69884956afa4e90a281e4df54dfcbc52da23dff021d01ea65d5",
+        "updatedAt": "2025-09-20T22:27:41.515Z"
       }
     },
     "j-0164": {
@@ -3449,9 +3449,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c2d223b4f71179a276ddce792246a72c3bfff5d28a6cef5731de466dfc927b4c",
-        "updatedAt": "2025-09-20T19:50:05.257Z"
+        "model": "fake-64",
+        "vectorSha256": "bdf849297967fb403d00b2e37252d3059fd65770a490065528d0b47a63c5ee96",
+        "updatedAt": "2025-09-20T22:27:41.515Z"
       }
     },
     "j-0165": {
@@ -3470,9 +3470,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "85c319cc5fb58b1bb08557ba3e5bd6c75d53fd0b50a7280c27ca23eb87c9f564",
-        "updatedAt": "2025-09-20T19:50:05.257Z"
+        "model": "fake-64",
+        "vectorSha256": "9489d105b70dad7a9ef55c578953d0efc06682f4763a85d194770c9480bb02aa",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0166": {
@@ -3491,9 +3491,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5c38b37647f31dc4fc85e2f94d1481594882844e145249f85d1cfcc23c45577a",
-        "updatedAt": "2025-09-20T19:50:05.257Z"
+        "model": "fake-64",
+        "vectorSha256": "e26d8467285c27d7db48802b40f2bdf3b30cd55f59417468bcfbd56d96cbd764",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0167": {
@@ -3512,9 +3512,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0292f7f3e4e938c1b2ff36d7c92148bcc04d6fa6f81ee1b53386629f0495a965",
-        "updatedAt": "2025-09-20T19:50:05.257Z"
+        "model": "fake-64",
+        "vectorSha256": "019b2ca1dcfc39118fc9628222d5edc023ccb7bd9dc0cebd300ba68d56d796a2",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0168": {
@@ -3533,9 +3533,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "17b4df0bc282d4c51f3b0cf1767818bff4a70848cf9317bb120fbd3d3181ab94",
-        "updatedAt": "2025-09-20T19:50:05.257Z"
+        "model": "fake-64",
+        "vectorSha256": "528f5a744bc7e9791db76b6b5ce8b82d6a71a29dd481fbfa91fb887c8e822843",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0169": {
@@ -3554,9 +3554,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b93c469a5eb2d6660c1f981b0611d18afa3712030fbc912f05a45f08c9efa8b4",
-        "updatedAt": "2025-09-20T19:50:05.633Z"
+        "model": "fake-64",
+        "vectorSha256": "50648df09ac6bdec960b2d772cc34d6389f39abae457b0bec1bb5acd85ef95f4",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0170": {
@@ -3575,9 +3575,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "983d7515263438b450eec6094b1d3d40c770f43d6e2c3568c15df6de571a65b0",
-        "updatedAt": "2025-09-20T19:50:05.633Z"
+        "model": "fake-64",
+        "vectorSha256": "6afb391c3496505992d2526786a963997622633265e3fdc5d75c951702c8b475",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0171": {
@@ -3596,9 +3596,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "024b574e0f549b7134bfd8b922cf0ddc2d9f15c55e1e23dc695e065d91fc58ae",
-        "updatedAt": "2025-09-20T19:50:05.633Z"
+        "model": "fake-64",
+        "vectorSha256": "80e6f68238e84b56b16f2e96977787e8e67b18deaaa489228bc64bf1ded94937",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0172": {
@@ -3617,9 +3617,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2f66a535dd01c61ddd6a8643a1d6c46f82830b17b1eb8b91307f7de62dea7ac1",
-        "updatedAt": "2025-09-20T19:50:05.633Z"
+        "model": "fake-64",
+        "vectorSha256": "6e72c9cd6aac006106ec0069318c53f904547335cc00fc93931456273615b829",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0173": {
@@ -3638,9 +3638,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eaf2e9516b7dc4a1b991cadb83b9c53bb1690e8d532ed90f9adea25f4f445f3f",
-        "updatedAt": "2025-09-20T19:50:05.633Z"
+        "model": "fake-64",
+        "vectorSha256": "737b9749589c85d061520151e85e561275f38d47927c357341a7a0220426e76c",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0174": {
@@ -3659,9 +3659,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4abd32adaa08099dbbf0cacc1743c331e2b436933cae5207d68b86e68107a5db",
-        "updatedAt": "2025-09-20T19:50:05.633Z"
+        "model": "fake-64",
+        "vectorSha256": "c6b2ff04fe78d71716f6346cbe1d12ca75bdc2f0f153b5621d3770317320936d",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0175": {
@@ -3680,9 +3680,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4f7cf486c0befe835a2376526d0044f32773b047400f3cb449a989ac163ed4c3",
-        "updatedAt": "2025-09-20T19:50:05.633Z"
+        "model": "fake-64",
+        "vectorSha256": "e737eefa575ff5e6a2ce868f4e784f0c060bcb60cd6bf245ace6025703d11349",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0176": {
@@ -3701,9 +3701,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "96eeac4b6276ed0b2453b4c4e651efcd60b17ab427c31f500bf1aac729ef37c7",
-        "updatedAt": "2025-09-20T19:50:05.633Z"
+        "model": "fake-64",
+        "vectorSha256": "842a579663af67d6bd91af534b1643f29e8afc51bde3089c64abf90569adb626",
+        "updatedAt": "2025-09-20T22:27:41.516Z"
       }
     },
     "j-0177": {
@@ -3722,9 +3722,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "26d593d3e2d50a5de248e93eaf75d434031f5724375bddcbbd92566c474c4a24",
-        "updatedAt": "2025-09-20T19:50:05.889Z"
+        "model": "fake-64",
+        "vectorSha256": "c7f2fc6ccfedfcb96370e482b8230c29528cbef850edb648b2fe6e98f20a7787",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0178": {
@@ -3743,9 +3743,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b97d8beae9ae056a46da8cee2d463af46af8d8c7461325ac11218eb6ef9015cc",
-        "updatedAt": "2025-09-20T19:50:05.889Z"
+        "model": "fake-64",
+        "vectorSha256": "c4aab0a0570bc05203c81fa09581e210b4d5909f6ea44065730c097c6a886e9c",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0179": {
@@ -3764,9 +3764,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ca6538b22d61ce4bc5a47a7f0954206e21f0e8d669628d9994ad6e1ade057238",
-        "updatedAt": "2025-09-20T19:50:05.889Z"
+        "model": "fake-64",
+        "vectorSha256": "330024435866cbf23a0b406167c8598dc3bed019ddce78cd34da1c47c502e9fd",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0180": {
@@ -3785,9 +3785,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b9d4243d1c4d30e42ee83f33a36bb8014f4c448168c20a100a1f7be6d5fc4791",
-        "updatedAt": "2025-09-20T19:50:05.889Z"
+        "model": "fake-64",
+        "vectorSha256": "9356ccea8715cbb7f59be519f785392ce3e7a9e19be4bb0dff6efaa501bc0d6d",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0181": {
@@ -3806,9 +3806,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8dff6e9d46e56af1379bd6e19cdd636798103c61022201387a6cb09d188139cb",
-        "updatedAt": "2025-09-20T19:50:05.889Z"
+        "model": "fake-64",
+        "vectorSha256": "5d4519b596b786f7930f7037eca062059cb91fd974ee5afc6b7d9475c7464cd6",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0182": {
@@ -3827,9 +3827,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7820ef88819a3f77f7b445149f0ba453d033f3cf0d8d7aadba0462b362602281",
-        "updatedAt": "2025-09-20T19:50:05.890Z"
+        "model": "fake-64",
+        "vectorSha256": "21830244646034cceafffa747e99f7dd8ef633a7926fbb719211c3a4d9fdc293",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0183": {
@@ -3848,9 +3848,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5fe908b6003afa6c3e25543d6a3c39e7da5ce3f89289f290180b857230581ec5",
-        "updatedAt": "2025-09-20T19:50:05.890Z"
+        "model": "fake-64",
+        "vectorSha256": "628803ea70bf885d37875a0dd3d136814c5a1ec80f4df65e4ac7a9a77eb9e022",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0184": {
@@ -3869,9 +3869,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5bccd035272fcf6e31d6daa5b9946937db9d879bf20e68b99bdf02f1083b60a2",
-        "updatedAt": "2025-09-20T19:50:05.891Z"
+        "model": "fake-64",
+        "vectorSha256": "754aef28d8e833f092d5d16bbb49de6187f9ba0601e96428c3deab017961fa12",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0185": {
@@ -3890,9 +3890,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3ad4eace80144dc80da2d3c1181e4b49d1d9c8ab69e4c0ac0a983ae0670bcc23",
-        "updatedAt": "2025-09-20T19:50:06.260Z"
+        "model": "fake-64",
+        "vectorSha256": "e75557198f414a11c5ded6bd3e288f42a20287fd1008356947170808e426bae6",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0186": {
@@ -3911,9 +3911,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9452d1aea33c95a4f2833e37a2c76d8723b75ddbe65c6d84bd420a31953acf92",
-        "updatedAt": "2025-09-20T19:50:06.261Z"
+        "model": "fake-64",
+        "vectorSha256": "1999046c60aaa16eeec2bfa5acf355d65afd2e45b44c2cd4caaead4a4384e4b4",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0187": {
@@ -3932,9 +3932,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9d153edf28c0bcaad040c171291cb01684b965ce20cf780f5f6a6c3ec9f69039",
-        "updatedAt": "2025-09-20T19:50:06.261Z"
+        "model": "fake-64",
+        "vectorSha256": "19b9c1ddd5f583bbbec53b6a85ec46ead24875beac2f1e1cd373d049742aae03",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0188": {
@@ -3953,9 +3953,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dc1cf38cf7e62921b7552c77f712a5455354d6c834a984bca4f413660636a9b0",
-        "updatedAt": "2025-09-20T19:50:06.261Z"
+        "model": "fake-64",
+        "vectorSha256": "31923f00690c733440e43d241ddab26401abdbb95a3a2d1e22da2b1a75499f66",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0189": {
@@ -3974,9 +3974,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ea4b97fa58f7fb03c64a984350596a013deb94776f6ef38211db345665584ea4",
-        "updatedAt": "2025-09-20T19:50:06.261Z"
+        "model": "fake-64",
+        "vectorSha256": "5d5168929af68ac56d71496f10a7a25fdd7a25a77e58f65be2f817ff81d0d835",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0190": {
@@ -3995,9 +3995,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "52449eb83821717c2add3e8375764ac6a9857c012df584003286e01103f9fb77",
-        "updatedAt": "2025-09-20T19:50:06.261Z"
+        "model": "fake-64",
+        "vectorSha256": "f8ee9ab33c5cb9a40549dc0c6e31e1ef06f2da081fdc4e88b4474b3afd6259fb",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0191": {
@@ -4016,9 +4016,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f259cf5d19f97a0aee8571e0a11216334a184823a233125e4a735f5009113636",
-        "updatedAt": "2025-09-20T19:50:06.261Z"
+        "model": "fake-64",
+        "vectorSha256": "9168315c89ff3f0be54d3eaaff64504ec7341a0b2bc2bd3e318e789b825679a1",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0192": {
@@ -4037,9 +4037,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c5a3cf814eebb561454560413324c640dedc47ba4b42a71e20865fbeea51be0f",
-        "updatedAt": "2025-09-20T19:50:06.261Z"
+        "model": "fake-64",
+        "vectorSha256": "261a672930fffba0b8c7cfdb8adba02ce00bf7eda9b94c6baa99abba9101202c",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0193": {
@@ -4058,9 +4058,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b6ea540c65f8c437294909ddb69faec9e2f12f265db50d272c7b8e240cbe2c0c",
-        "updatedAt": "2025-09-20T19:50:06.589Z"
+        "model": "fake-64",
+        "vectorSha256": "2b0f8cdc6d0307ade4ca8438b7adb22360742e0633eade1f26efff62e0082a25",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0194": {
@@ -4079,9 +4079,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1664d798c989742ca7d2bd9c9c955b249a821de57f41029658a7da33e782d744",
-        "updatedAt": "2025-09-20T19:50:06.589Z"
+        "model": "fake-64",
+        "vectorSha256": "3ed777cfb4bde7cb5107e63af3bfc13b44c6e8392c57b3322bd1253695726f6e",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0195": {
@@ -4100,9 +4100,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3deb80383f8efe7417244a075848e3c1d5d906eaa28974a26af151e9f2ceb879",
-        "updatedAt": "2025-09-20T19:50:06.589Z"
+        "model": "fake-64",
+        "vectorSha256": "ecefac56b628ff1b6010a36d68764e2b64e764ad4a4955771495b4f3df11f74c",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0196": {
@@ -4121,9 +4121,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "87321097a5940a92e1f47cb1bd96948201181b02ccd09577be28022af39fa559",
-        "updatedAt": "2025-09-20T19:50:06.589Z"
+        "model": "fake-64",
+        "vectorSha256": "1156cb5b3cde89c728953dbdd805eb5c0440a76f44be636bd20f560840167f95",
+        "updatedAt": "2025-09-20T22:27:41.517Z"
       }
     },
     "j-0197": {
@@ -4142,9 +4142,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "72b8fb4737bfd706bcf03c0ba84f071b04b80e796be07aad841a15ffe9721fab",
-        "updatedAt": "2025-09-20T19:50:06.589Z"
+        "model": "fake-64",
+        "vectorSha256": "8283bf2c260ed1915dc6aec3fe250a85d6f6bc3e45788d4082261ec37276a4a5",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0198": {
@@ -4163,9 +4163,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c9d0fecd2841b397c89efe8bc62ef29f48bc49ea9b449d8d4269dfba6890f276",
-        "updatedAt": "2025-09-20T19:50:06.589Z"
+        "model": "fake-64",
+        "vectorSha256": "7179eae7b90143d0320566313532d2803913b778e81a46c0b1d1ed42f5c52196",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0199": {
@@ -4184,9 +4184,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "472ea169e6030886d4ce29485016ba63dfcc76afccbe91ae47f160b2bb1f18fd",
-        "updatedAt": "2025-09-20T19:50:06.590Z"
+        "model": "fake-64",
+        "vectorSha256": "ee046d39afa81d40a7cf650ff0933038b6f36ebfba2a46c3b5882a771ca44241",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0200": {
@@ -4205,9 +4205,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "456220a64e4e2780acef4d7d87ba43dc076727c643459cdeb6a055beb7fde088",
-        "updatedAt": "2025-09-20T19:50:06.590Z"
+        "model": "fake-64",
+        "vectorSha256": "42697eb341f548a77a5772f2a5f0bb0057d5a3cfe20d59d96737310e4a11ac0f",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0201": {
@@ -4226,9 +4226,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a90d388966776b7165edbe28ec8a9b3c837a34e7ce7949003a9ff2a727b5222c",
-        "updatedAt": "2025-09-20T19:50:06.894Z"
+        "model": "fake-64",
+        "vectorSha256": "9b9f6f7ae6f8d062df1cae9179b925cc3b506bd239119d7df000e5e2271a1e5a",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0202": {
@@ -4247,9 +4247,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fd1c7ce830f909a94df4d0faa09f77715f1458f023c8614f25df4dba4eb13ebb",
-        "updatedAt": "2025-09-20T19:50:06.895Z"
+        "model": "fake-64",
+        "vectorSha256": "ee5577d5cbf1d01407b125d1b8e85dc873af841b6850d2d038681a26f1c611dd",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0203": {
@@ -4268,9 +4268,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3cfada578fdcbfb959fba9a7c706de072503a84adf6b4a6ae75d1ec1c4931ad9",
-        "updatedAt": "2025-09-20T19:50:06.895Z"
+        "model": "fake-64",
+        "vectorSha256": "e00aacc41283e4f2deb42b0d083cb08aa84929263fbe83e66b889b69b962c249",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0204": {
@@ -4289,9 +4289,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cc95799e7bf3753b07afd775930969d71981cb84771fe2ca594dc8d5c652a5f4",
-        "updatedAt": "2025-09-20T19:50:06.895Z"
+        "model": "fake-64",
+        "vectorSha256": "9d91026b102a13789df2126746c39ea4a804250233680dce7d8febcdfd430c9b",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0205": {
@@ -4310,9 +4310,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "861b07688461d372b01932c72da66dd38e3c35d9bdd768e2062b14b8b976625a",
-        "updatedAt": "2025-09-20T19:50:06.895Z"
+        "model": "fake-64",
+        "vectorSha256": "b0210bb1413d7c149bc47656f2aa407e8531a7351793b928b1db44816d831e66",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0206": {
@@ -4331,9 +4331,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e8c5f46f97f5903af0424314beb4005b9ea8581c164b1b624cb511ab5eddc72e",
-        "updatedAt": "2025-09-20T19:50:06.896Z"
+        "model": "fake-64",
+        "vectorSha256": "4a9231ec4e07b866653d6f91a4bb33e81a8f1246795ca897b8aefee9661ea4d5",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0207": {
@@ -4352,9 +4352,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3f6fae58cee29b2f53973503ba96bdf557612d3c1ec2bf53e820f36afe7edebf",
-        "updatedAt": "2025-09-20T19:50:06.896Z"
+        "model": "fake-64",
+        "vectorSha256": "f7ffee549948c89cc240d9f3d05204595fe0ed7d17ee9b3edcecd6b5c5f28106",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0208": {
@@ -4373,9 +4373,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fd988ac7d3b0ceece59f3ab41dfac0e5a98d8d18630a1d9934d8cdf0bc71d349",
-        "updatedAt": "2025-09-20T19:50:06.896Z"
+        "model": "fake-64",
+        "vectorSha256": "91810c5eccdce523ed32e8e144a253f73a7231decd62139f3ea096b3c0d196f4",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0209": {
@@ -4394,9 +4394,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bf3e417d0c2121fb28417f1b6f065eb451a0e77d728ba57f4e9309ac424d934e",
-        "updatedAt": "2025-09-20T19:50:07.210Z"
+        "model": "fake-64",
+        "vectorSha256": "5d24acf468315fc1103444889f50509955053bb3cb9dfe98dd518df894b86b6c",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0210": {
@@ -4415,9 +4415,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "36e5d29e05307c6e673e8c1e061ae83fe772e5e6621ecc314cd8149ee8219652",
-        "updatedAt": "2025-09-20T19:50:07.210Z"
+        "model": "fake-64",
+        "vectorSha256": "78e2b3ffc6caa466d5b730f78b381d077b3758d6db27fdd39a59a78fd9f67c56",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0211": {
@@ -4436,9 +4436,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d5b4bc1c19c8827a49a2afe719832712b2cd3638fc1bf1014d1e719db10d2f6a",
-        "updatedAt": "2025-09-20T19:50:07.210Z"
+        "model": "fake-64",
+        "vectorSha256": "f9196cf08dadd2ac10724ce18dc8aef7602aa0bfd96ccb62337322ebbd1d2d9d",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0212": {
@@ -4457,9 +4457,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bf188d946d5e114674597926e67975c5bee76047b07b73fe39709dacbd8b2bd2",
-        "updatedAt": "2025-09-20T19:50:07.210Z"
+        "model": "fake-64",
+        "vectorSha256": "03e804fd6e9a124803d6b5d6fdfcf511583c9c4e579d87712e6e25a7148dab77",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0213": {
@@ -4478,9 +4478,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d6de63acc83619e094e88ac990d34b301a2813a25f16e02055a8e8ae33571baa",
-        "updatedAt": "2025-09-20T19:50:07.210Z"
+        "model": "fake-64",
+        "vectorSha256": "84c16e0a4fb20a6312ed405fadbc7c2459a02f6ebd2d06f9ab009ff5fad56172",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0214": {
@@ -4499,9 +4499,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e480244a5b8b98c5a498cb429e96e40ab228e26a2925326c1ca38a8d6b64af5b",
-        "updatedAt": "2025-09-20T19:50:07.210Z"
+        "model": "fake-64",
+        "vectorSha256": "af7a0ed70f25d31af15828e98b6b619c62c4e5c2ae36abea8115a228501ac56c",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0215": {
@@ -4520,9 +4520,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "149837e147c81f84673a740777ceeb87cec078328ea8289353410438fadc4698",
-        "updatedAt": "2025-09-20T19:50:07.210Z"
+        "model": "fake-64",
+        "vectorSha256": "162af39f4f5d7322a454e1211ccf34b6145d4b8425d0d89655c8d3bfeb165dc3",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0216": {
@@ -4541,9 +4541,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "004a8752b25fc212ab95632b6cca51b06c1d4a61e7cfc60408feb058b7e53106",
-        "updatedAt": "2025-09-20T19:50:07.210Z"
+        "model": "fake-64",
+        "vectorSha256": "3e396efc45f378ffe7b14dd14d59a532ceff29e6d37b3df120cd3a506b157324",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0217": {
@@ -4562,9 +4562,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "29f73fdc32490dfb0503358100b8664e047b2dd520129df7398c60c9420fd1e4",
-        "updatedAt": "2025-09-20T19:50:07.527Z"
+        "model": "fake-64",
+        "vectorSha256": "934e448d731666a58d681eeb203e07d3410756d002b94b8d9f2ef5516c2ac3f7",
+        "updatedAt": "2025-09-20T22:27:41.518Z"
       }
     },
     "j-0218": {
@@ -4583,9 +4583,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4b482240534072ae75804b540d111c5317066f486fe4ac618e66759b32f14c4e",
-        "updatedAt": "2025-09-20T19:50:07.527Z"
+        "model": "fake-64",
+        "vectorSha256": "63016681ac971c039baa64a2c1331a3a091756c59163030664cd66fb8330e0ef",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0219": {
@@ -4604,9 +4604,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f4edc28be0f2d1e27e8230a54f91cab136b24caa57d9e12e7e165c0a05f2a314",
-        "updatedAt": "2025-09-20T19:50:07.527Z"
+        "model": "fake-64",
+        "vectorSha256": "253e0de364ecac36fd661fc292abb4acc2c8a4f30749c1b9ae2ab27ea85d79be",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0220": {
@@ -4625,9 +4625,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8f4e6c0325923f980a3b0a8eca21467e414504069b98be57488b62edfbb56b99",
-        "updatedAt": "2025-09-20T19:50:07.527Z"
+        "model": "fake-64",
+        "vectorSha256": "20beeceae0ae8128559e207718853d0400aba0b6ce44f0a7134f68a75d2a1f0a",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0221": {
@@ -4646,9 +4646,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3c29984cc89e442e4441d79c0b9879d13437d2af62c0c7de2e85399738f2b5ec",
-        "updatedAt": "2025-09-20T19:50:07.527Z"
+        "model": "fake-64",
+        "vectorSha256": "5b4107fd5266ba59719f2313c795909d44391e37a877611a81741ad4e5fb0c0c",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0222": {
@@ -4667,9 +4667,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "978d21cf6d3c8425b9c9979c75adbb311ac2b1acc4a9cec059dfd16a98b9bdff",
-        "updatedAt": "2025-09-20T19:50:07.527Z"
+        "model": "fake-64",
+        "vectorSha256": "35041e57740033a91acd968e1643d472f2015f38c3656f065d335c6839d2070d",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0223": {
@@ -4688,9 +4688,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6bff31564bfd50dfd92a6047cdf776d18fa8d71460266aaf0c60c07c6e619dd9",
-        "updatedAt": "2025-09-20T19:50:07.528Z"
+        "model": "fake-64",
+        "vectorSha256": "7a47e731400d13b4735aef7f252e381fb208380d131552f062de599a09f5ebae",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0224": {
@@ -4709,9 +4709,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "953ff8f1caf2bd86878dedf7c939ffcd319b67d1671435f34ab020bddfc012fe",
-        "updatedAt": "2025-09-20T19:50:07.528Z"
+        "model": "fake-64",
+        "vectorSha256": "277e5966560d84ea64b50e3821ece34578a5d42db255efe38d0ce6436461d229",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0225": {
@@ -4730,9 +4730,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f504447970bbcd9c25e492c53ee4cccbf94437bc68e2a74267529416975ec485",
-        "updatedAt": "2025-09-20T19:50:08.011Z"
+        "model": "fake-64",
+        "vectorSha256": "62bb393e81ba5c9051fc0a6dd6a683a5387abb7f08ab98fea5b1f1175d7ee54b",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0226": {
@@ -4751,9 +4751,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e0613640fea8178dd42063c812c184862ed8e6ad17cb76a5bf06cec5e8edba88",
-        "updatedAt": "2025-09-20T19:50:08.011Z"
+        "model": "fake-64",
+        "vectorSha256": "fffaf54f5d1f6e6919ce9991935f78406414c3ebc1a964a8228e2084b64eae4a",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0227": {
@@ -4772,9 +4772,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d830c84297f5aa36ad9b3cfc399f12c4a23fbaf12971fd446f39ef20d1b7e182",
-        "updatedAt": "2025-09-20T19:50:08.011Z"
+        "model": "fake-64",
+        "vectorSha256": "330e523ece7f3c48794f5c44e08619e6893fd4a83afb61025b02b290df857b45",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0228": {
@@ -4793,9 +4793,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "adb7a5efe4beea64fccaaaac55c1c704dcdf6af7098370afbefaf4dfd1424ad6",
-        "updatedAt": "2025-09-20T19:50:08.011Z"
+        "model": "fake-64",
+        "vectorSha256": "18ecbb4c1bcc82ec6d63200ebe7ceaebab5d27bcd0ac739080b0f5cdf5fb77a6",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0229": {
@@ -4814,9 +4814,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e63411e26a3d006285f3007ef8e9d03a89e83192f76a5f7e72709881b0116d30",
-        "updatedAt": "2025-09-20T19:50:08.012Z"
+        "model": "fake-64",
+        "vectorSha256": "10dcc84c3c7204e69f48b1313a1fcbc495d2e6c51011ac336336b364e1a28048",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0230": {
@@ -4835,9 +4835,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d6534416ac0642e8aaed54c5c40e1af4f5af46b22a7d9cf9752c91e7f185f462",
-        "updatedAt": "2025-09-20T19:50:08.012Z"
+        "model": "fake-64",
+        "vectorSha256": "f794a2a4f19c882035794fba9ea639275d4fe1b5784dadb4d23743aa8f85f958",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0231": {
@@ -4856,9 +4856,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "932aef2e76c8a718eba6bc9eb54f925ce24f7811b91a89670515188860e4f63d",
-        "updatedAt": "2025-09-20T19:50:08.012Z"
+        "model": "fake-64",
+        "vectorSha256": "a70cb1c259d6e7572c6026ddb9e82be30744b664e4918a64a281a6aa116417ff",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0232": {
@@ -4877,9 +4877,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1d50b6b3d1e9f6f861d4b389859bcffbfe282e8410fef70b564b0cefe9e8ee83",
-        "updatedAt": "2025-09-20T19:50:08.012Z"
+        "model": "fake-64",
+        "vectorSha256": "b735183da16492434cdbf1cb394faecf22d8fb09dd09796f17a73776dd4d270f",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0233": {
@@ -4898,9 +4898,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4389fcbe39174bbdb9ca8a9b25d92b05cccadf5154322f8817f00b8a3187e072",
-        "updatedAt": "2025-09-20T19:50:08.340Z"
+        "model": "fake-64",
+        "vectorSha256": "28bd0559f45df7809b74a525aa6fe8d71f2415dfc9cecca6216202dc1da3293e",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0234": {
@@ -4919,9 +4919,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fe92a51a55d6265b27717ab0ef4b187f4db29c14cf43988d1511367cee97241e",
-        "updatedAt": "2025-09-20T19:50:08.340Z"
+        "model": "fake-64",
+        "vectorSha256": "4995971bacbb9a452b5e6a6f1ec28b0af33bec1057a57cf1c6c4a0f6702aafbe",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0235": {
@@ -4940,9 +4940,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d5f590b031e78fc60095230851a3af32a9303911c73fbcad47d1c1cacf794039",
-        "updatedAt": "2025-09-20T19:50:08.340Z"
+        "model": "fake-64",
+        "vectorSha256": "f8d97ab2a5a53e3f8b0f05bbf5a697172ca244bb065e03705169cd8c0e84a781",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0236": {
@@ -4961,9 +4961,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "21bd6dad503e82f4be10c26e91384a4a445fa4006f1690cafbfeddfabb8d5261",
-        "updatedAt": "2025-09-20T19:50:08.340Z"
+        "model": "fake-64",
+        "vectorSha256": "f733b29897d86bd092836565ce5187c078473ffc50a759a4d37061831ec91c80",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0237": {
@@ -4982,9 +4982,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bff840165317f6ad470220d1b8e98c9a5efa00a033c9aaaef6bb97656d4009ef",
-        "updatedAt": "2025-09-20T19:50:08.340Z"
+        "model": "fake-64",
+        "vectorSha256": "49b376eb2c4cf98f90cc3d0563a78b2f3a6f9fb80859f29834b7d5619bee5509",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0238": {
@@ -5003,9 +5003,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ce99409fc17282875e7f9d80c5d74443a9cfc41f79cfb126357983891053ce1e",
-        "updatedAt": "2025-09-20T19:50:08.340Z"
+        "model": "fake-64",
+        "vectorSha256": "d743086a2a52693c8570a021f28a65b98b44a5945eb970517b75bf6713e2b519",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0239": {
@@ -5024,9 +5024,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4da70b7fe7261d43b59ff63d4842827b1516ed2a52dd79b1df512b0baed72f26",
-        "updatedAt": "2025-09-20T19:50:08.340Z"
+        "model": "fake-64",
+        "vectorSha256": "8b6657ee9cf04a8ef977e819ab5da9560ce7f6040b5966d2047e2b4394018615",
+        "updatedAt": "2025-09-20T22:27:41.519Z"
       }
     },
     "j-0240": {
@@ -5045,9 +5045,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f34700249867dcf4a4eba8a27503367c4d6890fcc90045561c8b7076b276fd1a",
-        "updatedAt": "2025-09-20T19:50:08.340Z"
+        "model": "fake-64",
+        "vectorSha256": "ef9536d3e4e580c55ebbd035f66941c5210ba134ff285b13f57a212a5c1d8f01",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0241": {
@@ -5066,9 +5066,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0bb05487f941bfb7609da78e047466f59869183b98df3f61a30c72b3b406ca08",
-        "updatedAt": "2025-09-20T19:50:08.653Z"
+        "model": "fake-64",
+        "vectorSha256": "fcbf7e3e66a0635487b40e2d5351c8cb6997947832c7926db2ce2f9b6ab1a340",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0242": {
@@ -5087,9 +5087,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2b834292230bb06af47cc182731b4847d51a22af95af250b3dee17d8e19369a2",
-        "updatedAt": "2025-09-20T19:50:08.653Z"
+        "model": "fake-64",
+        "vectorSha256": "f244aeba1a5caa8b1186c9519c794f0cc9e35a6334b3e697a43f6124a389e00e",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0243": {
@@ -5108,9 +5108,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e2fa38584693d423dc7f4497343c697110d4b3191f58fb3b80634567dc4c90fd",
-        "updatedAt": "2025-09-20T19:50:08.654Z"
+        "model": "fake-64",
+        "vectorSha256": "72b01f66a5095d3fe9754182921dbdd0a91363d6a31f37e936924b3589c01622",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0244": {
@@ -5129,9 +5129,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e54f980e262268302d4bd012d00582b7b21a69a9a621fcf442ba5ad4c4e865ec",
-        "updatedAt": "2025-09-20T19:50:08.654Z"
+        "model": "fake-64",
+        "vectorSha256": "a703431c9c98137df6b0326158eb95e1aa6884ef88b3988670ec5857708b5980",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0245": {
@@ -5150,9 +5150,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ee41c376b28526d160ad4e8c1849860c6a04ae6fcf70d0b4cf559e0b516ae038",
-        "updatedAt": "2025-09-20T19:50:08.654Z"
+        "model": "fake-64",
+        "vectorSha256": "748b58206eb5154cb527beb51a9bbe149c20c90c4d41f648d91846465e35f631",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0246": {
@@ -5171,9 +5171,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ed5ef8eec6aa3965ade95e5c1506ded5a53729f4341dae849969692af882d111",
-        "updatedAt": "2025-09-20T19:50:08.654Z"
+        "model": "fake-64",
+        "vectorSha256": "8b5dca7a7a8d3e559b942353f5e35409a7e7cd40502674248e3855d991da3633",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0247": {
@@ -5192,9 +5192,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8c3baeb1724b6aac260699681210a502c7d370ad3cfc0a8f8ba36372335a37b6",
-        "updatedAt": "2025-09-20T19:50:08.654Z"
+        "model": "fake-64",
+        "vectorSha256": "326af365a8ed18083b9f5280eca8f08a0a5e52f2ab687c682820a2b324ed5c26",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0248": {
@@ -5213,9 +5213,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e8ea1bad2e8a3cab0e4d5263491b29b8ca33cf943b8859a556cc3a0a83648a60",
-        "updatedAt": "2025-09-20T19:50:08.654Z"
+        "model": "fake-64",
+        "vectorSha256": "a3f166498716371865e030802859b8132291840a04456c4a5504fc2a922bc151",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0249": {
@@ -5234,9 +5234,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ac79186f7cba209acae6188672b9bc89019470b64c6b779b73510ad6b7f4dedb",
-        "updatedAt": "2025-09-20T19:50:08.963Z"
+        "model": "fake-64",
+        "vectorSha256": "7009b196608a6e33fb31e0736cee3d904baf5e10a6740f31482aa2f085bd1d5c",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0250": {
@@ -5255,9 +5255,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3ff09602ec92579bab884b0c5a28fa87e5bd30f1078312e1fa909436480f4f32",
-        "updatedAt": "2025-09-20T19:50:08.963Z"
+        "model": "fake-64",
+        "vectorSha256": "eab6b7fa0ec2e3529eed0adb1ccc2335847c3b2744ceb7e1e94adfaa0acc9151",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0251": {
@@ -5276,9 +5276,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "29b35cb982d3d79ae9ca39a1041a6098703739879823333894b03ac02e67ec39",
-        "updatedAt": "2025-09-20T19:50:08.963Z"
+        "model": "fake-64",
+        "vectorSha256": "5fa783a6bcec93e52ecb1335e27a73bef6695add4a642d60cf6ffb42bf96ee7c",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0252": {
@@ -5297,9 +5297,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "89039fd1f2cb22120b5fb6e8a48d997d658bda0c961d79ebe66c78f628938408",
-        "updatedAt": "2025-09-20T19:50:08.963Z"
+        "model": "fake-64",
+        "vectorSha256": "0da570d15e546124c8d40a1e408f49efc082a982fda93410d58a7dd179c5c7c9",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0253": {
@@ -5318,9 +5318,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a7ad0956dff7e3b2268d76dafd71d92abca784b229d2ea4706a3fd387bbe09c5",
-        "updatedAt": "2025-09-20T19:50:08.963Z"
+        "model": "fake-64",
+        "vectorSha256": "3e761b3f18ec5fbac003c58f4888f6f81b38c589fc93f7ef1d2d05ac29f6f25e",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0254": {
@@ -5339,9 +5339,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d0205f73bd4b753237e708ef5308738c015af9221a9509aba998b095d169c695",
-        "updatedAt": "2025-09-20T19:50:08.963Z"
+        "model": "fake-64",
+        "vectorSha256": "352102daaa07d9c68b67eaff980eb427f079534c0f7a033797a65be850ad4540",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0255": {
@@ -5360,9 +5360,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "12bc96e37f80ba5de5a1885546a4c6a394851854fbbd5b7244de1dedfb71d9bb",
-        "updatedAt": "2025-09-20T19:50:08.963Z"
+        "model": "fake-64",
+        "vectorSha256": "94aea705b6681356044556866b250e19d2edd787960c0e6fcdcb7b9a6a1d8116",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0256": {
@@ -5381,9 +5381,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2db7a016bc6dbd09a8925c2eadad07ff515b69780de84ae166a5154a4ec29adf",
-        "updatedAt": "2025-09-20T19:50:08.963Z"
+        "model": "fake-64",
+        "vectorSha256": "3a912a074df1d39202a03130b3b8c96d63bf59a27bcfcc9c2468420984eb2642",
+        "updatedAt": "2025-09-20T22:27:41.520Z"
       }
     },
     "j-0257": {
@@ -5402,9 +5402,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f54cae39a3dde78549d386d98e64f8bdda8003dc1d1d51995fa1db00967361c2",
-        "updatedAt": "2025-09-20T19:50:09.262Z"
+        "model": "fake-64",
+        "vectorSha256": "11fdb3bf6e0aef82a059e56d7ece52555e93395719c3073a863c9abe8581e613",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0258": {
@@ -5423,9 +5423,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0d4a41fa1aae7e333f8d179d12e3967d522be44fd6d240b27427deb8509b0072",
-        "updatedAt": "2025-09-20T19:50:09.263Z"
+        "model": "fake-64",
+        "vectorSha256": "7bbc624f4c5eecd1c55498c829a1ad2bc63747a6956aba99034a53be71c4c2c4",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0259": {
@@ -5444,9 +5444,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8c819f538acda2395644d914a5671a87008974f5d26316f73de88f305d28d4fc",
-        "updatedAt": "2025-09-20T19:50:09.263Z"
+        "model": "fake-64",
+        "vectorSha256": "15a7afe91adb04906903f2cce8864e10ea6f93d6badda807750ade366c78c95a",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0260": {
@@ -5465,9 +5465,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e8234411a2eeee7c3e6526ea687f545c18079118e04caef4bf4eb1669d2476c6",
-        "updatedAt": "2025-09-20T19:50:09.263Z"
+        "model": "fake-64",
+        "vectorSha256": "203f84554ba270355d49b440ba6b58b75ad3b6e27748eab4370411724bee0a6b",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0261": {
@@ -5486,9 +5486,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7065b5ef00b23136629200b90ab12f4b4b10f143153fbc688097d71fe6a14a49",
-        "updatedAt": "2025-09-20T19:50:09.263Z"
+        "model": "fake-64",
+        "vectorSha256": "f0857c1665795ee4538d0f5c6032d4a890e7b2515f60c72b4955cb9dfae816e6",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0262": {
@@ -5507,9 +5507,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "304a068f432178d6cdf71c10921688d290f0dbb295a1adeb6689e3581d8f1309",
-        "updatedAt": "2025-09-20T19:50:09.263Z"
+        "model": "fake-64",
+        "vectorSha256": "7deddc8c90755ad94a0878fc3f79f78abf7fb07b6a6747e44b43242d32cfbd00",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0263": {
@@ -5528,9 +5528,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "394e996cfebf8892fe03e894f86874b9d876f073b72b2851d597625c389915dd",
-        "updatedAt": "2025-09-20T19:50:09.263Z"
+        "model": "fake-64",
+        "vectorSha256": "a8fa09a146b9ac0d179da58e4c210e271645d5176e8abbd69f94c698754081dd",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0264": {
@@ -5549,9 +5549,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f50f5f7bb8ffa4a4bb9f110c6b120873df96d42a828949bd1ab7debf573ef454",
-        "updatedAt": "2025-09-20T19:50:09.263Z"
+        "model": "fake-64",
+        "vectorSha256": "dd0766adc82dbedc6b51e03bd415123e41da0a3a06297a91f285e96ee2bb5d9b",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0265": {
@@ -5570,9 +5570,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a35a947466926d1a0993f4228437905967d8b04894d135a828301b213dbc6a29",
-        "updatedAt": "2025-09-20T19:50:09.667Z"
+        "model": "fake-64",
+        "vectorSha256": "e4a85b9b6bf667daa64ada84081835bc7e1448f0fdba4c5f1f94e2bb2d6152fe",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0266": {
@@ -5591,9 +5591,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "21e89cbc347026bfe5075d4317e412897f3db934899182e4d11e57816af85dc9",
-        "updatedAt": "2025-09-20T19:50:09.667Z"
+        "model": "fake-64",
+        "vectorSha256": "f354457dcf0a3260df88d16bb50049b33220d576776be6a75ed7ee46f7bf5da1",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0267": {
@@ -5612,9 +5612,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "67fb5908a335a6bc9f6d014baadf0d6766e3ded993d69f9c01347b4631a48cb8",
-        "updatedAt": "2025-09-20T19:50:09.668Z"
+        "model": "fake-64",
+        "vectorSha256": "c118dce47a177ce640a25d7640bd60405cdb2f92bb4351e415addd3070d676f9",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0268": {
@@ -5633,9 +5633,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "75a6f15b82602a8e10421d89c2ad2660423f8cbf2f4f95329af330e97ec81606",
-        "updatedAt": "2025-09-20T19:50:09.668Z"
+        "model": "fake-64",
+        "vectorSha256": "d44c7ee253a909ebab499626b6a98dc12d35aed0188f5ee68158fc3f3298607a",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0269": {
@@ -5654,9 +5654,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0e9cc121298dcc61b6b82237f1871be6be57c32c8793d85403a3e6fc8c51cd54",
-        "updatedAt": "2025-09-20T19:50:09.668Z"
+        "model": "fake-64",
+        "vectorSha256": "dc9d10a3065eba899905b474bc2862b20cf5fe968d81a54c10865d9fecff1587",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0270": {
@@ -5675,9 +5675,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c73f04665317ca742239b3d257990ace819cb1d9992c0ef5eb086c783f137ad6",
-        "updatedAt": "2025-09-20T19:50:09.668Z"
+        "model": "fake-64",
+        "vectorSha256": "3dd65c6c1f8496cbe597450c02e3ca0b335e06585866652cdf5b3ead5882c4ca",
+        "updatedAt": "2025-09-20T22:27:41.521Z"
       }
     },
     "j-0271": {
@@ -5696,9 +5696,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dec5449831ef337b6e1c202645bd64ad8d17d67ef0e8ff4d301d26b7f69475ea",
-        "updatedAt": "2025-09-20T19:50:09.668Z"
+        "model": "fake-64",
+        "vectorSha256": "4f70410ffb14a5a8a92611333a7ebf11481f57f6cec44688c6b80dcd30bffd44",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0272": {
@@ -5717,9 +5717,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "edbb9e2a5d007e80fdc6421c8d80e7db206239560d6d5ea3e7347a3626265af2",
-        "updatedAt": "2025-09-20T19:50:09.668Z"
+        "model": "fake-64",
+        "vectorSha256": "fdba44555d4386ad08ed69765d3812c076792acabf1dd1011f7c38a544d9c346",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0273": {
@@ -5738,9 +5738,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4c880034de7f3cc9d41b8700d572b69d13186450b7cbed3dcb380c35d8ebcf89",
-        "updatedAt": "2025-09-20T19:50:10.067Z"
+        "model": "fake-64",
+        "vectorSha256": "8c7ce7e2da24f7627b96c4e274602c5b04434a24944de2e081a4ca30a0df849f",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0274": {
@@ -5759,9 +5759,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4b5c813bd16d9c8e32f15bdf6b0b335d144f51dcd1c1294b8069e315ed4b2ec5",
-        "updatedAt": "2025-09-20T19:50:10.067Z"
+        "model": "fake-64",
+        "vectorSha256": "1849efdffd178a174735c6b3b2ec33597c470ff1b4f8d9d473b3c9262eb508a3",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0275": {
@@ -5780,9 +5780,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4189f5cc9f79524d3cd0b2898f819b50f468f9fc91ac654339b3e101a1ca11bf",
-        "updatedAt": "2025-09-20T19:50:10.067Z"
+        "model": "fake-64",
+        "vectorSha256": "93c3e75cd2501aa76282261bacc1b36746d5cc705860affe752e1dfd1f8239fd",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0276": {
@@ -5801,9 +5801,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e4d76d0b10a626c449cd409b51b720b0f063ab9cdd57ae0febca23c872ead3f7",
-        "updatedAt": "2025-09-20T19:50:10.067Z"
+        "model": "fake-64",
+        "vectorSha256": "4abf7eec256fa08a1f58108e09616252359faf48ad4aeeee3048cea361e2466a",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0277": {
@@ -5822,9 +5822,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c11c539860c96d9dd51eca4a0c7d584e07c17b6c94e9cc754c14c2c19b6f9b83",
-        "updatedAt": "2025-09-20T19:50:10.067Z"
+        "model": "fake-64",
+        "vectorSha256": "820d2b10e682fb1abb4ee4395ae0dbf030ef101400ab8130aeea1765a1552488",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0278": {
@@ -5843,9 +5843,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dcf92567a8f0d5efac3ec1d1bb04b73fba850687c01a40d1726c26191b3caa2d",
-        "updatedAt": "2025-09-20T19:50:10.067Z"
+        "model": "fake-64",
+        "vectorSha256": "1b4a1b50e3d0d2e9f33bf032cbc057bcfe41c222a1b49c74fd37c83c68ed941a",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0279": {
@@ -5864,9 +5864,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "44c77f04e0b599471d850795d0a60d9d9fc440c187c582ad00669cb64d204f36",
-        "updatedAt": "2025-09-20T19:50:10.067Z"
+        "model": "fake-64",
+        "vectorSha256": "50f233a4d6d1a4ec1136c65787374e25bf6fb3f39adc0546abfaede6c4dc9c95",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0280": {
@@ -5885,9 +5885,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cb3d13ea2667a02e4b5f32cc92755e244285e809fd1a91d8d2c6e63df2f9f5c3",
-        "updatedAt": "2025-09-20T19:50:10.067Z"
+        "model": "fake-64",
+        "vectorSha256": "4039207ed9283837b5050ea8313f9bc4031f7869fe8e5b6bbdc2e6b20e18982a",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0281": {
@@ -5906,9 +5906,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "09366bb5355f6c56b240f4e0a1c62b22e8792477736bb84e480d9af11943a145",
-        "updatedAt": "2025-09-20T19:50:10.393Z"
+        "model": "fake-64",
+        "vectorSha256": "49a503b8254d6b1e23b425214f7257ce84e370da5aa59c0b8fb16de483927ee7",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0282": {
@@ -5927,9 +5927,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1919e0a333ce5f2c3defcce11dd3fa1ef1230bca3ac443df2aea59c8557fe0a9",
-        "updatedAt": "2025-09-20T19:50:10.393Z"
+        "model": "fake-64",
+        "vectorSha256": "b45fc870a7dd14a0a2ba194fc5ffdba98ab630f83b85bc25c7a949746f25ad60",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0283": {
@@ -5948,9 +5948,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c75c71b0c93dc26aa30ffa6f7c8a7d076e146a44bd288f2b5f714c862fde73c4",
-        "updatedAt": "2025-09-20T19:50:10.393Z"
+        "model": "fake-64",
+        "vectorSha256": "2c1e92de5a350b140c8ad5b386beba86ea5c11cdc752cc1afbb436969688c17d",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0284": {
@@ -5969,9 +5969,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e06fa1bc292e3b3b482da84c5c2bed1cefd2c2d30f1cd22623a6a146c44bb608",
-        "updatedAt": "2025-09-20T19:50:10.393Z"
+        "model": "fake-64",
+        "vectorSha256": "1183115e2c5e555c54125c72ba1ad9e2098e51bb9fa9f5a9480fe3db30c57d04",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0285": {
@@ -5990,9 +5990,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "765d568938d932fafcb2018a39c00af45ea8461d3cd72e6aa1d05be7d0b45472",
-        "updatedAt": "2025-09-20T19:50:10.394Z"
+        "model": "fake-64",
+        "vectorSha256": "d66b55e233d8bb3362bfc438da26e44a15207384b2a27f69d567f36986debf98",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0286": {
@@ -6011,9 +6011,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6ec5dce60c12b2e7e588a699e50fec19f70de5987af07361d1d28099d5a19134",
-        "updatedAt": "2025-09-20T19:50:10.394Z"
+        "model": "fake-64",
+        "vectorSha256": "d58e3404b1ac36f3283ea8485e1da98e3680363b90f7c744c87151aafd46a825",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0287": {
@@ -6032,9 +6032,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4da51802b518750f64b3f8e7b9c5754d6afb35f44068cd5ba03f3605538a3646",
-        "updatedAt": "2025-09-20T19:50:10.394Z"
+        "model": "fake-64",
+        "vectorSha256": "1cae1c78723dc11067756e1de945c11f7387bacb24f0ce2f82b099c866d63890",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0288": {
@@ -6053,9 +6053,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c813551cbcc3efe293c2d4b15070a87bb9adf10d17a9ce3169457def478ce56c",
-        "updatedAt": "2025-09-20T19:50:10.394Z"
+        "model": "fake-64",
+        "vectorSha256": "fd43b77d6ba2e41d9308e621eaa0c5e8fb8061f310a96e81ec6f710708c13c08",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0289": {
@@ -6074,9 +6074,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6eb189ecf480a1be8cd76c9ec54c11eb82d3853ab9a5620d8c23473df87b250c",
-        "updatedAt": "2025-09-20T19:50:10.824Z"
+        "model": "fake-64",
+        "vectorSha256": "d13eb80252681a98d22148b4775af34fba907167d5f1f50448c4f7182d6977ed",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0290": {
@@ -6095,9 +6095,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d7a6cebbc04a6bc87e0157f471596d90ba85141cfdc296cbc2663e30cc6efab1",
-        "updatedAt": "2025-09-20T19:50:10.825Z"
+        "model": "fake-64",
+        "vectorSha256": "e0846cf7c9ed17c4279c43cbf5a7380e6847c3ab9be8d1f87155e90f8736c7de",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0291": {
@@ -6116,9 +6116,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c5c50972022934023077d61be43492896f7e70d4a3b464321d27d9e9ff7a6117",
-        "updatedAt": "2025-09-20T19:50:10.825Z"
+        "model": "fake-64",
+        "vectorSha256": "c4cae21aa2ce737859bcb7735ab610c2b5ae5cc966c4c5ce17597c401c123274",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0292": {
@@ -6137,9 +6137,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7e3a257aaa9fb92e3d34b18a0ffdf8b96a245fd1d59db1669cdeebd4c8fb68e0",
-        "updatedAt": "2025-09-20T19:50:10.825Z"
+        "model": "fake-64",
+        "vectorSha256": "3d8aa5531aeb06d184761468645bc4eede4ebd892fb3fdf734168b3349a62d3e",
+        "updatedAt": "2025-09-20T22:27:41.522Z"
       }
     },
     "j-0293": {
@@ -6158,9 +6158,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "544fe2076ffb828f1921fa31fb4e341dc1602e1def85a435594b8e5eb52fd9a9",
-        "updatedAt": "2025-09-20T19:50:10.825Z"
+        "model": "fake-64",
+        "vectorSha256": "fb2c0dec8e4fda9788a61388a98ff23717de5055224fe6a16e7998c5a34873ab",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0294": {
@@ -6179,9 +6179,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b02c73895868402df52afbd39de7ecac7483139e0d4769808fefbba69bb51b41",
-        "updatedAt": "2025-09-20T19:50:10.825Z"
+        "model": "fake-64",
+        "vectorSha256": "5e878c6381e802e70193236f9456e13286b0c47140dcb1aeb15b5aa14bced900",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0295": {
@@ -6200,9 +6200,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1410c7eb83dfe4551bc0087c27448056b8e8ec4591c98fe729b9092862325742",
-        "updatedAt": "2025-09-20T19:50:10.825Z"
+        "model": "fake-64",
+        "vectorSha256": "250cf913598f312db191c8430ebe8109eafe2bafe4bf4955942f91ebe871c58e",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0296": {
@@ -6221,9 +6221,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0c7fdde9cc86f54665f6caffe960d78e438f31b33e8498f2b0d396923a1fd5ba",
-        "updatedAt": "2025-09-20T19:50:10.825Z"
+        "model": "fake-64",
+        "vectorSha256": "fdbb6adf8358abd6d41bad1fd57f4d9d656c6438ef973400b641c0d2aa4c5e42",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0297": {
@@ -6242,9 +6242,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b099e8b9beeface3c4c1a48b9a7f57b3f7790c2e904ee2b40339255ca8132616",
-        "updatedAt": "2025-09-20T19:50:11.169Z"
+        "model": "fake-64",
+        "vectorSha256": "e488a08fd3485f0386b26d9b9caa30cb31b76a471a13d2b2f0264360ae541f91",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0298": {
@@ -6263,9 +6263,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "53d6203434719085d782471ed5893d9be2b21358106ae1d17ca405bd101ae7bb",
-        "updatedAt": "2025-09-20T19:50:11.169Z"
+        "model": "fake-64",
+        "vectorSha256": "d5e1df1fc4694e52b246df86bb3f0ab9c042ed46494262912c0c7e01f7334215",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0299": {
@@ -6284,9 +6284,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6dad6309d0dbb0e6ee6bf9c016fb1608132bb69234797d66210aa9dff5d576d0",
-        "updatedAt": "2025-09-20T19:50:11.169Z"
+        "model": "fake-64",
+        "vectorSha256": "8eaeffe71f70a975018df9cb44a8c05f7e936f7114ed79970b895452dde4d4a2",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0300": {
@@ -6305,9 +6305,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "694553775b586663806bd2f7688d77162c31a5f621132a97ec322b0be1f51b5b",
-        "updatedAt": "2025-09-20T19:50:11.169Z"
+        "model": "fake-64",
+        "vectorSha256": "2a99ea58b47a3f047f03b96f702c66f99c29097c9214d38d3f13c55b00fd2992",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0301": {
@@ -6326,9 +6326,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2836bb25b2d3a2e15b5dff555a60ce0bf5a0b0eb29b4ffc83d49e886e4cc05d4",
-        "updatedAt": "2025-09-20T19:50:11.169Z"
+        "model": "fake-64",
+        "vectorSha256": "bdffae2316667ddc7641cd1a575616be2c62df41f73636648583f4248b1175e5",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0302": {
@@ -6347,9 +6347,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f54fba6c12228f2868faec5b2260cd3d69dc3185850b928c2ae9088e43499969",
-        "updatedAt": "2025-09-20T19:50:11.169Z"
+        "model": "fake-64",
+        "vectorSha256": "dfdf0a1165621ba1a2f6e53dd1ebcde83fa7c5f742830b330887d7d6024ca7e6",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0303": {
@@ -6368,9 +6368,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "92e8bf40ff4ead3eb62b8bdc411662a3a34e46b8706bb9bd1a161f60fb2fd829",
-        "updatedAt": "2025-09-20T19:50:11.169Z"
+        "model": "fake-64",
+        "vectorSha256": "ba8a75e3c4132a0fa2039448522bb0c8d78bf02f96860db064f940cba0e9ca85",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0304": {
@@ -6389,9 +6389,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c54522c8edd8484ed95aad21ba4fb6a47116174308dbaf8c0ad567dde4b9f148",
-        "updatedAt": "2025-09-20T19:50:11.170Z"
+        "model": "fake-64",
+        "vectorSha256": "1b2c134b32d9d8ca42a0c0e8132786f1810346696dab7db82ae02bd4c0d42ab9",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0305": {
@@ -6410,9 +6410,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ea685b6ecf57ce593c4b8809610a8b8b2622417a97cb00eedcc18c5490afcf6a",
-        "updatedAt": "2025-09-20T19:50:11.565Z"
+        "model": "fake-64",
+        "vectorSha256": "18dc55fb145dbd89248a9023b26155dc3f9d49a2cdf14cad472b06fdc8561a98",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0306": {
@@ -6431,9 +6431,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "50f1a1f44e74cf75f3c19b70abae3be1e4632aa7f32b32834af77ea49a48f0d5",
-        "updatedAt": "2025-09-20T19:50:11.565Z"
+        "model": "fake-64",
+        "vectorSha256": "716908c6a7fd515a60146cbf823a8da2d720fab301e06150a85d1cdde5915254",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0307": {
@@ -6452,9 +6452,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4c7c876ddb9677a64a6f6822aae0afe01bc1c8b11d3ce81fba5a438df02ff610",
-        "updatedAt": "2025-09-20T19:50:11.565Z"
+        "model": "fake-64",
+        "vectorSha256": "4ca0c4968d9213d4f6b544185ad34052ddecc364af457e2950d8de37798e90cc",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0308": {
@@ -6473,9 +6473,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "acc2960a4700faae0a0669d3d974608a0ef0e934b3f1143bb1b6b2173a74b5f2",
-        "updatedAt": "2025-09-20T19:50:11.565Z"
+        "model": "fake-64",
+        "vectorSha256": "54b304f219827bf896902775f3196d312dd6b4555c101b73038f9681bf21032f",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0309": {
@@ -6494,9 +6494,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2e8785ad4948b29d82bdb95aac2ec4f8e5cb5cfd3d7779ccb1d3d16e268d88fb",
-        "updatedAt": "2025-09-20T19:50:11.565Z"
+        "model": "fake-64",
+        "vectorSha256": "f1e13cda2d4c0be9ef62a18209e2ee4b2c48e9d93797de27740a58be69088b92",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0310": {
@@ -6515,9 +6515,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "08cbe2356b92d1e0a593447e270356fe54b1e0b8cdc52b02036328b20fd0910b",
-        "updatedAt": "2025-09-20T19:50:11.565Z"
+        "model": "fake-64",
+        "vectorSha256": "150ef8fe51ce08bdb3b5fbfde2796679e73bfb60814844957d20e169f06c0861",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0311": {
@@ -6536,9 +6536,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8b6935bbcbe55c3debc08f0f4040f2230202b3f34139bbf51ac7c5f8cb85b010",
-        "updatedAt": "2025-09-20T19:50:11.565Z"
+        "model": "fake-64",
+        "vectorSha256": "d2530b3c68c64b3ba1e1306e73d5d46696cb8d8d1ce3c28a8911c35853f87d53",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0312": {
@@ -6557,9 +6557,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f2088d4065b24790aa455647832a9b662c314c24d56dc1c1be6ed68aafd9cceb",
-        "updatedAt": "2025-09-20T19:50:11.565Z"
+        "model": "fake-64",
+        "vectorSha256": "47f48d18f699501be81b02d3112fd401ad636142197ae9a4c40e14fe80ccbe41",
+        "updatedAt": "2025-09-20T22:27:41.523Z"
       }
     },
     "j-0313": {
@@ -6578,9 +6578,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5575528f7c4cc2c18cd7f1b7510af1ae22af8e38c077e86b29829893f388a5b9",
-        "updatedAt": "2025-09-20T19:50:11.853Z"
+        "model": "fake-64",
+        "vectorSha256": "b32c4001ab08a6b979b40c8f40eca41784aea030800d66c2b9425ebc870e1955",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0314": {
@@ -6599,9 +6599,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d7f1240aa9906e7197bbd8a98eb4982926ab9300d7c4b0071a60310157c6590e",
-        "updatedAt": "2025-09-20T19:50:11.853Z"
+        "model": "fake-64",
+        "vectorSha256": "298f12547050c7e2a462859fa83bf0029b768b3e2da5af7f8a4b677866931aef",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0315": {
@@ -6620,9 +6620,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0db4f6ab451993a6c9341bfd1f3d9d735c900ffa51effaa26938a145d8dc825b",
-        "updatedAt": "2025-09-20T19:50:11.854Z"
+        "model": "fake-64",
+        "vectorSha256": "9d4c6fb748091186ccb06bc005c0e9934ca92b6b5d77ab855c15ad34c9ae9d36",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0316": {
@@ -6641,9 +6641,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b21a0098a1c4f9a8658e08baef6a917e8684851bdf01a0ac35446102bb238eb6",
-        "updatedAt": "2025-09-20T19:50:11.854Z"
+        "model": "fake-64",
+        "vectorSha256": "f33f2c736771776332be3a95941b313cef7ae5c2255fc852294ab50aca1ef678",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0317": {
@@ -6662,9 +6662,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "655ef6254fae70aa3bed57ce36dd0081e56f676f3fb29ae08bf49c1ddfe459e0",
-        "updatedAt": "2025-09-20T19:50:11.854Z"
+        "model": "fake-64",
+        "vectorSha256": "a278be6d7f5fa994007aea3bafb895c737e9752041efc6aa5f13363fea8b6d7f",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0318": {
@@ -6683,9 +6683,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3f61bc8308921870ac83586f3ecb9757ea20ba890f1dc77d477b121f3cfa037a",
-        "updatedAt": "2025-09-20T19:50:11.854Z"
+        "model": "fake-64",
+        "vectorSha256": "73aecf9575100e174f07f570ca2f995b3e2ecf63e8a30a512ee0ea9a45c1e4e7",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0319": {
@@ -6704,9 +6704,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2b6a87e6f5a620a706a19b9e6d24891f8ffe1bdc7730cbf46613019b8126785c",
-        "updatedAt": "2025-09-20T19:50:11.854Z"
+        "model": "fake-64",
+        "vectorSha256": "44c70f301400221012f4171f0e1d7fec286f96a437f33b990ed7ef26f8027cb4",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0320": {
@@ -6725,9 +6725,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "92991f9883a0af3a3df61fae7cfcbdeb4609f8a53a594082da83c4b9f18d38d4",
-        "updatedAt": "2025-09-20T19:50:11.854Z"
+        "model": "fake-64",
+        "vectorSha256": "faedfcd3b6a92fbb1eb10757befb865a0cabef97de00efae84c99c5197af23b8",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0321": {
@@ -6746,9 +6746,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4efbefd9bf3dd4f80a61ecf6c0968ebcebdd3edf100a73accfe6a903dad3e069",
-        "updatedAt": "2025-09-20T19:50:12.136Z"
+        "model": "fake-64",
+        "vectorSha256": "304c72c2f74866ecd4c1743fb947495b186547f140c705d97d46de6f1fe516ba",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0322": {
@@ -6767,9 +6767,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "955d73f6a656a125b677401ca75084948edf2483cd542209e0e0a36ff3a63dda",
-        "updatedAt": "2025-09-20T19:50:12.136Z"
+        "model": "fake-64",
+        "vectorSha256": "8b45898f7eb338b4a0166f094a6d5e9e90268b9463bc9678b5a16083a5c68350",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0323": {
@@ -6788,9 +6788,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3de9cb0e974a4a00ce237f90e7b594d281a8117c02da6740fdff5661a4c71de1",
-        "updatedAt": "2025-09-20T19:50:12.136Z"
+        "model": "fake-64",
+        "vectorSha256": "40963a47f0c1966fc31945c5dda12b9cb5b52f8ddfdffa04e0679e7884685132",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0324": {
@@ -6809,9 +6809,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "904ab2ed655aa691840aef57469670fad95062b7bf5c9b4d5662e5f5574e1eb0",
-        "updatedAt": "2025-09-20T19:50:12.136Z"
+        "model": "fake-64",
+        "vectorSha256": "0e23129219a5b74c81d3dfd6bde7085c097a8222601698c527c408d87f2d2b2c",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0325": {
@@ -6830,9 +6830,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ed9ad2d1a30eac65a28fd586d5ea76560eeb71a192f07c55949e83d23a86a396",
-        "updatedAt": "2025-09-20T19:50:12.136Z"
+        "model": "fake-64",
+        "vectorSha256": "e67c6a8c74784d69a116a7b443dee6a2115b5d7ef08dc363dede6630ce50d706",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0326": {
@@ -6851,9 +6851,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "48f55a5a7afadd767ffe7ccae03e8f399ba2b3601c6cdc53475d0a2c54696696",
-        "updatedAt": "2025-09-20T19:50:12.136Z"
+        "model": "fake-64",
+        "vectorSha256": "902866244b4dfe7da1e7d6851049eb0bbb86f466812eec7b87f394199dcaaccb",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0327": {
@@ -6872,9 +6872,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7f9d8bd738b580d25b876093e023ef185ac3d867cc34b71c6321fbea49540beb",
-        "updatedAt": "2025-09-20T19:50:12.136Z"
+        "model": "fake-64",
+        "vectorSha256": "3c6df1e3a920b320eba10e333bae4a67e1ff919bc9c26f18d4ad7eed173427ed",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0328": {
@@ -6893,9 +6893,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "954770003774b4fb54bddc30b72f1548eacc1349640a6e96a904f9ea9555383f",
-        "updatedAt": "2025-09-20T19:50:12.136Z"
+        "model": "fake-64",
+        "vectorSha256": "ad51ad8525f2f8fc80d4b319809a931806e63f79d8ebd96bac302cff4568ef72",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0329": {
@@ -6914,9 +6914,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2fd78a1cd486e44ace28a634c57d02ce355a5492aece9da27fb5f5883bd7ecbf",
-        "updatedAt": "2025-09-20T19:50:12.454Z"
+        "model": "fake-64",
+        "vectorSha256": "d54b3ff6d03d4f781840296ff53d79dff42a817125e84031f44c481433f8fdee",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0330": {
@@ -6935,9 +6935,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cf1e5bbfed745956c80841f07297c08d8e714ffe6922a040c2924405df369f53",
-        "updatedAt": "2025-09-20T19:50:12.454Z"
+        "model": "fake-64",
+        "vectorSha256": "8bb8e232732e72b2d6ee4d794f7c234116948e945aff99055aee3321ae1e0d0f",
+        "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
     "j-0331": {
@@ -6956,9 +6956,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "519b4f7ac73b6d696fb11a1db7dfda9be1c6ad18f41a792e48fa2a26e9d218c7",
-        "updatedAt": "2025-09-20T19:50:12.454Z"
+        "model": "fake-64",
+        "vectorSha256": "70301e938556d3cc3cc5e5f5f8dae4328c26787100595774823ec59cb5da8a43",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0332": {
@@ -6977,9 +6977,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "30842c0d08c9a5b5260d748894564b40da69c3b9ff26d2317bff6565b1bce5e3",
-        "updatedAt": "2025-09-20T19:50:12.454Z"
+        "model": "fake-64",
+        "vectorSha256": "d8e0f968aa3362382edb627b52dcf953608ede73d51d7faa87bdfe04e64fa4bf",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0333": {
@@ -6998,9 +6998,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1211cd7cd6d67f66a4fa63de0d61f20631a0d7a8eb5d054d24dd9b4cab393195",
-        "updatedAt": "2025-09-20T19:50:12.454Z"
+        "model": "fake-64",
+        "vectorSha256": "0ce8117276000f75de64799f14d423975959a6e738d8094c3c80e1fe07caaa38",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0334": {
@@ -7019,9 +7019,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c3e8668b9ac5b90ebcebbd1298c913174817826bbdafc8ee73ec997d698f1316",
-        "updatedAt": "2025-09-20T19:50:12.454Z"
+        "model": "fake-64",
+        "vectorSha256": "46522b9d273e85603418e5db604f4d2c5c526d517a1c0e72b6758a5afcbc870e",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0335": {
@@ -7040,9 +7040,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "72a5b8545faf63fdd359ec37a78be5724551b75d3450b96ac15a2cd2a0e8dfa1",
-        "updatedAt": "2025-09-20T19:50:12.454Z"
+        "model": "fake-64",
+        "vectorSha256": "b12bef7c2f6324366911a368e9395c25b6b2d74b16ab48bab9d1fdd5e468f4fe",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0336": {
@@ -7061,9 +7061,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "15c69f210380a9171022ade1e016dda2cba5f7a52b0f4ddb3281523fa60c550e",
-        "updatedAt": "2025-09-20T19:50:12.454Z"
+        "model": "fake-64",
+        "vectorSha256": "92b64ea33894e6ab6918ca823961d932ef9b84777d5e199f9b7aa14b029faba5",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0337": {
@@ -7082,9 +7082,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5acbea071954888a26d1cb221f7d164645c08de7ab2a7e6322a78b3df011e00d",
-        "updatedAt": "2025-09-20T19:50:12.696Z"
+        "model": "fake-64",
+        "vectorSha256": "faf1c9e1ccd53568bb08a94a1415af95a7a7fe581ca2b42e8219ae3fe7360b64",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0338": {
@@ -7103,9 +7103,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "495bdd8c215d4ff5c060e06be7504b72ee86ac1194643ad527b2e13c8077d52e",
-        "updatedAt": "2025-09-20T19:50:12.696Z"
+        "model": "fake-64",
+        "vectorSha256": "a3d949099848ae07c6e06488281f6f8ab645f7cfeaa27d972eb06f15993675b1",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0339": {
@@ -7124,9 +7124,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b03ba630fb3e9572a2dd91bee32e9abbf2e641ecc3fea4b5a22d2635b1723225",
-        "updatedAt": "2025-09-20T19:50:12.696Z"
+        "model": "fake-64",
+        "vectorSha256": "3ac0fb17f11826b4afc62634953011c9b097da8a4678a214c8389079be7a9f35",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0340": {
@@ -7145,9 +7145,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3961b95a6f7786008e7ece66e0c5ba68ef64f3f4296e818883ff1ab517b3f8cf",
-        "updatedAt": "2025-09-20T19:50:12.696Z"
+        "model": "fake-64",
+        "vectorSha256": "c23a20ecf9d19bd57641e5df90c1967b6e06f068da00e3d514b13be0b12430a0",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0341": {
@@ -7166,9 +7166,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f04d98a86a6288254b2f7d1dbdf1ea8d47a0ec0a63c6706780b636231e837af9",
-        "updatedAt": "2025-09-20T19:50:12.697Z"
+        "model": "fake-64",
+        "vectorSha256": "a70d756bc4220004a9b99752e4973b0bb24bfe07cc17c9c8df73b76ba9365846",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0342": {
@@ -7187,9 +7187,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "95cfbab3e54e4081a5bc86e1566035769735abbfc4ab51195583123621e9eb78",
-        "updatedAt": "2025-09-20T19:50:12.697Z"
+        "model": "fake-64",
+        "vectorSha256": "7db1bdc71db5ae5a10f6899d43466a793c1435429560c93269fae55eb23370dc",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0343": {
@@ -7208,9 +7208,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f4d8679507e491f2e2b24ad3592af7f25a00b1e6962804dfce51836f469dc9e9",
-        "updatedAt": "2025-09-20T19:50:12.697Z"
+        "model": "fake-64",
+        "vectorSha256": "d645c7311237cf7b93d20269ffef0b35e6d0fef2259a68ddf771fcbf68336d4a",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0344": {
@@ -7229,9 +7229,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "45458666323a2e3a1a82beed647e1e944e9318d9fe355f6cc699946b8d68a5df",
-        "updatedAt": "2025-09-20T19:50:12.697Z"
+        "model": "fake-64",
+        "vectorSha256": "3c18229c93bdcc7756c7dff8cf48b4be7fed7cc0e16e0d5243d536666089a39f",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0345": {
@@ -7250,9 +7250,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "61daaab89e659efbc549fc795fcc996b31c1f78d21635b5d3eca70161b54e49f",
-        "updatedAt": "2025-09-20T19:50:12.952Z"
+        "model": "fake-64",
+        "vectorSha256": "a9db79282efbafee640819bee96015a813b90629dbf9f9bca2d99a8540f5fa70",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0346": {
@@ -7271,9 +7271,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3119b6e066b952372eb3b4b2296a13e781abc932dec5213975c00e745c2a97a8",
-        "updatedAt": "2025-09-20T19:50:12.952Z"
+        "model": "fake-64",
+        "vectorSha256": "2a0e428da8168b27abeb480782f050e6664f31829288f62ed0661c6f6ea08a22",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0347": {
@@ -7292,9 +7292,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "13ec269b1b2b666ac55795eea51354b7c7e110927953232e730a058a9d215ac6",
-        "updatedAt": "2025-09-20T19:50:12.952Z"
+        "model": "fake-64",
+        "vectorSha256": "3ebd0a10bc378ba527f03bd37823197dc0473ff8a62ab83a9e59a871c2b0913c",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0348": {
@@ -7313,9 +7313,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b1655edd0c070e91e58954383ddba5ee0c9248b6bd98ea56bdc2461f732c089a",
-        "updatedAt": "2025-09-20T19:50:12.952Z"
+        "model": "fake-64",
+        "vectorSha256": "a9c36c0d6593374aeb4719c0ca61dd3db3c75c6eee3885cd68cbb4d226b4a2f0",
+        "updatedAt": "2025-09-20T22:27:41.525Z"
       }
     },
     "j-0349": {
@@ -7334,9 +7334,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f16073ae56056ff728c58c5bfe95bbe8046f21dc977d15847386fa129284cadf",
-        "updatedAt": "2025-09-20T19:50:12.953Z"
+        "model": "fake-64",
+        "vectorSha256": "e10f96e04590016dab305bba6f2a7d70746a33b33e55f9d003433a78becef677",
+        "updatedAt": "2025-09-20T22:27:41.526Z"
       }
     },
     "j-0350": {
@@ -7355,9 +7355,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "70c8de51b91d9bbde669f70f4dcb4d6c984689437f548c0f9c50ccbca6ff668d",
-        "updatedAt": "2025-09-20T19:50:12.953Z"
+        "model": "fake-64",
+        "vectorSha256": "c576601f02b5b579b7f6448d739df07fdc35d3da60425c604b8162e60b6e4f49",
+        "updatedAt": "2025-09-20T22:27:41.526Z"
       }
     },
     "j-0351": {
@@ -7376,9 +7376,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "06addfc16c51617c5fc9e6e7c5b010a1f8a1037d8323fd634feea79c28a081b1",
-        "updatedAt": "2025-09-20T19:50:12.953Z"
+        "model": "fake-64",
+        "vectorSha256": "496768aab5bdf4075ef9ad098436f1bbdfe6046076bc99f8c86324e2c60be461",
+        "updatedAt": "2025-09-20T22:27:41.526Z"
       }
     },
     "j-0352": {
@@ -7397,9 +7397,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2bd73b7b73039a40e50983d48ce7047e0b759a9596e00b76f0da6a0c8ea2abdf",
-        "updatedAt": "2025-09-20T19:50:12.953Z"
+        "model": "fake-64",
+        "vectorSha256": "227070e66a04d1a3e3520cbb66d69cfb254fafff00f26bd6577974fb2b188092",
+        "updatedAt": "2025-09-20T22:27:41.526Z"
       }
     },
     "j-0353": {
@@ -7418,9 +7418,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ca3f8168c27d42efeac2a3ad51c5327154349ce7abc67e04526ffd5532ca3c6c",
-        "updatedAt": "2025-09-20T19:50:13.216Z"
+        "model": "fake-64",
+        "vectorSha256": "aa4567e40b0d4031474b15de33693bcedc3ebff508f100e897ade38fd0e956fe",
+        "updatedAt": "2025-09-20T22:27:41.526Z"
       }
     },
     "j-0354": {
@@ -7439,9 +7439,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5a15fbde0e07d8433491cb601f06e0d3e9f8d0218aec4a75f583e0b879cd4ddf",
-        "updatedAt": "2025-09-20T19:50:13.216Z"
+        "model": "fake-64",
+        "vectorSha256": "bee90f672aea03e1cab90c6d45387887ea3ec67e663d8abe295d3f52b8023989",
+        "updatedAt": "2025-09-20T22:27:41.526Z"
       }
     },
     "j-0355": {
@@ -7460,9 +7460,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dd449910ecd8225ac9fb789f3f7950a9dec597c9552508aa6d52325f4c51faa9",
-        "updatedAt": "2025-09-20T19:50:13.216Z"
+        "model": "fake-64",
+        "vectorSha256": "33bbd814f2c7f0bb727a6d00d4c1af7c9f9022439d75853a8eb2bdd193b7256e",
+        "updatedAt": "2025-09-20T22:27:41.526Z"
       }
     },
     "j-0356": {
@@ -7481,9 +7481,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "640c36cf3c20b06571ba608dde95b84c27b992b51ecf75ab2200e0cc8880bcfd",
-        "updatedAt": "2025-09-20T19:50:13.216Z"
+        "model": "fake-64",
+        "vectorSha256": "4b2312c3bcdd90207d0ed8e520fc1e671c6cc8bf306b49491812b2681089716f",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0357": {
@@ -7502,9 +7502,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "901906db34e84ef8d72a205bf0a25c48cd332b3f44ecd9bd20317184b2ef16c9",
-        "updatedAt": "2025-09-20T19:50:13.217Z"
+        "model": "fake-64",
+        "vectorSha256": "1ece131c42610c5d46535e31de1075027fe9b53deca56904cabee48856f9a08f",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0358": {
@@ -7523,9 +7523,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d9cda1fa13771503021cb92699ab24210df9b93eb8f7015689f987979d80577d",
-        "updatedAt": "2025-09-20T19:50:13.217Z"
+        "model": "fake-64",
+        "vectorSha256": "7077a120004b5595ea638e6414597995e27d9c3a9317e57f350f28bc42f3feb1",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0359": {
@@ -7544,9 +7544,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b8157d703a01e45a23d15bb870227e3e672d04c97ac29cdeb04206c87e9146af",
-        "updatedAt": "2025-09-20T19:50:13.217Z"
+        "model": "fake-64",
+        "vectorSha256": "f4d2abdc291cc44f8b68fb0fc87b86a78d61bb18b740e25662e58eacd0b76289",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0360": {
@@ -7565,9 +7565,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c81735a51d71367bcde4736604615dcb9e29e0619cc6917428bfd32d87f1f060",
-        "updatedAt": "2025-09-20T19:50:13.217Z"
+        "model": "fake-64",
+        "vectorSha256": "e7d17277ba2aaef982816c1cad3276f339ef5f80ef1ef976ce4dee1dd5db4c04",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0361": {
@@ -7586,9 +7586,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0a3137db5af8fc1b857b5050dfb0174d1d8ca8c356b344204d68a24bf767d671",
-        "updatedAt": "2025-09-20T19:50:13.486Z"
+        "model": "fake-64",
+        "vectorSha256": "857466795affbc37f70c13604c7a1c09eee992599db9c9e21b9aeb60291b53fc",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0362": {
@@ -7607,9 +7607,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3c7b734c616ca98b6c5d8294579906f741157e6548123de5336e636a17d8c4fe",
-        "updatedAt": "2025-09-20T19:50:13.486Z"
+        "model": "fake-64",
+        "vectorSha256": "140dc5daf80f1cca2c564ed7640aa3e07c3d0e35091e076d36f7eb2898445d2b",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0363": {
@@ -7628,9 +7628,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0e097e9df1fa81b207c30c7d6fc40aed41adf3ae1954f9de2333577663287d5e",
-        "updatedAt": "2025-09-20T19:50:13.486Z"
+        "model": "fake-64",
+        "vectorSha256": "b080a928311017aacb488d65416a87893232a7f5c323cd91405038ab4299a5cb",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0364": {
@@ -7649,9 +7649,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "61950d28a0e41e3773374a6ba75cea8888bf826342b097ac87a86cee651c2095",
-        "updatedAt": "2025-09-20T19:50:13.486Z"
+        "model": "fake-64",
+        "vectorSha256": "907065b86e27a8a37792bae0fd5f00c6cdc7a4aa727d82b9bda4fc7f3a38b51a",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0365": {
@@ -7670,9 +7670,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "227d812de96235cda5fd8c005c865f55c87f3f264477b2b0bf5af9d69cab49dd",
-        "updatedAt": "2025-09-20T19:50:13.486Z"
+        "model": "fake-64",
+        "vectorSha256": "2b6fcf7e6c8775255d0c4c1b6dc34e612e7ac01b397c25bd44d0c31c2d57a28d",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0366": {
@@ -7691,9 +7691,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0806e6ec744c54b8e25fc034cefae9f4545aa3166a36835932a676e3c631d806",
-        "updatedAt": "2025-09-20T19:50:13.487Z"
+        "model": "fake-64",
+        "vectorSha256": "5dc80f55650c8873a7b00a024e4b7d68bec12bf109b99f11d1a659d39d30abd5",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0367": {
@@ -7712,9 +7712,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ebca1f453daded4d93f991a59733fc845ebe9ecb10bd19ebfc9c2e89b3c244a4",
-        "updatedAt": "2025-09-20T19:50:13.488Z"
+        "model": "fake-64",
+        "vectorSha256": "fa53097efb242b2301c5702c044a829526dd733892a0c4342b0fe7dcf79c32c0",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0368": {
@@ -7733,9 +7733,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2ae5e5834c43729a5929021877b34a96778485a93feb6f0dda9e502c3f8bb893",
-        "updatedAt": "2025-09-20T19:50:13.488Z"
+        "model": "fake-64",
+        "vectorSha256": "c9c46ccc2cb323f19f400d7cfa2e39f4a2d3371ae471a1e2c860f9409e63f074",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0369": {
@@ -7754,9 +7754,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f979074611d708d6a589fbb252819ad84e60cc199cfc4220ad246409cefa6c2c",
-        "updatedAt": "2025-09-20T19:50:13.850Z"
+        "model": "fake-64",
+        "vectorSha256": "7538b4f1aa663a84ec1c4af62af7930248d9d2daf7278d44b71f233d3ddf6536",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0370": {
@@ -7775,9 +7775,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c92c61c7291c006d8e08805e9e4ef1c64ed285c3ccf8eae6d63812ce1a9de61a",
-        "updatedAt": "2025-09-20T19:50:13.850Z"
+        "model": "fake-64",
+        "vectorSha256": "fc40b8c20bd13b12b3a557d22a99392748387ab2ef46434103e6ead2ec6459c1",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0371": {
@@ -7796,9 +7796,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "50174daee5cfa1a4f5614eda420138a6796a31846d178ef30e3e00aa1f38b4fa",
-        "updatedAt": "2025-09-20T19:50:13.850Z"
+        "model": "fake-64",
+        "vectorSha256": "2cd62a0aac2d8ae673cce46a49be102b054efffa77072a22b158cec3250f4ae5",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0372": {
@@ -7817,9 +7817,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4cc0efbd930164ecf767deedacb82630ca0ced69a5dd7149707396fa9cf26ce1",
-        "updatedAt": "2025-09-20T19:50:13.850Z"
+        "model": "fake-64",
+        "vectorSha256": "92f8c640e4b198cf6a9439e5cb4af1766655aac427376c994887ddd9ff0cebf9",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0373": {
@@ -7838,9 +7838,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7d2974bf9c819edbd2544e1bbbda2b0163301f90b78d7eb9ed548d5cdd514652",
-        "updatedAt": "2025-09-20T19:50:13.850Z"
+        "model": "fake-64",
+        "vectorSha256": "369929f9377402ed80aa0af6a5c9d22cde7336f67a7a0a59e01a4f9a5362e59d",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0374": {
@@ -7859,9 +7859,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1e78077ed307145084b1f51937a95415b38cb8a334ee5500d01391f2bf88af0c",
-        "updatedAt": "2025-09-20T19:50:13.850Z"
+        "model": "fake-64",
+        "vectorSha256": "451a60bed5eaff6ab7f29f6e4973ea8d0f82f85fdbe87b949f89ee4390200938",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0375": {
@@ -7880,9 +7880,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9ddf564cedf4b1052b9f496888f4ea65bace05a565a8fba855a3fea2be576e4a",
-        "updatedAt": "2025-09-20T19:50:13.850Z"
+        "model": "fake-64",
+        "vectorSha256": "db873768747a89788687526e1ddb6d5dd69507f149a2acc7de926f71579b6407",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0376": {
@@ -7901,9 +7901,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aa159356033c3e5dc4dccb47b1a2645e400ea3c40f5899d030b653c45e6389aa",
-        "updatedAt": "2025-09-20T19:50:13.850Z"
+        "model": "fake-64",
+        "vectorSha256": "d265307f081d70671d49448abc22eef78eb46e9a34ac61904ed75db1e5662193",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0377": {
@@ -7922,9 +7922,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ce990cb69d97905f1261e5f1104dadf1ffe900cebf21177043bb0ef824141e01",
-        "updatedAt": "2025-09-20T19:50:14.090Z"
+        "model": "fake-64",
+        "vectorSha256": "88ac7232d2e6c841d5daa1ffe1316e82edc5c962ac5ee232f6317033fba4b117",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0378": {
@@ -7943,9 +7943,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b66265b7c674ee3575009a3b4f369eebcaed8b2adbbfb9b54bf007ed0d5558dd",
-        "updatedAt": "2025-09-20T19:50:14.090Z"
+        "model": "fake-64",
+        "vectorSha256": "1a33a2d41b8daf3b398bd653e674340aff74a935e3f944e43b07c17eca8792df",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0379": {
@@ -7964,9 +7964,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "407dc7470af5abc37eaba55db9427b905e1aebe348d1399157e90648d0abe552",
-        "updatedAt": "2025-09-20T19:50:14.090Z"
+        "model": "fake-64",
+        "vectorSha256": "06d4ae06d72a1777852d8fe24cd99ef56e2068594f4b7f5972d6ff216b985bce",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0380": {
@@ -7985,9 +7985,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "64a8d7e0683d39a5944282cd44bd12187e685685e6c713cff3a36ba334f69f37",
-        "updatedAt": "2025-09-20T19:50:14.090Z"
+        "model": "fake-64",
+        "vectorSha256": "6bc82c070e580d036504386a01858e496f56b8994bd9637e9b504949b21e55e8",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0381": {
@@ -8006,9 +8006,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aa8a60c82aa1e2419e5082a6ab48e62ce54ba25b3cc5061790853e3ec05dd542",
-        "updatedAt": "2025-09-20T19:50:14.090Z"
+        "model": "fake-64",
+        "vectorSha256": "03eb9ff27e28a4dda12d98b36371e7579eb51dc679a5978e1b6000e609a4294e",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0382": {
@@ -8027,9 +8027,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "56ffc7ae7d04267a30290ee1bf856f8b545c390fdfb31c1bc1f59facde904103",
-        "updatedAt": "2025-09-20T19:50:14.090Z"
+        "model": "fake-64",
+        "vectorSha256": "51c3ea7806c7caf0350562b12bc931c5a62b39c53036199aa980812028aa13eb",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0383": {
@@ -8048,9 +8048,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4627ff7f2a0f6e6da24b82a43b7addc46007bf0ac17ad4feb6e16b76c4ac1603",
-        "updatedAt": "2025-09-20T19:50:14.091Z"
+        "model": "fake-64",
+        "vectorSha256": "250d8d96a9196dd6ec83e6b22db7e4d333866f4e4765d3a3cce3a26a9ea0b0ed",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0384": {
@@ -8069,9 +8069,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "31db1035ceccee7ec2ac163f8accd968780ab7acc6f797bc7e585aebc11e18a8",
-        "updatedAt": "2025-09-20T19:50:14.091Z"
+        "model": "fake-64",
+        "vectorSha256": "d489435fe0baec2f043d71128ac486e344249518452e39ac77d91f65a49a9776",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0385": {
@@ -8090,9 +8090,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b404dbc08567489d1e245b5b350dabd7ac84caf47af5103ad1ef588261100583",
-        "updatedAt": "2025-09-20T19:50:14.350Z"
+        "model": "fake-64",
+        "vectorSha256": "b0a5305acbf7c0dcd815f6881fd5c17a85f57beb73c46517482e2c6ca72d9fe5",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0386": {
@@ -8111,9 +8111,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1af38ffdc3fe14d8ffca32feee94f230836b265179a70110fea51c124fd9848c",
-        "updatedAt": "2025-09-20T19:50:14.350Z"
+        "model": "fake-64",
+        "vectorSha256": "3d80b2ff75ff8b81f9eaba6c9eb249d1bc5f07a8d41591c97d6c80f28fcada47",
+        "updatedAt": "2025-09-20T22:27:41.532Z"
       }
     },
     "j-0387": {
@@ -8132,9 +8132,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6676b5ca0e071916883dd16c3af3ccde1cf2de4f05d15b63e8b708c6adad2c96",
-        "updatedAt": "2025-09-20T19:50:14.350Z"
+        "model": "fake-64",
+        "vectorSha256": "1e19535d81c1a288d52617c344ae02398e7ff254ba9e370af3a7644c02a5257a",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0388": {
@@ -8153,9 +8153,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f08a1dc016c610e584e8e395dcf1e5089f9da0b32c93bebbab46368f33a35a88",
-        "updatedAt": "2025-09-20T19:50:14.350Z"
+        "model": "fake-64",
+        "vectorSha256": "971f11c8cde4975538e6cb9d987a83f9b52237e73f996692c65e59a1ce50e35a",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0389": {
@@ -8174,9 +8174,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "60c207c56321319c8fa7d76d637dc418016f0a9df4acbaec1e2ce62c6f036f0b",
-        "updatedAt": "2025-09-20T19:50:14.350Z"
+        "model": "fake-64",
+        "vectorSha256": "f37f9b2f0204e2f301e563d2ec11078a387c95764e42a8aad3c0fef7bab15440",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0390": {
@@ -8195,9 +8195,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6ebd974bb2a7397c256e33784005d15fa9077b87f9900fd4a35ee6cbd44418a1",
-        "updatedAt": "2025-09-20T19:50:14.350Z"
+        "model": "fake-64",
+        "vectorSha256": "1f2cb8760d9658434c788ffb7a9daac39749cbde73a8c7c4711c7cae3b3f2936",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0391": {
@@ -8216,9 +8216,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "32c131874fa6074cacb80b338c89e76ca9c849998b9e8103e177c7cf66bc1efd",
-        "updatedAt": "2025-09-20T19:50:14.350Z"
+        "model": "fake-64",
+        "vectorSha256": "e7d4a68edbb8601acc4697505d7dfa89e7f9a47cab90a80184d9a44fccc5e041",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0392": {
@@ -8237,9 +8237,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e467eb48da11959a55cad0806cf36722cff3f21fae2a9497df875d2a6ccf73c2",
-        "updatedAt": "2025-09-20T19:50:14.350Z"
+        "model": "fake-64",
+        "vectorSha256": "1476023c938168f7db841166631c21e5378205b638eccb8cb99669688c000b04",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0393": {
@@ -8258,9 +8258,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e3e4e9fb863132ce3a8c57f13690a38ba37327217d2e6a2ed7415b784630df24",
-        "updatedAt": "2025-09-20T19:50:14.665Z"
+        "model": "fake-64",
+        "vectorSha256": "dc8c4b02e5557fed44cfa520f9a3a396df76afd3e07d4d037b7ad0e41dd14ff7",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0394": {
@@ -8279,9 +8279,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d7cbba14cf8f98c010b788ac681a1a05299804ac5a00be772da74494335294d1",
-        "updatedAt": "2025-09-20T19:50:14.665Z"
+        "model": "fake-64",
+        "vectorSha256": "71d60b7a3aae49a016b41e5ea57400402e3b647539af9cedcf72ca08a92b8e21",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0395": {
@@ -8300,9 +8300,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a0d8c868b331226a49411386b3dfc108eac77b926efe9f3622dbb543aa657c0a",
-        "updatedAt": "2025-09-20T19:50:14.666Z"
+        "model": "fake-64",
+        "vectorSha256": "d6c1092c229908676e96aeebc116b728cb3f3e34df9639b46f0e6e370bd326ca",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0396": {
@@ -8321,9 +8321,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dd6292a54ab0eb3843efeeeb40358c449bd8516319b99a38703aa8434a9eafcc",
-        "updatedAt": "2025-09-20T19:50:14.666Z"
+        "model": "fake-64",
+        "vectorSha256": "91e5e14e625d2cee175f6478a13a88ed2660581b61b7f2b642aa0e30fcd498bc",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0397": {
@@ -8342,9 +8342,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3a57098604dec722fc6dadbec8a3604d535d7e405d339d04e3cd35b21473967b",
-        "updatedAt": "2025-09-20T19:50:14.666Z"
+        "model": "fake-64",
+        "vectorSha256": "6e48c58f3bcdd864284b182260cd2070210a8d2862e0d8139cfed9bc2df9a30f",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0398": {
@@ -8363,9 +8363,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7f87b4ad08050c5ebb8fe684810a6bbfad1869a20e9a351e5d29f48f55af7705",
-        "updatedAt": "2025-09-20T19:50:14.666Z"
+        "model": "fake-64",
+        "vectorSha256": "92a8350a3241b377c46f7647d733d64f3bfa3cc1a8522b5cf9360406f9769ece",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0399": {
@@ -8384,9 +8384,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "62b1ffa3a0c6009a9b39a6634c683d68b623739c6e778e24a5f3a3fb5cdecfed",
-        "updatedAt": "2025-09-20T19:50:14.666Z"
+        "model": "fake-64",
+        "vectorSha256": "b69de227fe4268491b36ddd81e0f2b46e8f4ef15c1945ac374e77d7c4c1bc154",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0400": {
@@ -8405,9 +8405,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6bc209404c133b7eac472b08c2130c6b4dbe49b0d6b0e8d52c1eda59c3025ec8",
-        "updatedAt": "2025-09-20T19:50:14.666Z"
+        "model": "fake-64",
+        "vectorSha256": "5af76e6d1f60a88cc3bfc7a1ca215502af9058330558f809ec4e9956479868b3",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0401": {
@@ -8426,9 +8426,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a047b65a7ca484272c987178dbc7ff04bfe4a4b67cc0e73dba104923e43dcb76",
-        "updatedAt": "2025-09-20T19:50:15.031Z"
+        "model": "fake-64",
+        "vectorSha256": "f810e7da92501ad3cd11945b5192eb66e6826190314543a9200d4314c1848c77",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0402": {
@@ -8447,9 +8447,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6b468015fa35514d5a834c69167c2fa05526a28a9881a1bf52c3398da52c75d5",
-        "updatedAt": "2025-09-20T19:50:15.031Z"
+        "model": "fake-64",
+        "vectorSha256": "0672ec70eaa349d802d5d320616a08abd6984761b0b0641f1c486ae7e2e7cac6",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0403": {
@@ -8468,9 +8468,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dd231290848e853c9d90b0ec644491ce4f56d101cd98b5eb2fe0e5c2b3e57dba",
-        "updatedAt": "2025-09-20T19:50:15.031Z"
+        "model": "fake-64",
+        "vectorSha256": "892a36bff48954143220ad8e10bebdf283db85493537f4bb257a769deb93a91a",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0404": {
@@ -8489,9 +8489,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "542edc88c0bef604af9fac847ca33880dd00a24b0fd01c2f8a9803042465af12",
-        "updatedAt": "2025-09-20T19:50:15.031Z"
+        "model": "fake-64",
+        "vectorSha256": "0ab26c58c04c986d0d2cdfce2a3a3b73b957b2c5f827a2707744f67416df610a",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0405": {
@@ -8510,9 +8510,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ff5b7f6a1234fe98e456ed02b85cdec9b96145e4b108ad6e2d04c08cb8625afc",
-        "updatedAt": "2025-09-20T19:50:15.031Z"
+        "model": "fake-64",
+        "vectorSha256": "e973bde9a504b44fc3795387ef7a7b5f0d62b7fc551fcbff3e0c00f7ebd9e7a0",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0406": {
@@ -8531,9 +8531,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d8a7654fcb8f9bce18eaed7d0b16aa44b3629f029ce4796e6ef90d08c093307b",
-        "updatedAt": "2025-09-20T19:50:15.031Z"
+        "model": "fake-64",
+        "vectorSha256": "39633b343b6d06dc9748aa96dd6ef7e63b912f52f1d58959694c333f5d197d84",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0407": {
@@ -8552,9 +8552,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ecc5da577e4fd404d798134783a1e2097a7b64e5c4501d5fdc64dcf5df6d741a",
-        "updatedAt": "2025-09-20T19:50:15.031Z"
+        "model": "fake-64",
+        "vectorSha256": "4392f3087e06e11d578dbf88cf46d4320fe6af24c223dd94f19d0cf4cdeecc30",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0408": {
@@ -8573,9 +8573,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cc07bd9ee66948f9e95cab33526b887979e2f4878b43dd42e8a950383dc1b4f0",
-        "updatedAt": "2025-09-20T19:50:15.031Z"
+        "model": "fake-64",
+        "vectorSha256": "db6731d229918dba986924c2c2af96545d60a5ad447e6b226b24da85d6f3336b",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0409": {
@@ -8594,9 +8594,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d09cd914839e2f2808a9fa42b205a0005ef94bcbb0d9fcc0f3d24eea56f8063e",
-        "updatedAt": "2025-09-20T19:50:15.267Z"
+        "model": "fake-64",
+        "vectorSha256": "45288f6f3616e3911bf2251f65e9c61771af83914d0389b5a29435f87582ac27",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0410": {
@@ -8615,9 +8615,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d8516e152b44aabeff075e100d1fc06e1964c9b79dd556649ac661076ca5d161",
-        "updatedAt": "2025-09-20T19:50:15.267Z"
+        "model": "fake-64",
+        "vectorSha256": "b2f4dc14373ba3e4d2358ecf37a459fb54ab1f9bff933f528070a2b6d883480c",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0411": {
@@ -8636,9 +8636,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "daf2a53d505444b3f1435e57dd57e6820234738c97892947b16221c7294dcfea",
-        "updatedAt": "2025-09-20T19:50:15.267Z"
+        "model": "fake-64",
+        "vectorSha256": "c302104940abc8ec2bb2bc025a3ffba0554e2974a3b90f3b68271b0ea87421f2",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0412": {
@@ -8657,9 +8657,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8d9d85d00fea3d1702a71ee5fd87db023fcf6dd269060e90dfc5c3f457afee14",
-        "updatedAt": "2025-09-20T19:50:15.267Z"
+        "model": "fake-64",
+        "vectorSha256": "fc609929b6afeb1155947bb2f284a2cb0dfe8edc09fb0dfe1eea5271c04a6bcd",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0413": {
@@ -8678,9 +8678,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "56ddb8bf0de57c51268ae662944b4b57b256875302818f32411a5233b075ac6e",
-        "updatedAt": "2025-09-20T19:50:15.267Z"
+        "model": "fake-64",
+        "vectorSha256": "3d21a19e46d6f52df9ab09edf47f818fe0be8d58f0d72e1f3999d3f699e87d4c",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0414": {
@@ -8699,9 +8699,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a1253f578a4a73dfb8d40c251a03c8b16f5ade573053590f502e4bb38d23d840",
-        "updatedAt": "2025-09-20T19:50:15.267Z"
+        "model": "fake-64",
+        "vectorSha256": "867633e4462993b5e1c23ae5f34db40a08b8d986020c50e758d9d5e4083a64b5",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0415": {
@@ -8720,9 +8720,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "891658c0bae5d333aa0f6add9b3aa8f7f8d6b17b9c2f31f3bbfaae2ef2baaa15",
-        "updatedAt": "2025-09-20T19:50:15.267Z"
+        "model": "fake-64",
+        "vectorSha256": "a38104351020e674b29b8068d7611dbc2bd75ab115fe6a3314f04ab26fa97b83",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0416": {
@@ -8741,9 +8741,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1fb9a0aeff2026345e1228e17dd603aae0be5d8f22cd46ef8eb26090439a4845",
-        "updatedAt": "2025-09-20T19:50:15.267Z"
+        "model": "fake-64",
+        "vectorSha256": "0d6a9e5dbd05fed343413658f5f8e1cb39d70c77bbff653a87a657962144abf7",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0417": {
@@ -8762,9 +8762,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ca9662f254c824802d778e3657c3ce5c3b1775b50bd9fb2cd4c31704e8b0f28c",
-        "updatedAt": "2025-09-20T19:50:15.612Z"
+        "model": "fake-64",
+        "vectorSha256": "55f626a01242f406f033703dff079d33742c883e662de433e8389e6276e55cf9",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0418": {
@@ -8783,9 +8783,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b129cd4f5815ac1faf4720512a285fdaa5a6192379ac5b38fa556328a6b53359",
-        "updatedAt": "2025-09-20T19:50:15.612Z"
+        "model": "fake-64",
+        "vectorSha256": "3f70f58b63c6c352a6996ca13da66a6f1deb45b3616bbf25ccbf49f2867af6e7",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0419": {
@@ -8804,9 +8804,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ae0e98052e8bd32431c8db1ccd2370612970870151f869bfcb182b87615c4433",
-        "updatedAt": "2025-09-20T19:50:15.612Z"
+        "model": "fake-64",
+        "vectorSha256": "ff90870b1f1a832fc1ed8684267ec333330668279a80990995e0a1ba432cc421",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0420": {
@@ -8825,9 +8825,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "95bad98e589a5b8fdf5d57a010151349b42df8e9d409711be11cac0e938f87ee",
-        "updatedAt": "2025-09-20T19:50:15.612Z"
+        "model": "fake-64",
+        "vectorSha256": "193bdc00787caf45e9b51ab41413ab976903f293bb1bea573ef407819e4c492d",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0421": {
@@ -8846,9 +8846,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d40de3d65c9b63900baf59f9193a3a80a50417916f36a2f92a9f008e6a863630",
-        "updatedAt": "2025-09-20T19:50:15.613Z"
+        "model": "fake-64",
+        "vectorSha256": "94108dc82e6a307f8c882e8de8e4aba041a83b368756e7f8cbf75dad792a455e",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0422": {
@@ -8867,9 +8867,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f749441664805474cc6f8ba429aa9557d5e3a036c2b6b5fbaaf5f4d7349ce609",
-        "updatedAt": "2025-09-20T19:50:15.613Z"
+        "model": "fake-64",
+        "vectorSha256": "f6c73a7b791e1a0773988438503cef254d0d6234bb72a676e1659371b448a4d8",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0423": {
@@ -8888,9 +8888,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d84aceab82b64a6a02b88bc51ef9ace179431023e1c362ed10aa734c6d44f612",
-        "updatedAt": "2025-09-20T19:50:15.613Z"
+        "model": "fake-64",
+        "vectorSha256": "c7badbd8b8abdd4556b41f3e0d353cdf1e109765e08bf335444511e7200eb8e4",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0424": {
@@ -8909,9 +8909,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d5b306c33bc4cc2ff8a8a562b9f7138ecdddd8ac6e0ae0d2200802809841103c",
-        "updatedAt": "2025-09-20T19:50:15.613Z"
+        "model": "fake-64",
+        "vectorSha256": "6b267221b5dd109433607dadd4cdc0102be0d2efa7d8a086af7b0ab6aad70031",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0425": {
@@ -8930,9 +8930,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "34421af47bec3372a88fc9e9e937c2a6df1c049955ecf63769996ae65c2154fc",
-        "updatedAt": "2025-09-20T19:50:15.943Z"
+        "model": "fake-64",
+        "vectorSha256": "583342d77b4c8fdd99f7d14fb56b7f652752888f98258b84fc145a50fd6f05b9",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0426": {
@@ -8951,9 +8951,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4b9a35be927e32f6433be9129cde29b35413a7d3bc824e5ef5956e8dc5b2b2a4",
-        "updatedAt": "2025-09-20T19:50:15.943Z"
+        "model": "fake-64",
+        "vectorSha256": "28e942f20fa8965c29078d9cb8321bd9b2ad03d8e662e48e75efdee71345466a",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0427": {
@@ -8972,9 +8972,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "de808abef650edd164ea2afffb9c94541cee97dfee3718b89d2078589f68abbf",
-        "updatedAt": "2025-09-20T19:50:15.943Z"
+        "model": "fake-64",
+        "vectorSha256": "1aa50401b9791107b98ffcfba1c8552e4985f05c6938c4ac72002c9c6cf428ac",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0428": {
@@ -8993,9 +8993,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f1e6faa0f9a5c6f9423423f358b75913345c1c2970b77de7dacd4ec57aabc8fd",
-        "updatedAt": "2025-09-20T19:50:15.944Z"
+        "model": "fake-64",
+        "vectorSha256": "66bd48857ec5e500869b16b4adfe1f23667d651e54705ce0cb00cf26bde68244",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0429": {
@@ -9014,9 +9014,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "79631ac260dbe437ac5784667bc49de1b88cfa9fd62363cab31039916966ba78",
-        "updatedAt": "2025-09-20T19:50:15.944Z"
+        "model": "fake-64",
+        "vectorSha256": "76c44066ecc4a2cd402b40bbaeb9b441bf72ebe50ed40605f3ab8705efaca4c6",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0430": {
@@ -9035,9 +9035,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "90f215eaff000b5e42957db568f9b7bf4fe575949660f13bf3181559b95bc2b6",
-        "updatedAt": "2025-09-20T19:50:15.944Z"
+        "model": "fake-64",
+        "vectorSha256": "98985419a2569b28f5643f3e684480bfc0c942dc66e2c7489bb9ff2beb6e9b86",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0431": {
@@ -9056,9 +9056,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "75f032b07784524215e41447f282fe6e8de703ea78aaf1b76dee7ae8b2d5cdfd",
-        "updatedAt": "2025-09-20T19:50:15.944Z"
+        "model": "fake-64",
+        "vectorSha256": "f8007f143387a9d50152c1e47d7bb9a0b65ae869280f101ae1e16f7cc14bd863",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0432": {
@@ -9077,9 +9077,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8fa21c1931bcff5b5401fda713eec39546a83f7900c4817a2d1cca387298abdb",
-        "updatedAt": "2025-09-20T19:50:15.944Z"
+        "model": "fake-64",
+        "vectorSha256": "93039a45b2b4d6749a90479896c93e906ec85ba09222cd4f25051368d312eb87",
+        "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
     "j-0433": {
@@ -9098,9 +9098,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fafe79f765ac4ae7b18d03f88a8057727feab72e74de82a066a45467f28f25d1",
-        "updatedAt": "2025-09-20T19:50:16.301Z"
+        "model": "fake-64",
+        "vectorSha256": "296f468883fb1dad4d5cfe95a16e22724a7d475cfe306d37a5595c8b85e6f050",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0434": {
@@ -9119,9 +9119,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7c3fc38730177e5aef5e6671372b14c3d2141a5cd6546b854b2a6c572207b979",
-        "updatedAt": "2025-09-20T19:50:16.301Z"
+        "model": "fake-64",
+        "vectorSha256": "b55db9be9bd8fa083321ac7335eee557223e27a759a043faa6a7e0f9c8166c54",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0435": {
@@ -9140,9 +9140,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "590d3d38c37df03d32b65731b1e5d46c86c6a873af73f2bb4ec50a513c97b068",
-        "updatedAt": "2025-09-20T19:50:16.302Z"
+        "model": "fake-64",
+        "vectorSha256": "de429233363075193ee6eefaef70a7a421b01460c62100818bc1d88357f8d366",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0436": {
@@ -9161,9 +9161,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0285ba29393367b3c14caee7120bc120490f781c67a3d6b965b95d90eae17127",
-        "updatedAt": "2025-09-20T19:50:16.302Z"
+        "model": "fake-64",
+        "vectorSha256": "6924e5c52975cfa942e6e8f32d66f6b5316f2bfe8d8ed83e66b3d8f5fbabdacf",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0437": {
@@ -9182,9 +9182,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3341de4b38dc2dad77571081a93289c6651e00375132f2a2bbd2356f7e419931",
-        "updatedAt": "2025-09-20T19:50:16.302Z"
+        "model": "fake-64",
+        "vectorSha256": "7ba9cd8475a37ec92c0fddd1ffec4ad9acbbe43534ba575bb315dcd370ae7cc0",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0438": {
@@ -9203,9 +9203,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "68b25ef407ca4cb63e340093cd0c4691a47bb479796f053aa6e6a456e11b39f1",
-        "updatedAt": "2025-09-20T19:50:16.302Z"
+        "model": "fake-64",
+        "vectorSha256": "7047b642f8f84b8c853a5687cbba9f0f941b1ef3815d7f3fd0909d9b4e738d5e",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0439": {
@@ -9224,9 +9224,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3d4bbcb87eb485d624ca2eb1492d6168101fa4fba400fc4f78d66e01965b235b",
-        "updatedAt": "2025-09-20T19:50:16.302Z"
+        "model": "fake-64",
+        "vectorSha256": "5bfdc63cb52ab3764343cc31a9f23651666bf8d3ff4367a22c2989e605a34744",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0440": {
@@ -9245,9 +9245,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "10244fee40920b5a4c199a51e619b750414b5e47ca6b68d16be8823dfb4c04d6",
-        "updatedAt": "2025-09-20T19:50:16.302Z"
+        "model": "fake-64",
+        "vectorSha256": "1c69dd419277f68b52cda4768bde4b5dceb65fc48b0779d5e6eea84f7c01671f",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0441": {
@@ -9266,9 +9266,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "db8eb5f1252d81161901d9db6be6dceea0a64d171694a7a6d02f0f4d8189e0ae",
-        "updatedAt": "2025-09-20T19:50:16.554Z"
+        "model": "fake-64",
+        "vectorSha256": "3bf27f0f54086f17c348145c12e926f6e4bb52e94492458d61a9164fd4613f8b",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0442": {
@@ -9287,9 +9287,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "30db2ce8d949a53af10baf36b00ab27b445ed1043234dd5a07aa5ecd475e19ce",
-        "updatedAt": "2025-09-20T19:50:16.554Z"
+        "model": "fake-64",
+        "vectorSha256": "52e292bdb42598b74b89c5d19908bf312f885a424268580fc54121c813817970",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0443": {
@@ -9308,9 +9308,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5f6dbc168dfb9cff5e09c7b628687c271a60619e01b928f05783bbbb2b4c86e6",
-        "updatedAt": "2025-09-20T19:50:16.554Z"
+        "model": "fake-64",
+        "vectorSha256": "84def8d587bbb32916e6b412cbda0f8698d5643a9037fad7a2fb4a97bdf5f22e",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0444": {
@@ -9329,9 +9329,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "efde1d4aec1fc325843a43b27e5cb4db67a988246dfecdfd9af97b41a77a20b0",
-        "updatedAt": "2025-09-20T19:50:16.554Z"
+        "model": "fake-64",
+        "vectorSha256": "4054b6e67d1fc1c6582b77c3d1c001abd07401c6851f974d6a921d39c3aee844",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0445": {
@@ -9350,9 +9350,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "04d2b8c1fc9d2a69683c0a6a415d617d1d202be1fd19786cb25d344e9bd74ae9",
-        "updatedAt": "2025-09-20T19:50:16.554Z"
+        "model": "fake-64",
+        "vectorSha256": "605521f37804d29c6ea21ef00eaac300a4507047d8cb5baaaf286c7bc7fe7622",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0446": {
@@ -9371,9 +9371,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ea0ccdf21b91ab0af5fc9ac4793c004c57de1771e56174c59a4a2f7c684647fe",
-        "updatedAt": "2025-09-20T19:50:16.555Z"
+        "model": "fake-64",
+        "vectorSha256": "f9909bc51afa6d2caffedadb521f836e625237873edc60894dea912d2c823208",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0447": {
@@ -9392,9 +9392,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cfef3a3dcce0bd6951289c18d9c6ce109f7b56ceae2012aa6e0f6260480b827d",
-        "updatedAt": "2025-09-20T19:50:16.555Z"
+        "model": "fake-64",
+        "vectorSha256": "856f1e7526711838d2812ca6694e639b80aaec4f118017d84eb931e00deb14a1",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0448": {
@@ -9413,9 +9413,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d0790e70b7c73554e378b6a043cb264bd49f9658d5b44c295f12fda3e9a8fd2d",
-        "updatedAt": "2025-09-20T19:50:16.555Z"
+        "model": "fake-64",
+        "vectorSha256": "5706b956daea7641e2975e6b9c6aa3f3280dc2f898028e01dd5459f1eb0197bd",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0449": {
@@ -9434,9 +9434,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cdd7378fc5fe46551302be79b487db5d4f3fa0bc7d2413dad2297400f4b0796a",
-        "updatedAt": "2025-09-20T19:50:16.849Z"
+        "model": "fake-64",
+        "vectorSha256": "8209a724ff484f3cf0d18b0702d233034bca83d1caa5cc6329f4d02a808bd8a9",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0450": {
@@ -9455,9 +9455,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ca89746f00a5bf2382f0109462572429905865175fe0ce9eaa57cf650ee65bed",
-        "updatedAt": "2025-09-20T19:50:16.849Z"
+        "model": "fake-64",
+        "vectorSha256": "651a6f5eec1444bee956f4f96ae742aa93f5a9bd40f27d94338544ccb2d068f9",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0451": {
@@ -9476,9 +9476,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "94a68583cb69cca5a715259f56c0f1e4814d8f93baa2392047cb2aa03a9f5381",
-        "updatedAt": "2025-09-20T19:50:16.849Z"
+        "model": "fake-64",
+        "vectorSha256": "c450182194b158beed55161c2cff696c85315720d1a80644112cdddb3b86154e",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0452": {
@@ -9497,9 +9497,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9ae46a25e28e370239e3b6ee77a29523e34c9ad3cdcc1017e5f4e6b268f79ce1",
-        "updatedAt": "2025-09-20T19:50:16.849Z"
+        "model": "fake-64",
+        "vectorSha256": "cdef324eba084291dca2ba3304792f9c74232e0eabe218758aaab95252a94360",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0453": {
@@ -9518,9 +9518,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a101b11ef15d1434cb0fcca277e6aea8f56d3cbfef54121d1f9c35133d326c62",
-        "updatedAt": "2025-09-20T19:50:16.849Z"
+        "model": "fake-64",
+        "vectorSha256": "8ce1bb21a4f294b39bb8ca355891e2233305bd8d20a2b5f27e935a0980355416",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0454": {
@@ -9539,9 +9539,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b54cbfc34ad90d2803eaa4c59d01e4302f0cabad6fcd820aabe7e44a66a4ec3a",
-        "updatedAt": "2025-09-20T19:50:16.849Z"
+        "model": "fake-64",
+        "vectorSha256": "9f2556dcfd9ee7817f36f5087f878b63840908fb869f6c631426a9b42bf05d9f",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0455": {
@@ -9560,9 +9560,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cf46da7eb39bea15d5266c3820468b7e68317b89bca62b87c953d47535888765",
-        "updatedAt": "2025-09-20T19:50:16.849Z"
+        "model": "fake-64",
+        "vectorSha256": "6bdb8b29aa893ad722784d5dce5bbbcc285679d834b406b415c26d46f21bdca8",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0456": {
@@ -9581,9 +9581,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dba43fbcd0004b71c03077ebd0c9751971f67e5b41011df26ddc46e29b9785ab",
-        "updatedAt": "2025-09-20T19:50:16.849Z"
+        "model": "fake-64",
+        "vectorSha256": "dd3847d65464e38175940b700695fe80f50ec302c50bc535cb267f0cf054634e",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0457": {
@@ -9602,9 +9602,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "69c5d25fcfdbe27ad1a00143f84b33dbce00e254e167eb66373daa6f7ea25f6b",
-        "updatedAt": "2025-09-20T19:50:17.026Z"
+        "model": "fake-64",
+        "vectorSha256": "84c6ab6864ffd022502b8284ca100acd9dc83a68c59d9fa66b9b8ce57d3cfee1",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0458": {
@@ -9623,9 +9623,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d1c431ac8fc6fc9f0f6ac1cdfd84e35033c80971bbee50181873fdb9774b34f1",
-        "updatedAt": "2025-09-20T19:50:17.026Z"
+        "model": "fake-64",
+        "vectorSha256": "b0e7595fe4c998ddd2cc85a0969de540bd128b304e758fac26ba06043b1928d3",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0459": {
@@ -9644,9 +9644,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d09ea284a92ea316ea41d2bd511780a4ab22cf54525c3ee6167ec5fcbc1be542",
-        "updatedAt": "2025-09-20T19:50:17.026Z"
+        "model": "fake-64",
+        "vectorSha256": "1346807a5fdcb691a5b8581b03cd2585ab8432a59dd8337077983ecc7232eb7b",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0460": {
@@ -9665,9 +9665,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "da5558e6db6972074c68b02d8d87af5d31f79c8b4951c6c04d0b38b684cf0e39",
-        "updatedAt": "2025-09-20T19:50:17.026Z"
+        "model": "fake-64",
+        "vectorSha256": "e73857e55df3a3ce4344553166008f0acd4761ff1a4688fcdb4c9e624cb334f5",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0461": {
@@ -9686,9 +9686,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "79a7da07754119f6bf40bebb33ed5b0e66bb2301c49a3486f0b72f07c91bfc6b",
-        "updatedAt": "2025-09-20T19:50:17.026Z"
+        "model": "fake-64",
+        "vectorSha256": "265dae54f39c41d9eb9de31c02ffcd6e7fe36041eb57e8b8ec4474ff497141d1",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0462": {
@@ -9707,9 +9707,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3f75bcb7da11bab101ee1db32d6743fd06043b3cf6beff8118fb054cc8a74250",
-        "updatedAt": "2025-09-20T19:50:17.026Z"
+        "model": "fake-64",
+        "vectorSha256": "ad831831bcf05543eaff18a2224107200cceb9d10f7ed231721ceabd7c68279c",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0463": {
@@ -9728,9 +9728,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5429db7fa083a6a8b9531d468e5f88a722d3adbf3f32f9286208694426dd13d0",
-        "updatedAt": "2025-09-20T19:50:17.026Z"
+        "model": "fake-64",
+        "vectorSha256": "41a5b49cef532a25e87a8d6e0c50b0fda47dbd8f6e259da1ba89d12a68eb8ec4",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0464": {
@@ -9749,30 +9749,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cd31ba5a1b591e76c29f88dace3f4390c1d2f6fc79271233a155d79e8ee28f21",
-        "updatedAt": "2025-09-20T19:50:17.026Z"
-      }
-    },
-    "j-0465": {
-      "hashes": {
-        "setup": "16e71b4f91b12483fbe4bb5b6c62263505b178aad59c7a55a14ec6813eb1db88",
-        "punchline": "e044264e0b72ed7fcb001254832b6e83ce0ba6e8c55b203415758d4ca27fccf3",
-        "combined": "2310c095e156e69b169457634ab0b377f07ae09dbb1660a461b686f6fc21f5d7",
-        "tokenSignature": "a-apparently-fired-florist-from-got-i-leaves-many-too-took"
-      },
-      "lengths": {
-        "joke": 26,
-        "punchline": 34
-      },
-      "source": {
-        "sequence": 465
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7fa11b29c0bba1918c21835b082ec6a358e68ba042b4e038f1b3ac68379fe4e3",
-        "updatedAt": "2025-09-20T19:50:17.250Z"
+        "model": "fake-64",
+        "vectorSha256": "82e52e893b04444af09061e4921e5657c687c4b51c96692378f3f4d3ba97d2ca",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0466": {
@@ -9787,13 +9766,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 466
+        "sequence": 465
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d867425ed530f598276f401544aafc4c6251eb3410d473496e10645abc386519",
-        "updatedAt": "2025-09-20T19:50:17.250Z"
+        "model": "fake-64",
+        "vectorSha256": "59d6949e02fdb8abcd8de649b5b249c20d3a00b904fbd823cf280ce403170369",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0467": {
@@ -9808,13 +9787,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 467
+        "sequence": 466
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b0008deecf60bb978afe00e37f296f8f20679b3c46ed77921d9827e67a7e51a7",
-        "updatedAt": "2025-09-20T19:50:17.251Z"
+        "model": "fake-64",
+        "vectorSha256": "6fa13087ccb2375879128b3beb5f2692f6f90266dc1f42b3649c290cbfae30a0",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0468": {
@@ -9829,13 +9808,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 468
+        "sequence": 467
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4f648024bc7e14fc9706004fdabb91172d62b4e83a29366a871b605d2df861a2",
-        "updatedAt": "2025-09-20T19:50:17.251Z"
+        "model": "fake-64",
+        "vectorSha256": "51eba6add50437907c74eb20e32bb0f50918ba24ae6b9075796195d62dc41410",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0469": {
@@ -9850,13 +9829,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 469
+        "sequence": 468
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aa4d7b07146e67053ff129752f550f451364a54ab8c62ef0b2d472b2d9b354e3",
-        "updatedAt": "2025-09-20T19:50:17.251Z"
+        "model": "fake-64",
+        "vectorSha256": "5080cb365947cf74ade88d1fe82bd2659bccf70df298217bd7d7a03b5bf93fea",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0470": {
@@ -9871,13 +9850,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 470
+        "sequence": 469
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "af1c498b0241a53a01ac73b17ab0e6370dad79d332e14d95db91fc8b9499e75c",
-        "updatedAt": "2025-09-20T19:50:17.251Z"
+        "model": "fake-64",
+        "vectorSha256": "947916c557ff099ec8dbe896c13ed78be2a7d7da5d510fc28c1315bda25bc5f2",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0471": {
@@ -9892,13 +9871,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 471
+        "sequence": 470
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4fae09999befdccff6d98b3e3200da4bd23d2d822beda1c398b176c7971a245f",
-        "updatedAt": "2025-09-20T19:50:17.251Z"
+        "model": "fake-64",
+        "vectorSha256": "f85add8b3f939dc1ec30e6a16d5367bc627d1609566c3e81a9b187154f906c76",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0472": {
@@ -9913,13 +9892,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 472
+        "sequence": 471
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d5d999d3481806f853c407de2868c3c82602074afbb0ee2eca30b6c6d39be6a5",
-        "updatedAt": "2025-09-20T19:50:17.251Z"
+        "model": "fake-64",
+        "vectorSha256": "9308151032af0543d4750450523f0aab058e827844f9f4de7a1f69b91bfbf08a",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0473": {
@@ -9934,13 +9913,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 473
+        "sequence": 472
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "19ee0782ac19e2e6b88cb830e9d370736f7a71c00eeb412a6ea35260da7a901a",
-        "updatedAt": "2025-09-20T19:50:17.540Z"
+        "model": "fake-64",
+        "vectorSha256": "dd41830da0b674fd51c57f80da27b7c74f6ebbd2e72b46eb94d33652528dcc55",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0474": {
@@ -9955,13 +9934,13 @@
         "punchline": 44
       },
       "source": {
-        "sequence": 474
+        "sequence": 473
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f6c1940c509712fbd05d588303d31a474b71c154a48f6c8be85b7d7a41f16e36",
-        "updatedAt": "2025-09-20T19:50:17.540Z"
+        "model": "fake-64",
+        "vectorSha256": "03f5444a246a58d4fe7521af1c9b5ab24956520e60b34317d6ae637db93cea1a",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0475": {
@@ -9976,13 +9955,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 475
+        "sequence": 474
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "686de3d27187bd9435e2718f9304229a2dd76bfded4c47d8ae6631e4f38c0fb2",
-        "updatedAt": "2025-09-20T19:50:17.540Z"
+        "model": "fake-64",
+        "vectorSha256": "f243f75cd1091dcd7309fe3203c78c83366626bb278b70417bfe220cb0f5be7a",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0476": {
@@ -9997,13 +9976,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 476
+        "sequence": 475
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "18b9688633530c3c8938b81c290de11218fe358bc002e1442fd92bf7a3326d42",
-        "updatedAt": "2025-09-20T19:50:17.541Z"
+        "model": "fake-64",
+        "vectorSha256": "7d3ba5dd12946d2096146ac347c5eed0029a6801a7f7cb81d1c8164e8618683d",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0477": {
@@ -10018,13 +9997,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 477
+        "sequence": 476
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b8162a3c1db6413ff7a4b6c071efe682b64ed0cd733be1275c74230988311a63",
-        "updatedAt": "2025-09-20T19:50:17.541Z"
+        "model": "fake-64",
+        "vectorSha256": "34bd1d7733b59b3487b4edd7cfcc6102739d9a6bc5b6f18182c93a859ab6b107",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0478": {
@@ -10039,13 +10018,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 478
+        "sequence": 477
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a19e02ece844c6b1ef0d37ed5411c16fd2338a93b1e1f99719e4cbcbfb129b35",
-        "updatedAt": "2025-09-20T19:50:17.541Z"
+        "model": "fake-64",
+        "vectorSha256": "77b668bb95f2fdbde237e8b7a1ee7d61802ab4d7c603251d5438b4fad570e6ea",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0479": {
@@ -10060,13 +10039,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 479
+        "sequence": 478
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a79196733b1d099bdc2e0bcf93ac4ad5224643013eee3a57f556ef29c4c73fd9",
-        "updatedAt": "2025-09-20T19:50:17.541Z"
+        "model": "fake-64",
+        "vectorSha256": "2cae5b479aebbb62e15f13f6ec86cfa384ec1fb6de3e8a2f61aa1006dc00897e",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0480": {
@@ -10081,13 +10060,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 480
+        "sequence": 479
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6ee0993292f8b71686d3625af1b38697bdefc46fcda786597f56a63577a81dfe",
-        "updatedAt": "2025-09-20T19:50:17.541Z"
+        "model": "fake-64",
+        "vectorSha256": "388f32006825fbf9b346f75871b6bda05c5da1b86f1df65ecaeb48aacc261f74",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0481": {
@@ -10102,13 +10081,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 481
+        "sequence": 480
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ca6da56a28af5e9f87b58552561bbd20f99e01894a93c4e12154341d814d70bf",
-        "updatedAt": "2025-09-20T19:50:17.882Z"
+        "model": "fake-64",
+        "vectorSha256": "b86e8a4acd469688ee1e96abe36ef2eb5606cebbaf981892af327554ba10fc23",
+        "updatedAt": "2025-09-20T22:27:41.534Z"
       }
     },
     "j-0482": {
@@ -10123,13 +10102,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 482
+        "sequence": 481
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3029f9aaac319870949167f4f42f18779e0ce6ad24a8fbd442f0b6004dfd7c35",
-        "updatedAt": "2025-09-20T19:50:17.882Z"
+        "model": "fake-64",
+        "vectorSha256": "09ec0e7df206aca281bf9bbdb1279f172c59a6e1fdae0efb602a1538f2a9db98",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0483": {
@@ -10144,13 +10123,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 483
+        "sequence": 482
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "37dc11a26c931619106a69a34da387a7e84b6313768b7468c8832b5846d0cd02",
-        "updatedAt": "2025-09-20T19:50:17.882Z"
+        "model": "fake-64",
+        "vectorSha256": "364869b9b28f07949709548e2a13fc2d4991ebd31c5fe6577cc0d6039a1c466d",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0484": {
@@ -10165,13 +10144,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 484
+        "sequence": 483
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a611c9ef96e783e4c1463dbbf953d919ceeddf444ce2ab6446bb7d25be5cc711",
-        "updatedAt": "2025-09-20T19:50:17.882Z"
+        "model": "fake-64",
+        "vectorSha256": "fbea6fd1effb99a1f1cc28357de3f5e85cd57edb232bc7050fbe3b2b974bd18f",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0485": {
@@ -10186,13 +10165,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 485
+        "sequence": 484
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b3fdb491fb86ddcffdf2ba9ca1bd5736d0fb502935a345599426704457271e63",
-        "updatedAt": "2025-09-20T19:50:17.882Z"
+        "model": "fake-64",
+        "vectorSha256": "fda7c3bcdfa1cbe0a233480a9af95bb0b473b66093b23da5a9c19a4257d16b5f",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0486": {
@@ -10207,13 +10186,13 @@
         "punchline": 44
       },
       "source": {
-        "sequence": 486
+        "sequence": 485
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7c0fb8eca3c945525b710429650a7498022a3abbb8f67f46a99ceeb468b66e4f",
-        "updatedAt": "2025-09-20T19:50:17.883Z"
+        "model": "fake-64",
+        "vectorSha256": "69257f8b0e05cc64d462aa8eb76794a5558cc233a3f1953490c509df1375112f",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0487": {
@@ -10228,13 +10207,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 487
+        "sequence": 486
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c54f47898a94eeff5caeaadef738f95871899bd466b166fb944d003fe1ae898a",
-        "updatedAt": "2025-09-20T19:50:17.883Z"
+        "model": "fake-64",
+        "vectorSha256": "4e6d3ba76ca9851f523882224371beca99e092ea6b3eff5f623a0030d5b5173d",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0488": {
@@ -10249,13 +10228,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 488
+        "sequence": 487
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a9ca2fb7dda7207511c1d2e95e3e9498acc21183e78b2b05e0fabd6cade72a8d",
-        "updatedAt": "2025-09-20T19:50:17.883Z"
+        "model": "fake-64",
+        "vectorSha256": "e8f74c945411d119c185611d0e6beab11c78c5ed9ebb31496530c661e28e7698",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0489": {
@@ -10270,13 +10249,13 @@
         "punchline": 45
       },
       "source": {
-        "sequence": 489
+        "sequence": 488
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b0f49852e00564a0d4b014698e7cf3d1407a79eed13cf3d1571d7a62f2352e04",
-        "updatedAt": "2025-09-20T19:50:18.212Z"
+        "model": "fake-64",
+        "vectorSha256": "b0418b1172aafd9ccd7c838306ea33c9977ddcb79940f391f3a0fd793f8af9c1",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0490": {
@@ -10291,13 +10270,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 490
+        "sequence": 489
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "878c55481e4dff9779ffecaba465a89376f5b0b36aa32bb2910536088a6c0954",
-        "updatedAt": "2025-09-20T19:50:18.212Z"
+        "model": "fake-64",
+        "vectorSha256": "f2d6d7a24e234c82de43b588c9a3d4a1cf07ae367b5356bc0fb7584cd8f4cb8f",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0491": {
@@ -10312,13 +10291,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 491
+        "sequence": 490
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cb8ecb1eb12d5f5c912bd043e1834d9944db750a7cee3056bd7970c6f9264105",
-        "updatedAt": "2025-09-20T19:50:18.212Z"
+        "model": "fake-64",
+        "vectorSha256": "4961ff480be412f656efd01f38e9fb3451a805f97e66826b3e26ccdb70f284ed",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0492": {
@@ -10333,13 +10312,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 492
+        "sequence": 491
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aa187e8f6a17ac5caad5abe29f96ce5489ee7923afe4cfe3b8d81145da80b6ce",
-        "updatedAt": "2025-09-20T19:50:18.213Z"
+        "model": "fake-64",
+        "vectorSha256": "325c3d75aa974f88d7cc83fe8bb49e6992c289986b8700095992a573abef5bbf",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0493": {
@@ -10354,13 +10333,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 493
+        "sequence": 492
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "133bdaaa878028a8b34ad539a50265d8a860c0b6c3c1baaa843368829d3cbb61",
-        "updatedAt": "2025-09-20T19:50:18.213Z"
+        "model": "fake-64",
+        "vectorSha256": "4c544c0a170fa5cfdbe6fd97bd5bc838e33db603f7bb8f4a7ae8dfd6ef7c6cf3",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0494": {
@@ -10375,13 +10354,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 494
+        "sequence": 493
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f4aac83c9a55c8cb3dd9f6f7d2cb4a404eb1cfe20b45ec711f691ddd79050d4f",
-        "updatedAt": "2025-09-20T19:50:18.213Z"
+        "model": "fake-64",
+        "vectorSha256": "cb0bcc8ab20e4d4b91f0ffb06942617632df50cb435d14aa2fbee2f5402f4e27",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0495": {
@@ -10396,13 +10375,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 495
+        "sequence": 494
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0ee5060e6240cd53a4095def3b9d1d84405690628d18aa28f55c8e8f1625b64c",
-        "updatedAt": "2025-09-20T19:50:18.213Z"
+        "model": "fake-64",
+        "vectorSha256": "5d6275080a76c4688f6fd51917d21274c1dc8015923b9156660df7d909a32267",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0496": {
@@ -10417,13 +10396,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 496
+        "sequence": 495
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9e69152e800d60a97eaec75135d847b6c49c4885c56dc1ec5f93f4455365b8cd",
-        "updatedAt": "2025-09-20T19:50:18.213Z"
+        "model": "fake-64",
+        "vectorSha256": "26728b1a9005ee9dbe8b5d0c94b62c3b76c3daf6e3890795c5dd39207f9b63fc",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0497": {
@@ -10438,13 +10417,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 497
+        "sequence": 496
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f76afa2c4b1e3a05f2513719cba016aa9e93b5ad3dbd271adf7c4dc63234a65d",
-        "updatedAt": "2025-09-20T19:50:18.453Z"
+        "model": "fake-64",
+        "vectorSha256": "66a89a0c4387034b2edfbc691f612cb12235cf7bf9061aa52383ace6e6640eaf",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0498": {
@@ -10459,13 +10438,13 @@
         "punchline": 56
       },
       "source": {
-        "sequence": 498
+        "sequence": 497
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4354a6a191a774f5da9f0f74fca852fabd205e75d3b824ce8f003bb5b6cddf24",
-        "updatedAt": "2025-09-20T19:50:18.453Z"
+        "model": "fake-64",
+        "vectorSha256": "f07626f8eedb0024324c872b2edafc2a436025e8d1b0595f9f246dea919ae054",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0499": {
@@ -10480,13 +10459,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 499
+        "sequence": 498
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c02417dd7a3b0c1e78a904d43bdba6776d3d6ba97b0404e978cbca3791d08ae4",
-        "updatedAt": "2025-09-20T19:50:18.453Z"
+        "model": "fake-64",
+        "vectorSha256": "6bdbf2d25f7b30c7c3af4a750a6b75be078da255ab245d6b497199c381e32350",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0500": {
@@ -10501,13 +10480,13 @@
         "punchline": 5
       },
       "source": {
-        "sequence": 500
+        "sequence": 499
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "834fbdafc8e8ca3720ca156d122e54769735a2cf1894e021471e1eed069bd319",
-        "updatedAt": "2025-09-20T19:50:18.453Z"
+        "model": "fake-64",
+        "vectorSha256": "200cdd6430d12865dcf233599b36d5c12a52f512c3f2966e440fa7e01c203bba",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0501": {
@@ -10522,13 +10501,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 501
+        "sequence": 500
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eb2f9e019be61e230d7ba2d3500b6f45e7b553666dbbab2b1e3667853dccc565",
-        "updatedAt": "2025-09-20T19:50:18.453Z"
+        "model": "fake-64",
+        "vectorSha256": "7753f5f2b1c659bbc3cfdc837d3ec7f685cf1c0aefba4775cb0c6e7305144e9f",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0502": {
@@ -10543,13 +10522,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 502
+        "sequence": 501
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "05516d02cb8d9f48b7fb193302d285a76bff486075636af011533b96003539dd",
-        "updatedAt": "2025-09-20T19:50:18.453Z"
+        "model": "fake-64",
+        "vectorSha256": "da90f8ca8084b299eea611628e893aae638ff4efaa9dd327ea0ff24e44196a0c",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0503": {
@@ -10564,13 +10543,13 @@
         "punchline": 5
       },
       "source": {
-        "sequence": 503
+        "sequence": 502
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f897196f6bd9e79c56d619db3e6bc0268a8f6738d57ecc7b2b7c8427225d037d",
-        "updatedAt": "2025-09-20T19:50:18.453Z"
+        "model": "fake-64",
+        "vectorSha256": "678ecf885bee5ca1be038b1d8d1cba5b6e3268d6550e8d68f818be0c2215cb85",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0504": {
@@ -10585,13 +10564,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 504
+        "sequence": 503
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7d664b2218c4699f61c01a3d4cfb135bb8f801e8af6eff86fb680f37b80e9b3c",
-        "updatedAt": "2025-09-20T19:50:18.453Z"
+        "model": "fake-64",
+        "vectorSha256": "6734306cc99f54e29237f7d284b9b7136e065e88ba235c96c24ee70ca8a4ecc8",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0505": {
@@ -10606,13 +10585,13 @@
         "punchline": 50
       },
       "source": {
-        "sequence": 505
+        "sequence": 504
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "32c09286609b25f695b64bb8d02259b020967daa6577a5b90980371defe7e107",
-        "updatedAt": "2025-09-20T19:50:18.699Z"
+        "model": "fake-64",
+        "vectorSha256": "e6290accbcd053b17e565a75f1ef749d8e5ad6ad827192ccc631f475628cf39d",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0506": {
@@ -10627,13 +10606,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 506
+        "sequence": 505
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fbd22681b59bf1be7b3f28eeda8a4402cbc3500b53a0f88544de74165e043297",
-        "updatedAt": "2025-09-20T19:50:18.699Z"
+        "model": "fake-64",
+        "vectorSha256": "05103aefca06a98f35b2586257e7d66cff7f56f43a66e40aefa79eec7b1ddfd8",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0507": {
@@ -10648,13 +10627,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 507
+        "sequence": 506
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b2bdcc9463c9cc6caac9a90da85bc7a5297874057420ec7244e184ea2195e8b7",
-        "updatedAt": "2025-09-20T19:50:18.699Z"
+        "model": "fake-64",
+        "vectorSha256": "6591d1e011af414d5016b10ff0761061f803de9fddc0ab14a4d0024241ee190e",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0508": {
@@ -10669,13 +10648,13 @@
         "punchline": 66
       },
       "source": {
-        "sequence": 508
+        "sequence": 507
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1c7e870afc5da11ab324f1cbb380dd46b5dde3920ba9a202f432b271bfdcc271",
-        "updatedAt": "2025-09-20T19:50:18.699Z"
+        "model": "fake-64",
+        "vectorSha256": "fc904074ce1cd9b136f1d9acfcce6855a4003d39b68633e047fc0e9d71060863",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0509": {
@@ -10690,13 +10669,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 509
+        "sequence": 508
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "51559e056a578596f934610af98b4833316c52c859dcb84aa397245c9f2c3d0f",
-        "updatedAt": "2025-09-20T19:50:18.699Z"
+        "model": "fake-64",
+        "vectorSha256": "cca3f375b0b41b7a3de2c3e68523abbd5b06b4770ddf2f83680e5904bc74d91e",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0510": {
@@ -10711,13 +10690,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 510
+        "sequence": 509
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4589c665b35357925983a0d420d3647b6b1ebe343812ccc584a5d7707a4a2530",
-        "updatedAt": "2025-09-20T19:50:18.699Z"
+        "model": "fake-64",
+        "vectorSha256": "a60812aa4713c32be3f78fa78de92d0b08eb7d279c068967de1099478e35052d",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0511": {
@@ -10732,13 +10711,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 511
+        "sequence": 510
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "317a229a18c1d0fee771e63b8f08a0b714255fd182aa29b81b1dfefd8731b178",
-        "updatedAt": "2025-09-20T19:50:18.699Z"
+        "model": "fake-64",
+        "vectorSha256": "e4b2b5811bf95e2e8cc35c7ec284bae74792dbc92bbb3bcedf5964dae92f0c49",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0512": {
@@ -10753,13 +10732,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 512
+        "sequence": 511
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9e8a3961abe4fc5dfba6f345bf5806f640fa816239e3994dc8d5bde3ff16048f",
-        "updatedAt": "2025-09-20T19:50:18.699Z"
+        "model": "fake-64",
+        "vectorSha256": "a385e729a03200230eab48733e17a86a3f71331164581394337a899c1f558aba",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0513": {
@@ -10774,13 +10753,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 513
+        "sequence": 512
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f8b626b2f8cd64712d068eb6d749867a95121d41039d524715903b24e383786a",
-        "updatedAt": "2025-09-20T19:50:18.995Z"
+        "model": "fake-64",
+        "vectorSha256": "dfe6cdf2290229f244abf8b94ab6b7aaf5583672b8808ffec770d8e57347af69",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0514": {
@@ -10795,13 +10774,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 514
+        "sequence": 513
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "767d548e7bfa9e5395d32abc6e13c011dbfb92966428a0f878301bbbbeb30c79",
-        "updatedAt": "2025-09-20T19:50:18.995Z"
+        "model": "fake-64",
+        "vectorSha256": "21a217337904dcf2785d236c82a99b3ef376551af81fc249fdbecadbe4e219ac",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0515": {
@@ -10816,13 +10795,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 515
+        "sequence": 514
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bcc552efc96a94c3f0fd8cb0f7773ed672caa5e9e67b55e2d96f5af61c864046",
-        "updatedAt": "2025-09-20T19:50:18.995Z"
+        "model": "fake-64",
+        "vectorSha256": "9bf8654a9508c9769efeeee8f17c954109088f1377ae2156fd4bf3cb3c9fcf58",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0516": {
@@ -10837,13 +10816,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 516
+        "sequence": 515
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "22168b9ee8d2445ee737cb6277348a6d97d7b9802b949b111a1965be714fd7fd",
-        "updatedAt": "2025-09-20T19:50:18.995Z"
+        "model": "fake-64",
+        "vectorSha256": "0077f1122c28601e00481564bf9f0a89639f5904d5e3806a2226dfaf68cca690",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0517": {
@@ -10858,13 +10837,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 517
+        "sequence": 516
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "86d8db4156d2324490031172a596cac2aee37cb64a99ea1c6593a0dcf25f0bdb",
-        "updatedAt": "2025-09-20T19:50:18.995Z"
+        "model": "fake-64",
+        "vectorSha256": "563f0b228aaa9e0aaea1cf023799b0caa91042b534f7afcd6ecfd00d623bba15",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0518": {
@@ -10879,13 +10858,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 518
+        "sequence": 517
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f0145b3e75fce6c268847d58a2c02a333036132f02a2c7a05072082911bbade6",
-        "updatedAt": "2025-09-20T19:50:18.995Z"
+        "model": "fake-64",
+        "vectorSha256": "87d94379e78c312c83c156214a0e74d52b4b7cd4187c917081860e48d100bd0f",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0519": {
@@ -10900,13 +10879,13 @@
         "punchline": 55
       },
       "source": {
-        "sequence": 519
+        "sequence": 518
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aeb7d0a1b0df1f61397c691de26ea180170470c303985947539817a38868c656",
-        "updatedAt": "2025-09-20T19:50:18.995Z"
+        "model": "fake-64",
+        "vectorSha256": "3e09a8c7f3c090c1be9ebac25dad9baad0c0976a4330a9425916aea3a5f4ebed",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0520": {
@@ -10921,13 +10900,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 520
+        "sequence": 519
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dade7b150d4d860c104fe5fcb652ebc7d5b8cb82ab9b44d1b3d3604ab945eb79",
-        "updatedAt": "2025-09-20T19:50:18.996Z"
+        "model": "fake-64",
+        "vectorSha256": "0493995de949b2c0de6ca255fbd53459b925500ce395fd5e6c25037a642d404c",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0521": {
@@ -10942,13 +10921,13 @@
         "punchline": 67
       },
       "source": {
-        "sequence": 521
+        "sequence": 520
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e268423a71f252c888b60f640385cecb171e10ae879bacc5b7f57efad5d1dca4",
-        "updatedAt": "2025-09-20T19:50:19.211Z"
+        "model": "fake-64",
+        "vectorSha256": "86963172ccc275d8e4352fd849227a3838dbfc0c35ece3fa04939975f66255dd",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0522": {
@@ -10963,13 +10942,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 522
+        "sequence": 521
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "81bae493966986620bc599cdf921f529edb26ed72ae953713acc72e3e9544b01",
-        "updatedAt": "2025-09-20T19:50:19.211Z"
+        "model": "fake-64",
+        "vectorSha256": "b14aaa15e4bef272c17eadbfdc3948934803fe5bffdeb16f018f038033e74f78",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0523": {
@@ -10984,13 +10963,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 523
+        "sequence": 522
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7aa99bc0b20cc098a284224a8d553623d03e8f016ed6cf7c5f88d6ace4e35d81",
-        "updatedAt": "2025-09-20T19:50:19.211Z"
+        "model": "fake-64",
+        "vectorSha256": "33c901842926e41639a7a42779bfc31aeca8a39ffac595bee9f10f2932f324a3",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0524": {
@@ -11005,13 +10984,13 @@
         "punchline": 52
       },
       "source": {
-        "sequence": 524
+        "sequence": 523
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aaddd5c744dbe9a49d1da0aa13a0e8027c075272838c5a6eb3305c25efdf05ae",
-        "updatedAt": "2025-09-20T19:50:19.211Z"
+        "model": "fake-64",
+        "vectorSha256": "962cb9ab825f78588814440fd4e748fa62b32de9f67834d77fa98799b328d233",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0525": {
@@ -11026,13 +11005,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 525
+        "sequence": 524
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bb58bde02069be7c7d631f045e27a228bcc9de3e923c7ab35500f594d5119be5",
-        "updatedAt": "2025-09-20T19:50:19.211Z"
+        "model": "fake-64",
+        "vectorSha256": "8f0676c3b705cd9959e7aebec5f81d73800c2b49483ad2cfc448191783f8f924",
+        "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
     "j-0526": {
@@ -11047,13 +11026,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 526
+        "sequence": 525
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0ad31bde4b5fa74b2582e7f38f991f5cdbf23b6a978db65cccd3775d5a89c652",
-        "updatedAt": "2025-09-20T19:50:19.211Z"
+        "model": "fake-64",
+        "vectorSha256": "10957be9f188e5fba2dc85d1535ea0f530c9f47488865c6ff0bd886b9d923db9",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0527": {
@@ -11068,13 +11047,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 527
+        "sequence": 526
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ed8cd17a0bc49e59854422fa73d213dd9030698d58542970c8bd3fb4dc14e993",
-        "updatedAt": "2025-09-20T19:50:19.211Z"
+        "model": "fake-64",
+        "vectorSha256": "109e6a7c038f7b19693a1d04ec90da4c5e4036bd555fb4992f0afc808104d3f7",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0528": {
@@ -11089,13 +11068,13 @@
         "punchline": 7
       },
       "source": {
-        "sequence": 528
+        "sequence": 527
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aa882dd4c8cd7fd2c2a7576ea9fec343d1ff246641d41922b2fc83cc11d44dca",
-        "updatedAt": "2025-09-20T19:50:19.211Z"
+        "model": "fake-64",
+        "vectorSha256": "f9c651c5f2d92c6405e6ec3b245c63d4e2aed80d901dd4761f67c56297a91706",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0529": {
@@ -11110,13 +11089,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 529
+        "sequence": 528
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "643ffa2d5a5f7379768521dfeb66b4957b92c843b4e654763cbf095c1e3b6440",
-        "updatedAt": "2025-09-20T19:50:19.468Z"
+        "model": "fake-64",
+        "vectorSha256": "ef7ace5325b76b8124ebdb059d8cbbef161c7181a71cadfcb736aef441067caa",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0530": {
@@ -11131,13 +11110,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 530
+        "sequence": 529
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b2b2523569ab57b9c7fd2c9dc1c4a6d41ade26c44b41e8e1494bc85978f01462",
-        "updatedAt": "2025-09-20T19:50:19.468Z"
+        "model": "fake-64",
+        "vectorSha256": "cf118ea1341489c325690bfb9fd389687c7ef81cc20058fe1b612cefee808894",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0531": {
@@ -11152,13 +11131,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 531
+        "sequence": 530
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "428847512b120aa7a8c710d482a922e6a63ebb2c1936ec78ef0e00c16a517c86",
-        "updatedAt": "2025-09-20T19:50:19.468Z"
+        "model": "fake-64",
+        "vectorSha256": "5b47509e2c4284cdd8c7ca62a0ee03c4a6fd928a8348c557ba9fef85b9d2e74a",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0532": {
@@ -11173,13 +11152,13 @@
         "punchline": 41
       },
       "source": {
-        "sequence": 532
+        "sequence": 531
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "51c71f372bdaf2623e2816bda73d209111a59c1921adace803f2326240c9027d",
-        "updatedAt": "2025-09-20T19:50:19.468Z"
+        "model": "fake-64",
+        "vectorSha256": "134d23be81fcca22709a12d2465b08a72b7ed6761fffa418e055d65a24a9dfb1",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0533": {
@@ -11194,13 +11173,13 @@
         "punchline": 81
       },
       "source": {
-        "sequence": 533
+        "sequence": 532
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ab670ed61cbdd38cd785528a8e063ee45f9dfab7f97a3b399beb2a0ad8a575c6",
-        "updatedAt": "2025-09-20T19:50:19.468Z"
+        "model": "fake-64",
+        "vectorSha256": "9479f75898471ee0562bd6af24bb63781b532e9f6084cd32fd7bc8606ceebb11",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0534": {
@@ -11215,13 +11194,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 534
+        "sequence": 533
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a35a6a87c3a92107469022b4351bf5bf15d60084d8fd0386190e6616d108c660",
-        "updatedAt": "2025-09-20T19:50:19.468Z"
+        "model": "fake-64",
+        "vectorSha256": "afadfdd4819ca2c82f7820ee4fd474b603c9ae2b41e83d4d530cf946350576d9",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0535": {
@@ -11236,13 +11215,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 535
+        "sequence": 534
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6724c017ccd1aaa3b10024dcf18d6b9032a3c125ea96416e5158fac36175e824",
-        "updatedAt": "2025-09-20T19:50:19.468Z"
+        "model": "fake-64",
+        "vectorSha256": "9392e78bcc01bbd00d4b8004910815d1dc23530858880dda3a69fa6384f6f54b",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0536": {
@@ -11257,13 +11236,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 536
+        "sequence": 535
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8baba99edaaa82d2cae6b052522c91cf5edf92c59c875fa963a9138f2fd31a2e",
-        "updatedAt": "2025-09-20T19:50:19.468Z"
+        "model": "fake-64",
+        "vectorSha256": "7d4ce5e1022f6b07dd4f9efa87f0296c28793d110ee31647448b35230cb2a41c",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0537": {
@@ -11278,13 +11257,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 537
+        "sequence": 536
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8e2b55d0b7ffd19915967b38f13b2de76ee8165033dbf022fc1f27743506f2d5",
-        "updatedAt": "2025-09-20T19:50:19.721Z"
+        "model": "fake-64",
+        "vectorSha256": "9b7638ed4f58b0f2c40a429eeb612212083c149fb79430fff6bf820ac60b99c9",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0538": {
@@ -11299,13 +11278,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 538
+        "sequence": 537
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "87ac50abb8970dc675e44fe2efbae00a2650800b12f468d3fb9e6ba0a4a5d9c1",
-        "updatedAt": "2025-09-20T19:50:19.722Z"
+        "model": "fake-64",
+        "vectorSha256": "477b29e4a048667d88d3a8b7acd5ef88ceef61e6e86ead31fd7100efd0c0fa58",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0539": {
@@ -11320,13 +11299,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 539
+        "sequence": 538
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b64a8011a5f7330c6d6030479d433673841320b4a2329dcf8c809c7c1f9445b8",
-        "updatedAt": "2025-09-20T19:50:19.722Z"
+        "model": "fake-64",
+        "vectorSha256": "f593984334b49d093d2be82027ae10c0a3f35a62dd6aacb5239082b1621b5b68",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0540": {
@@ -11341,13 +11320,13 @@
         "punchline": 7
       },
       "source": {
-        "sequence": 540
+        "sequence": 539
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ecfb43ada3d920a51dc8616e4ad5ac94df11114d2b433e01531175f5c97083c3",
-        "updatedAt": "2025-09-20T19:50:19.722Z"
+        "model": "fake-64",
+        "vectorSha256": "3842bbcc71d79331c2e874cf8cbf5f773b7080b120fdce18dc16dccf9152d431",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0541": {
@@ -11362,13 +11341,13 @@
         "punchline": 37
       },
       "source": {
-        "sequence": 541
+        "sequence": 540
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "501dea6b7fb78dc802dddef34176168bdf3fe71c4545b244502679058bf447c2",
-        "updatedAt": "2025-09-20T19:50:19.722Z"
+        "model": "fake-64",
+        "vectorSha256": "ee676d94d047ba59cb015db4a23ed1ee37bff02f627c22cdfff7f17271f9684b",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0542": {
@@ -11383,13 +11362,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 542
+        "sequence": 541
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c5b56aa5bf03e1b7438261d4cd7c41feaf090c2f6090cee04bd0059648bcbf30",
-        "updatedAt": "2025-09-20T19:50:19.722Z"
+        "model": "fake-64",
+        "vectorSha256": "74f4a9cb804a1b381143e238c36504a06c5b47063da0bfd348e9f7aa04dd9ac4",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0543": {
@@ -11404,13 +11383,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 543
+        "sequence": 542
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cb7135b5322a3b911f125e879bc1feb210db8cb87ad9b67157968e5fa438e6d1",
-        "updatedAt": "2025-09-20T19:50:19.722Z"
+        "model": "fake-64",
+        "vectorSha256": "0fba0e39a9afc49e56e77a40d61b1a123981d2dd6b7fb3377c01d28639b2238e",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0544": {
@@ -11425,13 +11404,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 544
+        "sequence": 543
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8784d85c9be9b18476de5aecc71f48995403a2af503b4970dff1c2cd96aff8c2",
-        "updatedAt": "2025-09-20T19:50:19.722Z"
+        "model": "fake-64",
+        "vectorSha256": "8fadb3fbd085b17d223e0db96468e15a23cea928a4e1de86e9955bf108245ee0",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0545": {
@@ -11446,13 +11425,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 545
+        "sequence": 544
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4fab66bf51df792e362c38527a2ab599cb852291c64bed062f1b75b061f9fbb5",
-        "updatedAt": "2025-09-20T19:50:20.031Z"
+        "model": "fake-64",
+        "vectorSha256": "d91599cdcfa4585d5c22158027c9d47b39e4424b19330115b3d6630a41841b85",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0546": {
@@ -11467,13 +11446,13 @@
         "punchline": 78
       },
       "source": {
-        "sequence": 546
+        "sequence": 545
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7588b977049c22ef636fe97d1e4b02ea051a8c0f2a248090d4fa3abbe75b40c4",
-        "updatedAt": "2025-09-20T19:50:20.031Z"
+        "model": "fake-64",
+        "vectorSha256": "7fcbfd4a475e4bab0af9abb4a7840e10f0681227a129a8126378e2756bebb834",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0547": {
@@ -11488,13 +11467,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 547
+        "sequence": 546
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a7784361ff45ce1be17a40287a4a0756200f8ecd85e1a7ced13a910afb8d6a6e",
-        "updatedAt": "2025-09-20T19:50:20.032Z"
+        "model": "fake-64",
+        "vectorSha256": "a375aa7ddaa838b2164b59d36d9baab443489bd725cfd0337bf6af8e39e23fdb",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0548": {
@@ -11509,13 +11488,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 548
+        "sequence": 547
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7e901f7b2257815a4b16bd24446e49690eb383580bd23b02a8ff84ce76606334",
-        "updatedAt": "2025-09-20T19:50:20.032Z"
+        "model": "fake-64",
+        "vectorSha256": "fece6cb87d93541093317b60fdb9ff69494ce59b20a8bf528fe7c137f1ab08b5",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0549": {
@@ -11530,13 +11509,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 549
+        "sequence": 548
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e0e12a75f1000ee9e7a7de30ae71e5872c9fd1920a0a68de829f8c2b6fa87339",
-        "updatedAt": "2025-09-20T19:50:20.032Z"
+        "model": "fake-64",
+        "vectorSha256": "bf5b8a1e48de76e22be88b9635fff9766735e3da1440b39b13fd64a2252ca91d",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0550": {
@@ -11551,13 +11530,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 550
+        "sequence": 549
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6a5222a645ab964faeac34038e7ee9b5b1d0e125a1e8705e456af978f6e621ab",
-        "updatedAt": "2025-09-20T19:50:20.032Z"
+        "model": "fake-64",
+        "vectorSha256": "509e40d41f31a381a6e91d91b23c2648ca035fa0f99cdbfdfc10747b836a0748",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0551": {
@@ -11572,13 +11551,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 551
+        "sequence": 550
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "551552de9f9d21ee93ea5d4a072b082ae1deead57d555d123bf02a16613e7509",
-        "updatedAt": "2025-09-20T19:50:20.032Z"
+        "model": "fake-64",
+        "vectorSha256": "2eb23e7741541871b8fe3096ebff9b6bf2e361e54faa2443980a51c400cff187",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0552": {
@@ -11593,13 +11572,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 552
+        "sequence": 551
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c9e2b0a84395fc65fce382674017d1eda27a2bea9df97d1db058f8a067dd41dc",
-        "updatedAt": "2025-09-20T19:50:20.032Z"
+        "model": "fake-64",
+        "vectorSha256": "03630ed0b3752c49135e3b6ae03cfab1ebed1bb576748a36c32308a0dd8edebb",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0553": {
@@ -11614,13 +11593,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 553
+        "sequence": 552
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "55cb23a200183d4fc178a73e7de9f6b7d137ca8ee07fbfc250f3af8854ac247b",
-        "updatedAt": "2025-09-20T19:50:20.298Z"
+        "model": "fake-64",
+        "vectorSha256": "992dbebd5d385d6cef23eb0c79eeb2791e03c23a5bc28e03ae46051d02cc8e79",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0554": {
@@ -11635,13 +11614,13 @@
         "punchline": 37
       },
       "source": {
-        "sequence": 554
+        "sequence": 553
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "10c0f99cf3cfccf29cfc91e3a8e1ba1a596d224c16df60f609cb551d106fcdf8",
-        "updatedAt": "2025-09-20T19:50:20.299Z"
+        "model": "fake-64",
+        "vectorSha256": "526159a42d41106b8c71595f9ba557aead81ea6788cba5eb511ea5549b5a381f",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0555": {
@@ -11656,13 +11635,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 555
+        "sequence": 554
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4a39170166f4de36bf70422d9f76d1b9602fa22ebe6c25da8df994294e48be83",
-        "updatedAt": "2025-09-20T19:50:20.299Z"
+        "model": "fake-64",
+        "vectorSha256": "93f689ff574a985ff9f0aebf8ea3e177d94cf944bfa05db5e0803ad3cb555838",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0556": {
@@ -11677,13 +11656,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 556
+        "sequence": 555
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fc69a1a6e085bb3a88fd5e767c6db3a858fc22606135e32987d7dade3ca6cc9b",
-        "updatedAt": "2025-09-20T19:50:20.299Z"
+        "model": "fake-64",
+        "vectorSha256": "38c483ec3301640126580210ce79db0b9ee3a8c25b0d8160ee06a47561954c67",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0557": {
@@ -11698,13 +11677,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 557
+        "sequence": 556
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "83d8c50f4317530b4f5a05d19af47566e333d39c0345560a50c3d5f769a3cdd8",
-        "updatedAt": "2025-09-20T19:50:20.299Z"
+        "model": "fake-64",
+        "vectorSha256": "c622f635c1538364d705687363e1e6a829296b05a43b1d528523d2b5bbeff1a3",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0558": {
@@ -11719,13 +11698,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 558
+        "sequence": 557
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c61f5651371a7fd59cecb2c1e4c2520cfa7365f9425f1852b017bfc2377721bc",
-        "updatedAt": "2025-09-20T19:50:20.299Z"
+        "model": "fake-64",
+        "vectorSha256": "b92891851486e8247373c0503764d866d608cfdb7777e98d6b4bcdec96a80e0a",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0559": {
@@ -11740,13 +11719,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 559
+        "sequence": 558
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ff8ce5b135cd8ac29395d89d1100b5dde35507765bfc9745890debbb8f14c8ac",
-        "updatedAt": "2025-09-20T19:50:20.299Z"
+        "model": "fake-64",
+        "vectorSha256": "175892bc1d2920a7d1d34995f64980d9004112bd298456ab98f404501cfa283a",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0560": {
@@ -11761,13 +11740,13 @@
         "punchline": 58
       },
       "source": {
-        "sequence": 560
+        "sequence": 559
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "db8c7262e7fc18fae492db838bed060d2c5f79be2184448a233feb1a6caed27c",
-        "updatedAt": "2025-09-20T19:50:20.299Z"
+        "model": "fake-64",
+        "vectorSha256": "605057cccbc3134860c204dc1dda64c844df3f4789c80d3669757b7b90b603e5",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0561": {
@@ -11782,13 +11761,13 @@
         "punchline": 46
       },
       "source": {
-        "sequence": 561
+        "sequence": 560
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5eda2c06d82ae5bda6c2089e965be3b40645ec9c752070d07be79177e2e9cede",
-        "updatedAt": "2025-09-20T19:50:20.555Z"
+        "model": "fake-64",
+        "vectorSha256": "6074286975d8ffd157558a56ff40c87a967bc3315422c7185d0cf9b04cdd0092",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0562": {
@@ -11803,13 +11782,13 @@
         "punchline": 61
       },
       "source": {
-        "sequence": 562
+        "sequence": 561
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1da72071ae41e7ba39b698720d5ab682ea5cebd3f0d0864e84430ec636439608",
-        "updatedAt": "2025-09-20T19:50:20.555Z"
+        "model": "fake-64",
+        "vectorSha256": "b624952ac7a7da3f30072159491c9b96457fdc1f7b5f28f2c72d95723460b610",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0563": {
@@ -11824,13 +11803,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 563
+        "sequence": 562
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bba0894a9a7ca2689af7cd5c22e701348ecf4df1b580899e1c36ae977ce56ab8",
-        "updatedAt": "2025-09-20T19:50:20.555Z"
+        "model": "fake-64",
+        "vectorSha256": "68d1c327c09dd302a7f3b1bab53ca08695bdcd1ce10f5a2b5b3232308e4d8a35",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0564": {
@@ -11845,13 +11824,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 564
+        "sequence": 563
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d8de500464f7f114efa556d8e0d5d980283a0339dd274fe8aac64c89f44b74bc",
-        "updatedAt": "2025-09-20T19:50:20.555Z"
+        "model": "fake-64",
+        "vectorSha256": "23ff2bfe6654d177ab04024a17a90ae1fa69c073224e4d869725e77c8438b22f",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0565": {
@@ -11866,13 +11845,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 565
+        "sequence": 564
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f9c6667b784796135c7f3fdf5a040b54b688017670a1bce04e1416c4cdb12301",
-        "updatedAt": "2025-09-20T19:50:20.556Z"
+        "model": "fake-64",
+        "vectorSha256": "a5cb422bd9a48984e7492b749c638bbacbf97d245a1f5d2ed9a0b47efab1926c",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0566": {
@@ -11887,13 +11866,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 566
+        "sequence": 565
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a2f32d6964238d35ed52fb37babc732f9697c7e1ca2f6e0adda453d7f6108b9a",
-        "updatedAt": "2025-09-20T19:50:20.556Z"
+        "model": "fake-64",
+        "vectorSha256": "ca413477cc101dcb07adc344a60019a634b5d64c11adc56e66cac697c29bd037",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0567": {
@@ -11908,13 +11887,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 567
+        "sequence": 566
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a1dbadaa33bf043cc80935780a33556253500112ed5ef9b67db38735849d33f1",
-        "updatedAt": "2025-09-20T19:50:20.556Z"
+        "model": "fake-64",
+        "vectorSha256": "0c07c53dafcb33d1f0bcdc4dd0dbd02017d947524a9efb37a5f7fe1bc7328971",
+        "updatedAt": "2025-09-20T22:27:41.536Z"
       }
     },
     "j-0568": {
@@ -11929,13 +11908,13 @@
         "punchline": 74
       },
       "source": {
-        "sequence": 568
+        "sequence": 567
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9a96b94fa27f2a8f0d71a14b3a26f900b68b7ac13bddafe52075de85d5163e49",
-        "updatedAt": "2025-09-20T19:50:20.556Z"
+        "model": "fake-64",
+        "vectorSha256": "cc4514a1a9f2ce159fb5dd56dbd1aade3fc8f1bee223f861e32b8d0c7ce31dff",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0569": {
@@ -11950,13 +11929,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 569
+        "sequence": 568
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2b29f5471b4aa923f9c9325ff9bd66041e5a2bee226c94662132afb0598b676a",
-        "updatedAt": "2025-09-20T19:50:20.874Z"
+        "model": "fake-64",
+        "vectorSha256": "ddf7b8540001bff60104abee6b05d4d2f1de47890bac0a64717c5d40a522d931",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0570": {
@@ -11971,13 +11950,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 570
+        "sequence": 569
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f60ac36865aff02be640b8336ac076840d7b054d84b458e9501a887b746e8407",
-        "updatedAt": "2025-09-20T19:50:20.874Z"
+        "model": "fake-64",
+        "vectorSha256": "7060e628d75395de5ca23bb8b5f15e839ba3bfba92095dc1a63d80e1c017d8c1",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0571": {
@@ -11992,13 +11971,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 571
+        "sequence": 570
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "33942dd795c4131bd5f7be48b25fbb16931f23547bb4ea88b78e5432592aa24f",
-        "updatedAt": "2025-09-20T19:50:20.874Z"
+        "model": "fake-64",
+        "vectorSha256": "5be619328f587ed26f2b701a257eee2a71a6787a32321fd68d9fbbff2596eb3f",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0572": {
@@ -12013,13 +11992,13 @@
         "punchline": 44
       },
       "source": {
-        "sequence": 572
+        "sequence": 571
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ebf8ab7881e589007760c34f9aba485206054eb010209257c62156c1f25d25ab",
-        "updatedAt": "2025-09-20T19:50:20.874Z"
+        "model": "fake-64",
+        "vectorSha256": "44939da514c933efd5a347a1e4490b92d0e615a71246839fcbc3dddf97605669",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0573": {
@@ -12034,13 +12013,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 573
+        "sequence": 572
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2099189ce6d3c31fa4553f940272b34028f90d3c781605a49442c58c16ff22e9",
-        "updatedAt": "2025-09-20T19:50:20.874Z"
+        "model": "fake-64",
+        "vectorSha256": "d8c9191c739bb19ad8198f38ee2a03e7856c779563264e4d4e3b2facee7f65db",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0574": {
@@ -12055,13 +12034,13 @@
         "punchline": 51
       },
       "source": {
-        "sequence": 574
+        "sequence": 573
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4b402a66bd4149e23205478869717ae1711ba32050e6e289571189ffdf993eac",
-        "updatedAt": "2025-09-20T19:50:20.874Z"
+        "model": "fake-64",
+        "vectorSha256": "a6a80f351cf15fde2d7b5d00fade7db52b2badab49acd82a9b15cad6624c55a9",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0575": {
@@ -12076,13 +12055,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 575
+        "sequence": 574
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d0f5621ffb2e5626eeaa23787df6b977e5e6938bf1f512e07073c4f9b54d2c06",
-        "updatedAt": "2025-09-20T19:50:20.874Z"
+        "model": "fake-64",
+        "vectorSha256": "ba54705a50cc9cd39951a0c58e3a1e6bae76f5bd8e6ca4aeca09157e80ce5ade",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0576": {
@@ -12097,13 +12076,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 576
+        "sequence": 575
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b5de0df986b9b8d1791eb0f00fcf782fe875d719a5b3d46946cfd6c63443832d",
-        "updatedAt": "2025-09-20T19:50:20.874Z"
+        "model": "fake-64",
+        "vectorSha256": "06e440905516f8ea5a606432ddf3eb8f1015fc2bf2d1b2fdb9154a447a5363cf",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0577": {
@@ -12118,13 +12097,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 577
+        "sequence": 576
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f7378d53a8f24f99add8f6fccbbf6636a71391ae76942b38a931f2d5e88f3c4e",
-        "updatedAt": "2025-09-20T19:50:21.108Z"
+        "model": "fake-64",
+        "vectorSha256": "611c19001f8d2c55f131e9a4791ea4152a620b781612ca7ece68c91dafc113e1",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0578": {
@@ -12139,13 +12118,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 578
+        "sequence": 577
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "62677703393b80adcd56aa79ee235337650914ec2841015bbf4f1ca029cc8532",
-        "updatedAt": "2025-09-20T19:50:21.109Z"
+        "model": "fake-64",
+        "vectorSha256": "9a91542646df9ee510f1671fa35a43df7b06152d1386584c81a71ffc4a22650d",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0579": {
@@ -12160,13 +12139,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 579
+        "sequence": 578
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2ab1f172531b21a4ca02b58e63c399e991b8917a7ac0be3fec9758e892dd5382",
-        "updatedAt": "2025-09-20T19:50:21.109Z"
+        "model": "fake-64",
+        "vectorSha256": "c17520105809842d9884c23c186908909f60f016511fcd2dd0fd5d651e5326af",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0580": {
@@ -12181,13 +12160,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 580
+        "sequence": 579
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4c91ea243b14f8bf080b472a17294d230b1692b04ef8fbd881d4e88d5d3d4678",
-        "updatedAt": "2025-09-20T19:50:21.109Z"
+        "model": "fake-64",
+        "vectorSha256": "0e0e820dd404ea2331294b3093647f8516455110379b30d5f9c56191b85f2a50",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0581": {
@@ -12202,13 +12181,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 581
+        "sequence": 580
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e4ec9612af556d1cd48838fdbadb14636ddae2c436c17818218e981b90798343",
-        "updatedAt": "2025-09-20T19:50:21.109Z"
+        "model": "fake-64",
+        "vectorSha256": "673bd5e9cdfcf90a9addef36fb984ec5e1258eeaed9dab6ae6557b40c532539d",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0582": {
@@ -12223,13 +12202,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 582
+        "sequence": 581
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a3cd916d566911b9954f34abe6c95bb25b33a2b49ac771ed52ed313442a4a3d8",
-        "updatedAt": "2025-09-20T19:50:21.109Z"
+        "model": "fake-64",
+        "vectorSha256": "c4ae0ce3882e40d1266e2d10e10e56bdb6e4a1da685bc95bc7c6592595d45afe",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0583": {
@@ -12244,13 +12223,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 583
+        "sequence": 582
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "69c94370ef42b46df5aad13df9a3a17702ed186d87b3863729213f84c2522ac8",
-        "updatedAt": "2025-09-20T19:50:21.109Z"
+        "model": "fake-64",
+        "vectorSha256": "8dfcca57a9e5f0d95e79240128c5e79f578e631f0e69508676644de0211558d1",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0584": {
@@ -12265,13 +12244,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 584
+        "sequence": 583
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1d187fd6f94c86eb0b10982384a1c5b5f05dd3bd235c4e5c05040e68ab0b5d8d",
-        "updatedAt": "2025-09-20T19:50:21.109Z"
+        "model": "fake-64",
+        "vectorSha256": "477cf45d3fff8254f6d6b1e9f6ede0274f51c8184bce04bde971b6fcf938237f",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0585": {
@@ -12286,13 +12265,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 585
+        "sequence": 584
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d3be76812138eda3f8358775f1ce7fbc072b55433cee9b11eae77de6b0754b9b",
-        "updatedAt": "2025-09-20T19:50:21.372Z"
+        "model": "fake-64",
+        "vectorSha256": "035d88c2eae7f22d86ee6d38a608b03aac6ae37b7d05870a0304f523e7f1c73f",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0586": {
@@ -12307,13 +12286,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 586
+        "sequence": 585
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "75aa7cce2ef71b6c2e198d6ad5098c9662d171287a9fb4bf77e1bd72db7463c0",
-        "updatedAt": "2025-09-20T19:50:21.372Z"
+        "model": "fake-64",
+        "vectorSha256": "090d6d2bdc407eb5251305623bd3fd175e865ec7f71f3cc84046d5c399b7d567",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0587": {
@@ -12328,13 +12307,13 @@
         "punchline": 4
       },
       "source": {
-        "sequence": 587
+        "sequence": 586
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "490f0ba89752bf22eba7bf15406b5a50fe8d51955bb04af6d9fc6f8b41e08e52",
-        "updatedAt": "2025-09-20T19:50:21.372Z"
+        "model": "fake-64",
+        "vectorSha256": "8e6b563080a9770a1d772052f80cb61bbd52f10199c589b5721ac069c9adbc8c",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0588": {
@@ -12349,13 +12328,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 588
+        "sequence": 587
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "53570f9bccc7b18abb841065cf17d4e3a96581a04f7599d2295712e7e165852d",
-        "updatedAt": "2025-09-20T19:50:21.372Z"
+        "model": "fake-64",
+        "vectorSha256": "a580a49fff2fb676f2062642b278c3a50ebbabf1b0d5463afaa2478ae3460550",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0589": {
@@ -12370,13 +12349,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 589
+        "sequence": 588
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ebbf04fa41b272b61ef99ec5e95562f1cd33ecf38bdfcc21bd1140e59c885d2d",
-        "updatedAt": "2025-09-20T19:50:21.372Z"
+        "model": "fake-64",
+        "vectorSha256": "49b6f1994c80cd3a8c33573791284228fc26e27972033a3e9e3ce7fb94d7ce83",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0590": {
@@ -12391,13 +12370,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 590
+        "sequence": 589
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2117e0da52575516b58ea7595263eb99c55e36246cc951a96085eb1a7fd86246",
-        "updatedAt": "2025-09-20T19:50:21.372Z"
+        "model": "fake-64",
+        "vectorSha256": "4b1daacc937332845e6a84c1bbe5d414e85eee2c3648fe375d9f83c7bca38399",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0591": {
@@ -12412,13 +12391,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 591
+        "sequence": 590
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f093b29bb8e9048e6abcc109cad18399afb39c0b3d1fd1723d758dd57610bd2f",
-        "updatedAt": "2025-09-20T19:50:21.372Z"
+        "model": "fake-64",
+        "vectorSha256": "086bfa923690c68af9031a690c21a500dc575d7dbf3f4e0323b7ffe7142f66ae",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0592": {
@@ -12433,13 +12412,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 592
+        "sequence": 591
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "db00f26f367b9fd5eb5ed531a81e60bfb299c51fc9edf738cadc5b048ff84a96",
-        "updatedAt": "2025-09-20T19:50:21.372Z"
+        "model": "fake-64",
+        "vectorSha256": "f1452b12992abbc6d85a3d5cbb3e3da69356d9384abcd461bad40a741d68a36b",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0593": {
@@ -12454,13 +12433,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 593
+        "sequence": 592
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b4884981a2b94bc88bc0919f288a35b2939dd1394378b623b9e5b4a7d9015696",
-        "updatedAt": "2025-09-20T19:50:21.611Z"
+        "model": "fake-64",
+        "vectorSha256": "998b5b0d6baaaeaad0b4785395ddf89072b21db9011db59d13b1a6e6c3a7bab2",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0594": {
@@ -12475,13 +12454,13 @@
         "punchline": 58
       },
       "source": {
-        "sequence": 594
+        "sequence": 593
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aa08d1285d881cedc10c4ff7164024915569fe1d3a0508e3284dc5c3884d8767",
-        "updatedAt": "2025-09-20T19:50:21.611Z"
+        "model": "fake-64",
+        "vectorSha256": "d583c13201f6a0f08c5be61d36b0fd455406f3b30daa432cab1b7939fa9c1dfa",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0595": {
@@ -12496,13 +12475,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 595
+        "sequence": 594
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6caf562f7e42e3938a9cfbb6dc05d2f40b770b6f8222871b5e3b0418cbe56634",
-        "updatedAt": "2025-09-20T19:50:21.611Z"
+        "model": "fake-64",
+        "vectorSha256": "6ac8028d91bc27dd1897d1aece4809bd1c51df0c6a2d8304aa5900eec37f2325",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0596": {
@@ -12517,13 +12496,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 596
+        "sequence": 595
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bcba9678bb6b2ea7ae488ae6a15eaca96a4fcb055ace4bb224f769015e582a91",
-        "updatedAt": "2025-09-20T19:50:21.611Z"
+        "model": "fake-64",
+        "vectorSha256": "7f50b82101e6989fe3b6fe27cd483c77b6b717e3e68a6db5113bea8a6bb7ada5",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0597": {
@@ -12538,13 +12517,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 597
+        "sequence": 596
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c452d17405fc98e0eacad5a8210910f15b181919d8adb954eee4c72f30edcfd3",
-        "updatedAt": "2025-09-20T19:50:21.611Z"
+        "model": "fake-64",
+        "vectorSha256": "752248561cc0943e1d6372f7cb53c5c4a98a187591b095c6098c44bb5f38e486",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0598": {
@@ -12559,13 +12538,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 598
+        "sequence": 597
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "92de9254c19302410b85137e9cf374e678c45c1bed8a60161a0a4897310a5dcc",
-        "updatedAt": "2025-09-20T19:50:21.611Z"
+        "model": "fake-64",
+        "vectorSha256": "f17db82ba7513d488172846d9dbbd36324ac19c3ef539a4264f6abaea12d6701",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0599": {
@@ -12580,13 +12559,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 599
+        "sequence": 598
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5a1e5d74cd9749c1dc26657938845c70d104a597fc78ee21729973f161a28861",
-        "updatedAt": "2025-09-20T19:50:21.612Z"
+        "model": "fake-64",
+        "vectorSha256": "6d7e625c3ea2c5e29202867df01a53dfd53a0e67fe560f62800f1f037aa4d9d5",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0600": {
@@ -12601,13 +12580,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 600
+        "sequence": 599
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9f52dd80841ec8c168689fc9b2ab5d2158e0436ed5989ff761e2f816744dd419",
-        "updatedAt": "2025-09-20T19:50:21.612Z"
+        "model": "fake-64",
+        "vectorSha256": "32e9e15eedbf6cdb7e176441f913d55602f18991fba96808865a17f969f2be9a",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0601": {
@@ -12622,13 +12601,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 601
+        "sequence": 600
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b8708f3a3a9f9a19ab57a8a9c3471e1038fcc49158e132a559114e8bc69ea7ae",
-        "updatedAt": "2025-09-20T19:50:21.829Z"
+        "model": "fake-64",
+        "vectorSha256": "33c94b64d13c36de493345089b998cb9ac2a79a846d47069e9e2f6bf03d4a59f",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0602": {
@@ -12643,13 +12622,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 602
+        "sequence": 601
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9acffae78c9ba83269f8cdef604e0947c4fc628622c472dd714606fba84013b4",
-        "updatedAt": "2025-09-20T19:50:21.829Z"
+        "model": "fake-64",
+        "vectorSha256": "96fe4bd2575cd83eec8382708875ebe72be73f59968c908163ab024d1c627a57",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0603": {
@@ -12664,13 +12643,13 @@
         "punchline": 58
       },
       "source": {
-        "sequence": 603
+        "sequence": 602
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4d5c96adb80ac29b455726a5cb078347e1b48a141f65a075c904cbd32f4cf408",
-        "updatedAt": "2025-09-20T19:50:21.829Z"
+        "model": "fake-64",
+        "vectorSha256": "ed1ad13a8156b020abb0d9be8c3d4d9949a5c254c12d484400704203517686db",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0604": {
@@ -12685,13 +12664,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 604
+        "sequence": 603
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cbedee1705d5f4da26f7c7ff4834e1dca4d424126fe3cf83c24bf8f9b91f1265",
-        "updatedAt": "2025-09-20T19:50:21.829Z"
+        "model": "fake-64",
+        "vectorSha256": "584562f8e6f0bbd607d611830c02fb1721e6cd1f3d62ab7e6e270ee0082a5164",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0605": {
@@ -12706,13 +12685,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 605
+        "sequence": 604
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3af2b01f9d21a4eb2dae0d76777af85789725e118eb68703b0ae8a2a6785be05",
-        "updatedAt": "2025-09-20T19:50:21.829Z"
+        "model": "fake-64",
+        "vectorSha256": "bf8fe47effa0734daeb5906cac33d2e82edb305e9d4668f6748c1240b223149a",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0606": {
@@ -12727,13 +12706,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 606
+        "sequence": 605
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "805439919b6bd7a8d6869547aaf34e7ae5488a179d9c392deb61e5f8ad09ecff",
-        "updatedAt": "2025-09-20T19:50:21.830Z"
+        "model": "fake-64",
+        "vectorSha256": "766384139d44ebef4a378414516ca2aa3393e1efa4ab7e334cc7010aac090030",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0607": {
@@ -12748,13 +12727,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 607
+        "sequence": 606
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3fbef1df7566e438a92e01e19f93da417016633c3f519e9da9fd1dc1dfd00398",
-        "updatedAt": "2025-09-20T19:50:21.830Z"
+        "model": "fake-64",
+        "vectorSha256": "6f17d5c00b3ef681f1b7b359056ab7ba5ff608f0a5d0aff979c9c421f48bd7ce",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0608": {
@@ -12769,13 +12748,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 608
+        "sequence": 607
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9b144f85223e9faf3d0565f75d83bc356744158d601fcd4f5f23e9de2a2921a8",
-        "updatedAt": "2025-09-20T19:50:21.830Z"
+        "model": "fake-64",
+        "vectorSha256": "376d398ddf3e6f7a156aefc024b178c11ff385f7072edc099608fe403692d993",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0609": {
@@ -12790,13 +12769,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 609
+        "sequence": 608
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "94b9ac2c139eca6d6e8f4e067fbc61f62b285f00c32ed9d2a5d91d184ce0a101",
-        "updatedAt": "2025-09-20T19:50:22.082Z"
+        "model": "fake-64",
+        "vectorSha256": "dabb9515a934a4c2000bbaf23cf8129fd88bc66e5b0b1162b309e894b78b4721",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0610": {
@@ -12811,13 +12790,13 @@
         "punchline": 45
       },
       "source": {
-        "sequence": 610
+        "sequence": 609
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d894bae653294612cab4eca9239a4b63c7126c46eb19d429d3bf19aa50758102",
-        "updatedAt": "2025-09-20T19:50:22.082Z"
+        "model": "fake-64",
+        "vectorSha256": "6e84077c3576d3681a9bf7ec2260ceea95b0fe9e25ce05283ddccd894f9a0550",
+        "updatedAt": "2025-09-20T22:27:41.537Z"
       }
     },
     "j-0611": {
@@ -12832,13 +12811,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 611
+        "sequence": 610
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "331d67acca2551564b1b8d00c9bf3273040cdcfe1372fb229462217ffaf2440c",
-        "updatedAt": "2025-09-20T19:50:22.082Z"
+        "model": "fake-64",
+        "vectorSha256": "ff55d9c2757ddc08d06909aa172e693fa03d7062b30fad1543629da3ad4d62b8",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0612": {
@@ -12853,13 +12832,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 612
+        "sequence": 611
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "84f311e0e36bc4b37de8458f762c6750e865efc282b85cf411c56b6259708d27",
-        "updatedAt": "2025-09-20T19:50:22.082Z"
+        "model": "fake-64",
+        "vectorSha256": "f0b3a5ae0c13796609ad20d9232f73e138ad9cd205651e9e9e1159247f761075",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0613": {
@@ -12874,13 +12853,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 613
+        "sequence": 612
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d7a9765e4b359e7e0db8b74feef3dd863ad76206a0e6971278cd830eff175568",
-        "updatedAt": "2025-09-20T19:50:22.082Z"
+        "model": "fake-64",
+        "vectorSha256": "540592c9144117cd0891f81df1e51c8cb32e6366f0e1e4126243c03db77b3173",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0614": {
@@ -12895,13 +12874,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 614
+        "sequence": 613
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "71aafc7eec57b89d0ddb0256581befa7ae67eb8ddc341572819ef39e74da7eb4",
-        "updatedAt": "2025-09-20T19:50:22.082Z"
+        "model": "fake-64",
+        "vectorSha256": "c6ce2a9e5bce13840673f46dbfba5104cc4af29f1a10d11627b11651614b5349",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0615": {
@@ -12916,13 +12895,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 615
+        "sequence": 614
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "980682eeb165adb5dbc868397212b85acf71c0ecbca7abcb795c2d3405fbf77d",
-        "updatedAt": "2025-09-20T19:50:22.082Z"
+        "model": "fake-64",
+        "vectorSha256": "fecf95a71aefda5d8f6eab0c01f54d08d5ab06700c05c72a5d4d127c296a3297",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0616": {
@@ -12937,13 +12916,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 616
+        "sequence": 615
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "751cfe0feff6bca8f2cb1b8c392f8f6b4ed7b08d9ca1cf48f3e78f47e9db16ae",
-        "updatedAt": "2025-09-20T19:50:22.082Z"
+        "model": "fake-64",
+        "vectorSha256": "2453a4d7c4d752dacaf051ff6ad83ae14c61700864e2649d6c8be7e9ec44ade7",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0617": {
@@ -12958,13 +12937,13 @@
         "punchline": 66
       },
       "source": {
-        "sequence": 617
+        "sequence": 616
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "90b0dd71da08c6faf9a63a3faf0a60e434f5a48ecda58d347518ca64a6df6d85",
-        "updatedAt": "2025-09-20T19:50:22.494Z"
+        "model": "fake-64",
+        "vectorSha256": "368f5fb7ab7432b13bcc0df29ad1646ada62cc217e8ea5a5b9c24c45a2bfa1d3",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0618": {
@@ -12979,13 +12958,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 618
+        "sequence": 617
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cb14d230b4c4bb2b52f1d7037ec41973cd64f82e8ef3ffbf56f599c268bcd98e",
-        "updatedAt": "2025-09-20T19:50:22.494Z"
+        "model": "fake-64",
+        "vectorSha256": "b0a7a78db464b704fa7c403e072ba260dc1bf958934d8371168527beec003a2a",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0619": {
@@ -13000,13 +12979,13 @@
         "punchline": 54
       },
       "source": {
-        "sequence": 619
+        "sequence": 618
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fadcc166e6805c1eba729b36ef2c560dcba6b3e7c231adecfe9e016fb28557fb",
-        "updatedAt": "2025-09-20T19:50:22.494Z"
+        "model": "fake-64",
+        "vectorSha256": "393e4c3457a5c6e926ccad60a6e316a90b18916ab9c8005f6aacfbf5a17a59b4",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0620": {
@@ -13021,13 +13000,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 620
+        "sequence": 619
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "62ddde7716ce35be01d3ea15ba74054ab1524e711e2398120b3745319e91179b",
-        "updatedAt": "2025-09-20T19:50:22.495Z"
+        "model": "fake-64",
+        "vectorSha256": "f6367cc347282692413ce5723765946e0d08c61427b38f6c7cc9722143f20a79",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0621": {
@@ -13042,13 +13021,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 621
+        "sequence": 620
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a8891483e8da923a29ce20bef208094c3278bbd903afd9c2277d0ea2d1071f79",
-        "updatedAt": "2025-09-20T19:50:22.495Z"
+        "model": "fake-64",
+        "vectorSha256": "e60a956c7250c89b7f747b2a59f685ff6b7cbc47d321f6da251b9071cd7e6436",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0622": {
@@ -13063,13 +13042,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 622
+        "sequence": 621
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dc226201ac56389b10edf81e4c7123a342d855b63cfeca13c71e438583e2831d",
-        "updatedAt": "2025-09-20T19:50:22.495Z"
+        "model": "fake-64",
+        "vectorSha256": "9720846710c1b6cf57aa93ac4632f7ad91a340fc8e251998a6436c42c813edf4",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0623": {
@@ -13084,13 +13063,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 623
+        "sequence": 622
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8cb6f291955d1ef19a727560f419e4c072807a617312c392657ed05524bc882f",
-        "updatedAt": "2025-09-20T19:50:22.495Z"
+        "model": "fake-64",
+        "vectorSha256": "e9524ab0466a600c204728d8829b365159aac83ab13465e45764d180722057e2",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0624": {
@@ -13105,13 +13084,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 624
+        "sequence": 623
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f900711d798e26eedfe4c02e7e6005d045278d12a73375b4b2a2593d8906f627",
-        "updatedAt": "2025-09-20T19:50:22.495Z"
+        "model": "fake-64",
+        "vectorSha256": "6f0b575810b6d978099ab9c7bc58763c5f2f37e6612f9f2fa8cc2705116bfb40",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0625": {
@@ -13126,13 +13105,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 625
+        "sequence": 624
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3b20d1fbbd67c3f3fd67195e3c966d29e243a547fc3adf1ed3325e4f1fa74697",
-        "updatedAt": "2025-09-20T19:50:22.753Z"
+        "model": "fake-64",
+        "vectorSha256": "4368eec9aa12a37447b114b418dd0fb33fe0e614b39a8fdc4a89456e978af3bb",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0626": {
@@ -13147,13 +13126,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 626
+        "sequence": 625
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "697c626b7ae3c5dd4620652db6225584c0343075e9d4519df04717e203c26cd3",
-        "updatedAt": "2025-09-20T19:50:22.753Z"
+        "model": "fake-64",
+        "vectorSha256": "968828b2538adaefd03f35a49ca93903fbb09a239f606f6d43d97f820931a124",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0627": {
@@ -13168,13 +13147,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 627
+        "sequence": 626
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d2a084f516ae22cfd3d1b3627a4cfa6d49748e917a26813e37694e5b0faf3389",
-        "updatedAt": "2025-09-20T19:50:22.753Z"
+        "model": "fake-64",
+        "vectorSha256": "c2517ccfdc4210b22bc2a137d3fb1dc722f7c0e06e857ab3250971e81eb59b75",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0628": {
@@ -13189,13 +13168,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 628
+        "sequence": 627
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "04457c68113c0e6d404f48b693ebc141e03191177234e5490f84f94722937810",
-        "updatedAt": "2025-09-20T19:50:22.753Z"
+        "model": "fake-64",
+        "vectorSha256": "d782bb35a870da609b52b5675fe9ba47085212f8abc90203aab4613b8b5a898f",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0629": {
@@ -13210,13 +13189,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 629
+        "sequence": 628
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "579375799c80ca913858878eed062bc1a1d8f88ccd729c5aee586786a410d928",
-        "updatedAt": "2025-09-20T19:50:22.753Z"
+        "model": "fake-64",
+        "vectorSha256": "185944da2d0f1b3d899c775b5d64fcbcb0c90577db3578a028afb33a3863ff65",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0630": {
@@ -13231,13 +13210,13 @@
         "punchline": 44
       },
       "source": {
-        "sequence": 630
+        "sequence": 629
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "225ba8f99f833946e0ca41cfeb474b181c96c89ed5aba47f2c115168ff488b73",
-        "updatedAt": "2025-09-20T19:50:22.754Z"
+        "model": "fake-64",
+        "vectorSha256": "1d51b605f9261a789ea470c717811165e7bab724abf047dfe7a268ba5607e9a5",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0631": {
@@ -13252,13 +13231,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 631
+        "sequence": 630
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f1949917db501a8d25c9fc16d2937555a69303073da1167a3ab620f9de59574f",
-        "updatedAt": "2025-09-20T19:50:22.754Z"
+        "model": "fake-64",
+        "vectorSha256": "457d9097a0eb3ee39868861ebb19acea027bd8be186bde4011b33eaa95f888c3",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0632": {
@@ -13273,13 +13252,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 632
+        "sequence": 631
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5b1cc0aea6adfd5e23b351d025b0f23e16a9a91bfc64816d268c0c1674d6abab",
-        "updatedAt": "2025-09-20T19:50:22.754Z"
+        "model": "fake-64",
+        "vectorSha256": "9cefa36ce838aba21e4ed360b7ffc87a1f1e13ef961fb3a36a593bd3045b1e18",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0633": {
@@ -13294,13 +13273,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 633
+        "sequence": 632
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b2b6c1c35dffcace71b9a25e0db9681fa4b72f86b33840558e9362e81a6fc0f8",
-        "updatedAt": "2025-09-20T19:50:22.996Z"
+        "model": "fake-64",
+        "vectorSha256": "af18485fb293c3d19334f03242e625593e5b289cb36a67253b1cd65a27209c59",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0634": {
@@ -13315,13 +13294,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 634
+        "sequence": 633
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3f34bf9f3b342bb5fc9dc9ff2c0da4aae4085e81625c4c64c67aa8f1838e5421",
-        "updatedAt": "2025-09-20T19:50:22.996Z"
+        "model": "fake-64",
+        "vectorSha256": "294f7f78a215ffa2ca9f0da44d40d710dd566fff7b00773253d62435e9532d53",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0635": {
@@ -13336,13 +13315,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 635
+        "sequence": 634
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3ee0c8bfa0647f72746a85a9358578bd910001908076010acf17be864b196369",
-        "updatedAt": "2025-09-20T19:50:22.996Z"
+        "model": "fake-64",
+        "vectorSha256": "c89c54f7b3c13eab18bfd977bf3c8682517e089268287d99a31dc77e58a084f4",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0636": {
@@ -13357,13 +13336,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 636
+        "sequence": 635
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f26589966f4086b2bba05a2ec9ff3e2fad41cbac1b3456058bbd39f09b52b13c",
-        "updatedAt": "2025-09-20T19:50:22.996Z"
+        "model": "fake-64",
+        "vectorSha256": "983e706241cc499fa64f8e3e0da2e0e4364ceb884397c6f98e70107fb46c14c5",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0637": {
@@ -13378,13 +13357,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 637
+        "sequence": 636
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3e0ee46ffa0867aa2bfb3c4d37e63076e3dea4c463e76bc2923d24b797396650",
-        "updatedAt": "2025-09-20T19:50:22.996Z"
+        "model": "fake-64",
+        "vectorSha256": "9ab90421acaf15f5cff2c1980b90362694172f7b5d25b8bbd357093f418c12aa",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0638": {
@@ -13399,13 +13378,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 638
+        "sequence": 637
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3658b48ce6eefb6c4bcb6b7336fdb1171c43dcae87218c906fed67f6da3a2c0a",
-        "updatedAt": "2025-09-20T19:50:22.996Z"
+        "model": "fake-64",
+        "vectorSha256": "970cba365d63c5ede4d53f1859529d890214c49ba6b6a8679ae8bf88996723a1",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0639": {
@@ -13420,13 +13399,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 639
+        "sequence": 638
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8e578909737007df274ec49f6032340e4f6892028af6b47faf767a46a9b25d2a",
-        "updatedAt": "2025-09-20T19:50:22.997Z"
+        "model": "fake-64",
+        "vectorSha256": "c6a3f64a07da7c2bdcf8be5a3e6fefa5ae422fa7189a9bcf40da0eef77588bcc",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0640": {
@@ -13441,13 +13420,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 640
+        "sequence": 639
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8099df840fa76a49ea579b0db6fa15f55cda2c2fe12e84431c21f0e315bad3d7",
-        "updatedAt": "2025-09-20T19:50:22.997Z"
+        "model": "fake-64",
+        "vectorSha256": "e6283b92a390fa35e0d06a0b5be54c41ead50f47fe7d4f9903c8eca350acf79f",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0641": {
@@ -13462,13 +13441,13 @@
         "punchline": 65
       },
       "source": {
-        "sequence": 641
+        "sequence": 640
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b19644c35590921321542b7492b73421f8954ae238b0e42e8c6d8f2cbf6781b1",
-        "updatedAt": "2025-09-20T19:50:23.220Z"
+        "model": "fake-64",
+        "vectorSha256": "8b823d30c993d24341e33ccbfc4a4ae23caf7914fc01e6d8741e0bb6c2442651",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0642": {
@@ -13483,13 +13462,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 642
+        "sequence": 641
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "774532bd5ca82cbdfc77902579e2577493ae7400a60676cd13e0f1bb8146ec6f",
-        "updatedAt": "2025-09-20T19:50:23.220Z"
+        "model": "fake-64",
+        "vectorSha256": "f5a41cd5c2b797f553839653cd1d5e3484e415aa9fa2d41b404219c6f8decefc",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0643": {
@@ -13504,13 +13483,13 @@
         "punchline": 46
       },
       "source": {
-        "sequence": 643
+        "sequence": 642
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "37b99038e6827126e71fecea78ae97b72858c90daac2ef2ad7d7d6b9c3263fd3",
-        "updatedAt": "2025-09-20T19:50:23.220Z"
+        "model": "fake-64",
+        "vectorSha256": "033439a22e3d5c513b7b6bad2548ad2bf108b23c96ca5f51ddbb2621e2546ea1",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0644": {
@@ -13525,13 +13504,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 644
+        "sequence": 643
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b62de85eb198475fdaa2b9633eb3cdbc0374a5e8fb0b73cb0eb5ebe634848427",
-        "updatedAt": "2025-09-20T19:50:23.220Z"
+        "model": "fake-64",
+        "vectorSha256": "d791f6dc7f1b7e22f6abac0b2edaf6efd08f5a9e53e4c3da3bce431a71a13462",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0645": {
@@ -13546,13 +13525,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 645
+        "sequence": 644
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5aafae4f616bd60ce42dcde09fd323113eb81b815d04907fb67837afc20ed2d3",
-        "updatedAt": "2025-09-20T19:50:23.220Z"
+        "model": "fake-64",
+        "vectorSha256": "62c47195e74fbf1486fc67809beb03645b3cf842a62799d9af5d96bd52002baa",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0646": {
@@ -13567,13 +13546,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 646
+        "sequence": 645
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "62db56a1f3691e1db67f4f46f826bffbb672bb1e769b0bca13cbe9a5be67a7e9",
-        "updatedAt": "2025-09-20T19:50:23.220Z"
+        "model": "fake-64",
+        "vectorSha256": "d5b00aa741bc49934d7d94db5b105238fccec61a39955e5aac660bedf7b42d0f",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0647": {
@@ -13588,13 +13567,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 647
+        "sequence": 646
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1b7539b0c048b075d3b2c1c2915a623de326977d6bfd0994b563bcc52ad09e65",
-        "updatedAt": "2025-09-20T19:50:23.220Z"
+        "model": "fake-64",
+        "vectorSha256": "0436ba22ff21a54052d2d93951121c720b2217f878b368b26858f66f719d5c87",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0648": {
@@ -13609,13 +13588,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 648
+        "sequence": 647
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "317818e7194d7447aa2c774437e44b0694f0357781b9d7c59b9cb5a0d3bf5418",
-        "updatedAt": "2025-09-20T19:50:23.220Z"
+        "model": "fake-64",
+        "vectorSha256": "dd4448abdf0aedf28c124cd30a1d56aeae7862201a59bcc37be7482c04f9ffb9",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0649": {
@@ -13630,13 +13609,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 649
+        "sequence": 648
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7121b395b6099221c169a5ecefcd564f9888ef0b12ea95509287abb204c15797",
-        "updatedAt": "2025-09-20T19:50:23.462Z"
+        "model": "fake-64",
+        "vectorSha256": "2915d6e519f11cfd9aaed01e7c483d9135c67b76070ea87e8b230e62bd78025d",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0650": {
@@ -13651,13 +13630,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 650
+        "sequence": 649
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2e76ad413a76b9103e525b7ccaa22b256eec3ed634942b7c8dc438a5b3dd8d60",
-        "updatedAt": "2025-09-20T19:50:23.462Z"
+        "model": "fake-64",
+        "vectorSha256": "0539744a0372d241b7f6a90ecad140a05aa3479d372577cd87b4510413d87370",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0651": {
@@ -13672,13 +13651,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 651
+        "sequence": 650
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "28edf26bd19266c78967c45dbe37c54beceb96bb9ece002b34bee2d91de85cad",
-        "updatedAt": "2025-09-20T19:50:23.462Z"
+        "model": "fake-64",
+        "vectorSha256": "59a3b83451dd606a6ace322eca9cb5add34c982b1af5842ffd50cc23139fdc42",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0652": {
@@ -13693,13 +13672,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 652
+        "sequence": 651
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6876ed449771fce2372e36cfa7b7fe51486551955864e73cdba3bbb7d475d529",
-        "updatedAt": "2025-09-20T19:50:23.463Z"
+        "model": "fake-64",
+        "vectorSha256": "e484cacfaa7b2b92331d44d8bd5d0f5e7d6edc51d495bd4a9680c267ce70063a",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0653": {
@@ -13714,13 +13693,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 653
+        "sequence": 652
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1e12b0423a820147984a0d850736bc984ca5829f4db99878c2294aff225504f0",
-        "updatedAt": "2025-09-20T19:50:23.463Z"
+        "model": "fake-64",
+        "vectorSha256": "fe33fb6b20a5ef4c9293801c9ccc9773ee81ebe7c8ee40d0ef549776fcd11edc",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0654": {
@@ -13735,13 +13714,13 @@
         "punchline": 50
       },
       "source": {
-        "sequence": 654
+        "sequence": 653
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0fad23ee0b4b3fd7f9e576cda0b0aa5f201157ee2289e1132363afe748f7151b",
-        "updatedAt": "2025-09-20T19:50:23.463Z"
+        "model": "fake-64",
+        "vectorSha256": "44ad2c9aa9c46601c624eb543fbe6f76c66ea99b173e6b50f2b6d1037e5a87e1",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0655": {
@@ -13756,13 +13735,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 655
+        "sequence": 654
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f9cc727b0c0a4ba2e8d808498d4f5c846383de143c9f8343997abfae2f3f4fb4",
-        "updatedAt": "2025-09-20T19:50:23.463Z"
+        "model": "fake-64",
+        "vectorSha256": "4558f437ebabbbb228d51d671e7dc2b2f20c9f98055d2ff818b89878d8fe1bb2",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0656": {
@@ -13777,13 +13756,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 656
+        "sequence": 655
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4b80a790d7005e701595662088995db3279cd7340c28a071083e546358e6efa0",
-        "updatedAt": "2025-09-20T19:50:23.463Z"
+        "model": "fake-64",
+        "vectorSha256": "46c37e6d873326ff1af3840ce763610de740ad63a3ec9aaa47c0923f6806ec42",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0657": {
@@ -13798,13 +13777,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 657
+        "sequence": 656
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fd497150de7dc955d7b9961e8c1cc422bf0d31dc20130585d04cd99df46a7bc3",
-        "updatedAt": "2025-09-20T19:50:23.755Z"
+        "model": "fake-64",
+        "vectorSha256": "b67cdc0b3f531768733288d3613f5c394ea6091cadc70681d0fa33afc37b8534",
+        "updatedAt": "2025-09-20T22:27:41.538Z"
       }
     },
     "j-0658": {
@@ -13819,13 +13798,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 658
+        "sequence": 657
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7481deeae11a23fdd82e7838ced42cc26b7e462256b5e3fd6846999245f75e60",
-        "updatedAt": "2025-09-20T19:50:23.755Z"
+        "model": "fake-64",
+        "vectorSha256": "3b95a2a7a95a07c979165862ae7f80bb7d9518040e282e86bd9933e72f9ba826",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0659": {
@@ -13840,13 +13819,13 @@
         "punchline": 49
       },
       "source": {
-        "sequence": 659
+        "sequence": 658
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "74e014905be867d9ce51c74540281ec92c32ed99a9ebec37933e39758561bd11",
-        "updatedAt": "2025-09-20T19:50:23.755Z"
+        "model": "fake-64",
+        "vectorSha256": "615d6b89a436f9b4d725386636324b530b7d1322f94601d3fd1c8b7e4149c2d3",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0660": {
@@ -13861,13 +13840,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 660
+        "sequence": 659
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "32b620ec8618bdfc7db60800be0c04c61ac14e43fb663af430c7e28be123764e",
-        "updatedAt": "2025-09-20T19:50:23.755Z"
+        "model": "fake-64",
+        "vectorSha256": "79a34c3c25adc10cb876419418bf519eb67466eba0005d09c173d4286cdca90e",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0661": {
@@ -13882,13 +13861,13 @@
         "punchline": 7
       },
       "source": {
-        "sequence": 661
+        "sequence": 660
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b90e05820916cb883702055e715a3c7fee9527f5da9546c9556af3c823b37947",
-        "updatedAt": "2025-09-20T19:50:23.755Z"
+        "model": "fake-64",
+        "vectorSha256": "37a7d6ed824b85b30537541e992bfbe4d7ecad940a79a6adafb6829a49afd677",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0662": {
@@ -13903,13 +13882,13 @@
         "punchline": 57
       },
       "source": {
-        "sequence": 662
+        "sequence": 661
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "996fadc688b21d95e5233e33816d03864fe3519c394c3f3119dc349c9a3ca1c9",
-        "updatedAt": "2025-09-20T19:50:23.755Z"
+        "model": "fake-64",
+        "vectorSha256": "41aba9743f5c9981705a5781c0f3462f3312f9f7e172c6cd24600869f91040bc",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0663": {
@@ -13924,13 +13903,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 663
+        "sequence": 662
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f8bd0f3db88152a321c319a087fd438d5d21caebc71c2607e9d4cf455ce340a5",
-        "updatedAt": "2025-09-20T19:50:23.756Z"
+        "model": "fake-64",
+        "vectorSha256": "9ed7d3e75ac8aa9e0b7bca20c91ac3d9d74404ff33da9b4d2b2619443f117969",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0664": {
@@ -13945,13 +13924,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 664
+        "sequence": 663
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b691ddcd0925608e8807cbc211000697f1a1dd7fdbeff6fbd338b1be471d6f55",
-        "updatedAt": "2025-09-20T19:50:23.756Z"
+        "model": "fake-64",
+        "vectorSha256": "fe78761a454cd185aa617728015df535359941d7a71cb18584eb803b167593eb",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0665": {
@@ -13966,13 +13945,13 @@
         "punchline": 5
       },
       "source": {
-        "sequence": 665
+        "sequence": 664
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1a23d9647e40c5bb245c219454995f213ff48826149914fc578125bd56c282ef",
-        "updatedAt": "2025-09-20T19:50:24.001Z"
+        "model": "fake-64",
+        "vectorSha256": "818eed9c28cc16f42aa327f8856e0f1deb3e68030139a2b3399cfa3c89ef53e0",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0666": {
@@ -13987,13 +13966,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 666
+        "sequence": 665
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "99af2e031b126e55f5e8851c32299bf67d21ba3026d860678dc11af575776143",
-        "updatedAt": "2025-09-20T19:50:24.001Z"
+        "model": "fake-64",
+        "vectorSha256": "ad04b454062dbee096de800ee2319b727e8459bf288921d60c4323353f8ae63e",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0667": {
@@ -14008,13 +13987,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 667
+        "sequence": 666
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "05fbc1d3cc6399bf0ea1decc5319dc144ff63afe524e930f2e6fda48ebc98e10",
-        "updatedAt": "2025-09-20T19:50:24.001Z"
+        "model": "fake-64",
+        "vectorSha256": "f84eaf1f5dbe3b0221082a5eb47b92ea5b0163bd4b2eef36bf0af800266971df",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0668": {
@@ -14029,13 +14008,13 @@
         "punchline": 39
       },
       "source": {
-        "sequence": 668
+        "sequence": 667
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fc7ef1171db668d27de34717feca799bb19dfdc1c595cbfdc5264ea03567213b",
-        "updatedAt": "2025-09-20T19:50:24.001Z"
+        "model": "fake-64",
+        "vectorSha256": "24122ec57a8846449c08dfa83008878ceaa5ad02ed55ce9d0674057386a4ed36",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0669": {
@@ -14050,34 +14029,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 669
+        "sequence": 668
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c6b47afc1620157f69693b9906c0639a81d8f921a415671a7be958ce7fac77d0",
-        "updatedAt": "2025-09-20T19:50:24.002Z"
-      }
-    },
-    "j-0670": {
-      "hashes": {
-        "setup": "2c47158659cfe64f88f31943ed7b79590cb575f5812006a264b12ccd8b90da95",
-        "punchline": "84077336f1a1ecdee358fd20167476a8e1831807a042953eca41c13223c38650",
-        "combined": "a8e366863afaf6f6e4ba04f4752b03715381189a3724458895285b9ab7c397a7",
-        "tokenSignature": "dam-did-fish-hit-it-say-the-wall-what-when"
-      },
-      "lengths": {
-        "joke": 43,
-        "punchline": 4
-      },
-      "source": {
-        "sequence": 670
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c6e9d1cc947cc804ec17ea307051dacbc4a5afa80599daec842339584e9f5222",
-        "updatedAt": "2025-09-20T19:50:24.002Z"
+        "model": "fake-64",
+        "vectorSha256": "96616afeb447bf4395bb76a8f9764d727029d64b0c965ce6d2e50d2357579e75",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0671": {
@@ -14092,13 +14050,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 671
+        "sequence": 669
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e56b8dd40de015ebe951446d65a5ed3da79e1abdf91bcbc2a1403300de6ab56d",
-        "updatedAt": "2025-09-20T19:50:24.002Z"
+        "model": "fake-64",
+        "vectorSha256": "1e7f837e06b13b600b84deeb8530cf9a52ba410bbf93d02c1441294f9b508b1d",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0672": {
@@ -14113,13 +14071,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 672
+        "sequence": 670
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "db591c4790c9225554564cdedbb78daf9b6be7fd446ddb7faa8bcd943e3938a0",
-        "updatedAt": "2025-09-20T19:50:24.002Z"
+        "model": "fake-64",
+        "vectorSha256": "960ec5cd87c943a2d3cea17221705a32d4a2a2cc38762929be90ba78c2d08f02",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0673": {
@@ -14134,34 +14092,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 673
+        "sequence": 671
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "04685a5e39c42f7719a06c8da45023842175beedc627f66e60f8e5047af882a1",
-        "updatedAt": "2025-09-20T19:50:24.260Z"
-      }
-    },
-    "j-0674": {
-      "hashes": {
-        "setup": "9f7ed7386e8be80e3c691ca64f8178534d4077c44a70829b964ea5a3d4d48f73",
-        "punchline": "a7d44042a78f9b5c2c0a2d5f3d8c54dd304db4c5c63e4853d5c5750819960665",
-        "combined": "82ed69a5ec7c6412e59c7b207b8dd860c1b6dee5b92a554dc86e9f6e60c2038c",
-        "tokenSignature": "are-bicycles-can-on-own-stand-t-their-they-tired-two-why"
-      },
-      "lengths": {
-        "joke": 38,
-        "punchline": 18
-      },
-      "source": {
-        "sequence": 674
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4ccf4abb216c893d6573145b46f18d1898a748c9c39348e00e345f3822092315",
-        "updatedAt": "2025-09-20T19:50:24.260Z"
+        "model": "fake-64",
+        "vectorSha256": "5bd34f2d519a1cced202000ae0cea1f5f657b71f124e7a34fd5c46dcf43c0f64",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0675": {
@@ -14176,13 +14113,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 675
+        "sequence": 672
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "61845e082fd8fec63a697d7e102c69e406143727b136f052d04286ce7b74e7ed",
-        "updatedAt": "2025-09-20T19:50:24.260Z"
+        "model": "fake-64",
+        "vectorSha256": "c78887789cfa03d7d4bcb98cb7ab9f4375e0345259c850d46ff0106d4a39778c",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0676": {
@@ -14197,13 +14134,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 676
+        "sequence": 673
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "258806a3fbb782e626e3ccfdd8b6f10667cd07eaae3b154f764beeb6728a276b",
-        "updatedAt": "2025-09-20T19:50:24.260Z"
+        "model": "fake-64",
+        "vectorSha256": "27198bae1fddfb77437f193a3d9052035a0acd5504b3ae405045588e711cfe3e",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0677": {
@@ -14218,13 +14155,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 677
+        "sequence": 674
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1369cd1682ed5aaf8da604be004d75632da9f833438c07ee62e5a6afb7f56ed3",
-        "updatedAt": "2025-09-20T19:50:24.261Z"
+        "model": "fake-64",
+        "vectorSha256": "78d5ec9bf0f33b6d5c06135054713e88f666406b19da1814af747022217cc84e",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0678": {
@@ -14239,13 +14176,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 678
+        "sequence": 675
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d50a1b4ad4f2ac6cc85141fbfbf4417410394a6e850c334abf313746ee1c7835",
-        "updatedAt": "2025-09-20T19:50:24.261Z"
+        "model": "fake-64",
+        "vectorSha256": "206921a33a8ae8e378d695e360a712a4c8f1718107bfbfbf9698d461177c85bc",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0679": {
@@ -14260,13 +14197,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 679
+        "sequence": 676
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f1401c6ba8d32e79c4e1e61affff29267f75d233c00d76ec702b3b71866b0554",
-        "updatedAt": "2025-09-20T19:50:24.261Z"
+        "model": "fake-64",
+        "vectorSha256": "2c1be0b80967dd4e216875ee319762adebbc543a863c3c485423bc3a5383e67a",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0680": {
@@ -14281,13 +14218,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 680
+        "sequence": 677
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b65c4883359da760a8e5a26c5b3416a14e5d4d6f755799aacedf8e436e510ce2",
-        "updatedAt": "2025-09-20T19:50:24.261Z"
+        "model": "fake-64",
+        "vectorSha256": "f3af3eb9262b9d0df31ac5a54dcfbffefd1717210eeaab16eb0489361e6bb11c",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0681": {
@@ -14302,13 +14239,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 681
+        "sequence": 678
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2c368d0bf84133d9e37ec104fd44d3b7675c798f706a9a3602690131f23a0952",
-        "updatedAt": "2025-09-20T19:50:24.500Z"
+        "model": "fake-64",
+        "vectorSha256": "f225ca2e044b267aa125476a3f160b9e12823fe6e0a69a989b0033bb27be0874",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0682": {
@@ -14323,13 +14260,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 682
+        "sequence": 679
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b7c169fc47521658f37efa9af7f5fa347ec2c391eb213de0dad48535f76ae1d2",
-        "updatedAt": "2025-09-20T19:50:24.500Z"
+        "model": "fake-64",
+        "vectorSha256": "f3ae73628c55f474baf86791965799bc69ddf180cc804c950ea89e3c25f5148e",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0683": {
@@ -14344,13 +14281,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 683
+        "sequence": 680
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3dc2489c7366084b0aa3a6bcae6d321b525b44b0360238d0087f318c1f8cf0bc",
-        "updatedAt": "2025-09-20T19:50:24.500Z"
+        "model": "fake-64",
+        "vectorSha256": "fee92f731e0c9c56d0dfb669e55f3c3d3f04d58ccdd4a10b7480bef38258b4d2",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0684": {
@@ -14365,13 +14302,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 684
+        "sequence": 681
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "87d8ee0d0ca0b12a56b8a066d74040131d8f41bc77214b618dedf13aa2bc93d8",
-        "updatedAt": "2025-09-20T19:50:24.501Z"
+        "model": "fake-64",
+        "vectorSha256": "ccd7c9f4f6fab7698f26a620bb25e81111731f2bed8ef7c0177091dc084125e3",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0685": {
@@ -14386,13 +14323,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 685
+        "sequence": 682
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a14a44265277368957464c4c684c9ef163bceb06f83b00882cfc35e9b8b2c3c7",
-        "updatedAt": "2025-09-20T19:50:24.501Z"
+        "model": "fake-64",
+        "vectorSha256": "f64ad0fd54074d4b1ef6d4f3b8199bd18db62423688d689a5a22c73954c784ba",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0686": {
@@ -14407,13 +14344,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 686
+        "sequence": 683
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "59c678c91ded36a91038bae72b4b052f5b5d2bf422a9cd53b532dc119dddc28c",
-        "updatedAt": "2025-09-20T19:50:24.501Z"
+        "model": "fake-64",
+        "vectorSha256": "8a694b825ffbfe5578c6240abc0f52185c9626b20ead4edcb5e43dd0a055e290",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0687": {
@@ -14428,13 +14365,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 687
+        "sequence": 684
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3418aafc7fa84a9c26bfb7d5de6bdffc7df32ff04ff8ee42a07fd400c5bae17f",
-        "updatedAt": "2025-09-20T19:50:24.501Z"
+        "model": "fake-64",
+        "vectorSha256": "afeb9981e762426c597fda96372136b84fa0a69f4c960c261277c588c4ba683a",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0688": {
@@ -14449,13 +14386,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 688
+        "sequence": 685
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "42586ed605f17962958850e9c94dfbdb3c128ed2172cdb1641dd323c95b2123b",
-        "updatedAt": "2025-09-20T19:50:24.501Z"
+        "model": "fake-64",
+        "vectorSha256": "aa9b90186f16b311a3568f1bb998dd4db5b9c6cc9cafca2bcae87b4f2db2bdb5",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0689": {
@@ -14470,13 +14407,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 689
+        "sequence": 686
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "78c6995dab660865e1e1c1b5ebc932993e2bd6ca081a3a4f017e92704ac5a7d7",
-        "updatedAt": "2025-09-20T19:50:24.835Z"
+        "model": "fake-64",
+        "vectorSha256": "a079381fb55474c0def999023f569c12dc4eedf316f6b9e16d5dcb1e87980916",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0690": {
@@ -14491,13 +14428,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 690
+        "sequence": 687
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "44a8f35a96849d20ff0bb5f33967060764f33f26703b1f77baf688f4e5f064f9",
-        "updatedAt": "2025-09-20T19:50:24.835Z"
+        "model": "fake-64",
+        "vectorSha256": "16400df9d408970176d1460de588a63be874f131b98ee501a4a30cca9d49c8b1",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0691": {
@@ -14512,13 +14449,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 691
+        "sequence": 688
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9280f88470e38edef408d1e650d2ae42975eca53b342964ea3ce64fc2301cf90",
-        "updatedAt": "2025-09-20T19:50:24.835Z"
+        "model": "fake-64",
+        "vectorSha256": "3f4a180775f52eb33cc772208bc657e94810a54ac96df77eb7315cce2fea5c37",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0692": {
@@ -14533,13 +14470,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 692
+        "sequence": 689
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a4ccdbeefa558a05d542e3c47e2736921402ba37e6da0d9ed542d7565320e63a",
-        "updatedAt": "2025-09-20T19:50:24.835Z"
+        "model": "fake-64",
+        "vectorSha256": "06e065af012d19e13b97c9e6a84ba70828b0969b75e5140a9e9b7122ae697b7e",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0693": {
@@ -14554,13 +14491,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 693
+        "sequence": 690
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a537845e12b1f816bd1655b50c7dd0d667f693a1649299219fb984ce7c799e50",
-        "updatedAt": "2025-09-20T19:50:24.835Z"
+        "model": "fake-64",
+        "vectorSha256": "89bbaa4a694fc637e43a2ef46cd5247b2140cbe6c2279443c08f176de90c3567",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0694": {
@@ -14575,13 +14512,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 694
+        "sequence": 691
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9988d95794a6d1aecae0c13bd7f52e5a0a7c19b3f2834a2b5ed8b44b7b6ce03d",
-        "updatedAt": "2025-09-20T19:50:24.835Z"
+        "model": "fake-64",
+        "vectorSha256": "6ca5c315e2ee5a4543d450db965e5441655025ba675ef53a9b712d6e3cc63ed0",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0695": {
@@ -14596,13 +14533,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 695
+        "sequence": 692
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d5cd0cf58540096d147a3283bd708b0659185432c1b69373db699fee4a420ac5",
-        "updatedAt": "2025-09-20T19:50:24.835Z"
+        "model": "fake-64",
+        "vectorSha256": "1d4bf88f30ee969a330cd44daff3b9ae70cadd95e8d75ca7a7aed3102f0a7961",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0696": {
@@ -14617,13 +14554,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 696
+        "sequence": 693
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2a5bfa84b8f2ddd50655cf26025b9aed6ee9015bed0d5ed1307c48085fb5185e",
-        "updatedAt": "2025-09-20T19:50:24.835Z"
+        "model": "fake-64",
+        "vectorSha256": "867fddfea668fee59b27ea25d81d5212deec8612d2442353aac6e80481faa229",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0697": {
@@ -14638,13 +14575,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 697
+        "sequence": 694
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "949ba308701971d9c763ed7d0771aa45b8dfba75e35724536e59735da32bde6e",
-        "updatedAt": "2025-09-20T19:50:25.107Z"
+        "model": "fake-64",
+        "vectorSha256": "8a215b3ee63996ddab2a32ee01dc2b98582e8b5354bea9673b8f9edbd5b97c9e",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0698": {
@@ -14659,34 +14596,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 698
+        "sequence": 695
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "353f2a82cb4154d2363827d49b332f061b1964dfaf1a73c7726432c78e03ee4d",
-        "updatedAt": "2025-09-20T19:50:25.107Z"
-      }
-    },
-    "j-0699": {
-      "hashes": {
-        "setup": "53c66a41c47250b36d8df590e96f75b0335a84b7782eea83909452d7808a7c22",
-        "punchline": "698dfd38e87e2d9da1982a390956720b42e20fa029a2d9f27e6b7b20b043e6a3",
-        "combined": "d66003ee34450abb848d39aa2bfbcb939320677a8eac89a7ec5f860666144910",
-        "tokenSignature": "a-away-breaks-car-down-frog-gets-happens-it-s-to-toad-what-when"
-      },
-      "lengths": {
-        "joke": 49,
-        "punchline": 17
-      },
-      "source": {
-        "sequence": 699
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0f0840b8ec112fcd27e4a1401dea5ab4bf2ef0b3a3eea231dc840d887244c05f",
-        "updatedAt": "2025-09-20T19:50:25.108Z"
+        "model": "fake-64",
+        "vectorSha256": "d72a6640f4967051839194179082c4e285e190797d71a1b48e0fd213bbaccaf9",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0700": {
@@ -14701,13 +14617,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 700
+        "sequence": 696
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e37f8d1a19f30c559736d445993bfcef626bfdeafc8ad285be9d46c0a341c990",
-        "updatedAt": "2025-09-20T19:50:25.108Z"
+        "model": "fake-64",
+        "vectorSha256": "acd18cf8a952bff98d4105a57fedb891cfbd8d0014c270677160781573abb29a",
+        "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
     "j-0701": {
@@ -14722,13 +14638,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 701
+        "sequence": 697
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "09d78f07522e8d7adf039a2b8d0309e3f961ee7d1b0de8ddfda8ef08185ec327",
-        "updatedAt": "2025-09-20T19:50:25.108Z"
+        "model": "fake-64",
+        "vectorSha256": "625b57da04ccdd9e0a618206ac276c4d915bcc94b15466055ca83dd129959ea5",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0702": {
@@ -14743,13 +14659,13 @@
         "punchline": 60
       },
       "source": {
-        "sequence": 702
+        "sequence": 698
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "889ae00cf018690d1d87e01bf952961f6c9a9677d17f59e050b5844102449f4a",
-        "updatedAt": "2025-09-20T19:50:25.108Z"
+        "model": "fake-64",
+        "vectorSha256": "6028e16ad4ac474b8c3339a03c5b7a1d167a52dd387800ed4b8d827638126be1",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0703": {
@@ -14764,13 +14680,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 703
+        "sequence": 699
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "117ca42e4176b4d9e64096b3388671bbda203c4c73a878d9c4d59a2438b7c2e8",
-        "updatedAt": "2025-09-20T19:50:25.108Z"
+        "model": "fake-64",
+        "vectorSha256": "79f2b002f15692045c94f186152d462fda8ae0080e6311d3bf8d325cd7ca7470",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0704": {
@@ -14785,13 +14701,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 704
+        "sequence": 700
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3512fb328466f0aafadff4c9babb66e31622ef90c9dfeed1903a51385d880c0d",
-        "updatedAt": "2025-09-20T19:50:25.108Z"
+        "model": "fake-64",
+        "vectorSha256": "26ac40f89d2aa93b8a6201d5596ad3ca74508aa8c7262d85dcc3e203ad1e5998",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0705": {
@@ -14806,13 +14722,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 705
+        "sequence": 701
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "152537317592c020d0cf5da6504330d65bb23545c01adca6593b4a897fa05ad8",
-        "updatedAt": "2025-09-20T19:50:25.350Z"
+        "model": "fake-64",
+        "vectorSha256": "c7920ca23923709b3b41a892075c984e0b385d5bd4855945a4e9b6c98964b999",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0706": {
@@ -14827,13 +14743,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 706
+        "sequence": 702
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "df412f34667392b84f6d20fd84c82ed31c915ae4967667e74ed7412ec8d1123c",
-        "updatedAt": "2025-09-20T19:50:25.350Z"
+        "model": "fake-64",
+        "vectorSha256": "ed7d6f243d69bed63ef80e6fa7a4f746d5417cf14f9e4d36f6341cb034fb4212",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0707": {
@@ -14848,13 +14764,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 707
+        "sequence": 703
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e66c5b7edc5abbe893f8126ce912069c3c73d55640f8e98f04d37d1c3827c69e",
-        "updatedAt": "2025-09-20T19:50:25.350Z"
+        "model": "fake-64",
+        "vectorSha256": "40b213540a85e3022107155ee8315ace74be726d82e656343c89ff205f5ecc20",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0708": {
@@ -14869,13 +14785,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 708
+        "sequence": 704
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "37462ef38ef73deb9bdee65d35965ff16b728b13f041a986295c228ce70fe194",
-        "updatedAt": "2025-09-20T19:50:25.350Z"
+        "model": "fake-64",
+        "vectorSha256": "d5463ae65694985206f490ec34b44e0f19707c35b81a93142bc6b00133aca09a",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0709": {
@@ -14890,13 +14806,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 709
+        "sequence": 705
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a5cf8b7037060e94cd501a7207ea174637bfeba3a4fa5fcc64f5c2c1024e5a6c",
-        "updatedAt": "2025-09-20T19:50:25.350Z"
+        "model": "fake-64",
+        "vectorSha256": "067eaeadadf540dbeceb68d0d71aad10eb65f037b1f015cb1e9e342a5c03d3ea",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0710": {
@@ -14911,13 +14827,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 710
+        "sequence": 706
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1a24725358a185420cdd7904b83e90c7e30989b96b0afe3234602239c2647033",
-        "updatedAt": "2025-09-20T19:50:25.350Z"
+        "model": "fake-64",
+        "vectorSha256": "71cc883cd21a52f15abe4eb4f049df3da8a8eaffd9d85ae4b269fba78c53459a",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0711": {
@@ -14932,13 +14848,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 711
+        "sequence": 707
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c08cd2ef713350bc9ea1d47e1118cac158f6166f75592871e43ce7ec6302b788",
-        "updatedAt": "2025-09-20T19:50:25.350Z"
+        "model": "fake-64",
+        "vectorSha256": "019d52fd7f6a2d1c40c00252577ac21977af68e011f86fe9f2fad1f856be44a9",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0712": {
@@ -14953,13 +14869,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 712
+        "sequence": 708
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "75747945665309fc8ce09e58a38cde183f16b4fa3c5c319122c6b5e3bc56023e",
-        "updatedAt": "2025-09-20T19:50:25.351Z"
+        "model": "fake-64",
+        "vectorSha256": "6ee6f598116c983946549c66bb2a310d480b8df91f0ec59ef6234feba4a82948",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0713": {
@@ -14974,13 +14890,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 713
+        "sequence": 709
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dd16831f3c8fc9f9c6b5bc30f8d0eded127bf8cad6eebfa1f4d9647640cb908a",
-        "updatedAt": "2025-09-20T19:50:25.613Z"
+        "model": "fake-64",
+        "vectorSha256": "ce22a74f7de009212a6012f832203e1d15d57616f4f3207023e900c4268eff1b",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0714": {
@@ -14995,55 +14911,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 714
+        "sequence": 710
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bab1d1254ec7b050289c3a7ce3cbcc2c41392c3fd21b1e7f2cc046a5f451fad3",
-        "updatedAt": "2025-09-20T19:50:25.613Z"
-      }
-    },
-    "j-0715": {
-      "hashes": {
-        "setup": "aa68f6c8701566c8b53d9675c08051550d561287dfc8e44b575cec408c78ce88",
-        "punchline": "fba1d8e92e7d6f157cd549b2e9f577ff26f3b7cfd4f64b50456fd54a5f95e623",
-        "combined": "a8dfacf77c43bcf3076bdc57d9214ccc0520a077c77db5d7862d88611cfc6396",
-        "tokenSignature": "a-all-bought-but-day-dealer-don-drug-from-he-i-know-laced-shoes-some-t-them-tripping-was-what-with"
-      },
-      "lengths": {
-        "joke": 39,
-        "punchline": 65
-      },
-      "source": {
-        "sequence": 715
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "79cf67f4f03cf884068d71f7647feead6aeb840391491e91462f2f92e3daf916",
-        "updatedAt": "2025-09-20T19:50:25.614Z"
-      }
-    },
-    "j-0716": {
-      "hashes": {
-        "setup": "086e660440f2ba2a13821b75569e0fc0bced448071f0c92f6251eaba6745c4b9",
-        "punchline": "25cf8bb4440d026605a5132c7140d5e0c19310c5702d3d70c78fc0f6734bdff9",
-        "combined": "c1c1a7d67209d52bcbc6d586270260798aa78d2f9667c534da07c0d601b1acb3",
-        "tokenSignature": "be-because-chicken-coops-do-doors-four-had-have-if-only-sedans-they-two-why-would"
-      },
-      "lengths": {
-        "joke": 41,
-        "punchline": 54
-      },
-      "source": {
-        "sequence": 716
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2c3ede8782c9c059866dd8db4598b9647fae152c1b3e5caee1c8a10aa721189c",
-        "updatedAt": "2025-09-20T19:50:25.614Z"
+        "model": "fake-64",
+        "vectorSha256": "1cbe540f86f963a496b71ca0e41e1e1f62603fbcaae66bbabebd0fc0858cece8",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0717": {
@@ -15058,13 +14932,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 717
+        "sequence": 711
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5c655d1909667c3a7debbccfcc1edd93868a708b09d2ba42a4863ba500869ad3",
-        "updatedAt": "2025-09-20T19:50:25.614Z"
+        "model": "fake-64",
+        "vectorSha256": "11b62431a07341bf42249771a70dc5b0eab5bb341cc9e9a1ac7d340348459dd7",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0718": {
@@ -15079,13 +14953,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 718
+        "sequence": 712
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "446f09f59cff9881dc9762e017d9ce99072a758505655ba7af152b37f749ba7d",
-        "updatedAt": "2025-09-20T19:50:25.614Z"
+        "model": "fake-64",
+        "vectorSha256": "ab7306f36f77462b4158ae173856fcaa0804017410d19325c2b2dd8cacb108f3",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0719": {
@@ -15100,13 +14974,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 719
+        "sequence": 713
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "07de4129f83fc61d9d0d9079537581a93c95f8eee37524495d4688f4e4d540f7",
-        "updatedAt": "2025-09-20T19:50:25.614Z"
+        "model": "fake-64",
+        "vectorSha256": "5edccd434030b9979ad618c8651e99de17ad5db6e228216839a3d5ec9539def1",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0720": {
@@ -15121,13 +14995,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 720
+        "sequence": 714
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "66210e898d29f35bf378de0fbafd244497a8f4bef3ff7259670ec4877e344389",
-        "updatedAt": "2025-09-20T19:50:25.614Z"
+        "model": "fake-64",
+        "vectorSha256": "1d2d685a23d8dea217e1c6c4761f0996a1e90f876e9f76c28d4e220ba9aaddd7",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0721": {
@@ -15142,13 +15016,13 @@
         "punchline": 56
       },
       "source": {
-        "sequence": 721
+        "sequence": 715
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5836060dd43fb645442b4b1cfd5486f4e11bd038be8c5a61d5d317ee53848450",
-        "updatedAt": "2025-09-20T19:50:25.887Z"
+        "model": "fake-64",
+        "vectorSha256": "40473571bbf4b9bc89abfd64dc1f0d2a6c566caa45fff717cdc3f828cc7cd77b",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0722": {
@@ -15163,13 +15037,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 722
+        "sequence": 716
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "50fe0f865fb50bf1ca3e459c4f3f2d344dcaafa66efe7141f5a1aaa2914293af",
-        "updatedAt": "2025-09-20T19:50:25.887Z"
+        "model": "fake-64",
+        "vectorSha256": "8a8c1a5fdbc40e9293bd5bf054b9f299775ba14051b5d4733cbe1e772798b22d",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0723": {
@@ -15184,13 +15058,13 @@
         "punchline": 51
       },
       "source": {
-        "sequence": 723
+        "sequence": 717
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8bcc35a5a58fa95327867993e3492e518abbd9b8b174dbfa13274c114aa0f252",
-        "updatedAt": "2025-09-20T19:50:25.887Z"
+        "model": "fake-64",
+        "vectorSha256": "68bbe4ab1c903d14dc7e549440c57c9d324a85cb5c0d87586b80a0ce6668c98a",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0724": {
@@ -15205,13 +15079,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 724
+        "sequence": 718
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "371aea1345c4edb2caa298f4a130a7fd6a6ce56cbe347d81db4d38b741676809",
-        "updatedAt": "2025-09-20T19:50:25.887Z"
+        "model": "fake-64",
+        "vectorSha256": "8651fec03f67d6a6fa90f7240a34d9c3e7b970807babd2b24ba0f979b1e8adbd",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0725": {
@@ -15226,13 +15100,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 725
+        "sequence": 719
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "135bb49f16f9078dd68ef8ac694a4eb583d9c38e1571e4afee3c6bd3bae018d3",
-        "updatedAt": "2025-09-20T19:50:25.887Z"
+        "model": "fake-64",
+        "vectorSha256": "88884e420ec9079f7de8bc7cfe3a71cffa6452ffb94bbd6ce3c713890f3b4f4a",
+        "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
     "j-0726": {
@@ -15247,13 +15121,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 726
+        "sequence": 720
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a53ea2b0925d7060b31fdb24a04127f31b8bfca5c88f09e97f6d3cc78fb2aa4d",
-        "updatedAt": "2025-09-20T19:50:25.887Z"
+        "model": "fake-64",
+        "vectorSha256": "e00189d1f4cee50635f7e0e1c89db7725e93653d247a44056e156986edf29a36",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0727": {
@@ -15268,13 +15142,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 727
+        "sequence": 721
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9fdfaef3e247f188ddad3ba1aafa3e454e3ee8e75201f75d0a0c144eae754af6",
-        "updatedAt": "2025-09-20T19:50:25.887Z"
+        "model": "fake-64",
+        "vectorSha256": "9adc57a849d8927c57fd4d07bd3cdced7c38d1aefaa73ab6f085855b6dc9d886",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0728": {
@@ -15289,13 +15163,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 728
+        "sequence": 722
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b7805be21b89a7a2cbeddead5e6d2ec942d7f063d39e1ea4d1edd315f64df78e",
-        "updatedAt": "2025-09-20T19:50:25.887Z"
+        "model": "fake-64",
+        "vectorSha256": "41dc96a592d541859970c6f013e46167a15535935231fd71f349841808ee5c43",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0729": {
@@ -15310,13 +15184,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 729
+        "sequence": 723
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c18179cd16609249849d866e02dac0993af0e2133fddfdaa71e1ca4274ef27c5",
-        "updatedAt": "2025-09-20T19:50:26.190Z"
+        "model": "fake-64",
+        "vectorSha256": "6a2eaf11770497fe37e356d698dbf05c5b6555fa4b1718667bc1ec1fa394a381",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0730": {
@@ -15331,13 +15205,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 730
+        "sequence": 724
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "57e613be7432933e9a562c3daec791c5f0cb5aa045555d864c8cc7df40d3d342",
-        "updatedAt": "2025-09-20T19:50:26.190Z"
+        "model": "fake-64",
+        "vectorSha256": "3cf329c80d7426686731b91b610461f5447cec7ae235380b0014a742d2cda381",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0731": {
@@ -15352,13 +15226,13 @@
         "punchline": 37
       },
       "source": {
-        "sequence": 731
+        "sequence": 725
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "986f7d9db5dc41f21d8f66a26962c9579d5017c305442af72b0173a281a6daec",
-        "updatedAt": "2025-09-20T19:50:26.190Z"
+        "model": "fake-64",
+        "vectorSha256": "ce454efa75ca3a5d96ad78f79340e5f9dc192116c55c96a0d535a73e6ac2490d",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0732": {
@@ -15373,13 +15247,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 732
+        "sequence": 726
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ac048f48251755e7bf2a15a00036c716bbb8478972937fead10d1b77ef7954ab",
-        "updatedAt": "2025-09-20T19:50:26.191Z"
+        "model": "fake-64",
+        "vectorSha256": "152b204902d495079dd346b6cc6a1cb54b74df001d3759f6c13b418c96488c0f",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0733": {
@@ -15394,13 +15268,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 733
+        "sequence": 727
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b8509e17bb0a9ba1e1165f468bfa6967660470eb7f99ea23a633893f0f3a405c",
-        "updatedAt": "2025-09-20T19:50:26.191Z"
+        "model": "fake-64",
+        "vectorSha256": "baacb9bbc2ff861af9ed7e92f66d4d1f35a77bce393fa9ce194cd436dba8ebc4",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0734": {
@@ -15415,13 +15289,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 734
+        "sequence": 728
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a4bd42533bffe799341ec40c4672d39395c39b293476685cc3e4dbc8bcd92f6d",
-        "updatedAt": "2025-09-20T19:50:26.191Z"
+        "model": "fake-64",
+        "vectorSha256": "8f6c06d184cfb5f89db4de054d1145210f38cbd2f801f360fd0cea7ba2e4f32e",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0735": {
@@ -15436,13 +15310,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 735
+        "sequence": 729
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6982d8b861e42d44e216c167b3cf439edba8e3478352de9fbaa39af5d1aaa9ed",
-        "updatedAt": "2025-09-20T19:50:26.191Z"
+        "model": "fake-64",
+        "vectorSha256": "ee458728223954badbe8e4987c702d393cef50e790117386069d3b4822d44811",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0736": {
@@ -15457,13 +15331,13 @@
         "punchline": 39
       },
       "source": {
-        "sequence": 736
+        "sequence": 730
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ad59560de85152c8e902782001e6b9d9f51e0b29333350f797e53cefdd48277b",
-        "updatedAt": "2025-09-20T19:50:26.191Z"
+        "model": "fake-64",
+        "vectorSha256": "717bd5a138ed05c63c4aec70b3e25302bdbfa7051bda19a4317fc568072dd877",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0737": {
@@ -15478,55 +15352,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 737
+        "sequence": 731
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "57e3ad5ddbb19a2693dd4859c14b82b83e97a2e3be4d75821e599afcb34dce5d",
-        "updatedAt": "2025-09-20T19:50:26.498Z"
-      }
-    },
-    "j-0738": {
-      "hashes": {
-        "setup": "b7eac12ae658f93eec3775ba768563dc7c509bf24ba0535e3fd67233e07416f1",
-        "punchline": "bd99bc161256dc536445680e7fdd2787e36591eaf2699291e917a168ddf84d7e",
-        "combined": "f69c5ef86ff426ee2d25b9507c2f9bcfc65f7822761660e0e05ff7a4f7f04882",
-        "tokenSignature": "a-do-give-in-lemon-lemonaid-need-to-what-you"
-      },
-      "lengths": {
-        "joke": 36,
-        "punchline": 9
-      },
-      "source": {
-        "sequence": 738
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cb8974e25bafbc68197718e63724462a29811308b2886601fbfac3dedfdfcc10",
-        "updatedAt": "2025-09-20T19:50:26.498Z"
-      }
-    },
-    "j-0739": {
-      "hashes": {
-        "setup": "83a8b79ef6835590540053947891310ba6c8bcbbbee70bfdc304ea6b2c6bf82b",
-        "punchline": "19163dc794fce3b492497e109ff9471464022c2d32a994cb5c2242bb23f4e2f6",
-        "combined": "096eaa425183d54949d9b932bfcb0ea97fb143926c741f8aec73b661e8542884",
-        "tokenSignature": "a-bar-bartender-before-can-for-get-goes-i-into-never-pop-says-served-the-ve-walks-weasel-what-wow-you"
-      },
-      "lengths": {
-        "joke": 112,
-        "punchline": 20
-      },
-      "source": {
-        "sequence": 739
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "03d3004958897dca4a63a714d2360149c973395c5befdf9fc51bba333c7560cc",
-        "updatedAt": "2025-09-20T19:50:26.498Z"
+        "model": "fake-64",
+        "vectorSha256": "45de56d1fcbe9575d1ac9872c732f220c13b21e80e769dcd87ac57c3c47c4d9e",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0740": {
@@ -15541,13 +15373,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 740
+        "sequence": 732
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "623fd321a1a9e1b99662cc335d0664b3bad9dd548109bb4b866ceff87cd8c58f",
-        "updatedAt": "2025-09-20T19:50:26.498Z"
+        "model": "fake-64",
+        "vectorSha256": "8c2edcbf9aafc681e7cd3fe6b2bc6f0abe7c5107c519e472666919b1495cf3de",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0741": {
@@ -15562,13 +15394,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 741
+        "sequence": 733
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "051b60d91635c6329c3eb0101aa0637084b765651437d2d7ef3159f2f871a541",
-        "updatedAt": "2025-09-20T19:50:26.498Z"
+        "model": "fake-64",
+        "vectorSha256": "fc08dcf9c4255f861c4176ae5a7c6a5f3d56aefd3bddfcafc6be51dfba77028c",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0742": {
@@ -15583,34 +15415,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 742
+        "sequence": 734
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "751bfd468869f8e2e75e20d51a0a47a5a437a9066ffb2815bea3f3cbf72b8b71",
-        "updatedAt": "2025-09-20T19:50:26.498Z"
-      }
-    },
-    "j-0743": {
-      "hashes": {
-        "setup": "87f800db89cd5ba3f352f901911d8f04349a07385ce93d3d60c1a89767dfa027",
-        "punchline": "6eb05ff604740d43879b47dd71910a4f3e2b63a5e8e5effbb20ecd8b8881ff9b",
-        "combined": "5eb8faa76d4bee55041b51c810620759572241f914a961478b012b80f2bb3a97",
-        "tokenSignature": "12-2nd-a-april-are-etc-february-how-in-january-many-march-seconds-year"
-      },
-      "lengths": {
-        "joke": 31,
-        "punchline": 59
-      },
-      "source": {
-        "sequence": 743
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ecf4e2f87a253adbc76edb9231da8266bdced27ee569d322d153eebf4f3e7e04",
-        "updatedAt": "2025-09-20T19:50:26.498Z"
+        "model": "fake-64",
+        "vectorSha256": "426d408ec300c6f9b6a867b159e5b69fdb0bd4bd1c6e37e57085e6f556caf46b",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0744": {
@@ -15625,34 +15436,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 744
+        "sequence": 735
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "562cea07bcdd48cc444f61c5b55353ea89ae6e0f18955d1937cd455a347e7025",
-        "updatedAt": "2025-09-20T19:50:26.498Z"
-      }
-    },
-    "j-0745": {
-      "hashes": {
-        "setup": "b22c1df822ae72976f690540f29d1014d7d9919b663be4470b09a9aaebb354bc",
-        "punchline": "d6acce58810d89e5a423471d83cbb0ed7c85ad9dd1080e35af7a384ce01ca140",
-        "combined": "989c17ec5220c771f8a14d6a3f903c699ad9a5dbf0887f95a4db55572fc8615b",
-        "tokenSignature": "anywhere-been-bin-haven-i-s-t-the-where"
-      },
-      "lengths": {
-        "joke": 16,
-        "punchline": 24
-      },
-      "source": {
-        "sequence": 745
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1845d5aeafc8f8c66686b6af9baedbe9284dd38f2ffda418195f3a04da1ff239",
-        "updatedAt": "2025-09-20T19:50:26.821Z"
+        "model": "fake-64",
+        "vectorSha256": "1e0d4ccfb65da4f49a599f2c0b4b6f8c664dec5d7586d96f44b739136e484f6e",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0746": {
@@ -15667,13 +15457,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 746
+        "sequence": 736
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f54722d082895ef369fa7bfe4aff9f11d283b2b7e73845f7ce86416fe4a80b7f",
-        "updatedAt": "2025-09-20T19:50:26.821Z"
+        "model": "fake-64",
+        "vectorSha256": "9f5706e7884758d97b891f28a526c8e468312cbc3199464507d86df80dd9ea19",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0747": {
@@ -15688,13 +15478,13 @@
         "punchline": 46
       },
       "source": {
-        "sequence": 747
+        "sequence": 737
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e3846ec4329d93e0c449eaeb4a38662b9065e3c052b03ddf7ba80390e3cec153",
-        "updatedAt": "2025-09-20T19:50:26.822Z"
+        "model": "fake-64",
+        "vectorSha256": "63817c89cbe242a464fa4519bef3073be2c8b8ec595ea19d2ccbb001a4e1401c",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0748": {
@@ -15709,13 +15499,13 @@
         "punchline": 74
       },
       "source": {
-        "sequence": 748
+        "sequence": 738
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a19add76734f5e24628b7b34e34ab55e8db926e0bc2d40cbb1a4da93942485da",
-        "updatedAt": "2025-09-20T19:50:26.822Z"
+        "model": "fake-64",
+        "vectorSha256": "71d0f21761f927ebcfabc0be57551f18fe6c4986be10910826ea2545185cac4e",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0749": {
@@ -15730,13 +15520,13 @@
         "punchline": 78
       },
       "source": {
-        "sequence": 749
+        "sequence": 739
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1064f3fcd4b566ae50a57b73de77a6349def50aaf7385e97dec86bc109c5087f",
-        "updatedAt": "2025-09-20T19:50:26.822Z"
+        "model": "fake-64",
+        "vectorSha256": "1b194a306cf5d30b4b3cb00bff365833421f276d10c0e078147d585dd67db333",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0750": {
@@ -15751,13 +15541,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 750
+        "sequence": 740
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2c8f7b0178c8ffd1ed1f88ec4cc9b02a0f5e58e5f7c3f7204c54c13a9b1113ca",
-        "updatedAt": "2025-09-20T19:50:26.822Z"
+        "model": "fake-64",
+        "vectorSha256": "a5c28b9b810f31b3a2ab2079486d1ca5c90545e17f9d02744cd7b095583666c1",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0751": {
@@ -15772,13 +15562,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 751
+        "sequence": 741
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "08e8871099c3a928ca7a95deb53c018a21063ad31d9ce203ad89b165899b88fd",
-        "updatedAt": "2025-09-20T19:50:26.822Z"
+        "model": "fake-64",
+        "vectorSha256": "dcd17e5c1b70b94156a2f1396fa9ae6568c9a62042d9c2c65fa8cde69c89b9e1",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0752": {
@@ -15793,13 +15583,13 @@
         "punchline": 59
       },
       "source": {
-        "sequence": 752
+        "sequence": 742
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "61ad5c7e861a45cd072807170345ae00523fea5d81921744852a234ca513797b",
-        "updatedAt": "2025-09-20T19:50:26.822Z"
+        "model": "fake-64",
+        "vectorSha256": "e91754f5a92e99f5fb1cab3d73bde1250d409f0971227038eea68e9bc85f7a87",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0753": {
@@ -15814,13 +15604,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 753
+        "sequence": 743
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7648b02d059520c90e3fb0efb421469ff7e73d114c294e63dfd83caa6846cb36",
-        "updatedAt": "2025-09-20T19:50:27.065Z"
+        "model": "fake-64",
+        "vectorSha256": "c2c729a08cac7d71441c86edc7537dae724841040826c82da195954f617769ec",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0754": {
@@ -15835,13 +15625,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 754
+        "sequence": 744
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dc16d38fbf632718f89df8336b5d1b0d040ffea476034fb3d7f7c29d7f4362bc",
-        "updatedAt": "2025-09-20T19:50:27.065Z"
+        "model": "fake-64",
+        "vectorSha256": "2f8f64d5d81344da3250df2120b636d954f86d0eff62a6c35141ac8edeb41cbc",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0755": {
@@ -15856,13 +15646,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 755
+        "sequence": 745
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a2cf80f35497858afc35c6f36477bcdc898ab9221e8ddbe5d37b8518366cc077",
-        "updatedAt": "2025-09-20T19:50:27.065Z"
+        "model": "fake-64",
+        "vectorSha256": "9f44ebbb4a7df429f40630bebb0e054990593227b7e449accfb16e9f5eee5419",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0756": {
@@ -15877,13 +15667,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 756
+        "sequence": 746
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6b791edd8e441d10997eab18e59684461012fa4c685b0a9758ffa4ba3f8c3910",
-        "updatedAt": "2025-09-20T19:50:27.065Z"
+        "model": "fake-64",
+        "vectorSha256": "b3e2cd858ed47899b76400ea22d428531a435f4602d3958c5d1898d7ba7a61ce",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0757": {
@@ -15898,13 +15688,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 757
+        "sequence": 747
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "30f06d1d9aa7f8b929dac90d2ad305b23864b13b422a20b7757b948d2010ac6a",
-        "updatedAt": "2025-09-20T19:50:27.066Z"
+        "model": "fake-64",
+        "vectorSha256": "72b0b40757dba10bc62f7577a98151ec121d90b41325e3c143e9dc1c21552591",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0758": {
@@ -15919,13 +15709,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 758
+        "sequence": 748
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2d4f309d57fde92714b27ea329717d18559afc60d188f7e7e2577bc611943a02",
-        "updatedAt": "2025-09-20T19:50:27.066Z"
+        "model": "fake-64",
+        "vectorSha256": "e9808823ef5750330cc12b0e4cc3a285b7c9ae0df911a654caf5b1d29d02d1ba",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0759": {
@@ -15940,13 +15730,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 759
+        "sequence": 749
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0ae3a251d7ed130a1829244fab445618ce915251e832d6fd12e46b823e161ef9",
-        "updatedAt": "2025-09-20T19:50:27.066Z"
+        "model": "fake-64",
+        "vectorSha256": "75243deea0336711e7faf4d59f658b4b8fde3dd71802cad0538aa2659c2ca6e4",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0760": {
@@ -15961,13 +15751,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 760
+        "sequence": 750
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a76efa54bb59a18f10385b33107869a7c8e37a2a7bfa7de2ccddb8133ed632a0",
-        "updatedAt": "2025-09-20T19:50:27.066Z"
+        "model": "fake-64",
+        "vectorSha256": "369b03ad6df7fe0462e807f587a36f57187fd771cc4ea53a38f9da4c0ec6bf54",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0761": {
@@ -15982,13 +15772,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 761
+        "sequence": 751
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4e156c7f5c6f2ac8f25062d5a765a3f477ee24e99a17a38d56b98ec1d21d3564",
-        "updatedAt": "2025-09-20T19:50:27.413Z"
+        "model": "fake-64",
+        "vectorSha256": "92cea857f776627c5d4180f6927763a4860b978c2632eb56317e8ba1bebf4ac8",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0762": {
@@ -16003,13 +15793,13 @@
         "punchline": 4
       },
       "source": {
-        "sequence": 762
+        "sequence": 752
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8a440482760e992407fe0020bdef4919213a98bfc4f863f6d8594122e1d84607",
-        "updatedAt": "2025-09-20T19:50:27.414Z"
+        "model": "fake-64",
+        "vectorSha256": "04d42033488ef59cdb876c49317921b51b49dc041bfbaa582dee621ad5bfeb13",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0763": {
@@ -16024,13 +15814,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 763
+        "sequence": 753
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a05224c0b93dce3a250655a125be34c29b1e5b47dcf71f9cb9b8369a4afda4d7",
-        "updatedAt": "2025-09-20T19:50:27.414Z"
+        "model": "fake-64",
+        "vectorSha256": "a6e05807e0bb9300f6dac494e0b46304346f866ecef9544ae86df87c50653fb8",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0764": {
@@ -16045,13 +15835,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 764
+        "sequence": 754
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8263d6b06cb52e37d2fceb2f1c49949b861fa9ef8dec8dd2cc27bce065a3b831",
-        "updatedAt": "2025-09-20T19:50:27.414Z"
+        "model": "fake-64",
+        "vectorSha256": "320ee9de96c90e96c52cf79c0733fa63e08a39312bbe039349f0d8b48693e434",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0765": {
@@ -16066,13 +15856,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 765
+        "sequence": 755
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6e69ff1c10cfe211c1d053dd7c32d5855c971531a6c8029b3a65248f62681657",
-        "updatedAt": "2025-09-20T19:50:27.414Z"
+        "model": "fake-64",
+        "vectorSha256": "4ad4c466c85146c7f1df6a96842cb250552ecd94e2ff3268fe6480aa720f6628",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0766": {
@@ -16087,13 +15877,13 @@
         "punchline": 4
       },
       "source": {
-        "sequence": 766
+        "sequence": 756
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "69003241955d278827e58aacdbe99d7bb41c00dd077df1c7f6a3d2761d49f14f",
-        "updatedAt": "2025-09-20T19:50:27.414Z"
+        "model": "fake-64",
+        "vectorSha256": "2cbc1802d26ca10582cdd585ef1de96b1f37b8e9fdf1afa6aa85103395bb49e1",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0767": {
@@ -16108,13 +15898,13 @@
         "punchline": 39
       },
       "source": {
-        "sequence": 767
+        "sequence": 757
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f5a32c787a3c4b72f561c61e3e2f2fde027ff889bc6054ec37b099f097bd11cf",
-        "updatedAt": "2025-09-20T19:50:27.414Z"
+        "model": "fake-64",
+        "vectorSha256": "2d78dde195c4a14da1dc54a87a6de7331c3378b4826c0f78de37b3ffff4aa5fc",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0768": {
@@ -16129,13 +15919,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 768
+        "sequence": 758
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "edd1bca432f8769ed5c2bfdf235ad076a77cee9214de012c1a8dde9a4c8d9b42",
-        "updatedAt": "2025-09-20T19:50:27.414Z"
+        "model": "fake-64",
+        "vectorSha256": "cd3dc3d67b52beb649400bc80d95cb2cc0e1f656673f84e61c6374c3d81aec17",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0769": {
@@ -16150,13 +15940,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 769
+        "sequence": 759
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9e0f37d718602c21ac78374bc8868a120bbce4cff234322e1f077971f80df905",
-        "updatedAt": "2025-09-20T19:50:27.788Z"
+        "model": "fake-64",
+        "vectorSha256": "f1c33caaf47a81e69a2a621e11008dca86ddcef6e42305a69e852033163b0143",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0770": {
@@ -16171,13 +15961,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 770
+        "sequence": 760
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1e61d8186198db19fa45e34e152f3203f890975f1f9110697019ba4e549ccae2",
-        "updatedAt": "2025-09-20T19:50:27.788Z"
+        "model": "fake-64",
+        "vectorSha256": "9491bed5afbaf7854de146c23e10bce1dccbfed858337ffe35d7582b6b5e49ea",
+        "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
     "j-0771": {
@@ -16192,13 +15982,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 771
+        "sequence": 761
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "68a7f48fc4e442e2edcb66df01a25cb2050e20e28382d3e2a3374b3cd29708a6",
-        "updatedAt": "2025-09-20T19:50:27.788Z"
+        "model": "fake-64",
+        "vectorSha256": "89397a803e63205d027f4b44e078694b7381cc362bd64900ff93f53fa097bf35",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0772": {
@@ -16213,13 +16003,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 772
+        "sequence": 762
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e8e9e054eded4ce14c9d8837bd7843e9ffd4e63e0cb384019fc5edda49534467",
-        "updatedAt": "2025-09-20T19:50:27.788Z"
+        "model": "fake-64",
+        "vectorSha256": "47b321685e259837408acf6877f8a7db513556ae73d7202847511b6989aac56f",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0773": {
@@ -16234,13 +16024,13 @@
         "punchline": 50
       },
       "source": {
-        "sequence": 773
+        "sequence": 763
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3f269b05c1c46e8eac8c70bed8df820172c38ed4f46d28d866e2c1daca867d57",
-        "updatedAt": "2025-09-20T19:50:27.788Z"
+        "model": "fake-64",
+        "vectorSha256": "1fcf4cb189849b935d580ade4beff244a9cff8eb91cec6d18054977ffc384ede",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0774": {
@@ -16255,13 +16045,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 774
+        "sequence": 764
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "569020e5131d802f1b1e201ad79d98b50886d602a1dc0d33cf2c06e8061bd24e",
-        "updatedAt": "2025-09-20T19:50:27.788Z"
+        "model": "fake-64",
+        "vectorSha256": "8dc30dea2fa889b00d41eab2bd41e1c6ecd58240b23b4f0c428d122d8e93e28a",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0775": {
@@ -16276,13 +16066,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 775
+        "sequence": 765
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "00ad83233577b855e9a39a19baa020dee11eacf89df23af6a814cc0a8e140642",
-        "updatedAt": "2025-09-20T19:50:27.788Z"
+        "model": "fake-64",
+        "vectorSha256": "1d80fcb7ca3bd49679022c67812e4d6a15ef460d4893649f2c0074975d8c03ca",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0776": {
@@ -16297,13 +16087,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 776
+        "sequence": 766
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2204168170541f247289a49ddef08f1658fb4e65bcb44678e274a930b146dfd4",
-        "updatedAt": "2025-09-20T19:50:27.788Z"
+        "model": "fake-64",
+        "vectorSha256": "e458299b0fe81176fd1e0a2953da736703756a4a61667de59785995dae5f68d5",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0777": {
@@ -16318,13 +16108,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 777
+        "sequence": 767
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "629dcaa15db8e6e0a0b6705b40a8346a8c62254192816d35d9b800d65f39101f",
-        "updatedAt": "2025-09-20T19:50:28.116Z"
+        "model": "fake-64",
+        "vectorSha256": "d39130d5b340e2d626d7356f5aa988a549b279af6c668fc6c949fdd4c636cd9e",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0778": {
@@ -16339,13 +16129,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 778
+        "sequence": 768
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fac88a13e34aa8450240ad9535554e78ea2b26e5dd39afdde4fc182ff97e9c9c",
-        "updatedAt": "2025-09-20T19:50:28.116Z"
+        "model": "fake-64",
+        "vectorSha256": "4333a9f81b691ae5934e9bfd51bc161165bc4811065a2b2f13ab3f405e08915e",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0779": {
@@ -16360,13 +16150,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 779
+        "sequence": 769
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6e554607d11f0317f93bd3af331b8fe1736ca7319100f9dc75f31600e80cb3bf",
-        "updatedAt": "2025-09-20T19:50:28.116Z"
+        "model": "fake-64",
+        "vectorSha256": "48b36fde78d2f0991588d429013032d54ea1f6eada22f6271dc6d070ebc7ef27",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0780": {
@@ -16381,13 +16171,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 780
+        "sequence": 770
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f06111dddaa507d117ab0ae789db5df650fddde8ac9c882be66889f7863651b8",
-        "updatedAt": "2025-09-20T19:50:28.116Z"
+        "model": "fake-64",
+        "vectorSha256": "faa64b2a2b9f2f57921de54b9f9efd42ff713ed9580fce2d32a7d0aa545a86ea",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0781": {
@@ -16402,13 +16192,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 781
+        "sequence": 771
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b37cfeea5b7e5a4f4a474681113bba083b789c090fab7cefd4952c1899f42811",
-        "updatedAt": "2025-09-20T19:50:28.116Z"
+        "model": "fake-64",
+        "vectorSha256": "5c918cd07f307ea8167f6e3c5ad61c5a116bf4c92cb2d7ab2e9ea02d9056e320",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0782": {
@@ -16423,13 +16213,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 782
+        "sequence": 772
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "70a77ee58d58c468fb008fb81b107751c2c7a6320d1ed952e03eb528b9192382",
-        "updatedAt": "2025-09-20T19:50:28.116Z"
+        "model": "fake-64",
+        "vectorSha256": "ba606466997a78f09d311588300767cc92e3fa2cc6005268affaebbe774fbcac",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0783": {
@@ -16444,13 +16234,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 783
+        "sequence": 773
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8bbc42482c36cc0d9779ea9f14f9cbb8b21f1d7c9f31dda45796b28d3984c04e",
-        "updatedAt": "2025-09-20T19:50:28.117Z"
+        "model": "fake-64",
+        "vectorSha256": "71bedaa4e1965bba667b583a184d77f5994134366fc9c93699b383a1f43cb787",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0784": {
@@ -16465,13 +16255,13 @@
         "punchline": 62
       },
       "source": {
-        "sequence": 784
+        "sequence": 774
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "10ad581b52e4cb34c458f0aff9f36c45f849cb85e2ed3aff39014eccdc3c3cb3",
-        "updatedAt": "2025-09-20T19:50:28.117Z"
+        "model": "fake-64",
+        "vectorSha256": "b924468ff10d0a2c6423093ea54b0770f87d1d0c9e20917246faadaed268e8e3",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0785": {
@@ -16486,13 +16276,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 785
+        "sequence": 775
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "80a362d7bb97d8936bd4046908df17acd4cf492668f8a83b8da1f2c4b46706ea",
-        "updatedAt": "2025-09-20T19:50:28.357Z"
+        "model": "fake-64",
+        "vectorSha256": "142d39012a1b7f1b677af3f3f2fd413bf208563387e06a0004fc237d93e23256",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0786": {
@@ -16507,13 +16297,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 786
+        "sequence": 776
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a68b1008996f9dc5acbd1d4477754ae9e543b4e16c5793ce8dab595dcffa8e99",
-        "updatedAt": "2025-09-20T19:50:28.357Z"
+        "model": "fake-64",
+        "vectorSha256": "e1586eb478619044815cd3e80c46523d9bca6e0a8484e01381bb62937d727ae9",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0787": {
@@ -16528,13 +16318,13 @@
         "punchline": 57
       },
       "source": {
-        "sequence": 787
+        "sequence": 777
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "69f875e8a08bc8b81f3f00b0a0c99f26592cb412dc608060fbbe39c8265c5ad0",
-        "updatedAt": "2025-09-20T19:50:28.357Z"
+        "model": "fake-64",
+        "vectorSha256": "2772c6f875062dc2128cd7f3cf817a806e221e459aa89b7b59fa69718c4eb5ef",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0788": {
@@ -16549,13 +16339,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 788
+        "sequence": 778
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d025afdd50d7e9a04f37bccd4763cf2876975b41fa40fc0046bfd2ad171569a2",
-        "updatedAt": "2025-09-20T19:50:28.357Z"
+        "model": "fake-64",
+        "vectorSha256": "f760e25a494ffbd0a6f10bc83e38befa8300ee3a3c74ddbebb12cc854fd54e05",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0789": {
@@ -16570,34 +16360,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 789
+        "sequence": 779
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "da104cb8ec3f5c81098c9eeb738537985187e539a4250e9694f29833d917e020",
-        "updatedAt": "2025-09-20T19:50:28.357Z"
-      }
-    },
-    "j-0790": {
-      "hashes": {
-        "setup": "c227f141cbf6028f4ee4c5c34b7ae22cef0c118efe99e55a8d8df558a49107aa",
-        "punchline": "4f3dc2cfd1ad0bab8cc7648eb3fa85b633922714c0652a3cda36e085f1948099",
-        "combined": "893c567afbb79c75e512e2abcad2a59acaf2934331f9a609534a93202526b22d",
-        "tokenSignature": "arrays-because-developer-did-didn-get-he-his-job-quit-t-the-why"
-      },
-      "lengths": {
-        "joke": 35,
-        "punchline": 29
-      },
-      "source": {
-        "sequence": 790
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b05cf1a9d57a688595bbb4a3b5f27ee9975caeab45aa286e60ab1d38454c4325",
-        "updatedAt": "2025-09-20T19:50:28.357Z"
+        "model": "fake-64",
+        "vectorSha256": "b15a277c1b875f3a15b29be18ca4d564e1f3d80a468d67b24bfce7569db342f1",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0791": {
@@ -16612,13 +16381,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 791
+        "sequence": 780
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "880a73445af692f367b5ecb1ff3cf84ee86e0484c1d5ac69cb7c1dca1a6b1776",
-        "updatedAt": "2025-09-20T19:50:28.357Z"
+        "model": "fake-64",
+        "vectorSha256": "a6d3b8499ec29be37a3cfb3d0320fd4d5b548d59ac0e266e7a04c82faddbd06c",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0792": {
@@ -16633,13 +16402,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 792
+        "sequence": 781
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "396d98e51d7892987dec755b2a4ff98c5f79bd37487c8d669b7b15dd41331ca6",
-        "updatedAt": "2025-09-20T19:50:28.357Z"
+        "model": "fake-64",
+        "vectorSha256": "789e91590cd86447de0f2e75cb3cba6b45962d2ba32190576cae8a4171991e3f",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0793": {
@@ -16654,13 +16423,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 793
+        "sequence": 782
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e76a0ff33644399897d5bde74994c04b3fa2943544143111b82122a6015e26ba",
-        "updatedAt": "2025-09-20T19:50:28.603Z"
+        "model": "fake-64",
+        "vectorSha256": "3d2812c391f4e00e97299f864dc8326231affde97cd5483184f45e8ac062c24c",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0794": {
@@ -16675,13 +16444,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 794
+        "sequence": 783
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ab5f12fe252fe9c93dba97c3f9405ea5a0c87ee3e0316df91017b4b4d56e8211",
-        "updatedAt": "2025-09-20T19:50:28.603Z"
+        "model": "fake-64",
+        "vectorSha256": "b6534d298abaee0013896ddac08c9e8650dec091c9972f7dadbb504fda1086d1",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0795": {
@@ -16696,13 +16465,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 795
+        "sequence": 784
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e6e05af3e192657cd1ff0ba8362f4898ae198e088cb1b7732a1337ebd062e379",
-        "updatedAt": "2025-09-20T19:50:28.604Z"
+        "model": "fake-64",
+        "vectorSha256": "850a522f453c50ed5d027cda7e134658719ed172aab5aa4cee49878a117a6a8c",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0796": {
@@ -16717,13 +16486,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 796
+        "sequence": 785
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e17733023a5f2dad6808617e8cbae86d7efcda2fc54d7418a2af6072d3f35b7e",
-        "updatedAt": "2025-09-20T19:50:28.604Z"
+        "model": "fake-64",
+        "vectorSha256": "c78486e5bc34962b8c776c3ba8e5812996c9cb685749c7b30d5c3bad4b140ac9",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0797": {
@@ -16738,13 +16507,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 797
+        "sequence": 786
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "921210b67632bb9e8c036d6dfc7b697acc8208f798d2bfa03952c4f6f3834858",
-        "updatedAt": "2025-09-20T19:50:28.604Z"
+        "model": "fake-64",
+        "vectorSha256": "b20d7e2b4d0be1d51546b771f25d0ab290ddb33a6db032883c6c16f58b32911d",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0798": {
@@ -16759,34 +16528,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 798
+        "sequence": 787
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3009d19aac1a2239bdcdd29bd9bf18cf59e98df9a3bf17960179643653a65686",
-        "updatedAt": "2025-09-20T19:50:28.604Z"
-      }
-    },
-    "j-0799": {
-      "hashes": {
-        "setup": "482a56fefd39cff71ecdcbd3db58c39067b7fdc9b1c3d5b21dad82ab770eaf2c",
-        "punchline": "9926ac340b2c372c68bbef10d88ca697e87d3b47cc8d55cb7abbe802375f8029",
-        "combined": "305f821151eb9119c242f91bf23da9c9742cf9a4b71feaf1c74d5ed28a6b9184",
-        "tokenSignature": "25-31-always-and-because-christmas-dec-did-equals-halloween-mix-oct-programmer-the-up-why"
-      },
-      "lengths": {
-        "joke": 61,
-        "punchline": 29
-      },
-      "source": {
-        "sequence": 799
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "76ea510cc722c61502ee55701fda92ab64de7dd5736c984787d641947e88bbd3",
-        "updatedAt": "2025-09-20T19:50:28.604Z"
+        "model": "fake-64",
+        "vectorSha256": "451313fa9f54bb6aaf1ed4e16932bbc846692b12fc155ce06298aed5f8d9a146",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0800": {
@@ -16801,13 +16549,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 800
+        "sequence": 788
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8db3bf16cc39ea2326733261aa5d6ef901c577695129f4825e9f2592d99f37d5",
-        "updatedAt": "2025-09-20T19:50:28.604Z"
+        "model": "fake-64",
+        "vectorSha256": "bc5fdc7e898bf28c4fb746859150b5344a902fddb6af15bf59925a9c61350b3a",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0801": {
@@ -16822,13 +16570,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 801
+        "sequence": 789
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "405598166d2f9120a462c9f1ce47e559dc0170625b833c33327329473946c79c",
-        "updatedAt": "2025-09-20T19:50:28.800Z"
+        "model": "fake-64",
+        "vectorSha256": "640ac1d6c175d1a0775ec909e31211449976799ae5e7d955303f199775ee0ada",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0802": {
@@ -16843,13 +16591,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 802
+        "sequence": 790
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f5a05f135af468f8fb2fb1c7eb113ba36be0f0a257cd0eaa698d57ac2396e5af",
-        "updatedAt": "2025-09-20T19:50:28.800Z"
+        "model": "fake-64",
+        "vectorSha256": "52162787fb154545bce6cc61bc12ee36117c52c6136f45def58ee76621f56009",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0803": {
@@ -16864,13 +16612,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 803
+        "sequence": 791
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9db7c3d0693b1038e211ea84f43f8258ab5a746425c2014edabaacde81af40bc",
-        "updatedAt": "2025-09-20T19:50:28.800Z"
+        "model": "fake-64",
+        "vectorSha256": "3eaf37500fbdb517835349ad5f67d866d9930853b9e9fb21d9fa809fb1005d17",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0804": {
@@ -16885,13 +16633,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 804
+        "sequence": 792
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2e046dc78c2edd326695d93c4194453c9fffb04cbaad61f401982d9092a4bd93",
-        "updatedAt": "2025-09-20T19:50:28.800Z"
+        "model": "fake-64",
+        "vectorSha256": "3b41bfc6a56a26eb6e828a7e49736d35f03305a3cbf40bd56bddf2e07cad4724",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0805": {
@@ -16906,34 +16654,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 805
+        "sequence": 793
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3f5ec3e1c9640279ff719c313d8617ffebaa657d2b6f83f39c91f430b6def72c",
-        "updatedAt": "2025-09-20T19:50:28.800Z"
-      }
-    },
-    "j-0806": {
-      "hashes": {
-        "setup": "bfc2e27a170ca98453df9459bb8b44ac7c57be5c46831ae5d8b773e690af2501",
-        "punchline": "62fea14ac493eab395ef489be0d1a7a636c9134c88d96ed3e998e7359f4cfb97",
-        "combined": "0cc36d87fdd06a21ab2cc0f9ece3decc28c1b15d90c2b91c76687257b5230d41",
-        "tokenSignature": "did-just-nothing-ocean-one-other-say-the-they-to-waved-what"
-      },
-      "lengths": {
-        "joke": 42,
-        "punchline": 25
-      },
-      "source": {
-        "sequence": 806
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "12dbfb6c04da2d688c2e0eadbfbb05c1c8ed9214a0d3e6d0167e59768e371851",
-        "updatedAt": "2025-09-20T19:50:28.800Z"
+        "model": "fake-64",
+        "vectorSha256": "43414da1c258ce9f9d935940ad5063268d9b52033c73ec4026057ca40749c21a",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0807": {
@@ -16948,13 +16675,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 807
+        "sequence": 794
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "89ad5481a56413d7c929ac6e717a16f6eaeee0273bd38d1e830d9f37f44f4315",
-        "updatedAt": "2025-09-20T19:50:28.800Z"
+        "model": "fake-64",
+        "vectorSha256": "e30d7de7a9a509ef3c80fa33c9f11908468e1f83de1991e9bff1acdb31e9dc3f",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0808": {
@@ -16969,34 +16696,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 808
+        "sequence": 795
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eec58c799649d1bf6088fefc8c1c834f1581f3a18302368e8a9dd77b87f285da",
-        "updatedAt": "2025-09-20T19:50:28.800Z"
-      }
-    },
-    "j-0809": {
-      "hashes": {
-        "setup": "fa215373155eb039e49df92f948ecced743a631024179ea2c1a397a1746097d6",
-        "punchline": "e4d8a609f14d805cd3ab1794e306b10f6554b61fd6cd298feae4dbd78a23fc03",
-        "combined": "8dc58fe651249256a134eb83be77bc3103038cc1c4c169f7f0aa46a1e1f64159",
-        "tokenSignature": "chicken-cross-did-get-other-playground-slide-the-to-why"
-      },
-      "lengths": {
-        "joke": 41,
-        "punchline": 26
-      },
-      "source": {
-        "sequence": 809
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c28e0dccc8d9c391e644528859df2169b1b34f56a344e2745416c4a07f0d739f",
-        "updatedAt": "2025-09-20T19:50:29.049Z"
+        "model": "fake-64",
+        "vectorSha256": "c4d9d18f9c9e258c4197ffceb53b15de28101ce32bb12f678af48c51a1f0d83c",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0810": {
@@ -17011,34 +16717,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 810
+        "sequence": 796
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "75432c72b883b7512656fdc50a76ff5d287f83f363ff099ae382229301db738e",
-        "updatedAt": "2025-09-20T19:50:29.049Z"
-      }
-    },
-    "j-0811": {
-      "hashes": {
-        "setup": "e214dc6dad8030e0137cc9d0dc7f3f39be50f4de9a408aa243de93b3b393a2b8",
-        "punchline": "f68b11fe7347a81f8ac2a7c89116bc58c3b174648a23fd16306b0a36ff6a466a",
-        "combined": "e200117ed5af52ecc44d8bc806bbc50f2c51920a95e9a03bb7f6ba27240b08f7",
-        "tokenSignature": "because-charity-don-give-oysters-re-shellfish-t-they-to-why"
-      },
-      "lengths": {
-        "joke": 34,
-        "punchline": 26
-      },
-      "source": {
-        "sequence": 811
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f7fb1feee36d9bf9f0287326b48ebd14e0fcd7f050ee3054ceae0ceb48fb2c0d",
-        "updatedAt": "2025-09-20T19:50:29.049Z"
+        "model": "fake-64",
+        "vectorSha256": "da32261017a13f91f0eb14038cee54cb844da342454ea6389381a539def5504a",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0812": {
@@ -17053,13 +16738,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 812
+        "sequence": 797
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2607c555c45036b9d4e65b3d57fa79f80563332db8df8f49b85aec82c118a53b",
-        "updatedAt": "2025-09-20T19:50:29.049Z"
+        "model": "fake-64",
+        "vectorSha256": "cb652c1a58432880807c19192f20880677605ee8081dcc9fd4b196f162a36422",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0813": {
@@ -17074,13 +16759,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 813
+        "sequence": 798
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d0c1950611543c99daa75df142140766c130542eaff4c52227c6e8273b25b440",
-        "updatedAt": "2025-09-20T19:50:29.049Z"
+        "model": "fake-64",
+        "vectorSha256": "4e17727065e2ac6eaeefd6dd06be65aff46f8c18208e530f11ffdccf74349bb4",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0814": {
@@ -17095,34 +16780,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 814
+        "sequence": 799
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "859d17c43d4e7c4ecabe4f26ab9ab3387a6599d864755b501efbb8b14d72aab2",
-        "updatedAt": "2025-09-20T19:50:29.049Z"
-      }
-    },
-    "j-0815": {
-      "hashes": {
-        "setup": "257fd70e76bb2c1f989a1bbf027eae391bfb6e1ca7bb5e20b4c5235eddf25d2d",
-        "punchline": "7ca8ffd20a8f6197e189329d688c8e573bfbaedc21dc3c703bdc3f4c8e0d72b9",
-        "combined": "1c170a1fcd6b262a438f06020bf39c2f41212f0deb173c7607bfc08a08d11996",
-        "tokenSignature": "arrays-did-didn-get-job-programmer-quit-t-the-their-they-why"
-      },
-      "lengths": {
-        "joke": 38,
-        "punchline": 23
-      },
-      "source": {
-        "sequence": 815
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "91e810bb51dfe220310cfc19d8522cd598e187fdb0467589e81823ac8a0ddfa0",
-        "updatedAt": "2025-09-20T19:50:29.050Z"
+        "model": "fake-64",
+        "vectorSha256": "bf2f7302c429257e99ca7ff6195006509dd1fdb3c3fa6f37479d3e925faa13f8",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0816": {
@@ -17137,13 +16801,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 816
+        "sequence": 800
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "beadc2fc5b18d43b3d94f4e138b340cfa399618f8c7b40a27fa3dcf948061dfd",
-        "updatedAt": "2025-09-20T19:50:29.050Z"
+        "model": "fake-64",
+        "vectorSha256": "9e2a1283088a8f3133e9e8afa50933d057c7f423086ddb243b1aeee7066530f4",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0817": {
@@ -17158,13 +16822,13 @@
         "punchline": 49
       },
       "source": {
-        "sequence": 817
+        "sequence": 801
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c4c0d654bd5143402431aa4baee66f727f4c88e2b4b549c9bd4cdfe2b3813fb9",
-        "updatedAt": "2025-09-20T19:50:29.297Z"
+        "model": "fake-64",
+        "vectorSha256": "972021b10551f0b4a82800cc5d5a43189e4c551144b39d86e2a9073a22593b0c",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0819": {
@@ -17179,13 +16843,13 @@
         "punchline": 62
       },
       "source": {
-        "sequence": 819
+        "sequence": 802
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8f8804f96c19b2398435b6ab6bffe065b5c3cf93129ac5e0c5d4e8fda8461f33",
-        "updatedAt": "2025-09-20T19:50:29.297Z"
+        "model": "fake-64",
+        "vectorSha256": "268caeee53df9bd4fed8a5e306812113ff3f62f7e75757eead2e12bcdd182c55",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0820": {
@@ -17200,13 +16864,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 820
+        "sequence": 803
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "250cfbf8ecdb3748055227f153b01dbedbd0ad82b5d445c0a310dbc1d2410c39",
-        "updatedAt": "2025-09-20T19:50:29.297Z"
+        "model": "fake-64",
+        "vectorSha256": "20aea8c4aab0571c71fe228ac52e0dc3a7bee8e7e03f85cf1589584a5a40842e",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0821": {
@@ -17221,13 +16885,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 821
+        "sequence": 804
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fe3a644da9374794ea96f5085f4639c982adde144cf536518c5b222ab4bc4067",
-        "updatedAt": "2025-09-20T19:50:29.297Z"
+        "model": "fake-64",
+        "vectorSha256": "7f7cd2ffb9285564ea6c51633b2f1f24ea1701327fe1c3dcf7a036ee3c9c78e5",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0822": {
@@ -17242,13 +16906,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 822
+        "sequence": 805
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5129f0d68849ad2afd21cae52f6b5a93c43746ab7a575c62121e59f881d89b6a",
-        "updatedAt": "2025-09-20T19:50:29.297Z"
+        "model": "fake-64",
+        "vectorSha256": "17c3437a53fbb6bcba5436824ea71d9d4d476d64fbbb95f8638bd29e52d77313",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0823": {
@@ -17263,13 +16927,13 @@
         "punchline": 46
       },
       "source": {
-        "sequence": 823
+        "sequence": 806
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dd8d7c345e409af9d2e4d20761b36ef317f8005e34b335e5d904655f9f2f534d",
-        "updatedAt": "2025-09-20T19:50:29.298Z"
+        "model": "fake-64",
+        "vectorSha256": "ca4265a089ed46de8d04c9a4c7c8457baedec069afba07a5ff98d50db00082e6",
+        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0824": {
@@ -17284,13 +16948,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 824
+        "sequence": 807
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c18883ecd26074817edccae3be2c27d5411cd05f78bf4a3c7df4a2cdeb9e9c49",
-        "updatedAt": "2025-09-20T19:50:29.298Z"
+        "model": "fake-64",
+        "vectorSha256": "6064ac780d3080ec5e6d56a929f805aec2846b62fcebc1123ab35c188cef1c3a",
+        "updatedAt": "2025-09-20T22:27:41.543Z"
       }
     },
     "j-0825": {
@@ -17305,13 +16969,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 825
+        "sequence": 808
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "03371d163bad2804f0fb94bae25c5b1c91d5824031df59779206c47cbef8bb09",
-        "updatedAt": "2025-09-20T19:50:29.545Z"
+        "model": "fake-64",
+        "vectorSha256": "4606a8ddcb4bc27254be1dae8b12745ddfc5106b47c10bfaaf50212a3a19f2fe",
+        "updatedAt": "2025-09-20T22:27:41.543Z"
       }
     },
     "j-0826": {
@@ -17326,13 +16990,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 826
+        "sequence": 809
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6ed8a6324fc12ff4645adae0c772baa2473ee74dc56cbf80ecdea224b218a11b",
-        "updatedAt": "2025-09-20T19:50:29.546Z"
+        "model": "fake-64",
+        "vectorSha256": "1cfb177a38b1c952e11f5b436309c2e9dd40a60ca073a8e6d5195531ce47321d",
+        "updatedAt": "2025-09-20T22:27:41.543Z"
       }
     },
     "j-0827": {
@@ -17347,13 +17011,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 827
+        "sequence": 810
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b0c8f4b234c073605c652f66235299ab144e775e3f5f617110f8246e62086dfc",
-        "updatedAt": "2025-09-20T19:50:29.546Z"
+        "model": "fake-64",
+        "vectorSha256": "9c8d45c3600b988dfe00e0445a3238fc0f91bd914e457061fdc3988ff4d58caa",
+        "updatedAt": "2025-09-20T22:27:41.543Z"
       }
     },
     "j-0828": {
@@ -17368,13 +17032,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 828
+        "sequence": 811
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "089703a375b3378c9f74e40b014d8dc14e35aeaa36ac4fdcec731310f354e698",
-        "updatedAt": "2025-09-20T19:50:29.546Z"
+        "model": "fake-64",
+        "vectorSha256": "150330a049a39ed7dff8a137e0c2e547c08ae4b59107a816b0ae618e492be986",
+        "updatedAt": "2025-09-20T22:27:41.543Z"
       }
     },
     "j-0829": {
@@ -17389,13 +17053,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 829
+        "sequence": 812
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c3accd0e7675c0bab33d8d172cec726316f75da96abeac9fb14f73a3b857298d",
-        "updatedAt": "2025-09-20T19:50:29.546Z"
+        "model": "fake-64",
+        "vectorSha256": "b883bbee276581208cae3136f1d7d90374898e38adb3397124c0304843dfb681",
+        "updatedAt": "2025-09-20T22:27:41.543Z"
       }
     }
   }

--- a/data/quotes-embeddings.json
+++ b/data/quotes-embeddings.json
@@ -1,2 +1,4781 @@
-    "generatedAt": "2025-09-20T20:02:26.070Z",
-    "recordCount": 536
+{
+  "meta": {
+    "provider": "fake",
+    "model": "fake-64",
+    "dimensions": 64,
+    "generatedAt": "2025-09-20T22:28:15.462Z",
+    "recordCount": 530
+  },
+  "records": {
+    "adventure-01": {
+      "vector": "0dBQPcLBQT/n5uY+9vV1P8jHR7/c21s/9/b2PvLxcb+dnBw+xMNDv+zra7+2tTU/pqUlP/LxcT+2tTW/trU1v+vq6j6+vT2//v19P6KhIT/19HQ+6ejoPY6NDT/CwUE/s7KyvtDPT7+mpSW/7+7uPpSTE7+koyM/397evublZb/R0FA9wsFBP+fm5j729XU/yMdHv9zbWz/39vY+8vFxv52cHD7Ew0O/7Otrv7a1NT+mpSU/8vFxP7a1Nb+2tTW/6+rqPr69Pb/+/X0/oqEhP/X0dD7p6Og9jo0NP8LBQT+zsrK+0M9Pv6alJb/v7u4+lJMTv6SjIz/f3t6+5uVlvw==",
+      "vectorSha256": "b6fdb9efa0d7f00504824bc2da7048adb1ff66a94eca058260a47abe6ee59c5c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "86e0b9fa1cedbd07931e0adad2f82525ba21fed09e8ec6e053182dbb36d1480d",
+      "updatedAt": "2025-09-20T22:28:15.425Z"
+    },
+    "adventure-02": {
+      "vector": "5+bmvtzbWz/m5WW/2djYPa+urr7W1VW/paQkvt7dXb/Z2Ni9vLs7v+Pi4r6Lioo+19bWPqSjIz+Ylxc/m5qavgAAgD+amRk/qaioPZaVFT/8+3s//v19P8/Ozr6OjQ0/rawsPuDfX7/R0FA9kpERv4mIiL2hoKC86Odnv5qZGT/n5ua+3NtbP+blZb/Z2Ng9r66uvtbVVb+lpCS+3t1dv9nY2L28uzu/4+LivouKij7X1tY+pKMjP5iXFz+bmpq+AACAP5qZGT+pqKg9lpUVP/z7ez/+/X0/z87Ovo6NDT+trCw+4N9fv9HQUD2SkRG/iYiIvaGgoLzo52e/mpkZPw==",
+      "vectorSha256": "23f9cd486465b952ec11f57e5fe39584f4f693a32dad07c29864921e3abc0714",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "46ed0d8d54156b11722247a2b5d1cb59ffcc8acafdfe4cc695108637777d0ccc",
+      "updatedAt": "2025-09-20T22:28:15.426Z"
+    },
+    "adventure-03": {
+      "vector": "g4KCPsfGxj6fnp4+5ONjv9nY2L2ZmJg96+rqvsLBQT/Ix0e/wcBAvL28PD6Miws/zMtLv7y7Oz/GxUW/0M9PP9/e3j6DgoI+s7KyPsC/Pz+wry+/AACAv4KBAT+gnx+/+Pd3P8zLS7/T0tK+mpkZP4mIiL2qqSk/qKcnP5CPDz+DgoI+x8bGPp+enj7k42O/2djYvZmYmD3r6uq+wsFBP8jHR7/BwEC8vbw8PoyLCz/My0u/vLs7P8bFRb/Qz08/397ePoOCgj6zsrI+wL8/P7CvL78AAIC/goEBP6CfH7/493c/zMtLv9PS0r6amRk/iYiIvaqpKT+opyc/kI8PPw==",
+      "vectorSha256": "58d5b144bfb610bc3cde8368719fb62905d907853b38cb351e09dd4747c7c4cf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a0b1a70e728945e01c7e97c51add1de7b7a0acdf2800c030fb1a4bcc77d4d3c7",
+      "updatedAt": "2025-09-20T22:28:15.426Z"
+    },
+    "adventure-04": {
+      "vector": "zs1Nv6inJ7/c21u/qaiovZqZGb/39va+/fx8vuLhYT+vrq6+rq0tP+3sbL6SkRG/mZiYvYSDAz/m5WW/i4qKPuHg4LyurS2/zs1Nv+LhYb/NzEy+1dRUPv/+/r7p6Og92NdXv7q5Ob/Qz0+/8vFxP6+urj7f3t4+t7a2Pru6uj7OzU2/qKcnv9zbW7+pqKi9mpkZv/f29r79/Hy+4uFhP6+urr6urS0/7exsvpKREb+ZmJi9hIMDP+blZb+Lioo+4eDgvK6tLb/OzU2/4uFhv83MTL7V1FQ+//7+vuno6D3Y11e/urk5v9DPT7/y8XE/r66uPt/e3j63trY+u7q6Pg==",
+      "vectorSha256": "711c7ab3b1d08421ae71911752cb76ef49c3cfd049bc41ea0f139ae565bb2e3c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "192c1275334260f054d6623776c10da27c29190f669a408e142318f8abb7adae",
+      "updatedAt": "2025-09-20T22:28:15.427Z"
+    },
+    "adventure-05": {
+      "vector": "jYwMPpCPD7/X1tY+q6qqPquqqj61tDS+o6Kivu3sbD6enR2/sK8vP46NDT+npqY+v76+vp2cHL7a2Vk/7exsPvTzcz/U01M/oJ8fP+rpab+HhoY+paQkPtva2r76+Xk/1dRUPs3MTD7b2tq+6ejoPZeWlr6UkxM/3dxcvo2MDD6NjAw+kI8Pv9fW1j6rqqo+q6qqPrW0NL6joqK+7exsPp6dHb+wry8/jo0NP6empj6/vr6+nZwcvtrZWT/t7Gw+9PNzP9TTUz+gnx8/6ulpv4eGhj6lpCQ+29ravvr5eT/V1FQ+zcxMPtva2r7p6Og9l5aWvpSTEz/d3Fy+jYwMPg==",
+      "vectorSha256": "9ab5523046d218c50fb1f22dbf17d9c027ef8888f1b509e30cb7989275e51e56",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9138b5aaaa69579d31d7c6a9506cec9df9e9cf0ba19449fc9a99498e5ac96491",
+      "updatedAt": "2025-09-20T22:28:15.427Z"
+    },
+    "adventure-07": {
+      "vector": "8fBwPb28PL7OzU0/jYwMPqalJb/GxUU/iYiIPYaFBT+bmpo+29ravrSzM7/d3Fw+mJcXP9/e3j7f3t4+5+bmPpSTEz+9vDw+xMNDP6WkJD7083O/9fR0vuPi4r76+Xk/sK8vP5aVFb+rqqo+9PNzP4OCgr7Y11e/trU1P7a1Nb/x8HA9vbw8vs7NTT+NjAw+pqUlv8bFRT+JiIg9hoUFP5uamj7b2tq+tLMzv93cXD6Ylxc/397ePt/e3j7n5uY+lJMTP728PD7Ew0M/paQkPvTzc7/19HS+4+Livvr5eT+wry8/lpUVv6uqqj7083M/g4KCvtjXV7+2tTU/trU1vw==",
+      "vectorSha256": "f460deed234bb94e6ed1840da796ecbad6c2488c3907742018d17f28ff5473cf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8768e6912de288c2a649269bcbb7b7b9c997e194066147fcd735aaf95f14da25",
+      "updatedAt": "2025-09-20T22:28:15.427Z"
+    },
+    "adventure-08": {
+      "vector": "6ulpP5eWlr65uLg95eRkvs3MTL6npqa+sbAwvbq5Ob/39va+m5qavqalJb/c21u/AACAv8rJST/q6Wm/uLc3P7i3N7+ioSE/urk5P+TjYz/h4OA84+LivuXkZL7KyUm/paQkvuvq6j6urS2/q6qqPtDPT7/OzU2/kpERP7SzMz/q6Wk/l5aWvrm4uD3l5GS+zcxMvqempr6xsDC9urk5v/f29r6bmpq+pqUlv9zbW78AAIC/yslJP+rpab+4tzc/uLc3v6KhIT+6uTk/5ONjP+Hg4Dzj4uK+5eRkvsrJSb+lpCS+6+rqPq6tLb+rqqo+0M9Pv87NTb+SkRE/tLMzPw==",
+      "vectorSha256": "f877e1aa96bff7f4de2ac4fc9077f16a431ff1896f8e31acb1b0b42f22bc8d8e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f45a8b6366567a2342592d1200e40bdb24d0dcf18347631b6bba29aa1819c8d9",
+      "updatedAt": "2025-09-20T22:28:15.427Z"
+    },
+    "adventure-09": {
+      "vector": "uLc3v4SDAz/e3V2/0tFRP/79fT/8+3s/goEBP+XkZL7KyUk/g4KCvp2cHD7n5ua+nZwcPuzra7+JiIg9rKsrP7KxMb+qqSm/r66uPuHg4DzJyMg9o6KiPu7tbb/k42O/4eDgvPb1dT/x8HC97Otrv6inJz+GhQU/8/Lyvs3MTL64tze/hIMDP97dXb/S0VE//v19P/z7ez+CgQE/5eRkvsrJST+DgoK+nZwcPufm5r6dnBw+7Otrv4mIiD2sqys/srExv6qpKb+vrq4+4eDgPMnIyD2joqI+7u1tv+TjY7/h4OC89vV1P/HwcL3s62u/qKcnP4aFBT/z8vK+zcxMvg==",
+      "vectorSha256": "c0aceab942529f721bef7212a44760fd4f0eabc8481ad4b60657b0e5b5cdb65f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "24c111e8fefdc063e45f9346930a88d5272bab838ca8090e7cfa780ad3c24366",
+      "updatedAt": "2025-09-20T22:28:15.427Z"
+    },
+    "adventure-10": {
+      "vector": "8vFxP8rJSb+Lioo+urk5P6alJT/Hxsa+oqEhP7y7O7+npqY+7exsPtjXVz+1tDQ+6ulpv+blZb+pqKi9//7+PsbFRb+Miwu/oJ8fP9DPT7+0szM/iokJv8zLS7+enR0/pqUlv4uKir7Lysq+6OdnP8zLSz/u7W2/nJsbP9/e3j7y8XE/yslJv4uKij66uTk/pqUlP8fGxr6ioSE/vLs7v6empj7t7Gw+2NdXP7W0ND7q6Wm/5uVlv6moqL3//v4+xsVFv4yLC7+gnx8/0M9Pv7SzMz+KiQm/zMtLv56dHT+mpSW/i4qKvsvKyr7o52c/zMtLP+7tbb+cmxs/397ePg==",
+      "vectorSha256": "90633daa1cb80de1f4d3b4676961c96f892a7721ffff6f765740e83306e18bd1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f81ba2dcd24ed022a99deb960b0d75bf1d3acf18d93b1ace2d5d4df3e509cdb7",
+      "updatedAt": "2025-09-20T22:28:15.427Z"
+    },
+    "adventure-11": {
+      "vector": "1dRUvoKBAT+3tra+rKsrv87NTb/Hxsa+sK8vv/b1dT/b2to+6Odnv5iXFz/FxEQ+mpkZP6WkJD6dnBy+lJMTv9va2r76+Xk/hYQEvr28PD7e3V0/4N9fP6Oior7NzEw+oqEhv4OCgr7q6Wk/lZQUvvTzcz/h4OA8tLMzP/Py8j7V1FS+goEBP7e2tr6sqyu/zs1Nv8fGxr6wry+/9vV1P9va2j7o52e/mJcXP8XERD6amRk/paQkPp2cHL6UkxO/29ravvr5eT+FhAS+vbw8Pt7dXT/g318/o6Kivs3MTD6ioSG/g4KCvurpaT+VlBS+9PNzP+Hg4Dy0szM/8/LyPg==",
+      "vectorSha256": "ef7657cf4ea2fcb6a01ebf8db2c8941a6afec89f18ece2ed17b5fd89fb84101f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "65c0522a194e28fab60ccb98cc946c3649fc6f97eeef57992f5ff46df983d9bc",
+      "updatedAt": "2025-09-20T22:28:15.429Z"
+    },
+    "adventure-12": {
+      "vector": "nZwcvvj3dz/c21s/oqEhv8LBQT+mpSW/g4KCvsPCwr7T0tK+9/b2vtPS0j69vDy+oJ8fv7u6uj729XW/np0dP/HwcL3Z2Ng9kZAQPb69PT+7uro+q6qqvrGwMD3V1FQ++vl5P+vq6r7x8HC95ONjP8PCwr7Qz08/+fj4vby7O7+dnBy++Pd3P9zbWz+ioSG/wsFBP6alJb+DgoK+w8LCvtPS0r739va+09LSPr28PL6gnx+/u7q6Pvb1db+enR0/8fBwvdnY2D2RkBA9vr09P7u6uj6rqqq+sbAwPdXUVD76+Xk/6+rqvvHwcL3k42M/w8LCvtDPTz/5+Pi9vLs7vw==",
+      "vectorSha256": "fb26d4da9dea832f67a712686407f32e4b178c08511ca6b6f56173e3f62102cd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6cfbed2fe02d5f4f4b42b46830ae05ce788d84deae55859afc4578f14fe77022",
+      "updatedAt": "2025-09-20T22:28:15.429Z"
+    },
+    "adventure-13": {
+      "vector": "4N9fP/v6+r6urS0/vr09v9bVVb+0szO/6OdnP5CPD7/o52c/+fj4Pa2sLD7g318/iYiIvePi4j7S0VE/7exsvt/e3r7Avz+/+fj4PZ6dHb/h4OA8lpUVv7GwML2Pjo6+6+rqPqOioj6opyc/vLs7P5qZGT+gnx8/6OdnP//+/r7g318/+/r6vq6tLT++vT2/1tVVv7SzM7/o52c/kI8Pv+jnZz/5+Pg9rawsPuDfXz+JiIi94+LiPtLRUT/t7Gy+397evsC/P7/5+Pg9np0dv+Hg4DyWlRW/sbAwvY+Ojr7r6uo+o6KiPqinJz+8uzs/mpkZP6CfHz/o52c///7+vg==",
+      "vectorSha256": "9ec132d9d9f23d0fcd36e75899db81e3660cd53f86d27fef3f77bb920d1824e9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ef41d6211526f338f38f95ef77b8e86248208f3183357a5cbaa8d3ddcccff340",
+      "updatedAt": "2025-09-20T22:28:15.430Z"
+    },
+    "adventure-14": {
+      "vector": "w8LCPufm5j6Qjw8/zs1Nv8/Ozj7NzEw+4uFhP6+urr7Ix0c/lJMTP9nY2L2FhAS++fj4vcfGxr6ioSG/pqUlv9LRUb+dnBw+y8rKvpmYmL2UkxM/7u1tP/X0dD7//v4+hoUFP8fGxr78+3u/paQkvqmoqL39/Hw+p6amvrq5OT/DwsI+5+bmPpCPDz/OzU2/z87OPs3MTD7i4WE/r66uvsjHRz+UkxM/2djYvYWEBL75+Pi9x8bGvqKhIb+mpSW/0tFRv52cHD7Lysq+mZiYvZSTEz/u7W0/9fR0Pv/+/j6GhQU/x8bGvvz7e7+lpCS+qaiovf38fD6npqa+urk5Pw==",
+      "vectorSha256": "7b1cdddba21aa731a18d85881c7a575043ff5803e7c99b7a81ee77ed6f768cd1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b0b9c719b399f054e3c9726f704e2f2d17934d76c9f69ebfc24e026b759f56dc",
+      "updatedAt": "2025-09-20T22:28:15.430Z"
+    },
+    "adventure-15": {
+      "vector": "kpERv+Hg4DydnBy+s7KyPvTzcz+/vr4+w8LCvoOCgj7u7W2/nJsbP/LxcT+7uro+//7+vp2cHD66uTk/1dRUPsC/Pz+gnx8/3t1dv6inJz/My0u/iYiIPfX0dL7a2Vm/1dRUPtva2r7NzEw+g4KCvsfGxr6GhQW/jIsLv7++vj6SkRG/4eDgPJ2cHL6zsrI+9PNzP7++vj7DwsK+g4KCPu7tbb+cmxs/8vFxP7u6uj7//v6+nZwcPrq5OT/V1FQ+wL8/P6CfHz/e3V2/qKcnP8zLS7+JiIg99fR0vtrZWb/V1FQ+29ravs3MTD6DgoK+x8bGvoaFBb+Miwu/v76+Pg==",
+      "vectorSha256": "91879eb76667573bc9cbfb7e8c8c5e5f5c3c1943b477b941c3f298e8fae114c0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "37836cacf9af4fa009cdf8ae4093dc9adfcf11d31a8861139a49995f4e3d3aaf",
+      "updatedAt": "2025-09-20T22:28:15.430Z"
+    },
+    "adventure-16": {
+      "vector": "6OdnP9LRUb+0szM/m5qaPpWUFD6qqSk/vLs7v83MTL6FhAQ+t7a2PublZT/d3Fy+iYiIPbCvL7+UkxM/uLc3P+blZb/p6Og96+rqvt7dXT+xsDA9vr09P5KRET+0szO/oqEhP/79fb/CwUG/kI8Pv7e2tj729XW/i4qKvru6uj7o52c/0tFRv7SzMz+bmpo+lZQUPqqpKT+8uzu/zcxMvoWEBD63trY+5uVlP93cXL6JiIg9sK8vv5STEz+4tzc/5uVlv+no6D3r6uq+3t1dP7GwMD2+vT0/kpERP7SzM7+ioSE//v19v8LBQb+Qjw+/t7a2Pvb1db+Lioq+u7q6Pg==",
+      "vectorSha256": "691fceb025ac24a85b22b717fb6a5fff7ede4ccd4c54b60242c06a62c10ac48b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f317d9a692d4226690adf2648828c9db0d8e45ee85dec826d0011f38ad055dae",
+      "updatedAt": "2025-09-20T22:28:15.430Z"
+    },
+    "adventure-17": {
+      "vector": "xMNDv9PS0r62tTU/xsVFP/79fb+trCw+x8bGPvr5eb/NzEw++Pd3v//+/r6koyO/pKMjv/Py8r7Avz+/29raPrCvLz/R0FC9vr09P4eGhr7JyMg9zs1Nv83MTL7S0VE/i4qKvs3MTD7//v4+yMdHv/n4+D2XlpY+hYQEPr28PL7Ew0O/09LSvra1NT/GxUU//v19v62sLD7HxsY++vl5v83MTD7493e///7+vqSjI7+koyO/8/LyvsC/P7/b2to+sK8vP9HQUL2+vT0/h4aGvsnIyD3OzU2/zcxMvtLRUT+Lioq+zcxMPv/+/j7Ix0e/+fj4PZeWlj6FhAQ+vbw8vg==",
+      "vectorSha256": "c07bcce68e0b2bf1ff8aeee5bf87dcc423edcd0b5809a629807b3df4d6abca56",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1e4bdae20195b1039904402e2e4320b6d779de5e8c1966e85d99bf1c8fa59068",
+      "updatedAt": "2025-09-20T22:28:15.430Z"
+    },
+    "adventure-18": {
+      "vector": "8/LyvqmoqD3X1tY+09LSvgAAgL+dnBw+/v19P9TTU7/v7u6+y8rKPqyrK7/p6Og9qaioPY+Ojj7s62u/ycjIPcHAQLyPjo6+iokJP83MTD6OjQ0/goEBv9LRUb/+/X0/7u1tv6WkJL7j4uI+2tlZP+no6D2trCw+9vV1P6uqqr7z8vK+qaioPdfW1j7T0tK+AACAv52cHD7+/X0/1NNTv+/u7r7Lyso+rKsrv+no6D2pqKg9j46OPuzra7/JyMg9wcBAvI+Ojr6KiQk/zcxMPo6NDT+CgQG/0tFRv/79fT/u7W2/paQkvuPi4j7a2Vk/6ejoPa2sLD729XU/q6qqvg==",
+      "vectorSha256": "90f90d27b68c9437777d272011099df8937e14db679fb1a9047d1bcea033e3e9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "438ab54b0093fe1644b22a8e8aa30a8c7e5cc499c63f17fe096bb8ec8e95fa55",
+      "updatedAt": "2025-09-20T22:28:15.431Z"
+    },
+    "adventure-19": {
+      "vector": "jYwMPoKBAT/o52c/+/r6Pv38fL7k42M/v76+vvn4+D2amRk/7OtrP+vq6r7NzEy+ycjIPbm4uL2opye/n56ePqmoqD2TkpI+8/LyPqinJz+npqa+2NdXv6inJ7/o52e/tbQ0PpaVFb/c21s/hoUFP6moqD20szM/tLMzP8LBQT+NjAw+goEBP+jnZz/7+vo+/fx8vuTjYz+/vr6++fj4PZqZGT/s62s/6+rqvs3MTL7JyMg9ubi4vainJ7+fnp4+qaioPZOSkj7z8vI+qKcnP6empr7Y11e/qKcnv+jnZ7+1tDQ+lpUVv9zbWz+GhQU/qaioPbSzMz+0szM/wsFBPw==",
+      "vectorSha256": "b452280592860decb813fe582e37baa8f941337e32e3d3af9d100a013f8c4110",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "91c0f3be60f1508fccf545668c742ca78aa4bcd356142c0c9635edc28ad9d9e0",
+      "updatedAt": "2025-09-20T22:28:15.431Z"
+    },
+    "adventure-20": {
+      "vector": "x8bGPu7tbb/S0VG/19bWvo2MDL63trY+g4KCvvj3d7+sqys/8/Lyvvn4+D2NjAw+wL8/P9bVVT+ysTG/6ejoPfv6+r64tzc/pqUlP7++vr65uLg93dxcPsbFRT+UkxM/7OtrP9zbW7/Z2Ng91tVVv/38fD4AAIA/9PNzPwAAgL/HxsY+7u1tv9LRUb/X1ta+jYwMvre2tj6DgoK++Pd3v6yrKz/z8vK++fj4PY2MDD7Avz8/1tVVP7KxMb/p6Og9+/r6vri3Nz+mpSU/v76+vrm4uD3d3Fw+xsVFP5STEz/s62s/3Ntbv9nY2D3W1VW//fx8PgAAgD/083M/AACAvw==",
+      "vectorSha256": "3815902a277a52189d18985a628c6ae879d71b58222bf8c116e7ed1fc404a194",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b109174a6ead5f04d5438f91dfea278e41dbd2508b9be2c9f5128d159ffff900",
+      "updatedAt": "2025-09-20T22:28:15.431Z"
+    },
+    "adventure-21": {
+      "vector": "4N9fP/X0dD7U01M/g4KCvt3cXD7k42O/vr09P+zraz+hoKC83dxcPrCvL7/p6Og919bWPtPS0j6pqKi9goEBP/Py8j6enR0/hIMDP6uqqj6EgwM/5+bmvqCfHz/a2Vk/pqUlP6yrKz/Z2Ng9ycjIPY6NDb+EgwO/9fR0PpKRET/g318/9fR0PtTTUz+DgoK+3dxcPuTjY7++vT0/7OtrP6GgoLzd3Fw+sK8vv+no6D3X1tY+09LSPqmoqL2CgQE/8/LyPp6dHT+EgwM/q6qqPoSDAz/n5ua+oJ8fP9rZWT+mpSU/rKsrP9nY2D3JyMg9jo0Nv4SDA7/19HQ+kpERPw==",
+      "vectorSha256": "abdbb5896fed495cdbc573c70f38dac962f822c2607f8decca592ce33e2c82b4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ef9ee95f9b0edef57d9b288eb5b475c0bccec1aac146cfecd2d58d8c393e9ec8",
+      "updatedAt": "2025-09-20T22:28:15.431Z"
+    },
+    "adventure-22": {
+      "vector": "yMdHv4aFBb+cmxu/i4qKPtPS0j7q6Wk/rKsrP+zra7/c21s/rawsPufm5j65uLg9AACAv6SjI7+npqY+s7KyvuXkZL7DwsI+/Pt7P5WUFL6KiQm/j46OPv79fb+Hhoa+srExP7m4uL3493e/urk5P8nIyD2lpCQ+3NtbP7SzM7/Ix0e/hoUFv5ybG7+Lioo+09LSPurpaT+sqys/7Otrv9zbWz+trCw+5+bmPrm4uD0AAIC/pKMjv6empj6zsrK+5eRkvsPCwj78+3s/lZQUvoqJCb+Pjo4+/v19v4eGhr6ysTE/ubi4vfj3d7+6uTk/ycjIPaWkJD7c21s/tLMzvw==",
+      "vectorSha256": "e3fbf201f58c3922ab721a9a064400877af86469e5b42d083f8f7c171a4b58e6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1c3d32a2b4f4d50aed95b98b002ea95363b0fd6d3ba3015ed87404dc8c94ed26",
+      "updatedAt": "2025-09-20T22:28:15.431Z"
+    },
+    "adventure-23": {
+      "vector": "sK8vv/n4+D3r6uq+lJMTP7q5Ob/KyUk/nZwcvtrZWb/Qz0+/19bWPs/Ozr68uzu/x8bGPqempj6UkxM/4N9fv6empj6ysTE/8/LyPvb1dT+BgIA7y8rKPoiHB7/i4WG/urk5v/X0dD6enR2/wsFBv8C/P7+BgIA72djYvYGAgLuwry+/+fj4Pevq6r6UkxM/urk5v8rJST+dnBy+2tlZv9DPT7/X1tY+z87Ovry7O7/HxsY+p6amPpSTEz/g31+/p6amPrKxMT/z8vI+9vV1P4GAgDvLyso+iIcHv+LhYb+6uTm/9fR0Pp6dHb/CwUG/wL8/v4GAgDvZ2Ni9gYCAuw==",
+      "vectorSha256": "43ae8145c2f80f2bb0d91bbd39ee34268b10c726e51f8bbeb4b203fd5e3e2d74",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "288f45c923e46c1318b54c22b1a9c910a9d8bcfa80b23c0f239e311f2080727f",
+      "updatedAt": "2025-09-20T22:28:15.431Z"
+    },
+    "adventure-24": {
+      "vector": "qaiovfn4+L3+/X0/trU1P/z7ez/u7W0/g4KCvtfW1r6joqI+p6amvuHg4LydnBw+lJMTv6uqqj7w72+/4+LivpaVFT/9/Hy+5+bmPpuamj6lpCQ+iYiIPYGAgDuWlRW/7+7uvoqJCb/Y11c//Pt7P9zbW7+zsrK+4N9fv62sLD6pqKi9+fj4vf79fT+2tTU//Pt7P+7tbT+DgoK+19bWvqOioj6npqa+4eDgvJ2cHD6UkxO/q6qqPvDvb7/j4uK+lpUVP/38fL7n5uY+m5qaPqWkJD6JiIg9gYCAO5aVFb/v7u6+iokJv9jXVz/8+3s/3Ntbv7Oysr7g31+/rawsPg==",
+      "vectorSha256": "18b2b2017fbc9eefa6d78242a30f6b2338688196727d565e76f312efa2dd2a3e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7570fedafdf65f4aa8567c9336aa0847ca60b9a694888035443bebfd12531095",
+      "updatedAt": "2025-09-20T22:28:15.431Z"
+    },
+    "adventure-25": {
+      "vector": "5eRkvvb1dT+fnp6+h4aGPuXkZD7Avz+/8fBwve3sbL7Lyso+3dxcvpGQEL3U01M/vr09P6yrK7+Qjw+/mJcXP4WEBL6Pjo4+1tVVP8fGxr68uzu/zs1Nv5iXFz/9/Hy+k5KSvqalJb+SkRG/iokJv5STEz+TkpI+t7a2PujnZz/l5GS+9vV1P5+enr6HhoY+5eRkPsC/P7/x8HC97exsvsvKyj7d3Fy+kZAQvdTTUz++vT0/rKsrv5CPD7+Ylxc/hYQEvo+Ojj7W1VU/x8bGvry7O7/OzU2/mJcXP/38fL6TkpK+pqUlv5KREb+KiQm/lJMTP5OSkj63trY+6OdnPw==",
+      "vectorSha256": "f9ec2a745dceb0cab3e3418c9ee2f96e5b4acf98d8ce1e55c810bfc8dbd74092",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "63fa58a19c207862b2647be9de2a38cb6fa3ea4e2219cb605b2d373bc9a4adf3",
+      "updatedAt": "2025-09-20T22:28:15.431Z"
+    },
+    "adventure-26": {
+      "vector": "3NtbP8LBQb/My0s/pqUlP5OSkr6Qjw+/19bWvq+urr7u7W0/AACAv/Tzcz+Ylxc/hoUFv4iHB7+FhAQ+9vV1P97dXb/My0s/kI8PP8bFRb/Hxsa+q6qqvrOysj7f3t4+/fx8Po6NDb/b2tq+1tVVP56dHT+joqI+/fx8PsvKyr7c21s/wsFBv8zLSz+mpSU/k5KSvpCPD7/X1ta+r66uvu7tbT8AAIC/9PNzP5iXFz+GhQW/iIcHv4WEBD729XU/3t1dv8zLSz+Qjw8/xsVFv8fGxr6rqqq+s7KyPt/e3j79/Hw+jo0Nv9va2r7W1VU/np0dP6Oioj79/Hw+y8rKvg==",
+      "vectorSha256": "d0bfbaf1878dba433617671fb49721a86c2b96cfffb46977a83e9e626ff37321",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ed1fe5d25b384a54f600f9cb3d3c90fa11e5c71d4e55acb79f3949eacea89f4d",
+      "updatedAt": "2025-09-20T22:28:15.432Z"
+    },
+    "adventure-27": {
+      "vector": "kpERv7SzM7/o52e/np0dP7a1NT+/vr6+/v19P+/u7j68uzu/3NtbP+blZb+CgQG/+/r6vtTTU7+SkRE/sK8vP4uKij6xsDC9pqUlv6SjIz/a2Vm/397evpSTEz/p6Og9x8bGvpCPD7+GhQU/hIMDv/z7e7+vrq4+r66uPoyLC7+SkRG/tLMzv+jnZ7+enR0/trU1P7++vr7+/X0/7+7uPry7O7/c21s/5uVlv4KBAb/7+vq+1NNTv5KRET+wry8/i4qKPrGwML2mpSW/pKMjP9rZWb/f3t6+lJMTP+no6D3Hxsa+kI8Pv4aFBT+EgwO//Pt7v6+urj6vrq4+jIsLvw==",
+      "vectorSha256": "86a5d6b40bc39b560bb4c6dbaee708f0647772fa24559389538863f0146c8a03",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "37260cceda50febb22ed0d3f4116c8d7a27a2dd11348c98e4e38c23e02abab3a",
+      "updatedAt": "2025-09-20T22:28:15.432Z"
+    },
+    "adventure-28": {
+      "vector": "wL8/P+jnZz/x8HC93NtbP+fm5j7t7Gy+iIcHP6yrK7/083M/hYQEvvTzcz/v7u6+xcREvtrZWb+trCw+9PNzv/79fb+JiIg9nJsbv+3sbL7f3t6+AACAP6KhIT/m5WU/vbw8vqCfH7/DwsK+/Pt7v5CPDz/d3Fy+hoUFP/LxcT/Avz8/6OdnP/HwcL3c21s/5+bmPu3sbL6Ihwc/rKsrv/Tzcz+FhAS+9PNzP+/u7r7FxES+2tlZv62sLD7083O//v19v4mIiD2cmxu/7exsvt/e3r4AAIA/oqEhP+blZT+9vDy+oJ8fv8PCwr78+3u/kI8PP93cXL6GhQU/8vFxPw==",
+      "vectorSha256": "1a0bbc7cd90252cf13ebf9ba0414f527832bd016a2b497639a52a7141d746a79",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dff378edb962c32af96ff944671395060188326248ffd0f268304f02c764c2f8",
+      "updatedAt": "2025-09-20T22:28:15.432Z"
+    },
+    "adventure-29": {
+      "vector": "iYiIPfHwcL2gnx8/urk5P8TDQz+1tDS+trU1P7SzMz+npqY+AACAv7W0ND6Pjo6+/fx8PrW0NL7CwUG/y8rKPvDvbz+gnx+/8O9vP8zLSz/U01M/nJsbv//+/r7y8XE/0M9Pv93cXD6+vT0/x8bGPtzbWz8AAIA/y8rKPvb1db+JiIg98fBwvaCfHz+6uTk/xMNDP7W0NL62tTU/tLMzP6empj4AAIC/tbQ0Po+Ojr79/Hw+tbQ0vsLBQb/Lyso+8O9vP6CfH7/w728/zMtLP9TTUz+cmxu///7+vvLxcT/Qz0+/3dxcPr69PT/HxsY+3NtbPwAAgD/Lyso+9vV1vw==",
+      "vectorSha256": "36668fe4146904e07f8bee32184a7377c5b804da734de9a534b7e30e1a938136",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8878cfdce169dad9a900965c9f691fb2f730f7e5e93240f8189bdeb1edffb205",
+      "updatedAt": "2025-09-20T22:28:15.433Z"
+    },
+    "adventure-30": {
+      "vector": "mJcXv4OCgr6ioSG/8/Lyvq2sLD7r6uq+0tFRv52cHL6vrq6+oqEhv+Hg4LzOzU0/3t1dP9bVVb/r6uo+paQkPsnIyL2FhAQ+goEBP+Hg4DzV1FQ+zMtLP9HQUL3d3Fw+kZAQPba1NT/n5uY+qqkpP8HAQDyWlRU/hoUFv5KREb+Ylxe/g4KCvqKhIb/z8vK+rawsPuvq6r7S0VG/nZwcvq+urr6ioSG/4eDgvM7NTT/e3V0/1tVVv+vq6j6lpCQ+ycjIvYWEBD6CgQE/4eDgPNXUVD7My0s/0dBQvd3cXD6RkBA9trU1P+fm5j6qqSk/wcBAPJaVFT+GhQW/kpERvw==",
+      "vectorSha256": "674b2be5a2d4f7d351b44b2d9414dade04cd5a4cf190eccaca098c433a67e9a0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "345f2f439545176c542f7ce6ee15ba947390c0839ae5799b84dab9d481ca3d37",
+      "updatedAt": "2025-09-20T22:28:15.433Z"
+    },
+    "adventure-31": {
+      "vector": "9/b2PoiHB7+Ylxe/x8bGvvb1dT/T0tI+z87OPsTDQ7/g31+/iIcHv728PL7My0s/jo0Nv7Oysj7X1tY+oaCgvNXUVD6urS2/y8rKPp+enj6urS0/4+LivrKxMb+rqqq+3dxcPpKRET+/vr4+tbQ0Pqempj7j4uI++fj4vaempr739vY+iIcHv5iXF7/Hxsa+9vV1P9PS0j7Pzs4+xMNDv+DfX7+Ihwe/vbw8vszLSz+OjQ2/s7KyPtfW1j6hoKC81dRUPq6tLb/Lyso+n56ePq6tLT/j4uK+srExv6uqqr7d3Fw+kpERP7++vj61tDQ+p6amPuPi4j75+Pi9p6amvg==",
+      "vectorSha256": "8515e915ccc1109d297c66a3972a7db7bcbb78b7b010805043bb8af17a319590",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bd3c344efab4b31e103c68e539acb57d9a29b2a7d64727559bc8af96a9b87056",
+      "updatedAt": "2025-09-20T22:28:15.433Z"
+    },
+    "adventure-32": {
+      "vector": "2tlZv46NDT/i4WE/oaCgvKuqqj6amRm/p6amvqGgoLzj4uI+mZiYPfn4+D3y8XE/s7KyPrW0NL4AAIC/3t1dv4qJCb+GhQW/9PNzP4SDAz+BgIC7v76+PqalJT/k42O/6ulpv4aFBT/+/X0/mJcXv5WUFL6rqqo+qaioPc/Ozr7a2Vm/jo0NP+LhYT+hoKC8q6qqPpqZGb+npqa+oaCgvOPi4j6ZmJg9+fj4PfLxcT+zsrI+tbQ0vgAAgL/e3V2/iokJv4aFBb/083M/hIMDP4GAgLu/vr4+pqUlP+TjY7/q6Wm/hoUFP/79fT+Ylxe/lZQUvquqqj6pqKg9z87Ovg==",
+      "vectorSha256": "aa26f4d52495656aa2718a0ccaea938a2609036b0b5c073259283e3da40b7889",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "13c6f07daa33567db8898ff8ac6900113b3df9c17fafd20e0bc2fe346daa8a4c",
+      "updatedAt": "2025-09-20T22:28:15.433Z"
+    },
+    "adventure-33": {
+      "vector": "gYCAO4iHBz+TkpI+t7a2vsLBQT+lpCS+vr09v7GwMD3s62s/lpUVP4yLCz/s62u/v76+Pp6dHb/Ew0M/z87Ovr28PL7d3Fy+/Pt7P/z7ez+bmpq+rq0tP4uKij7Y11c/pqUlP+vq6j6DgoI+tLMzv7W0ND7T0tI+3t1dP/j3d7+BgIA7iIcHP5OSkj63tra+wsFBP6WkJL6+vT2/sbAwPezraz+WlRU/jIsLP+zra7+/vr4+np0dv8TDQz/Pzs6+vbw8vt3cXL78+3s//Pt7P5uamr6urS0/i4qKPtjXVz+mpSU/6+rqPoOCgj60szO/tbQ0PtPS0j7e3V0/+Pd3vw==",
+      "vectorSha256": "5057b44b3d18e08bfaec789f329581febc3378d95843d33c6447de43d98f9b9a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "80c3a452e06b2185f5cac50aaf31e14c6864fdfd59d6a2ebd2baa02696b4ee04",
+      "updatedAt": "2025-09-20T22:28:15.433Z"
+    },
+    "adventure-34": {
+      "vector": "/fx8Pquqqj6GhQW/np0dP/Tzcz/BwEA88/LyPpuamj66uTm/q6qqvsvKyr6JiIi9xMNDv7Oysr7DwsK+pKMjv4aFBb/8+3u/5uVlv5WUFL6wry8/rawsvtfW1j6BgIC7//7+PpKREb/Ew0O/9PNzv+Pi4j7q6Wm/8O9vP97dXT/9/Hw+q6qqPoaFBb+enR0/9PNzP8HAQDzz8vI+m5qaPrq5Ob+rqqq+y8rKvomIiL3Ew0O/s7KyvsPCwr6koyO/hoUFv/z7e7/m5WW/lZQUvrCvLz+trCy+19bWPoGAgLv//v4+kpERv8TDQ7/083O/4+LiPurpab/w728/3t1dPw==",
+      "vectorSha256": "63aa39d9654057ee5fc1496d5be40bc75ba6acffd2e8ceb153f91d1af7918c25",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9faa3dcef981bca623554d771e534f2e3d020d6dd76ab57fbf371e06b80bf7ee",
+      "updatedAt": "2025-09-20T22:28:15.434Z"
+    },
+    "adventure-35": {
+      "vector": "v76+vuPi4r6Ihwc/5uVlP7KxMb/e3V2/iIcHv5KRET/5+Pg90M9Pv4KBAb/Lysq+hYQEPu3sbD6vrq6+8/LyvsPCwj7083O/7exsPqCfH7/JyMi96Odnv4qJCb+RkBC98/LyPuvq6j6SkRG/3t1dP5KRET/U01M/7u1tv9nY2L2/vr6+4+LivoiHBz/m5WU/srExv97dXb+Ihwe/kpERP/n4+D3Qz0+/goEBv8vKyr6FhAQ+7exsPq+urr7z8vK+w8LCPvTzc7/t7Gw+oJ8fv8nIyL3o52e/iokJv5GQEL3z8vI+6+rqPpKREb/e3V0/kpERP9TTUz/u7W2/2djYvQ==",
+      "vectorSha256": "4dd383f59560bd794ff5bf5d967baff44cfc4f29812ea72cbd509e88ce38f108",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5047c3f227113cc88f183f4d909d5443b0069d30730c3b7bbcba37eec8e90972",
+      "updatedAt": "2025-09-20T22:28:15.434Z"
+    },
+    "adventure-36": {
+      "vector": "iokJP62sLL6FhAS+3NtbP6Oior6vrq4+2tlZP8fGxj7y8XG/rq0tv+no6L319HQ+2tlZP6uqqj7BwEC85uVlv+LhYT/Lysq+p6amPqinJ7/q6Wm/4+LiPtLRUb/q6Wm/1dRUvrCvL7+lpCQ+rKsrP/X0dL7OzU2/0tFRP6KhIb+KiQk/rawsvoWEBL7c21s/o6Kivq+urj7a2Vk/x8bGPvLxcb+urS2/6ejovfX0dD7a2Vk/q6qqPsHAQLzm5WW/4uFhP8vKyr6npqY+qKcnv+rpab/j4uI+0tFRv+rpab/V1FS+sK8vv6WkJD6sqys/9fR0vs7NTb/S0VE/oqEhvw==",
+      "vectorSha256": "0e35c5d4d32f0e0088001891225a842ee028f2da0e17e95c294b1bd97680fe0b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c46a6fed57abecb10729719eecaa7e0df04da92c0bb8170b652894d56119e82f",
+      "updatedAt": "2025-09-20T22:28:15.434Z"
+    },
+    "adventure-38": {
+      "vector": "np0dv83MTD6xsDA9hIMDP+rpaT+OjQ0/qKcnv+/u7j6gnx+/xMNDP8zLS7+Miwu/4eDgPKmoqL3KyUm/zs1Nv8C/Pz/S0VE/vLs7v9/e3j7S0VG/6+rqPomIiL38+3s/o6KivpybG7/Z2Ng9AACAv7a1Nb+1tDS+1NNTP42MDL6enR2/zcxMPrGwMD2EgwM/6ulpP46NDT+opye/7+7uPqCfH7/Ew0M/zMtLv4yLC7/h4OA8qaiovcrJSb/OzU2/wL8/P9LRUT+8uzu/397ePtLRUb/r6uo+iYiIvfz7ez+joqK+nJsbv9nY2D0AAIC/trU1v7W0NL7U01M/jYwMvg==",
+      "vectorSha256": "2626ea73d628da04a64b0474f3229564204f26a4d629559e98ac7e5659470f2a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "319985c1f4c62cbb30e11a3a83751b19dfe822b717ba77fd57328d002569e96e",
+      "updatedAt": "2025-09-20T22:28:15.434Z"
+    },
+    "adventure-39": {
+      "vector": "3t1dv8rJST+OjQ0/ycjIPbe2tj7083O/7OtrP/r5eb+Qjw8//v19v6uqqr7n5uY+oaCgPMjHR7/i4WG/19bWPqGgoLyqqSk/np0dv+Pi4r7493c/+vl5v9nY2D2CgQG/wsFBv9nY2D2+vT2/9vV1v8bFRb+ysTG/ubi4vc7NTT/e3V2/yslJP46NDT/JyMg9t7a2PvTzc7/s62s/+vl5v5CPDz/+/X2/q6qqvufm5j6hoKA8yMdHv+LhYb/X1tY+oaCgvKqpKT+enR2/4+Livvj3dz/6+Xm/2djYPYKBAb/CwUG/2djYPb69Pb/29XW/xsVFv7KxMb+5uLi9zs1NPw==",
+      "vectorSha256": "c9d96a710f603b3d77cda5c0367550a731edf861e475b575d28321815370e5be",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "11e4c68cad06f503c70155b9821c0fb57dd43147fb038d3f1f8d21051d2774e6",
+      "updatedAt": "2025-09-20T22:28:15.435Z"
+    },
+    "adventure-40": {
+      "vector": "iokJv+DfX7/e3V2/q6qqvsTDQ7///v4+uLc3v+LhYT+VlBS+2NdXP7KxMb/DwsI+qaioPaGgoDy5uLi90tFRv/38fL7OzU2/mZiYPauqqr719HS++vl5v62sLD6npqY+yslJv+zra7+SkRG/h4aGvtDPTz+opyc/4N9fP87NTb+KiQm/4N9fv97dXb+rqqq+xMNDv//+/j64tze/4uFhP5WUFL7Y11c/srExv8PCwj6pqKg9oaCgPLm4uL3S0VG//fx8vs7NTb+ZmJg9q6qqvvX0dL76+Xm/rawsPqempj7KyUm/7Otrv5KREb+Hhoa+0M9PP6inJz/g318/zs1Nvw==",
+      "vectorSha256": "6509d4912517cde85d40b0620fa06c183674b6b85f9c4788a871756d2de6ac8e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3b1011551ebf24f06deb27b08a82741760198955610395a91b0a375ee7d3ef19",
+      "updatedAt": "2025-09-20T22:28:15.435Z"
+    },
+    "adventure-41": {
+      "vector": "3Ntbv9TTU7+dnBw+xcREvs/Ozr62tTU//fx8vr28PL7v7u6+8/LyPvTzcz+CgQE/rq0tP9bVVb/CwUG/lJMTv8XERL65uLi9sbAwPbe2tj729XW/ycjIvaqpKT/NzEy+iIcHP8PCwj6xsDA9qaiovZSTE7+Miwu/sbAwvcfGxr7c21u/1NNTv52cHD7FxES+z87Ovra1NT/9/Hy+vbw8vu/u7r7z8vI+9PNzP4KBAT+urS0/1tVVv8LBQb+UkxO/xcREvrm4uL2xsDA9t7a2Pvb1db/JyMi9qqkpP83MTL6Ihwc/w8LCPrGwMD2pqKi9lJMTv4yLC7+xsDC9x8bGvg==",
+      "vectorSha256": "6ed0a6d304e644553bf790a4887bce45c53d01bb437ed7bb28c18534e05fe75c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "121693674cda606844bcf9c0d6151f36677485ad0573d466c3b08575363a7a4e",
+      "updatedAt": "2025-09-20T22:28:15.435Z"
+    },
+    "adventure-42": {
+      "vector": "9vV1P8TDQ7+ioSE/3t1dP//+/r6gnx+/rKsrP4WEBL6Pjo4+ubi4vf79fT+WlRU/sbAwvbOysj6urS2/rawsPrW0NL7W1VW/xsVFP7SzM7+dnBw+o6KiPvHwcD2WlRU/ycjIPZybGz/Pzs4+2tlZv9DPT7/DwsK+9vV1v/Dvb7/29XU/xMNDv6KhIT/e3V0///7+vqCfH7+sqys/hYQEvo+Ojj65uLi9/v19P5aVFT+xsDC9s7KyPq6tLb+trCw+tbQ0vtbVVb/GxUU/tLMzv52cHD6joqI+8fBwPZaVFT/JyMg9nJsbP8/Ozj7a2Vm/0M9Pv8PCwr729XW/8O9vvw==",
+      "vectorSha256": "b6633b40affbbc9f99d01794949a5378fcef492b53f16926845e722fbc821ea3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fa1ed0ee4030d56fa374feca7aac29956915e22693a887ca8ccdb313184f0508",
+      "updatedAt": "2025-09-20T22:28:15.435Z"
+    },
+    "adventure-43": {
+      "vector": "tbQ0PrSzM7/j4uK+m5qaPt7dXT/S0VG/np0dP8rJST+2tTU/09LSvtXUVL7HxsY+np0dv7KxMT/39va+5ONjP+Pi4r7w72+/v76+PsTDQz/CwUE/397ePsHAQDz083O/uLc3v5STEz+TkpI+0M9PP6WkJD6xsDC98vFxP6SjIz+1tDQ+tLMzv+Pi4r6bmpo+3t1dP9LRUb+enR0/yslJP7a1NT/T0tK+1dRUvsfGxj6enR2/srExP/f29r7k42M/4+LivvDvb7+/vr4+xMNDP8LBQT/f3t4+wcBAPPTzc7+4tze/lJMTP5OSkj7Qz08/paQkPrGwML3y8XE/pKMjPw==",
+      "vectorSha256": "4158c9bdc36ef0683bd062193710f5bf860649330a81ed6b4a91d737bdb78161",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "962647a6ee17cee4da4b65b131d842f14708afe1e0b7810624c9a4e7947af8d1",
+      "updatedAt": "2025-09-20T22:28:15.436Z"
+    },
+    "adventure-44": {
+      "vector": "4N9fP7m4uL3k42M/wcBAPNbVVb+bmpo+j46OPs/Ozr7Lysq+iokJv6qpKb+4tzc/sbAwPdDPTz/19HS+uLc3P+blZT+EgwO/kpERP6yrKz/BwEC8xcREvsLBQT+fnp6+19bWvuzra7/e3V2/tLMzP6moqL3493c/6OdnP6SjIz/g318/ubi4veTjYz/BwEA81tVVv5uamj6Pjo4+z87OvsvKyr6KiQm/qqkpv7i3Nz+xsDA90M9PP/X0dL64tzc/5uVlP4SDA7+SkRE/rKsrP8HAQLzFxES+wsFBP5+enr7X1ta+7Otrv97dXb+0szM/qaiovfj3dz/o52c/pKMjPw==",
+      "vectorSha256": "d564df8ff50b573df5d05b2034c71ce514a0a18843ac77b577d42c8bffe33029",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ef74f18115a6a34c4d3b2bdb85e761dbf23ec8d57e67e0584a0a11d975fbf3d1",
+      "updatedAt": "2025-09-20T22:28:15.436Z"
+    },
+    "adventure-45": {
+      "vector": "2djYPdHQUD2Ihwc/hIMDv4aFBb+1tDQ+zs1NP97dXT+/vr4+/v19P5KRET/Ix0e/rq0tv5STE7/T0tK+yMdHv7++vr6Miws/+Pd3v8zLS7+ZmJg98O9vP66tLb+NjAy+0dBQPePi4j7+/X0/y8rKPv79fT+joqK+urk5v5ybG7/Z2Ng90dBQPYiHBz+EgwO/hoUFv7W0ND7OzU0/3t1dP7++vj7+/X0/kpERP8jHR7+urS2/lJMTv9PS0r7Ix0e/v76+voyLCz/493e/zMtLv5mYmD3w728/rq0tv42MDL7R0FA94+LiPv79fT/Lyso+/v19P6Oior66uTm/nJsbvw==",
+      "vectorSha256": "e5fcf45297ba6e647296ee06232f0e84f3adfbb0d32ddb33f84ba73a306ca01d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8d86c33e3d96e6eeaffec81c29364b1c50c5041a89f7296e86b8feb2fe572332",
+      "updatedAt": "2025-09-20T22:28:15.436Z"
+    },
+    "adventure-46": {
+      "vector": "hIMDv7++vj7b2to+6ulpP9jXV7/e3V2/tLMzv6WkJL6XlpY+9vV1v6inJ7+OjQ0/paQkvpWUFL7V1FQ+2djYvcvKyr76+Xk/yMdHv+zra7+RkBC9j46OPp+enj7BwEA8rq0tP+LhYT+GhQU/nZwcvo2MDD6xsDA9r66uvp2cHL6EgwO/v76+Ptva2j7q6Wk/2NdXv97dXb+0szO/paQkvpeWlj729XW/qKcnv46NDT+lpCS+lZQUvtXUVD7Z2Ni9y8rKvvr5eT/Ix0e/7Otrv5GQEL2Pjo4+n56ePsHAQDyurS0/4uFhP4aFBT+dnBy+jYwMPrGwMD2vrq6+nZwcvg==",
+      "vectorSha256": "92a09a7a2e60364dce6f628768bf987de63ea263b25f058189a3b7fa8b8f2311",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3eafb6f41411266ba5052cc66b6d9a724dfc1c0a7ba3a781d6f0c26c9185546c",
+      "updatedAt": "2025-09-20T22:28:15.436Z"
+    },
+    "adventure-47": {
+      "vector": "9fR0Puno6D2WlRU/8vFxv/n4+D2urS2/hoUFv6Oior6/vr6+vr09v+3sbL7p6Oi96ejovaGgoLzLyso+xsVFv769Pb+koyM/urk5P5GQEL35+Pi92NdXP4SDA7/Avz8/ubi4vbCvLz+RkBC9zMtLv/b1dT/j4uK+6+rqvpmYmD319HQ+6ejoPZaVFT/y8XG/+fj4Pa6tLb+GhQW/o6Kivr++vr6+vT2/7exsvuno6L3p6Oi9oaCgvMvKyj7GxUW/vr09v6SjIz+6uTk/kZAQvfn4+L3Y11c/hIMDv8C/Pz+5uLi9sK8vP5GQEL3My0u/9vV1P+Pi4r7r6uq+mZiYPQ==",
+      "vectorSha256": "5ebbeb5a3e9ea4a2cc591bd7e77aecd235240b8ee6f900f30ad3e3a3f06de8d4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9e8eca078f293d5750216271717db21d21d1dc7b70eb3edf74d77b1afa474589",
+      "updatedAt": "2025-09-20T22:28:15.436Z"
+    },
+    "adventure-48": {
+      "vector": "qKcnP7W0ND6ysTE/vbw8vvTzc7/DwsI+/Pt7v5STE7+hoKA8mJcXv/r5eb+5uLg9h4aGPvHwcL2hoKC8u7q6Puzraz+6uTm/9fR0vuDfX7+NjAw+rawsvuDfX7+gnx8/jYwMvpmYmL2/vr4+zMtLP62sLL7e3V0/nZwcvsXERD6opyc/tbQ0PrKxMT+9vDy+9PNzv8PCwj78+3u/lJMTv6GgoDyYlxe/+vl5v7m4uD2HhoY+8fBwvaGgoLy7uro+7OtrP7q5Ob/19HS+4N9fv42MDD6trCy+4N9fv6CfHz+NjAy+mZiYvb++vj7My0s/rawsvt7dXT+dnBy+xcREPg==",
+      "vectorSha256": "b26449410cc5f3ea357dfd18456aa85c375aa3123b70052fcf6dd30e2d76a8fb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d396d86806b002368234038ba1787daef5236110916a10cf6e76afe56aee6c98",
+      "updatedAt": "2025-09-20T22:28:15.436Z"
+    },
+    "time-01": {
+      "vector": "ycjIPcbFRT+GhQW/+fj4vfHwcD2FhAS+/Pt7v7W0NL7JyMg9/Pt7v7a1NT+ZmJg9gYCAO4mIiL3NzEy+3t1dv97dXb+ysTG/7u1tP7y7Oz/f3t4+tbQ0vvz7ez+/vr4+8O9vP+/u7r6KiQm/yslJv9LRUT/Ix0c/lJMTP9PS0r7JyMg9xsVFP4aFBb/5+Pi98fBwPYWEBL78+3u/tbQ0vsnIyD38+3u/trU1P5mYmD2BgIA7iYiIvc3MTL7e3V2/3t1dv7KxMb/u7W0/vLs7P9/e3j61tDS+/Pt7P7++vj7w728/7+7uvoqJCb/KyUm/0tFRP8jHRz+UkxM/09LSvg==",
+      "vectorSha256": "edaf0b82a9a0ad7f39b710e7fbc877a63d6ef47a6328b030b010eb63e544f1bb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8ce23d70876f02698c02da89807766111127f6ddb769fdaff7443b1be8e3c94b",
+      "updatedAt": "2025-09-20T22:28:15.436Z"
+    },
+    "time-02": {
+      "vector": "iokJv7W0NL7z8vI+y8rKPsC/Pz+FhAS+2djYvfPy8j7V1FQ+7+7uPvTzc7/z8vK+jIsLP8/Ozj7+/X0/ubi4vbq5Ob/DwsK+1tVVP7q5Ob/T0tI++vl5v6Oioj4AAIC/h4aGPpeWlj7V1FQ+rq0tP+zra7/s62s/2NdXP8HAQLyKiQm/tbQ0vvPy8j7Lyso+wL8/P4WEBL7Z2Ni98/LyPtXUVD7v7u4+9PNzv/Py8r6Miws/z87OPv79fT+5uLi9urk5v8PCwr7W1VU/urk5v9PS0j76+Xm/o6KiPgAAgL+HhoY+l5aWPtXUVD6urS0/7Otrv+zraz/Y11c/wcBAvA==",
+      "vectorSha256": "929f1d670c35304ab094c626633a26a17074d6389a1fccb8ee5922c38920c823",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3b69bcb2df6f72bc9abb0643c5b3fe74234fea23b403a800a1a59ad60af5eb7e",
+      "updatedAt": "2025-09-20T22:28:15.436Z"
+    },
+    "time-03": {
+      "vector": "6+rqvs/Ozr7t7Gw+x8bGPomIiD3a2Vm/trU1P/Lxcb/Z2Ni9kZAQvc7NTb/s62u/v76+PqCfH7/19HQ+oJ8fP8nIyL2HhoY+rawsvtDPTz/U01O/6ulpP/X0dL6OjQ2/hoUFP+7tbb+ZmJg9o6Kivp+enr6UkxM/yMdHv6WkJD7r6uq+z87Ovu3sbD7HxsY+iYiIPdrZWb+2tTU/8vFxv9nY2L2RkBC9zs1Nv+zra7+/vr4+oJ8fv/X0dD6gnx8/ycjIvYeGhj6trCy+0M9PP9TTU7/q6Wk/9fR0vo6NDb+GhQU/7u1tv5mYmD2joqK+n56evpSTEz/Ix0e/paQkPg==",
+      "vectorSha256": "6fedd566d897744f4009939262a3e3de3ae3f9f8e69c1f0977e09ae017a8df3c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "454c9db18813da07727b190aaf309ecf73a16ae716f46139c209895758c91c94",
+      "updatedAt": "2025-09-20T22:28:15.436Z"
+    },
+    "time-04": {
+      "vector": "+fj4vaSjIz/Lyso+hYQEvt3cXD6ysTE/lpUVP+3sbD7e3V2/vLs7P5WUFD7CwUE/9vV1P8nIyL3Lysq++Pd3P+7tbb+urS0/7OtrP8vKyj62tTW/+/r6vrq5OT+bmpo+wcBAPIyLC7/Ix0e/yslJv6qpKT/083M/zcxMvo6NDT/5+Pi9pKMjP8vKyj6FhAS+3dxcPrKxMT+WlRU/7exsPt7dXb+8uzs/lZQUPsLBQT/29XU/ycjIvcvKyr7493c/7u1tv66tLT/s62s/y8rKPra1Nb/7+vq+urk5P5uamj7BwEA8jIsLv8jHR7/KyUm/qqkpP/Tzcz/NzEy+jo0NPw==",
+      "vectorSha256": "dc385e6e8e08ec34faaa24c864a2ee66acd839d624aafbdc953cfb0680541bcc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "70d1b26f9bd8ca9d11dd92e0fa734dfb09d6f5b22541dca6813a1c1bd4f966c6",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-05": {
+      "vector": "hIMDv9nY2L3v7u4+g4KCvuDfXz+5uLi929ravv/+/r7FxES+5uVlP6qpKb+TkpK+2djYvaalJb+4tzc/0M9PP9TTUz+hoKA8wsFBP5OSkj4AAIA/4eDgvIiHB7+Hhoa+/Pt7P5OSkr66uTm/kI8Pv66tLT/g31+/oJ8fP52cHL6EgwO/2djYve/u7j6DgoK+4N9fP7m4uL3b2tq+//7+vsXERL7m5WU/qqkpv5OSkr7Z2Ni9pqUlv7i3Nz/Qz08/1NNTP6GgoDzCwUE/k5KSPgAAgD/h4OC8iIcHv4eGhr78+3s/k5KSvrq5Ob+Qjw+/rq0tP+DfX7+gnx8/nZwcvg==",
+      "vectorSha256": "c520786fd09e94c67901072db9b76d7ffb4a9fb4fcab3c3caf9cd89d3840a06c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3e72bb5fef74494067f22b5b722ddbe7e982e0a4ff7c3c5efd5b2338d610cf6c",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-06": {
+      "vector": "yslJP/j3dz+EgwO/jIsLv/v6+j61tDS+n56evpybGz+9vDw+xsVFv+zra7+Hhoa+8fBwPdbVVb+GhQW/vLs7v5STEz+Ylxc/wL8/v66tLT/GxUU/4eDgPNrZWb/c21s/h4aGvuHg4Dyfnp4+o6Kivru6ur6OjQ0/v76+PtnY2L3KyUk/+Pd3P4SDA7+Miwu/+/r6PrW0NL6fnp6+nJsbP728PD7GxUW/7Otrv4eGhr7x8HA91tVVv4aFBb+8uzu/lJMTP5iXFz/Avz+/rq0tP8bFRT/h4OA82tlZv9zbWz+Hhoa+4eDgPJ+enj6joqK+u7q6vo6NDT+/vr4+2djYvQ==",
+      "vectorSha256": "4b84f00b0092703d22a191603e3064a9a4952b8e282a3950626e6f67ce7e0f7e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e4fb3e3abe6958cd971d0a5e87153d22c9cb20d6e28313ed5e83a75751c6af72",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-07": {
+      "vector": "7Otrv8rJST+OjQ0/u7q6vr28PD61tDS+qqkpv+jnZ7+6uTm/r66uvpybG7+GhQU/7+7uPpmYmD2EgwM/09LSvt/e3j4AAIA/7exsPpybGz+Pjo6+6+rqPtLRUT+2tTU/2djYvf79fb/S0VE/wcBAPKuqqr7Qz0+//Pt7v5iXF7/s62u/yslJP46NDT+7urq+vbw8PrW0NL6qqSm/6Odnv7q5Ob+vrq6+nJsbv4aFBT/v7u4+mZiYPYSDAz/T0tK+397ePgAAgD/t7Gw+nJsbP4+Ojr7r6uo+0tFRP7a1NT/Z2Ni9/v19v9LRUT/BwEA8q6qqvtDPT7/8+3u/mJcXvw==",
+      "vectorSha256": "67b2d0954b20be3ecd2a0a1ece4bf309860146da605c5622594020a269c16e67",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0ae4c65197692b0c235432c2bb89c14bb7ff9dcd5cbae8da7201e88155180234",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-08": {
+      "vector": "4+LiPqqpKT+BgIA7jo0Nv4uKij6WlRU/w8LCPu3sbD7Ew0O/tbQ0vv/+/j6ysTE/z87OPqyrK7/T0tK+ycjIPd7dXT+cmxs/qqkpv7GwMD3e3V2/i4qKvtrZWb+BgIC72NdXP8TDQz+BgIA72tlZP+fm5j6npqa+z87OPvLxcT/j4uI+qqkpP4GAgDuOjQ2/i4qKPpaVFT/DwsI+7exsPsTDQ7+1tDS+//7+PrKxMT/Pzs4+rKsrv9PS0r7JyMg93t1dP5ybGz+qqSm/sbAwPd7dXb+Lioq+2tlZv4GAgLvY11c/xMNDP4GAgDva2Vk/5+bmPqempr7Pzs4+8vFxPw==",
+      "vectorSha256": "f95efcda22cd638a91e76f00f208aeb429aac76cac4f6e7d1e8448b80e671eb3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b8d48039a2cab09d1e69bfd8b32a4b8ceecd2b85115d137febe180ecb956b3f8",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-09": {
+      "vector": "uLc3P9TTU7+hoKC82djYvf/+/r7KyUm/iYiIPeXkZL6npqY+yslJv7W0ND7j4uI+5eRkvt/e3r6lpCQ+7u1tv6+urj63trY+v76+PtTTUz++vT0/kZAQPaalJb+opyc/oJ8fv8bFRT+qqSk/7exsPoKBAb///v4+09LSvoSDA7+4tzc/1NNTv6GgoLzZ2Ni9//7+vsrJSb+JiIg95eRkvqempj7KyUm/tbQ0PuPi4j7l5GS+397evqWkJD7u7W2/r66uPre2tj6/vr4+1NNTP769PT+RkBA9pqUlv6inJz+gnx+/xsVFP6qpKT/t7Gw+goEBv//+/j7T0tK+hIMDvw==",
+      "vectorSha256": "33942c7d3d6c2f9945cd68cb7422258e9292c67039b1341199a849800d2c6e7d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "db167d72401b8863a91b96b863489409abadafe9de842dd330e2d49d3fbf4b3e",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-10": {
+      "vector": "6ulpP+fm5j6Miwu/p6amvt3cXD719HS+8fBwPaOioj7f3t4+6ulpP62sLD7My0s/jo0Nv8XERD6CgQE/9fR0Pq2sLL7Z2Ng9hIMDv/f29j62tTW/yslJP8C/P7/BwEA8rq0tv+no6L3c21s/lpUVv8zLS7+3tra+6ejoPb++vr7q6Wk/5+bmPoyLC7+npqa+3dxcPvX0dL7x8HA9o6KiPt/e3j7q6Wk/rawsPszLSz+OjQ2/xcREPoKBAT/19HQ+rawsvtnY2D2EgwO/9/b2Pra1Nb/KyUk/wL8/v8HAQDyurS2/6ejovdzbWz+WlRW/zMtLv7e2tr7p6Og9v76+vg==",
+      "vectorSha256": "0a13685cb4be454a7dedb69c5bdb16e0ef27f4402309178dcb0283c0cf76fcb3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f4b93a569b6187a8b7f495e53998c09e6a8d3ebd25e420812971ed351a528e50",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-11": {
+      "vector": "9/b2PoiHBz/l5GS+9/b2Pvn4+D22tTW/5+bmPsHAQLyjoqI+mpkZP9PS0j7R0FC99/b2PoWEBD7s62u/+/r6vsrJSb/m5WU/6Odnv8zLS7+vrq4+mZiYvevq6r62tTU/4eDgvJ+enr6rqqo+zcxMvoGAgDv8+3s/srExP4uKir739vY+iIcHP+XkZL739vY++fj4Pba1Nb/n5uY+wcBAvKOioj6amRk/09LSPtHQUL339vY+hYQEPuzra7/7+vq+yslJv+blZT/o52e/zMtLv6+urj6ZmJi96+rqvra1NT/h4OC8n56evquqqj7NzEy+gYCAO/z7ez+ysTE/i4qKvg==",
+      "vectorSha256": "f1bba776ff6d33c44bd42855ccf6df5eea6c992064b36c254816ecd1aeacb72c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bdc363bd8f25b97ea8ccb479bd900a411bf20c1aab7645da7c58aa6680fdd85d",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-12": {
+      "vector": "vr09v9jXVz/s62u/2tlZv7q5Ob/493c/yMdHv5CPD7+8uzu/srExP+rpaT/i4WG/qKcnv/79fT/GxUW/1tVVP+no6D339va+8fBwPcC/P7+OjQ2/6ulpv+rpaT/s62u/n56ePoaFBb/Z2Ng94+LiPsnIyL3My0u/x8bGPra1NT++vT2/2NdXP+zra7/a2Vm/urk5v/j3dz/Ix0e/kI8Pv7y7O7+ysTE/6ulpP+LhYb+opye//v19P8bFRb/W1VU/6ejoPff29r7x8HA9wL8/v46NDb/q6Wm/6ulpP+zra7+fnp4+hoUFv9nY2D3j4uI+ycjIvczLS7/HxsY+trU1Pw==",
+      "vectorSha256": "e0eccc898abcc07c92988c8c34a59e25f92be3049e0071d7a3adb7730d6f4777",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "21eb0a1323fb1c3822d8f40f2cfe1dea8e428720390bf40aa73d8db8731ab1da",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-13": {
+      "vector": "/v19P/j3dz+mpSW/+/r6Pu/u7j6ysTE/g4KCPs7NTT/t7Gw+l5aWPuLhYT/s62u/7exsPqSjIz/W1VU/np0dP8jHR7/w72+/vLs7v6GgoDy5uLi9goEBv+blZb/o52e/l5aWPry7O7/Lysq+hYQEvquqqr77+vo+jYwMPoaFBb/+/X0/+Pd3P6alJb/7+vo+7+7uPrKxMT+DgoI+zs1NP+3sbD6XlpY+4uFhP+zra7/t7Gw+pKMjP9bVVT+enR0/yMdHv/Dvb7+8uzu/oaCgPLm4uL2CgQG/5uVlv+jnZ7+XlpY+vLs7v8vKyr6FhAS+q6qqvvv6+j6NjAw+hoUFvw==",
+      "vectorSha256": "d9ea96437fee0d7b2ce8c733222e330bf7a512db5a335c765a8f2769cdf78d42",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fefb2dbebbd8a0e69da5f00a9dd1eace1c082282743f0d0ca5224d6f55be913d",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-14": {
+      "vector": "zMtLv5qZGb/o52e/8O9vP6KhIT/+/X0///7+voOCgr719HQ+29ravoqJCT/S0VG/kI8Pv6Oioj6EgwM/3t1dv9jXVz/x8HA9/Pt7P/b1dT/6+Xk/hIMDv6Oior7CwUE/iIcHP/79fT/q6Wk/urk5v9DPT7/NzEw+7exsvu3sbL7My0u/mpkZv+jnZ7/w728/oqEhP/79fT///v6+g4KCvvX0dD7b2tq+iokJP9LRUb+Qjw+/o6KiPoSDAz/e3V2/2NdXP/HwcD38+3s/9vV1P/r5eT+EgwO/o6KivsLBQT+Ihwc//v19P+rpaT+6uTm/0M9Pv83MTD7t7Gy+7exsvg==",
+      "vectorSha256": "f0d3a332899fe841b3f88c3c8d288b75c6d2dce76bdd2f2cb983876ed066f364",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1a330cf7d0fe405f9e49c41738a8c111eb87fdfafc3e57e0c3fef42318996262",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-15": {
+      "vector": "l5aWvq6tLb+hoKA86Odnv6GgoDzHxsY+5uVlP+3sbD6Ihwc/qaioPYGAgLuamRk//v19v4WEBD7Y11c/xsVFv+fm5j6hoKC89PNzv6alJb/Avz8/397ePv79fT+Lioq+uLc3v7CvL7+KiQm/j46OPsnIyD2ioSE/vbw8voqJCT+Xlpa+rq0tv6GgoDzo52e/oaCgPMfGxj7m5WU/7exsPoiHBz+pqKg9gYCAu5qZGT/+/X2/hYQEPtjXVz/GxUW/5+bmPqGgoLz083O/pqUlv8C/Pz/f3t4+/v19P4uKir64tze/sK8vv4qJCb+Pjo4+ycjIPaKhIT+9vDy+iokJPw==",
+      "vectorSha256": "aa402f42ef867f4c7d16e6e22e95d70b87f10217f5b769038336cc2f6d81219a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5a29820c82b1f29dc38a7fcc0190eb1db97d062ddfb7fe5d24283ba38cd068c4",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-16": {
+      "vector": "iIcHP+XkZD76+Xm//v19P7m4uD2fnp6+rKsrP5STEz/Ix0c/qKcnP4mIiL3Avz8/6Odnv4uKir7s62s/09LSPsbFRT/f3t6+4uFhP/LxcT/z8vK+k5KSPqGgoDzv7u4+rawsvoWEBD7Qz08/m5qaPrGwMD3w72+/mZiYPdbVVb+Ihwc/5eRkPvr5eb/+/X0/ubi4PZ+enr6sqys/lJMTP8jHRz+opyc/iYiIvcC/Pz/o52e/i4qKvuzraz/T0tI+xsVFP9/e3r7i4WE/8vFxP/Py8r6TkpI+oaCgPO/u7j6trCy+hYQEPtDPTz+bmpo+sbAwPfDvb7+ZmJg91tVVvw==",
+      "vectorSha256": "c8ac2af44cb6425c2d3013382bbf1ed40530823307b157cd8c52dc6e8df1aae8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c39c03fe8b58d5c9e3d377df0c5df5b4e248f0f843a482bb6a90e7a685088915",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-17": {
+      "vector": "6Odnv6+urj6enR2/iYiIvYuKij7S0VG/urk5P//+/j7p6Oi9xcREvp6dHb+Xlpa+y8rKPqmoqL2RkBC9uLc3P46NDT/Y11c/r66uPq2sLD68uzs/oaCgPPLxcb/Hxsa+5uVlv8nIyD3g318/nZwcPv38fL6BgIC719bWvr69Pb/o52e/r66uPp6dHb+JiIi9i4qKPtLRUb+6uTk///7+Puno6L3FxES+np0dv5eWlr7Lyso+qaiovZGQEL24tzc/jo0NP9jXVz+vrq4+rawsPry7Oz+hoKA88vFxv8fGxr7m5WW/ycjIPeDfXz+dnBw+/fx8voGAgLvX1ta+vr09vw==",
+      "vectorSha256": "bc59de1f6338f03bed346e9a6d2769150e2b666435a0393a3b04b3082f57b101",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0cab3177a217dcbf7167315ab2757bdbc6ebab95dd82074e0d8cef93607f4a21",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-18": {
+      "vector": "nZwcvsLBQT/Lyso+0M9PP/Py8j7Z2Ng91NNTv7W0ND6Ylxc/3t1dP6yrKz/z8vI+09LSvvb1dT+wry+/2tlZv5mYmD2WlRU/xcREvvb1dT+0szO/1NNTP6qpKT/z8vI+paQkvublZb+2tTW/trU1P6yrKz/u7W2/+/r6vtbVVb+dnBy+wsFBP8vKyj7Qz08/8/LyPtnY2D3U01O/tbQ0PpiXFz/e3V0/rKsrP/Py8j7T0tK+9vV1P7CvL7/a2Vm/mZiYPZaVFT/FxES+9vV1P7SzM7/U01M/qqkpP/Py8j6lpCS+5uVlv7a1Nb+2tTU/rKsrP+7tbb/7+vq+1tVVvw==",
+      "vectorSha256": "f6d84b559f20f38a347baf22fb7206097e6e367e01138c8baa30b3ddc93b8dea",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6ce0b2e7bc8d1696cbeed5bc4bfa281389ca67fa26e9d4bc6b0d25dad5094115",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-19": {
+      "vector": "mZiYvcTDQ7/x8HC9gYCAu6empr7X1ta+m5qaPpybGz+Ylxe/9vV1v/v6+r7X1ta+yMdHP/Dvbz+joqI+9vV1v4GAgLvh4OC80dBQvfX0dD7BwEC8nZwcPu3sbD6KiQm/29ravv/+/r7p6Oi9AACAv+LhYT+Qjw8/+fj4vZGQEL2ZmJi9xMNDv/HwcL2BgIC7p6amvtfW1r6bmpo+nJsbP5iXF7/29XW/+/r6vtfW1r7Ix0c/8O9vP6Oioj729XW/gYCAu+Hg4LzR0FC99fR0PsHAQLydnBw+7exsPoqJCb/b2tq+//7+vuno6L0AAIC/4uFhP5CPDz/5+Pi9kZAQvQ==",
+      "vectorSha256": "4c657f4f8f8b00b0102515621c50361c34cac202bdf8eebc6129682bf75f6544",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "761e787f564aa6cd3405414ae3f7a8057f7c799e7e939d3b49407100f0c7707b",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-20": {
+      "vector": "tLMzv9fW1r6mpSW/np0dv9TTU7+JiIi9wcBAvKyrK7/NzEw+29raPvr5eT+8uzs/yMdHP6SjI7+qqSk//Pt7v8fGxj6bmpo+1dRUPvz7ez/y8XE/m5qavq+urj6TkpK+l5aWvtbVVb/JyMi9hIMDP6CfHz+npqY+4+LivqmoqL20szO/19bWvqalJb+enR2/1NNTv4mIiL3BwEC8rKsrv83MTD7b2to++vl5P7y7Oz/Ix0c/pKMjv6qpKT/8+3u/x8bGPpuamj7V1FQ+/Pt7P/LxcT+bmpq+r66uPpOSkr6Xlpa+1tVVv8nIyL2EgwM/oJ8fP6empj7j4uK+qaiovQ==",
+      "vectorSha256": "ab19b1bb7b5624ea1e7f1adaf392a177eb3b3d6f4e19fcea1ffa0ad964e5e9a4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "264a2d3116777e2a99b6fcdde32ed402b1a69afdf859ab5b5a1573c1cfa94775",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-21": {
+      "vector": "goEBv6CfHz/BwEC8mJcXv769Pb/o52c/2djYPdLRUb+Lioo+trU1v/j3dz/Avz8/jo0Nv6yrK7+lpCS+19bWPvTzc7+6uTm/rKsrv7SzMz/b2to+1dRUvtzbW7+RkBA9kZAQvd7dXb/z8vK+3t1dP+TjY7+ioSE//fx8PoWEBL6CgQG/oJ8fP8HAQLyYlxe/vr09v+jnZz/Z2Ng90tFRv4uKij62tTW/+Pd3P8C/Pz+OjQ2/rKsrv6WkJL7X1tY+9PNzv7q5Ob+sqyu/tLMzP9va2j7V1FS+3Ntbv5GQED2RkBC93t1dv/Py8r7e3V0/5ONjv6KhIT/9/Hw+hYQEvg==",
+      "vectorSha256": "221362caf266c42e0eac8a2e70eb251ab61ca76f04e73fe38d25ab643ffe8ce6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3fcf7e3421f38d17a225fbdf392a6bb506232ad9b66512847b1143ee0ed09f6f",
+      "updatedAt": "2025-09-20T22:28:15.438Z"
+    },
+    "time-22": {
+      "vector": "1dRUPsLBQT/Qz0+/2djYPfTzcz+urS0/2djYPcnIyD3l5GQ+rawsPvLxcT/l5GS+8vFxv4aFBT+8uzu/lpUVv+vq6r6Miws/+/r6PtDPT7+1tDQ+6ulpv7GwMD3My0u/g4KCPoWEBL65uLi9zcxMPpOSkj6dnBy+w8LCPpWUFD7V1FQ+wsFBP9DPT7/Z2Ng99PNzP66tLT/Z2Ng9ycjIPeXkZD6trCw+8vFxP+XkZL7y8XG/hoUFP7y7O7+WlRW/6+rqvoyLCz/7+vo+0M9Pv7W0ND7q6Wm/sbAwPczLS7+DgoI+hYQEvrm4uL3NzEw+k5KSPp2cHL7DwsI+lZQUPg==",
+      "vectorSha256": "5faec91d1bffe27bc99473dd01b28047efb91a806b8d964922464e0608f722f3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9ae0188df9d68d8c9c95f86307c2223545c5be18960b851aa06f7499a46cb092",
+      "updatedAt": "2025-09-20T22:28:15.438Z"
+    },
+    "time-23": {
+      "vector": "7u1tP4WEBL7u7W0/1NNTP6+urr7s62u/mpkZv8zLSz/8+3u/j46OPt3cXD7+/X2/yMdHP/Tzcz+cmxu/19bWvtXUVL6KiQk/z87OPt3cXD6lpCQ+1tVVP/z7e7+TkpI+t7a2vtPS0j6enR0/i4qKvszLSz+pqKg9tbQ0vu3sbL7u7W0/hYQEvu7tbT/U01M/r66uvuzra7+amRm/zMtLP/z7e7+Pjo4+3dxcPv79fb/Ix0c/9PNzP5ybG7/X1ta+1dRUvoqJCT/Pzs4+3dxcPqWkJD7W1VU//Pt7v5OSkj63tra+09LSPp6dHT+Lioq+zMtLP6moqD21tDS+7exsvg==",
+      "vectorSha256": "51149bd269c5c733c3be06f2c14d7c9254c7bc9ffa0c580180588d4a5c360eea",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f66ff6e9540a33e502a39b01e3f9324a65c4b39b94ea02a452b4ce5de58a6962",
+      "updatedAt": "2025-09-20T22:28:15.438Z"
+    },
+    "time-24": {
+      "vector": "iYiIPeLhYb+6uTm/gYCAu7y7Oz+koyM/9PNzv4GAgLuxsDC9+vl5P6empr6qqSm/rq0tv9DPT7/n5uY+vLs7P8PCwr7OzU2/trU1v6+urr7r6uq+wsFBv+fm5j6ZmJi94uFhv5STE7+Lioo+qKcnv8zLS7+HhoY+19bWvrKxMT+JiIg94uFhv7q5Ob+BgIC7vLs7P6SjIz/083O/gYCAu7GwML36+Xk/p6amvqqpKb+urS2/0M9Pv+fm5j68uzs/w8LCvs7NTb+2tTW/r66uvuvq6r7CwUG/5+bmPpmYmL3i4WG/lJMTv4uKij6opye/zMtLv4eGhj7X1ta+srExPw==",
+      "vectorSha256": "d7453a9c03c07970db1eb4ee6e4db020e00903ad964670da7058dc85f87efc2b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "880f237fddd1067f7afc562b2918b9dd4f192554451fb9760f36a22c1aa14ad8",
+      "updatedAt": "2025-09-20T22:28:15.438Z"
+    },
+    "time-25": {
+      "vector": "hoUFP5mYmL3n5ua+8vFxv9/e3j7y8XG/4uFhv7i3Nz+Xlpa+iIcHv/Dvbz/n5uY+5eRkPoGAgLvKyUm/0M9Pv8PCwr719HS+7exsvszLS7+cmxu/paQkPqGgoLy4tzc/+/r6vs7NTb+sqyu/5+bmPqempj6Qjw8/zMtLP+/u7j6GhQU/mZiYvefm5r7y8XG/397ePvLxcb/i4WG/uLc3P5eWlr6Ihwe/8O9vP+fm5j7l5GQ+gYCAu8rJSb/Qz0+/w8LCvvX0dL7t7Gy+zMtLv5ybG7+lpCQ+oaCgvLi3Nz/7+vq+zs1Nv6yrK7/n5uY+p6amPpCPDz/My0s/7+7uPg==",
+      "vectorSha256": "f977f318bdfd0aabbf59dd2cc941eb89f48ff55167a83ea4546cb0746bdf5cf5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c2764607b7070fdb5a3cf7b99c7f1b184f61621a32947ddb41192ab9a9c7e5bb",
+      "updatedAt": "2025-09-20T22:28:15.438Z"
+    },
+    "time-26": {
+      "vector": "kZAQPcvKyr6WlRU/6ejoPbSzM7/u7W0//fx8Pp+enr6bmpo+np0dv9DPT7/n5uY+kI8PP8/Ozj6urS2/h4aGvqinJ7+UkxO/mZiYvainJz+rqqo+6ejoPaalJT/7+vo+5eRkvoeGhr6qqSm/9PNzP8vKyr7X1tY+09LSPoqJCT+RkBA9y8rKvpaVFT/p6Og9tLMzv+7tbT/9/Hw+n56evpuamj6enR2/0M9Pv+fm5j6Qjw8/z87OPq6tLb+Hhoa+qKcnv5STE7+ZmJi9qKcnP6uqqj7p6Og9pqUlP/v6+j7l5GS+h4aGvqqpKb/083M/y8rKvtfW1j7T0tI+iokJPw==",
+      "vectorSha256": "6f8725a879f56f0bb8df0e7a56c7b57a8b8f3dbc305712f1a9971dc8bd85f05b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "844dca8e26f69f58a63118b9c7b3295e2c3676d3aa8ed2be635e2bf94db5b4c4",
+      "updatedAt": "2025-09-20T22:28:15.438Z"
+    },
+    "time-27": {
+      "vector": "q6qqvri3N7+Miwu/r66uvtDPT7+ysTE//fx8Pvr5eT/Avz8/yMdHv+blZb/m5WU/iokJP7y7O7+urS2/xcREPvr5eT/U01O/3dxcPvj3d7/W1VW/rawsvqinJ7+KiQm/qqkpP9PS0r7f3t6+kI8PP/38fL7493c/ubi4PaWkJL6rqqq+uLc3v4yLC7+vrq6+0M9Pv7KxMT/9/Hw++vl5P8C/Pz/Ix0e/5uVlv+blZT+KiQk/vLs7v66tLb/FxEQ++vl5P9TTU7/d3Fw++Pd3v9bVVb+trCy+qKcnv4qJCb+qqSk/09LSvt/e3r6Qjw8//fx8vvj3dz+5uLg9paQkvg==",
+      "vectorSha256": "436146128bec7d6cc30c4bb9345e9a2a06933bd01850a325158e94e1ca927f40",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "55243a5418d89ffcdf1c0df2c4222998fc169b04156a2c3bd44b48c760fb8b6b",
+      "updatedAt": "2025-09-20T22:28:15.439Z"
+    },
+    "time-28": {
+      "vector": "n56ePru6ur7Qz08/+vl5P/38fD7493e/+Pd3P9XUVD6Qjw8/mJcXv4WEBD719HQ++vl5P6moqD3t7Gy+2tlZv7CvL7/7+vq+xMNDP5GQED3Pzs4+v76+vrm4uD3493c/gYCAu/b1dT+xsDC9urk5v9zbWz+TkpI+w8LCPoeGhr6fnp4+u7q6vtDPTz/6+Xk//fx8Pvj3d7/493c/1dRUPpCPDz+Ylxe/hYQEPvX0dD76+Xk/qaioPe3sbL7a2Vm/sK8vv/v6+r7Ew0M/kZAQPc/Ozj6/vr6+ubi4Pfj3dz+BgIC79vV1P7GwML26uTm/3NtbP5OSkj7DwsI+h4aGvg==",
+      "vectorSha256": "b70000fc8a1754ac019cc6a1df1c77132a4dd18502b0050819214a11b5219046",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a751e7fc9f04fb9ac734909efc8a62132841e184b3508bfb7ffa7a23eda4b05e",
+      "updatedAt": "2025-09-20T22:28:15.439Z"
+    },
+    "time-29": {
+      "vector": "o6KivqWkJD6lpCQ+lJMTP9/e3j7h4OA8wL8/v4KBAb+Qjw8/goEBv/b1dT/u7W0/rKsrP4KBAT+BgIC7g4KCPoWEBL6Ihwc/goEBP8LBQb/p6Og9zs1Nv87NTT/t7Gy+y8rKvtDPTz+joqK+gYCAO6CfH7+Miws/urk5v8C/Pz+joqK+paQkPqWkJD6UkxM/397ePuHg4DzAvz+/goEBv5CPDz+CgQG/9vV1P+7tbT+sqys/goEBP4GAgLuDgoI+hYQEvoiHBz+CgQE/wsFBv+no6D3OzU2/zs1NP+3sbL7Lysq+0M9PP6Oior6BgIA7oJ8fv4yLCz+6uTm/wL8/Pw==",
+      "vectorSha256": "afd8ec93241cf4f231932dbc1d42743780b65ba374d0e7a541d5c1b61cb673d0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "579494c9b783203fc73ffaf6d5c07fa06fc3c01f8e19e6624de7578030c523df",
+      "updatedAt": "2025-09-20T22:28:15.439Z"
+    },
+    "time-30": {
+      "vector": "5ONjP97dXT+koyM/s7KyPtLRUb/w728/iYiIPYiHB7+koyO/vr09P6WkJL739vY+yslJv4WEBL7JyMg9zs1Nv46NDb+Qjw+/+vl5P/z7e7+vrq4++/r6vra1Nb/p6Og94eDgPLCvLz+BgIC7iokJP+zraz/7+vo+7u1tP5qZGT/k42M/3t1dP6SjIz+zsrI+0tFRv/Dvbz+JiIg9iIcHv6SjI7++vT0/paQkvvf29j7KyUm/hYQEvsnIyD3OzU2/jo0Nv5CPD7/6+Xk//Pt7v6+urj77+vq+trU1v+no6D3h4OA8sK8vP4GAgLuKiQk/7OtrP/v6+j7u7W0/mpkZPw==",
+      "vectorSha256": "f8e01599778d0590f951617687440513a14675264fdded2368588e3d693dec51",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f1eed1ac17f7883c2ede6bbd1b6f8c193938fc02ab41258e83d77fc4f5bef6cc",
+      "updatedAt": "2025-09-20T22:28:15.439Z"
+    },
+    "time-31": {
+      "vector": "wL8/P4KBAT/JyMg98/LyvqyrKz/c21u/urk5v5eWlr7S0VE/vLs7P62sLD6lpCS++vl5v6alJT/e3V0/nJsbv46NDb/v7u4+x8bGPri3N7+pqKg909LSvt3cXD7083O/kZAQvcTDQ7+2tTU/4+LivuDfX7+ZmJi9iIcHv8XERL7Avz8/goEBP8nIyD3z8vK+rKsrP9zbW7+6uTm/l5aWvtLRUT+8uzs/rawsPqWkJL76+Xm/pqUlP97dXT+cmxu/jo0Nv+/u7j7HxsY+uLc3v6moqD3T0tK+3dxcPvTzc7+RkBC9xMNDv7a1NT/j4uK+4N9fv5mYmL2Ihwe/xcREvg==",
+      "vectorSha256": "04e3787b23eebaa6f65d0bcae8a2214f6db89a4cd8949188dfa1342793cf7559",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dfc08c43d512235ae8dd956b03d2ee3239bbb1248a4b9b067b1eda4710763c67",
+      "updatedAt": "2025-09-20T22:28:15.439Z"
+    },
+    "time-32": {
+      "vector": "m5qavrSzM7/8+3s//Pt7v9nY2D28uzu/2djYPZ6dHT/m5WU/09LSPv/+/r6WlRU/ubi4vc/Ozr69vDy+3NtbP769PT+FhAS+hIMDv97dXT/a2Vk/goEBv+3sbD7y8XE/9vV1P9fW1r7OzU0/np0dP+3sbL6rqqo+9/b2Pre2tj6bmpq+tLMzv/z7ez/8+3u/2djYPby7O7/Z2Ng9np0dP+blZT/T0tI+//7+vpaVFT+5uLi9z87Ovr28PL7c21s/vr09P4WEBL6EgwO/3t1dP9rZWT+CgQG/7exsPvLxcT/29XU/19bWvs7NTT+enR0/7exsvquqqj739vY+t7a2Pg==",
+      "vectorSha256": "8813084bced7adc9d604b4a7ee6a42fe6ea94b9da8f9fa5ad7d41bacc96aeb65",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5926fd028d228dcef2b440ca744c68edde6f3eeeec3f9df8fa4ae6ce62aabdad",
+      "updatedAt": "2025-09-20T22:28:15.439Z"
+    },
+    "time-33": {
+      "vector": "yMdHP5uamr7OzU2/wsFBP4uKir6amRk/yMdHv8jHR7+OjQ2/5eRkPqmoqL3z8vK+h4aGPqKhIT/R0FC9AACAP/79fb+BgIA7hYQEPvf29r78+3u//fx8vs3MTL7s62s/4eDgvIOCgr6dnBw+7exsvqSjI7/c21s/pKMjPwAAgD/Ix0c/m5qavs7NTb/CwUE/i4qKvpqZGT/Ix0e/yMdHv46NDb/l5GQ+qaiovfPy8r6HhoY+oqEhP9HQUL0AAIA//v19v4GAgDuFhAQ+9/b2vvz7e7/9/Hy+zcxMvuzraz/h4OC8g4KCvp2cHD7t7Gy+pKMjv9zbWz+koyM/AACAPw==",
+      "vectorSha256": "be9a153e15bb56fdf0d99b68c1364f0d0c3f5c2bfc7cadbf7ba91d960880c3b1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e35919e05dcc1c1c399c7543a1d079ff01809042026066f57c5f93622eedd1ff",
+      "updatedAt": "2025-09-20T22:28:15.439Z"
+    },
+    "time-34": {
+      "vector": "/fx8Pq6tLb/R0FC9ycjIPb28PL7DwsK+vbw8vvz7ez+HhoY+p6amPuPi4j6sqys/np0dv9DPT7+RkBA9jo0Nv8XERD7Pzs4+pKMjP6GgoDyWlRU/tbQ0vuno6L2JiIi9yMdHP9bVVT+ZmJg9t7a2vpqZGT+CgQE/kI8Pv9LRUb/9/Hw+rq0tv9HQUL3JyMg9vbw8vsPCwr69vDy+/Pt7P4eGhj6npqY+4+LiPqyrKz+enR2/0M9Pv5GQED2OjQ2/xcREPs/Ozj6koyM/oaCgPJaVFT+1tDS+6ejovYmIiL3Ix0c/1tVVP5mYmD23tra+mpkZP4KBAT+Qjw+/0tFRvw==",
+      "vectorSha256": "770b827c3aac609b8cf9b6d94110493ed4156576d2e65938aebfa65789f2ae7c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9f29798c684f68fda1a9b8d53118843998b3d182ca697177e3ea8952ccc03817",
+      "updatedAt": "2025-09-20T22:28:15.439Z"
+    },
+    "time-35": {
+      "vector": "mZiYPfj3dz+CgQG/0M9PvwAAgD/e3V0/gYCAu/X0dD6fnp6+ubi4PaOioj7Pzs6+6+rqvoSDA7/Y11e/jIsLv8/Ozj7c21s/5+bmPujnZ7/19HS+qKcnP5+enr7t7Gw+/Pt7v/z7ez/8+3u/h4aGvq+urj7FxES+iYiIvdPS0j6ZmJg9+Pd3P4KBAb/Qz0+/AACAP97dXT+BgIC79fR0Pp+enr65uLg9o6KiPs/Ozr7r6uq+hIMDv9jXV7+Miwu/z87OPtzbWz/n5uY+6Odnv/X0dL6opyc/n56evu3sbD78+3u//Pt7P/z7e7+Hhoa+r66uPsXERL6JiIi909LSPg==",
+      "vectorSha256": "de03990c3b171c944e57899b77a98a17a83311b32c6879c65cae739732bc390d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "89fb3f18ffee7f9e588ba84c453e143ab3edb90c61d3589d02fd025eab6777b4",
+      "updatedAt": "2025-09-20T22:28:15.440Z"
+    },
+    "time-36": {
+      "vector": "6OdnP/79fb+bmpq+qaioPYKBAT+NjAw+uLc3v5GQEL3u7W0/u7q6vrGwML2bmpo+0dBQPa+urr65uLi91tVVP4mIiL3t7Gy+x8bGvrq5OT+Lioq+lJMTP6KhIT+Pjo6++/r6vp6dHb+Ylxc/6Odnv4eGhr69vDw+t7a2vo+Ojr7o52c//v19v5uamr6pqKg9goEBP42MDD64tze/kZAQve7tbT+7urq+sbAwvZuamj7R0FA9r66uvrm4uL3W1VU/iYiIve3sbL7Hxsa+urk5P4uKir6UkxM/oqEhP4+Ojr77+vq+np0dv5iXFz/o52e/h4aGvr28PD63tra+j46Ovg==",
+      "vectorSha256": "3f0f38f00c5c45fce9fe43a6289de60c3adb6a684ffe5203be0ccc5f01a689fd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f301598ac091247bf6517aa6865474ea77624edc5dc9d05c4131cb0c5e97525c",
+      "updatedAt": "2025-09-20T22:28:15.440Z"
+    },
+    "time-37": {
+      "vector": "vr09v/v6+r6Qjw+/iokJP/Tzcz+qqSm/qKcnP52cHD7b2tq+iIcHP6CfHz/CwUE/6+rqPpmYmL2enR2/lZQUvuPi4j7y8XE/mJcXv7++vj7g31+/iokJP8LBQb+lpCS+srExP/n4+D3KyUm/6Odnv5STEz+FhAS+rq0tv/v6+j6+vT2/+/r6vpCPD7+KiQk/9PNzP6qpKb+opyc/nZwcPtva2r6Ihwc/oJ8fP8LBQT/r6uo+mZiYvZ6dHb+VlBS+4+LiPvLxcT+Ylxe/v76+PuDfX7+KiQk/wsFBv6WkJL6ysTE/+fj4PcrJSb/o52e/lJMTP4WEBL6urS2/+/r6Pg==",
+      "vectorSha256": "6fbae47a2dc21f0776670e8bcffc6b20298a40528ebd25e61403deccb8620bea",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "214138c4f92bd39349c3cfe0ba76316db8f834af10c41f6bd88f1b0cc96f29be",
+      "updatedAt": "2025-09-20T22:28:15.440Z"
+    },
+    "time-38": {
+      "vector": "iokJP5OSkr7Z2Ni9kI8Pv7CvLz+ysTE/9PNzv7m4uD3u7W2/mZiYvY6NDT/Qz0+/+vl5P6WkJD7GxUW/+Pd3P8PCwr6UkxM/kI8Pv6inJ7+DgoK+/Pt7P/b1db/X1tY+iIcHP9HQUD3o52c/x8bGPtTTU7/w728/hoUFv9bVVb+KiQk/k5KSvtnY2L2Qjw+/sK8vP7KxMT/083O/ubi4Pe7tbb+ZmJi9jo0NP9DPT7/6+Xk/paQkPsbFRb/493c/w8LCvpSTEz+Qjw+/qKcnv4OCgr78+3s/9vV1v9fW1j6Ihwc/0dBQPejnZz/HxsY+1NNTv/Dvbz+GhQW/1tVVvw==",
+      "vectorSha256": "f8f8947ae3cdd53ea6b49e4367277799403911f3b6c59577ca564b1a6525434c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c45b7238d7d8068b0976c618fc941dfb4fc9382c5ffd05b5c386f3b116f73d15",
+      "updatedAt": "2025-09-20T22:28:15.440Z"
+    },
+    "time-39": {
+      "vector": "ycjIPZCPD7/c21s/1tVVv/b1db+/vr6+AACAP9bVVb/f3t6+2NdXPwAAgD/Lyso+8fBwPauqqr7c21u/9/b2voKBAT/z8vI+29raPri3Nz+KiQm/lJMTP5ybG7/Z2Ng9+vl5P9bVVb+FhAQ++vl5P4SDA7+rqqo+2NdXv9TTU7/JyMg9kI8Pv9zbWz/W1VW/9vV1v7++vr4AAIA/1tVVv9/e3r7Y11c/AACAP8vKyj7x8HA9q6qqvtzbW7/39va+goEBP/Py8j7b2to+uLc3P4qJCb+UkxM/nJsbv9nY2D36+Xk/1tVVv4WEBD76+Xk/hIMDv6uqqj7Y11e/1NNTvw==",
+      "vectorSha256": "03747e2395d97ca3cc11882c9362fbee584c2e272ba5d41b067fbe7b34ccc70f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8c38ed150550ff1548ebffb287551242c0bcb6db3bc9328dfc1590fc3eaa1416",
+      "updatedAt": "2025-09-20T22:28:15.440Z"
+    },
+    "time-40": {
+      "vector": "wcBAvJeWlr7x8HC9kpERP+zra7+ysTG/qKcnv8PCwj61tDQ+uLc3v+7tbT+ZmJi9jo0Nv9va2j65uLg9ycjIvYOCgr7p6Og95+bmvpybG7/5+Pi9vbw8PuLhYT/19HQ+29ravrOysr64tzc/2NdXP+7tbT+TkpI+09LSvvz7e7/BwEC8l5aWvvHwcL2SkRE/7Otrv7KxMb+opye/w8LCPrW0ND64tze/7u1tP5mYmL2OjQ2/29raPrm4uD3JyMi9g4KCvuno6D3n5ua+nJsbv/n4+L29vDw+4uFhP/X0dD7b2tq+s7Kyvri3Nz/Y11c/7u1tP5OSkj7T0tK+/Pt7vw==",
+      "vectorSha256": "4b2ee439f1696802c34198b3bfe45f310aadd9d18a12ed4278302eae15889b6c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7e5a78c80a272cb09624f67639b68b735f8e46327097f09e4953dbebf6a44b02",
+      "updatedAt": "2025-09-20T22:28:15.440Z"
+    },
+    "time-41": {
+      "vector": "4uFhP8LBQb/HxsY+w8LCvqCfH7/BwEA8urk5P6alJb+ZmJi90M9Pv9XUVD7y8XE/wL8/P/Tzcz+xsDC97+7uPr69PT/m5WW/vbw8PoWEBL7r6uo+1tVVv83MTL7Qz0+/w8LCPuXkZL7s62u/ycjIPYyLCz/Z2Ng9v76+Ps7NTb/i4WE/wsFBv8fGxj7DwsK+oJ8fv8HAQDy6uTk/pqUlv5mYmL3Qz0+/1dRUPvLxcT/Avz8/9PNzP7GwML3v7u4+vr09P+blZb+9vDw+hYQEvuvq6j7W1VW/zcxMvtDPT7/DwsI+5eRkvuzra7/JyMg9jIsLP9nY2D2/vr4+zs1Nvw==",
+      "vectorSha256": "0a3e2f9fe3c6503c0cdcf386aab049bd47b5396a6789c4b44562f14ae35955e9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f01fb14f3081dc2d76189af8dff97abbde0d976fba156618b0630a8cc58daf19",
+      "updatedAt": "2025-09-20T22:28:15.440Z"
+    },
+    "time-42": {
+      "vector": "iYiIPejnZz/Pzs6+n56evpmYmD3Pzs4+/fx8PsXERD7p6Oi97exsvp6dHT/m5WW/8vFxP6Oior69vDy+srExP7q5Ob/19HS+iokJP/HwcL2Pjo4+7exsvru6ur7f3t6+0tFRv/j3dz+CgQE/oaCgvKalJb/W1VW/oqEhP4mIiL2JiIg96OdnP8/Ozr6fnp6+mZiYPc/Ozj79/Hw+xcREPuno6L3t7Gy+np0dP+blZb/y8XE/o6Kivr28PL6ysTE/urk5v/X0dL6KiQk/8fBwvY+Ojj7t7Gy+u7q6vt/e3r7S0VG/+Pd3P4KBAT+hoKC8pqUlv9bVVb+ioSE/iYiIvQ==",
+      "vectorSha256": "f3faea0a09cc69c018491839d6aee4ca35df1a551b554a6b657791c3863c920c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "88f34c5889b39f987162ce0df85768d82361c478a362514817fbc07d2d15d077",
+      "updatedAt": "2025-09-20T22:28:15.440Z"
+    },
+    "time-43": {
+      "vector": "jIsLP8zLS7/f3t6+urk5P4aFBT+fnp4+kZAQveHg4LyysTG/oaCgPIuKir7x8HC9xsVFP/f29r6trCw+goEBv6yrKz+dnBw+trU1P6yrKz+GhQU/wL8/v+vq6r6zsrI+gYCAu9DPT7/l5GS+mpkZP4mIiD2npqa+2djYveHg4LyMiws/zMtLv9/e3r66uTk/hoUFP5+enj6RkBC94eDgvLKxMb+hoKA8i4qKvvHwcL3GxUU/9/b2vq2sLD6CgQG/rKsrP52cHD62tTU/rKsrP4aFBT/Avz+/6+rqvrOysj6BgIC70M9Pv+XkZL6amRk/iYiIPaempr7Z2Ni94eDgvA==",
+      "vectorSha256": "7c9050100058c77102290014380999f8e7c676d6d52b23d82bdeac4e742c5980",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c51a48dcc2a77b7c27825d78e242953fd593dad5c22045ac7f1863cc8856727c",
+      "updatedAt": "2025-09-20T22:28:15.441Z"
+    },
+    "time-44": {
+      "vector": "jo0NP8PCwj6bmpo+p6amPsrJSb+GhQW/7exsPomIiD3y8XG/1tVVv4GAgLvl5GQ+iokJv6+urr6OjQ2/rKsrP66tLb+ioSE/7u1tP4yLC7/v7u4+2djYPYGAgDsAAIC//fx8PvHwcD2sqys/w8LCvrW0NL7S0VG/wcBAvKempj6OjQ0/w8LCPpuamj6npqY+yslJv4aFBb/t7Gw+iYiIPfLxcb/W1VW/gYCAu+XkZD6KiQm/r66uvo6NDb+sqys/rq0tv6KhIT/u7W0/jIsLv+/u7j7Z2Ng9gYCAOwAAgL/9/Hw+8fBwPayrKz/DwsK+tbQ0vtLRUb/BwEC8p6amPg==",
+      "vectorSha256": "b1bd5e6c0a2d8d2bc2083aba292871ccb70436850e7d904fb22a2540805d65b2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c6b0a6a91b3d9d8807157f9c3b5439d529d0f63abb8d80009f87d54f69177ea9",
+      "updatedAt": "2025-09-20T22:28:15.441Z"
+    },
+    "time-45": {
+      "vector": "tbQ0voOCgj7Lyso+jo0NP5uamr6amRm//v19P/v6+j7s62u/nZwcPs7NTb+qqSk/ycjIvbe2tr6Pjo4+7Otrv6WkJL6DgoI+lpUVv5KREb/m5WU/qKcnv4mIiL3Qz0+/r66uvvPy8j7CwUG/6ejoPYmIiD2TkpK+pqUlv4KBAT+1tDS+g4KCPsvKyj6OjQ0/m5qavpqZGb/+/X0/+/r6Puzra7+dnBw+zs1Nv6qpKT/JyMi9t7a2vo+Ojj7s62u/paQkvoOCgj6WlRW/kpERv+blZT+opye/iYiIvdDPT7+vrq6+8/LyPsLBQb/p6Og9iYiIPZOSkr6mpSW/goEBPw==",
+      "vectorSha256": "2d70f06196ecb6b8f6aa32b7a4b34fd46ce169dcfb9f140feca6c7f661bbc127",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "69a0b2c65933febe0a9319d47352a30a6ba03537f22c771854bc1f8e885b2dc0",
+      "updatedAt": "2025-09-20T22:28:15.441Z"
+    },
+    "time-46": {
+      "vector": "sbAwvePi4r6JiIi9t7a2vo6NDT/CwUE/zMtLv6CfH7+cmxu/oqEhv8XERL7t7Gy+zcxMvs7NTb+1tDQ+8fBwPcC/P7/+/X0/h4aGPrSzM7+opye/hYQEvurpab/i4WE/6OdnP56dHT/b2to+7u1tP+TjYz+Miwu/trU1vwAAgD+xsDC94+LivomIiL23tra+jo0NP8LBQT/My0u/oJ8fv5ybG7+ioSG/xcREvu3sbL7NzEy+zs1Nv7W0ND7x8HA9wL8/v/79fT+HhoY+tLMzv6inJ7+FhAS+6ulpv+LhYT/o52c/np0dP9va2j7u7W0/5ONjP4yLC7+2tTW/AACAPw==",
+      "vectorSha256": "139f5d14e339838c9864364a951af9bb7363abc087b453d084ab8b42816d27f1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7a477752c6e01a30322f67626619968720fea1262c6f0bf0f3ceb6f6f13a25ff",
+      "updatedAt": "2025-09-20T22:28:15.441Z"
+    },
+    "time-47": {
+      "vector": "mZiYvYeGhr7Qz0+/p6amvqGgoDzt7Gw+09LSPq+urj77+vq+3t1dv+zraz/7+vo+7u1tv83MTD7KyUm/q6qqPtTTU7/Y11c/mpkZP/b1dT+6uTm/oqEhP6CfH7/U01M/srExv7u6ur7r6uq+9/b2vrm4uD2HhoY+p6amvuno6D2ZmJi9h4aGvtDPT7+npqa+oaCgPO3sbD7T0tI+r66uPvv6+r7e3V2/7OtrP/v6+j7u7W2/zcxMPsrJSb+rqqo+1NNTv9jXVz+amRk/9vV1P7q5Ob+ioSE/oJ8fv9TTUz+ysTG/u7q6vuvq6r739va+ubi4PYeGhj6npqa+6ejoPQ==",
+      "vectorSha256": "e871e7b4436a2b18d875c0c53690556a3129c83f2dee60c0e5f56cc17491798c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "765e1856829db4ab4111f5be09991baa16ebccfa23d030e9275145428ba1568e",
+      "updatedAt": "2025-09-20T22:28:15.441Z"
+    },
+    "time-48": {
+      "vector": "l5aWPvn4+L3r6uo+0tFRv9rZWT/o52e/rKsrP7e2tj7T0tI+i4qKPo6NDb/m5WW/+fj4PaOioj7o52e/3Ntbv6CfH7+bmpq+np0dP7GwMD36+Xk/kI8Pv+rpab+8uzs/kI8Pv8fGxr7f3t6+m5qavtzbW7+WlRW/AACAP4+Ojj6XlpY++fj4vevq6j7S0VG/2tlZP+jnZ7+sqys/t7a2PtPS0j6Lioo+jo0Nv+blZb/5+Pg9o6KiPujnZ7/c21u/oJ8fv5uamr6enR0/sbAwPfr5eT+Qjw+/6ulpv7y7Oz+Qjw+/x8bGvt/e3r6bmpq+3Ntbv5aVFb8AAIA/j46OPg==",
+      "vectorSha256": "9d6839037e7f3e16c9e774369dac3086cea4232ccc6644c5bc3e028593c64fef",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a570ba17ec0cd5adb4a2390d8fa80c123059ce85fc380bdd384e48591235ffa3",
+      "updatedAt": "2025-09-20T22:28:15.441Z"
+    },
+    "time-49": {
+      "vector": "urk5v7++vj7Ew0M/mpkZP+jnZz/V1FQ+hYQEPvv6+r7W1VW/uLc3v+DfXz/Y11c/nZwcvoaFBb+dnBy+1dRUvpuamr6vrq6+/fx8PtjXV7+0szO/ycjIveLhYT+2tTW/5ONjv9rZWb/c21u/iokJv5mYmL2WlRW//Pt7v6WkJL66uTm/v76+PsTDQz+amRk/6OdnP9XUVD6FhAQ++/r6vtbVVb+4tze/4N9fP9jXVz+dnBy+hoUFv52cHL7V1FS+m5qavq+urr79/Hw+2NdXv7SzM7/JyMi94uFhP7a1Nb/k42O/2tlZv9zbW7+KiQm/mZiYvZaVFb/8+3u/paQkvg==",
+      "vectorSha256": "ad4e7e14dd15a1ab44a58ee4532ef0d814eb14afaa08cd6b7a6fd2bc8a959303",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "23afe1ccf39a90411524efeb6c3d6c6559549f142673f0250e13123b7635026b",
+      "updatedAt": "2025-09-20T22:28:15.441Z"
+    },
+    "time-50": {
+      "vector": "ycjIvfz7ez+6uTk/19bWPquqqr739vY+5eRkvvX0dL6ysTE/wcBAvLKxMb+npqa+i4qKPr69Pb/19HQ+oJ8fv8vKyr7CwUG/j46OvsTDQz/083M/mZiYvcLBQT/GxUW/7u1tP5ybG7+0szO///7+PpKRET/Avz+/9/b2vs3MTD7JyMi9/Pt7P7q5OT/X1tY+q6qqvvf29j7l5GS+9fR0vrKxMT/BwEC8srExv6empr6Lioo+vr09v/X0dD6gnx+/y8rKvsLBQb+Pjo6+xMNDP/Tzcz+ZmJi9wsFBP8bFRb/u7W0/nJsbv7SzM7///v4+kpERP8C/P7/39va+zcxMPg==",
+      "vectorSha256": "1d8e13e0832fd195299f73e681cae0be9260d79557f31558ca445d02b7973ac8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "73fddcb555bd6361d87e2756a2219e304d1f5ce1f976e01df63226bfc8204299",
+      "updatedAt": "2025-09-20T22:28:15.441Z"
+    },
+    "motivation-01": {
+      "vector": "wL8/v+vq6j7X1ta++/r6vqWkJL6/vr4+iYiIvdva2j6npqY+2tlZP8C/Pz+DgoK+tbQ0vqCfH7+JiIi95uVlP5ybGz/n5uY+7u1tP6moqD38+3s/1dRUvo+Ojr6KiQm/19bWPpiXF7/KyUk/o6KivqyrK7+Ihwc/xMNDv7SzM7/Avz+/6+rqPtfW1r77+vq+paQkvr++vj6JiIi929raPqempj7a2Vk/wL8/P4OCgr61tDS+oJ8fv4mIiL3m5WU/nJsbP+fm5j7u7W0/qaioPfz7ez/V1FS+j46OvoqJCb/X1tY+mJcXv8rJST+joqK+rKsrv4iHBz/Ew0O/tLMzvw==",
+      "vectorSha256": "14dcf42390cb5498c3a6d224f84dde1d3d9417b7e15ee78adccfb07d48ac595b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "20ba4a416baf77b6a9ecdf5f693077f2cdb9f68afd655c3bb534e4572ac31e26",
+      "updatedAt": "2025-09-20T22:28:15.442Z"
+    },
+    "motivation-02": {
+      "vector": "tbQ0vpOSkj7Lysq+wcBAPKalJb/S0VG/+Pd3v+3sbD7X1tY+sbAwvdva2j7e3V0/trU1v8vKyj7n5uY+goEBv66tLb+3trY+qqkpP/b1db+Miwu/7Otrv4+Ojr7Lysq+5+bmvrm4uL2lpCS+hIMDP8TDQ7+Miws/pKMjP4GAgLu1tDS+k5KSPsvKyr7BwEA8pqUlv9LRUb/493e/7exsPtfW1j6xsDC929raPt7dXT+2tTW/y8rKPufm5j6CgQG/rq0tv7e2tj6qqSk/9vV1v4yLC7/s62u/j46OvsvKyr7n5ua+ubi4vaWkJL6EgwM/xMNDv4yLCz+koyM/gYCAuw==",
+      "vectorSha256": "4de590227f42be74a1bd15586011b378049cc5f2ccd3e3e1ef9e8e5a44824e38",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "69a44d812d17049db57ab6ee25b2b93f29add4053a0a5c4d46746bc11ec5d17f",
+      "updatedAt": "2025-09-20T22:28:15.442Z"
+    },
+    "motivation-03": {
+      "vector": "qKcnv+Pi4r6TkpK+4uFhP+LhYb/z8vK+nJsbv/HwcL23tra+19bWPpCPDz+UkxO/1NNTP5STE7/i4WG/kpERP5eWlj6TkpK+j46OvrCvL78AAIA/vr09v8LBQb/39vY+8/LyPsTDQ7+9vDy+u7q6Pvf29j7Y11e/jo0Nv5mYmL2opye/4+LivpOSkr7i4WE/4uFhv/Py8r6cmxu/8fBwvbe2tr7X1tY+kI8PP5STE7/U01M/lJMTv+LhYb+SkRE/l5aWPpOSkr6Pjo6+sK8vvwAAgD++vT2/wsFBv/f29j7z8vI+xMNDv728PL67uro+9/b2PtjXV7+OjQ2/mZiYvQ==",
+      "vectorSha256": "5b99617cad3dbae8f579d9a3c0beaa734873e837251188fe0bf8afa6c9bd85d6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2c475bf00f43327852b5c736e9360fc8a55b5c28ff211fbdbc1e68aebd143976",
+      "updatedAt": "2025-09-20T22:28:15.442Z"
+    },
+    "motivation-04": {
+      "vector": "iokJv+no6L2WlRW/sK8vP7GwML3Y11c/k5KSPq6tLT+amRk/3dxcPu/u7j62tTU/2djYvdDPTz+ioSG/vLs7v5WUFL6SkRE/9/b2vsbFRb/V1FQ+srExP4OCgj7w728/5uVlv+vq6j7Z2Ni9AACAv7CvL7/y8XE/x8bGPoqJCb+KiQm/6ejovZaVFb+wry8/sbAwvdjXVz+TkpI+rq0tP5qZGT/d3Fw+7+7uPra1NT/Z2Ni90M9PP6KhIb+8uzu/lZQUvpKRET/39va+xsVFv9XUVD6ysTE/g4KCPvDvbz/m5WW/6+rqPtnY2L0AAIC/sK8vv/LxcT/HxsY+iokJvw==",
+      "vectorSha256": "1c2aa67b8c3f2432e8c21556738cd49514b82754c0fd45f1652f6e45d356856d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3b7135d77aeba4d6cc9bbbda72e72f226dc8421d9ad8a0f70dba720028f8b13b",
+      "updatedAt": "2025-09-20T22:28:15.442Z"
+    },
+    "motivation-05": {
+      "vector": "6ejoPYiHBz/083O/r66uPt7dXT/j4uI+uLc3P+XkZD6Lioo+oJ8fP5WUFD6mpSU/h4aGPsbFRb/r6uo+9/b2voKBAT+mpSU/09LSPomIiD3Qz0+/7+7uvtjXV7+npqa+4+Livo2MDL69vDy+vr09v4eGhj7a2Vk/2NdXv7e2tj7p6Og9iIcHP/Tzc7+vrq4+3t1dP+Pi4j64tzc/5eRkPouKij6gnx8/lZQUPqalJT+HhoY+xsVFv+vq6j739va+goEBP6alJT/T0tI+iYiIPdDPT7/v7u6+2NdXv6empr7j4uK+jYwMvr28PL6+vT2/h4aGPtrZWT/Y11e/t7a2Pg==",
+      "vectorSha256": "b33c59f1518afbe2ac42bf50a1ee2463d98aefee855b26e8051a74e0a3d11bc6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8ec306abeeb8db9ca2cf92d2a11dba42c0d2b48818441456476e6821a1ec14ad",
+      "updatedAt": "2025-09-20T22:28:15.442Z"
+    },
+    "motivation-06": {
+      "vector": "nJsbP4GAgDuioSG/q6qqvpiXFz+RkBC919bWvpqZGb+hoKA8tLMzP7CvL7/Ew0M/xcREPvHwcL2dnBw+m5qavqqpKT+0szM/q6qqvuno6L2zsrI+8/LyvrGwML2Miws/oqEhP7u6uj7Lysq+pKMjv/X0dD6+vT0/6ulpP/j3d7+cmxs/gYCAO6KhIb+rqqq+mJcXP5GQEL3X1ta+mpkZv6GgoDy0szM/sK8vv8TDQz/FxEQ+8fBwvZ2cHD6bmpq+qqkpP7SzMz+rqqq+6ejovbOysj7z8vK+sbAwvYyLCz+ioSE/u7q6PsvKyr6koyO/9fR0Pr69PT/q6Wk/+Pd3vw==",
+      "vectorSha256": "d493135a4f18dadcdb65c2b6391c6a7b6ef2144101aca5af4ae9bba64a562fb8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cd802f55cb7b4a3382d928e198789359d4d95571ac437ac5d0ae4d2e9edef404",
+      "updatedAt": "2025-09-20T22:28:15.442Z"
+    },
+    "motivation-07": {
+      "vector": "y8rKvsvKyj7h4OC8vLs7P/n4+D2Hhoa+goEBP9TTUz+opye/2djYPeHg4Dyrqqq+hIMDP6SjI7+NjAw+3NtbP7y7Oz/j4uK+kI8Pv8zLS7/Y11c/yslJP/Tzcz/o52c/oJ8fP4qJCb/OzU0/7+7uvrm4uL3z8vI+hYQEPuzraz/Lysq+y8rKPuHg4Ly8uzs/+fj4PYeGhr6CgQE/1NNTP6inJ7/Z2Ng94eDgPKuqqr6EgwM/pKMjv42MDD7c21s/vLs7P+Pi4r6Qjw+/zMtLv9jXVz/KyUk/9PNzP+jnZz+gnx8/iokJv87NTT/v7u6+ubi4vfPy8j6FhAQ+7OtrPw==",
+      "vectorSha256": "da48a56501abda71524537750042af094181fefc918664351b4802acd058f1cb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4db27cdd8f5ec0e92c8d8355c12e91eddd47381aebe4f9f3cf3be64474bc90f5",
+      "updatedAt": "2025-09-20T22:28:15.442Z"
+    },
+    "motivation-08": {
+      "vector": "0tFRP/b1dT/r6uq+jIsLP5mYmL3d3Fy+u7q6PuHg4DzGxUW/+vl5v7GwMD2Lioq+n56ePrq5OT/f3t6+kI8Pv5KREb+BgIA7zcxMvpqZGb+ioSE/vbw8Pru6uj7Pzs6+sbAwPaGgoDzW1VU/vr09P4uKij6koyO/mpkZP6CfH7/S0VE/9vV1P+vq6r6Miws/mZiYvd3cXL67uro+4eDgPMbFRb/6+Xm/sbAwPYuKir6fnp4+urk5P9/e3r6Qjw+/kpERv4GAgDvNzEy+mpkZv6KhIT+9vDw+u7q6Ps/Ozr6xsDA9oaCgPNbVVT++vT0/i4qKPqSjI7+amRk/oJ8fvw==",
+      "vectorSha256": "e6882283680d38994b01cffb08a2e7bb371dddb54f2d975cc8c828e04c3405c9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e8fa45c57664ae831d03855da7dc483837806633d097ae4c8582eadea22ecc30",
+      "updatedAt": "2025-09-20T22:28:15.442Z"
+    },
+    "motivation-09": {
+      "vector": "2NdXv+/u7r7r6uo+2NdXP5mYmL319HQ+/Pt7v6moqD2wry8///7+PvLxcT+VlBQ+s7KyPtjXV7+gnx+/hIMDv87NTT/d3Fw+6+rqPuPi4j7493e/qqkpv8HAQDzR0FA9wsFBv/Py8j6npqY+tbQ0Pra1Nb+5uLi95ONjv7CvL7/Y11e/7+7uvuvq6j7Y11c/mZiYvfX0dD78+3u/qaioPbCvLz///v4+8vFxP5WUFD6zsrI+2NdXv6CfH7+EgwO/zs1NP93cXD7r6uo+4+LiPvj3d7+qqSm/wcBAPNHQUD3CwUG/8/LyPqempj61tDQ+trU1v7m4uL3k42O/sK8vvw==",
+      "vectorSha256": "0296ebee156a554b33df097b9f291d676ebe91c7e111aa9ba0b2eb6c6df130b2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1444baeb769e028ad7bff892ac14303ee69bbab8042b81861fbca99625740e28",
+      "updatedAt": "2025-09-20T22:28:15.443Z"
+    },
+    "motivation-10": {
+      "vector": "z87OPpybG7+EgwM/tbQ0vqOioj6ysTE/ubi4PYGAgDvQz0+/5uVlP7y7O7+SkRE/p6amvuPi4r7f3t6+6OdnP6yrKz+trCw+kpERP66tLT+1tDS+o6KiPrSzMz/l5GS++fj4vbGwMD3Lysq+iIcHP9/e3r64tze/09LSvsTDQz/Pzs4+nJsbv4SDAz+1tDS+o6KiPrKxMT+5uLg9gYCAO9DPT7/m5WU/vLs7v5KRET+npqa+4+Livt/e3r7o52c/rKsrP62sLD6SkRE/rq0tP7W0NL6joqI+tLMzP+XkZL75+Pi9sbAwPcvKyr6Ihwc/397evri3N7/T0tK+xMNDPw==",
+      "vectorSha256": "0510e3a2882824c0b1993a3a9b4f0d0db286c8964e43202cd229091388f1f623",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b332c169a8d88b8018f222c8564748f3d595c8d669a8d96370854dc348244be1",
+      "updatedAt": "2025-09-20T22:28:15.443Z"
+    },
+    "motivation-11": {
+      "vector": "t7a2PuLhYT++vT2/rawsPu3sbL7Ew0O/goEBv4aFBb+sqyu/t7a2PouKij6Miwu/qqkpP7q5Ob+ZmJi929raPtPS0j6gnx+/6+rqPvf29r7Ix0e/zcxMvoKBAT+8uzs/tbQ0PuDfX7/e3V0/2NdXP/z7ez+enR0/hoUFv7q5Ob+3trY+4uFhP769Pb+trCw+7exsvsTDQ7+CgQG/hoUFv6yrK7+3trY+i4qKPoyLC7+qqSk/urk5v5mYmL3b2to+09LSPqCfH7/r6uo+9/b2vsjHR7/NzEy+goEBP7y7Oz+1tDQ+4N9fv97dXT/Y11c//Pt7P56dHT+GhQW/urk5vw==",
+      "vectorSha256": "8b270dff92ed722b67ab30a573547a9d5c131a40289b2cd89fc3272be35d2ad2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "adf02195621e3f3d2aada23ad42376b6b430ba421c66c0dd9610eeebfdce3d23",
+      "updatedAt": "2025-09-20T22:28:15.443Z"
+    },
+    "motivation-12": {
+      "vector": "p6amvuXkZL7U01O/7exsPv79fb+1tDQ+7exsvu/u7j7My0s/h4aGvtjXV7+0szO/+fj4vcC/Pz+xsDC9kZAQvcbFRb/V1FQ+pqUlP4qJCT/+/X2/7exsvquqqr7l5GS++Pd3v/Tzcz/5+Pg9trU1v9bVVb/g318/tLMzv9HQUD2npqa+5eRkvtTTU7/t7Gw+/v19v7W0ND7t7Gy+7+7uPszLSz+Hhoa+2NdXv7SzM7/5+Pi9wL8/P7GwML2RkBC9xsVFv9XUVD6mpSU/iokJP/79fb/t7Gy+q6qqvuXkZL7493e/9PNzP/n4+D22tTW/1tVVv+DfXz+0szO/0dBQPQ==",
+      "vectorSha256": "fe0aacebc1fd2431276a116f5ce9ca3ffb0baf69fe3ef01cc399a044d2522747",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5663169d019662bbe55e142670df7a7b1d9ad2c40162556304f98f2515ef2686",
+      "updatedAt": "2025-09-20T22:28:15.443Z"
+    },
+    "motivation-13": {
+      "vector": "rKsrv6empr7Lyso+xMNDP9/e3r62tTU/iYiIPbu6uj6zsrI+09LSvtXUVL7083M/6+rqvr++vr6TkpK+yMdHP5STEz+ZmJg9r66uPsnIyD3t7Gy+zs1Nv4+Ojj65uLi9jYwMvoaFBT+ioSE/uLc3v4KBAT+3trY+p6amPq+urr6sqyu/p6amvsvKyj7Ew0M/397evra1NT+JiIg9u7q6PrOysj7T0tK+1dRUvvTzcz/r6uq+v76+vpOSkr7Ix0c/lJMTP5mYmD2vrq4+ycjIPe3sbL7OzU2/j46OPrm4uL2NjAy+hoUFP6KhIT+4tze/goEBP7e2tj6npqY+r66uvg==",
+      "vectorSha256": "bd5e55aca870997e50beddc7a315aa05617eed7ff85da95ecc31dae5488e1703",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2a56b2e148da88aeac4b65f945505be3c989ab8c6219a3746ec2d024c0ada954",
+      "updatedAt": "2025-09-20T22:28:15.443Z"
+    },
+    "motivation-14": {
+      "vector": "p6amPszLSz+ZmJi98O9vv5uamr7My0u/jIsLv+TjY7+Ihwe/2djYvbu6ur7Hxsa+p6amPtPS0r6vrq6+lpUVv5STEz/f3t6+2djYPc3MTL7k42O/paQkvomIiL3r6uo+9PNzv9/e3j6ioSE/w8LCPu/u7j6wry+//fx8Pufm5r6npqY+zMtLP5mYmL3w72+/m5qavszLS7+Miwu/5ONjv4iHB7/Z2Ni9u7q6vsfGxr6npqY+09LSvq+urr6WlRW/lJMTP9/e3r7Z2Ng9zcxMvuTjY7+lpCS+iYiIvevq6j7083O/397ePqKhIT/DwsI+7+7uPrCvL7/9/Hw+5+bmvg==",
+      "vectorSha256": "bfcbbdcc6edb11e607420c553f3d9fd2c87194957337ab473ef0c25bab27cc09",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a9e57608591a3a0e3c72514ea94b5435c9488d660e6b77ba06b7d0b0bb289f46",
+      "updatedAt": "2025-09-20T22:28:15.443Z"
+    },
+    "motivation-15": {
+      "vector": "5uVlv/b1db+urS2/j46Ovvv6+r7493c/5eRkvgAAgD+Ihwe/hYQEvtbVVT+1tDS+urk5v9jXVz/m5WU/9/b2Purpab+Ylxe/4N9fP8fGxj7Pzs4+s7KyPoeGhr6VlBQ+5eRkPtva2r60szO/srExv5OSkr69vDy+x8bGvru6ur7m5WW/9vV1v66tLb+Pjo6++/r6vvj3dz/l5GS+AACAP4iHB7+FhAS+1tVVP7W0NL66uTm/2NdXP+blZT/39vY+6ulpv5iXF7/g318/x8bGPs/Ozj6zsrI+h4aGvpWUFD7l5GQ+29ravrSzM7+ysTG/k5KSvr28PL7Hxsa+u7q6vg==",
+      "vectorSha256": "10a93c3ecc0b4febe1cfb1d191d20b5df7d831c24ff263d4cb08c6c172c0dce8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0d05295c41fb63ff3c6fea6923ebf2bd0b34efb1b3ac5e929c4926275b684e51",
+      "updatedAt": "2025-09-20T22:28:15.443Z"
+    },
+    "motivation-16": {
+      "vector": "0M9PP/38fL6NjAw+x8bGvrCvL7/q6Wm/z87OvsC/Pz/W1VW/2NdXP9jXVz/g31+/iIcHv4GAgDva2Vm/pqUlv6CfHz8AAIA/0tFRv8rJSb+koyM/sK8vP9TTU7+9vDy+o6KivtjXV7+CgQE/vbw8vqGgoDzh4OA81NNTv8zLSz/Qz08//fx8vo2MDD7Hxsa+sK8vv+rpab/Pzs6+wL8/P9bVVb/Y11c/2NdXP+DfX7+Ihwe/gYCAO9rZWb+mpSW/oJ8fPwAAgD/S0VG/yslJv6SjIz+wry8/1NNTv728PL6joqK+2NdXv4KBAT+9vDy+oaCgPOHg4DzU01O/zMtLPw==",
+      "vectorSha256": "934f74517cd7d6e6015481f9114a55e2c82e7618a01e8b6f7adf4ec4bb21172e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e760914e280b4cdf15ebeb103c80132dcfff171bd1d716685714c068828316e5",
+      "updatedAt": "2025-09-20T22:28:15.443Z"
+    },
+    "motivation-17": {
+      "vector": "v76+vu/u7r6KiQk/vr09P9LRUT/b2to+8O9vP6empr68uzs/yMdHv7W0NL7KyUm/1NNTP8TDQz/9/Hw+mZiYvainJz+KiQk/29raPqalJb+Qjw+/5eRkvoOCgj6hoKA8sbAwvfHwcL2GhQU/jo0NP/Lxcb+fnp4+/fx8Pra1NT+/vr6+7+7uvoqJCT++vT0/0tFRP9va2j7w728/p6amvry7Oz/Ix0e/tbQ0vsrJSb/U01M/xMNDP/38fD6ZmJi9qKcnP4qJCT/b2to+pqUlv5CPD7/l5GS+g4KCPqGgoDyxsDC98fBwvYaFBT+OjQ0/8vFxv5+enj79/Hw+trU1Pw==",
+      "vectorSha256": "e1719be90b4d1c16a0501343bb2f1e34c2be1cdcedb70c45f90de4ef3e189830",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5044c4dee8b6f756dd1c691be9e19f76d3c4b62d3863a0827a78c2c607a79fda",
+      "updatedAt": "2025-09-20T22:28:15.444Z"
+    },
+    "motivation-18": {
+      "vector": "h4aGvoKBAb/q6Wm/qaioPZ2cHL7h4OA8wcBAvJOSkj7FxEQ+i4qKPsXERD6FhAQ+v76+PszLSz+ysTE/hIMDP8nIyL2zsrI+sK8vv7W0ND6SkRE/0tFRv+DfX7/NzEw+g4KCvuTjYz+Miws/6ulpv9bVVT+2tTW/4uFhv769Pb+Hhoa+goEBv+rpab+pqKg9nZwcvuHg4DzBwEC8k5KSPsXERD6Lioo+xcREPoWEBD6/vr4+zMtLP7KxMT+EgwM/ycjIvbOysj6wry+/tbQ0PpKRET/S0VG/4N9fv83MTD6DgoK+5ONjP4yLCz/q6Wm/1tVVP7a1Nb/i4WG/vr09vw==",
+      "vectorSha256": "c89c8a2487a0fdbc6d02def08cfef2ea828ae32849231b56ef073af31acf666a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5e3f0b8a6c837ea498a29890afe5d8c173ac2896c81710995ff1c50bea250f21",
+      "updatedAt": "2025-09-20T22:28:15.444Z"
+    },
+    "motivation-19": {
+      "vector": "0tFRv4OCgr78+3s/7Otrv/v6+r6xsDC95+bmPrSzMz+JiIi93dxcPtrZWT+DgoI+kI8PP4yLC7/NzEy+0tFRP8nIyD3Qz08/7+7uPtfW1r61tDQ+7exsvu7tbT/h4OA85ONjP93cXL6JiIi9uLc3v9va2r7FxES+g4KCvtPS0r7S0VG/g4KCvvz7ez/s62u/+/r6vrGwML3n5uY+tLMzP4mIiL3d3Fw+2tlZP4OCgj6Qjw8/jIsLv83MTL7S0VE/ycjIPdDPTz/v7u4+19bWvrW0ND7t7Gy+7u1tP+Hg4Dzk42M/3dxcvomIiL24tze/29ravsXERL6DgoK+09LSvg==",
+      "vectorSha256": "7af14376b1059c185ddbe898258a18f3b8384c35e403852ef8624e5f8f1a0337",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "175ffd0a417ab9d9779beca0c73a66e88ce7bb4a9662f683f164772449675f4b",
+      "updatedAt": "2025-09-20T22:28:15.444Z"
+    },
+    "motivation-20": {
+      "vector": "8vFxP83MTL6Miwu/AACAP6moqD3e3V0/zs1NP5STEz+9vDw+/v19P8zLS7/39vY+qaioPdrZWT/c21u/6Odnv6uqqr6cmxu/qaiovba1NT///v6+qKcnP+no6D3+/X0/lZQUvuPi4r6fnp6+qqkpP4yLCz+8uzu//Pt7P8rJSb/y8XE/zcxMvoyLC78AAIA/qaioPd7dXT/OzU0/lJMTP728PD7+/X0/zMtLv/f29j6pqKg92tlZP9zbW7/o52e/q6qqvpybG7+pqKi9trU1P//+/r6opyc/6ejoPf79fT+VlBS+4+Livp+enr6qqSk/jIsLP7y7O7/8+3s/yslJvw==",
+      "vectorSha256": "f88f63442e178406a748b7b502241670d12cc5431dc1724bcccc6bea69bb772e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f8663aff8aeee6c997fe1abd8aec120c553275da40d38efe6d4758d4c522fd1b",
+      "updatedAt": "2025-09-20T22:28:15.444Z"
+    },
+    "motivation-21": {
+      "vector": "ubi4PcfGxr7X1ta+z87OvomIiD22tTU/6ejovbCvLz/39va+k5KSvsHAQDz7+vq+7+7uPuDfX7/k42M/vr09P8vKyr7z8vI+9/b2vtDPT7+ioSE/mJcXv8HAQLzAvz+/3t1dv8C/P7/j4uK+yMdHv5qZGT+Ihwc///7+vp+enj65uLg9x8bGvtfW1r7Pzs6+iYiIPba1NT/p6Oi9sK8vP/f29r6TkpK+wcBAPPv6+r7v7u4+4N9fv+TjYz++vT0/y8rKvvPy8j739va+0M9Pv6KhIT+Ylxe/wcBAvMC/P7/e3V2/wL8/v+Pi4r7Ix0e/mpkZP4iHBz///v6+n56ePg==",
+      "vectorSha256": "9f746639d7a681db72f27b5c3f94bf8dac17d22d9f6baf3b958141277faf8dae",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8b4e4a4c88da71d7425b8141bb10f1de4dbc4218d0347e201120471cccc340a7",
+      "updatedAt": "2025-09-20T22:28:15.444Z"
+    },
+    "motivation-22": {
+      "vector": "o6KivpWUFD77+vo+goEBP/r5eT+Miws/7+7uvpybGz+/vr4+6OdnP9DPTz/i4WG/8/LyvvPy8j6gnx8/+/r6PtjXVz/Lysq+AACAP+rpaT/493c/7u1tvwAAgL/v7u6+qKcnP/Tzc7/r6uq+2djYPfv6+j65uLi9goEBP5WUFD6joqK+lZQUPvv6+j6CgQE/+vl5P4yLCz/v7u6+nJsbP7++vj7o52c/0M9PP+LhYb/z8vK+8/LyPqCfHz/7+vo+2NdXP8vKyr4AAIA/6ulpP/j3dz/u7W2/AACAv+/u7r6opyc/9PNzv+vq6r7Z2Ng9+/r6Prm4uL2CgQE/lZQUPg==",
+      "vectorSha256": "6503ea0cce0fd91a3ea596843dc11c5de8648c7108bac7804fcf8f094682732f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5792bec0fcc544cdaff3e70f43bccfbeeb4dfff4fb090044d306458dbe74c092",
+      "updatedAt": "2025-09-20T22:28:15.444Z"
+    },
+    "motivation-23": {
+      "vector": "tbQ0Pv38fD7g31+/t7a2PtDPT7+7urq+rKsrv/79fT/e3V2/vr09P+rpab/q6Wm/lJMTv//+/j7j4uI++/r6PvX0dL6sqyu/np0dP4eGhj79/Hy+/fx8vsPCwr6wry+/srExP4+Ojj6/vr4+4N9fv6+urr7Ew0O//Pt7v//+/r61tDQ+/fx8PuDfX7+3trY+0M9Pv7u6ur6sqyu//v19P97dXb++vT0/6ulpv+rpab+UkxO///7+PuPi4j77+vo+9fR0vqyrK7+enR0/h4aGPv38fL79/Hy+w8LCvrCvL7+ysTE/j46OPr++vj7g31+/r66uvsTDQ7/8+3u///7+vg==",
+      "vectorSha256": "6d9611ab9e53ef1cd750766cc1e3e8655a7d1dd82008325f4ca23bef805c1750",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "969f10ad18512afe11de0b0b36bfb8be612acea160604f28d8a3af10541e0240",
+      "updatedAt": "2025-09-20T22:28:15.444Z"
+    },
+    "motivation-24": {
+      "vector": "3dxcPtfW1r6wry+/5+bmPtTTUz+Lioo+xMNDP/f29j6ysTG/+vl5P+Hg4Dzp6Oi9qKcnP4yLCz/V1FQ+4+LivublZT/KyUk/pqUlP5qZGb/JyMi99vV1P9DPT7/Ew0O/+fj4Pauqqj6xsDA909LSPsTDQz/JyMi9xMNDv4eGhr7d3Fw+19bWvrCvL7/n5uY+1NNTP4uKij7Ew0M/9/b2PrKxMb/6+Xk/4eDgPOno6L2opyc/jIsLP9XUVD7j4uK+5uVlP8rJST+mpSU/mpkZv8nIyL329XU/0M9Pv8TDQ7/5+Pg9q6qqPrGwMD3T0tI+xMNDP8nIyL3Ew0O/h4aGvg==",
+      "vectorSha256": "fdb4a8c7c476a6f5c81bdd36d5fd9f1ebfbf77af59f35786cda09f6c006e98b4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9b4a28b9e9a2e1bd27fc8371d3c59a47f2e4d23373fa181e8faa85b4e1731e5e",
+      "updatedAt": "2025-09-20T22:28:15.444Z"
+    },
+    "motivation-25": {
+      "vector": "iYiIPejnZ7+vrq4+vbw8Pvn4+L3w72+/jYwMPvDvbz/R0FC95+bmvu/u7r6pqKg9y8rKvsnIyD2WlRU/8vFxP7e2tr7i4WE/wcBAPK2sLD6cmxu/hYQEvri3N7+wry+/8/Lyvv38fL65uLg9l5aWPpeWlr6dnBw+yMdHP6WkJL6JiIg96Odnv6+urj69vDw++fj4vfDvb7+NjAw+8O9vP9HQUL3n5ua+7+7uvqmoqD3Lysq+ycjIPZaVFT/y8XE/t7a2vuLhYT/BwEA8rawsPpybG7+FhAS+uLc3v7CvL7/z8vK+/fx8vrm4uD2XlpY+l5aWvp2cHD7Ix0c/paQkvg==",
+      "vectorSha256": "f1bdbed2c021424c14497051e987a3ecaae357c735bf10cdc736f4bcf451ef44",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "880cab97700891f77946448a4d8ccaf852f08195326f242843608ba55a93e36b",
+      "updatedAt": "2025-09-20T22:28:15.444Z"
+    },
+    "motivation-26": {
+      "vector": "+/r6vuXkZD68uzu/jIsLv8rJST+0szM/hIMDP4OCgr6vrq6+wcBAPM7NTb+OjQ2/4+LivpaVFT/R0FC95+bmvoSDAz/Qz08/1NNTv8LBQT/w72+/1tVVP7KxMT/q6Wk/mpkZP+blZT+9vDy++vl5v6yrK7/Qz0+/k5KSvoSDA7/7+vq+5eRkPry7O7+Miwu/yslJP7SzMz+EgwM/g4KCvq+urr7BwEA8zs1Nv46NDb/j4uK+lpUVP9HQUL3n5ua+hIMDP9DPTz/U01O/wsFBP/Dvb7/W1VU/srExP+rpaT+amRk/5uVlP728PL76+Xm/rKsrv9DPT7+TkpK+hIMDvw==",
+      "vectorSha256": "6f16ff505254306a0337e92ab4398cade0728760f863005048371ff52953e8b8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "419c223ae4d9c15f5481193947ca7946c1e716e008ead8f4ccf268032a185b3e",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-27": {
+      "vector": "wcBAPLy7O7+Qjw8/+fj4va+urj63tra+7u1tP/79fb/w728/4N9fP7Oysr7m5WW/iokJv9PS0r6sqyu/sK8vv/X0dL6NjAw+1dRUvtbVVT/a2Vm/t7a2Pv79fT/OzU0/ycjIvdHQUL37+vo+oqEhP7++vr6urS0/lJMTv+XkZD7BwEA8vLs7v5CPDz/5+Pi9r66uPre2tr7u7W0//v19v/Dvbz/g318/s7KyvublZb+KiQm/09LSvqyrK7+wry+/9fR0vo2MDD7V1FS+1tVVP9rZWb+3trY+/v19P87NTT/JyMi90dBQvfv6+j6ioSE/v76+vq6tLT+UkxO/5eRkPg==",
+      "vectorSha256": "4633e22a6e31ce0e2aeafaadaad6e197415ae41b36f6c8493e68ed6175f4f35e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8122c770ab52f601f7ef530d3b4b2a28619165ea13adfee67379bed050d6369c",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-29": {
+      "vector": "nJsbP//+/j7Hxsa+vLs7v+jnZz+hoKA82NdXv4qJCb+lpCQ+paQkvsrJSb+FhAQ+h4aGvvPy8j7k42M/8O9vvwAAgL/Y11c/x8bGPtnY2D2WlRW/u7q6PoaFBT/l5GQ+6Odnv4aFBb+koyO/29ravsrJST/BwEC81dRUPp2cHL6cmxs///7+PsfGxr68uzu/6OdnP6GgoDzY11e/iokJv6WkJD6lpCS+yslJv4WEBD6Hhoa+8/LyPuTjYz/w72+/AACAv9jXVz/HxsY+2djYPZaVFb+7uro+hoUFP+XkZD7o52e/hoUFv6SjI7/b2tq+yslJP8HAQLzV1FQ+nZwcvg==",
+      "vectorSha256": "c3c4e38f50e67923148baba5a92d6b24776f2b2e73a27eacf48229373d9d657a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cdbf4e22f382143b946b1b905ebcf10800ebb18d35aec29c0c3d2e49e47e9a6c",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-30": {
+      "vector": "l5aWPoWEBD7i4WG/7Otrv+fm5j6gnx+/1NNTv4aFBb++vT0/9/b2Pvv6+j6xsDA95ONjv/Lxcb+Ylxc/k5KSvrKxMb/Pzs6+vr09v9DPTz/Qz08/hIMDP62sLD7x8HA9sK8vv4OCgj7y8XG/sK8vv/r5eT/NzEw+1NNTv9XUVD6XlpY+hYQEPuLhYb/s62u/5+bmPqCfH7/U01O/hoUFv769PT/39vY++/r6PrGwMD3k42O/8vFxv5iXFz+TkpK+srExv8/Ozr6+vT2/0M9PP9DPTz+EgwM/rawsPvHwcD2wry+/g4KCPvLxcb+wry+/+vl5P83MTD7U01O/1dRUPg==",
+      "vectorSha256": "096f3e559aa2ba1d453d3e2cdb756343dc43caa796748b4aef9a3c3798570923",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a5900f0ab930163ddebdbe850e07cb5b274c21e7e7c1958728a00728fc99169a",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-31": {
+      "vector": "xcREPtzbW7+mpSW/qKcnP9LRUT+sqyu/iIcHP5ybGz+opyc/ycjIvYKBAT/FxEQ+mJcXv6KhIT/u7W2/jo0NP+7tbT+GhQU/sbAwvby7Oz/6+Xk/2NdXP9nY2L3Lyso+s7Kyvp+enr6zsrK+8O9vP87NTT/o52c/iIcHv/38fL7FxEQ+3Ntbv6alJb+opyc/0tFRP6yrK7+Ihwc/nJsbP6inJz/JyMi9goEBP8XERD6Ylxe/oqEhP+7tbb+OjQ0/7u1tP4aFBT+xsDC9vLs7P/r5eT/Y11c/2djYvcvKyj6zsrK+n56evrOysr7w728/zs1NP+jnZz+Ihwe//fx8vg==",
+      "vectorSha256": "408922b28e8be32c0ff6e16be7eed20e0ec0d16a276520086e17a30a5163d5e6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "98122dd3e82ac3cdd373c09834d009c6f6c27addfceb72b2535853f7e6f33c60",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-32": {
+      "vector": "lZQUvtva2r7493c/srExv7KxMb+zsrK+8vFxv/b1db/NzEy+nJsbv4uKij62tTW/z87OPqOioj7l5GQ+wcBAPK6tLb/o52e/mJcXP9jXVz/U01M/oaCgPPPy8j75+Pg9oaCgvOrpab/W1VU/n56ePpCPD7/s62u/zcxMvv79fb+VlBS+29ravvj3dz+ysTG/srExv7Oysr7y8XG/9vV1v83MTL6cmxu/i4qKPra1Nb/Pzs4+o6KiPuXkZD7BwEA8rq0tv+jnZ7+Ylxc/2NdXP9TTUz+hoKA88/LyPvn4+D2hoKC86ulpv9bVVT+fnp4+kI8Pv+zra7/NzEy+/v19vw==",
+      "vectorSha256": "b1a1dfcc723fd0ecf8332546a408e10726b32e82a1f10ea10946bda4feb17c16",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6d49fb27275307056632a225b3a89c81290ccbebe982bc8f7d0beaa7380a6601",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-33": {
+      "vector": "6+rqvr++vj78+3s/8fBwvb28PD719HQ+3t1dv/79fT/c21u/+/r6PvPy8j7v7u4+trU1P6moqL3Pzs6+ycjIvdrZWb/v7u4+2tlZv7q5OT/BwEA8/v19P9rZWb/s62u/w8LCPrGwMD29vDw+kI8PP9nY2D2UkxO/+Pd3P+Pi4j7r6uq+v76+Pvz7ez/x8HC9vbw8PvX0dD7e3V2//v19P9zbW7/7+vo+8/LyPu/u7j62tTU/qaiovc/Ozr7JyMi92tlZv+/u7j7a2Vm/urk5P8HAQDz+/X0/2tlZv+zra7/DwsI+sbAwPb28PD6Qjw8/2djYPZSTE7/493c/4+LiPg==",
+      "vectorSha256": "8ddb0b98b9a7fb31d342ca9c8d9e366a233f1104d1fa5d0e89ad66e95e578059",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "45affd78979e11fe12bebcbbda754c7313bb13dc81fe130ab08597c78d36fbb8",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-34": {
+      "vector": "wL8/v6qpKb/t7Gw+zMtLv4eGhr6enR0/kpERv7CvLz+bmpq+tLMzv7a1NT+CgQG/oqEhP769Pb/s62s/0M9PP93cXD7q6Wk/mJcXv6SjIz+2tTW/t7a2PoKBAb+joqI+2tlZP7q5Ob/R0FA9goEBv/Tzc7+qqSk/7+7uPpqZGT/Avz+/qqkpv+3sbD7My0u/h4aGvp6dHT+SkRG/sK8vP5uamr60szO/trU1P4KBAb+ioSE/vr09v+zraz/Qz08/3dxcPurpaT+Ylxe/pKMjP7a1Nb+3trY+goEBv6Oioj7a2Vk/urk5v9HQUD2CgQG/9PNzv6qpKT/v7u4+mpkZPw==",
+      "vectorSha256": "3a84a5a46da6d5008523219ee5aa02622a3c815ac29fa65907dc9f9608e85202",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "202b9d1a5ece37d75926da3fd021f5e79bf434d125ad3fa8ec23863f06d4bbcc",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-35": {
+      "vector": "vLs7v7i3Nz/Pzs4+hIMDv7e2tj7Y11e/iIcHP9DPT7/Y11e/oJ8fv6alJT/j4uK+5+bmvtrZWT+UkxM/3Ntbv5ybGz+OjQ0/rawsPrW0NL6wry8/3t1dv4aFBb+Qjw+/j46OPpmYmD2BgIC7+fj4PY2MDL6Pjo6+iYiIveTjYz+8uzu/uLc3P8/Ozj6EgwO/t7a2PtjXV7+Ihwc/0M9Pv9jXV7+gnx+/pqUlP+Pi4r7n5ua+2tlZP5STEz/c21u/nJsbP46NDT+trCw+tbQ0vrCvLz/e3V2/hoUFv5CPD7+Pjo4+mZiYPYGAgLv5+Pg9jYwMvo+Ojr6JiIi95ONjPw==",
+      "vectorSha256": "f80051520fe505af999233eb84bc6f0ff75925c6e8793df123368ec4e86704dd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "22dbb33ead14c3181430d24746ecc912cdc69569d7113d38a3897f8f6e5c77f1",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-36": {
+      "vector": "vbw8vvDvb7/493c/+fj4PcXERL7r6uo+5eRkPtLRUb+DgoK+kZAQPbOysj7v7u4+qKcnv9jXV7/DwsK+pKMjv+Pi4r7y8XE/+Pd3P//+/j66uTm/iYiIvd7dXb+TkpK+29ravuvq6r69vDy+lpUVv7a1NT/29XU/p6amPtDPT7+9vDy+8O9vv/j3dz/5+Pg9xcREvuvq6j7l5GQ+0tFRv4OCgr6RkBA9s7KyPu/u7j6opye/2NdXv8PCwr6koyO/4+LivvLxcT/493c///7+Prq5Ob+JiIi93t1dv5OSkr7b2tq+6+rqvr28PL6WlRW/trU1P/b1dT+npqY+0M9Pvw==",
+      "vectorSha256": "bf8d1d108521c0ed0edce58a0ed949ff763b79910ecd4c265a94b68f8f9b0418",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6808fb8f67ba9c175f84acbb2c144f2e47f8fbbf2377115b49456835dafaa918",
+      "updatedAt": "2025-09-20T22:28:15.445Z"
+    },
+    "motivation-37": {
+      "vector": "8/LyvsC/Pz/y8XE/kI8PP/b1db/T0tK+z87OPv38fL739va+397ePsrJST+0szM/5eRkPpGQED3S0VE/pKMjP5KRET+Xlpa+mJcXv6empj6TkpI+ycjIvamoqD3f3t6+9vV1P5WUFD7FxES+jIsLP5+enr7k42O/trU1P5STEz/z8vK+wL8/P/LxcT+Qjw8/9vV1v9PS0r7Pzs4+/fx8vvf29r7f3t4+yslJP7SzMz/l5GQ+kZAQPdLRUT+koyM/kpERP5eWlr6Ylxe/p6amPpOSkj7JyMi9qaioPd/e3r729XU/lZQUPsXERL6Miws/n56evuTjY7+2tTU/lJMTPw==",
+      "vectorSha256": "ee318de524cc578185517326ee9007deb9e2dcaf12afb7ac53d7bc55a2f293f8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "43dff8c7054bb36042b7e4d99c84e8d1c85a34a9a4738a48fa9267c5580edac9",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-38": {
+      "vector": "5ONjv6GgoLyVlBS+kpERv9nY2L3JyMg97u1tv5+enj6SkRE/kI8PP7++vj7CwUE/y8rKvsjHRz+cmxu/urk5P6WkJL6mpSU/oqEhP4+Ojr6TkpK+rawsvpGQED2SkRG/nJsbP87NTb/S0VG/lZQUvra1NT+BgIA7qaiovZaVFT/k42O/oaCgvJWUFL6SkRG/2djYvcnIyD3u7W2/n56ePpKRET+Qjw8/v76+PsLBQT/Lysq+yMdHP5ybG7+6uTk/paQkvqalJT+ioSE/j46OvpOSkr6trCy+kZAQPZKREb+cmxs/zs1Nv9LRUb+VlBS+trU1P4GAgDupqKi9lpUVPw==",
+      "vectorSha256": "a5439c9d55f403f8043ff7aae350e892345b28a03cdd2eccd9909e5b053a677f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0e7d6d37728c09a7c8c7afe04de332dc6bd2d05c5b6a8437cd19176dda8075ca",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-39": {
+      "vector": "ubi4PYKBAT+mpSW/paQkvr++vj6ysTG/8vFxP+fm5j6KiQm/1tVVP42MDD6KiQm/kZAQPY6NDb+gnx8/jIsLP8LBQb/T0tI+ycjIPfv6+j63trY+wsFBv/r5eT/y8XE/4N9fv4SDA7+DgoK+5+bmvtrZWT+bmpo+9/b2PtTTUz+5uLg9goEBP6alJb+lpCS+v76+PrKxMb/y8XE/5+bmPoqJCb/W1VU/jYwMPoqJCb+RkBA9jo0Nv6CfHz+Miws/wsFBv9PS0j7JyMg9+/r6Pre2tj7CwUG/+vl5P/LxcT/g31+/hIMDv4OCgr7n5ua+2tlZP5uamj739vY+1NNTPw==",
+      "vectorSha256": "55da8a695710dd20f5ac9ab435c8a25a1ec15b243dbc0256fa33829a44e2a3d9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8bc02d6baf27f8b93bea913b8439cfc51fb48cbead1ffcf8103e5f46eca6bde9",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-40": {
+      "vector": "hoUFv6empr6RkBC9+fj4PbCvLz/29XU/6ulpP4aFBb+RkBC9oqEhv7q5Ob/p6Og9uLc3P8bFRb/R0FC9/Pt7P5GQED2ZmJg96ejoPcPCwr7i4WE/np0dv5mYmD3Qz08/jIsLP+jnZz8AAIA/0M9PP5WUFL6NjAy+3NtbP/z7ez+GhQW/p6amvpGQEL35+Pg9sK8vP/b1dT/q6Wk/hoUFv5GQEL2ioSG/urk5v+no6D24tzc/xsVFv9HQUL38+3s/kZAQPZmYmD3p6Og9w8LCvuLhYT+enR2/mZiYPdDPTz+Miws/6OdnPwAAgD/Qz08/lZQUvo2MDL7c21s//Pt7Pw==",
+      "vectorSha256": "8afae42d751a1b3c4863fd3b864ee31ce51b3843a4ea7e714f120d8d0cb37869",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3d567b8fd7faf43d7b2f238edb1d79fd84898e4ff03189e7c5f3ffe76d6eedfd",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-41": {
+      "vector": "1NNTv8fGxj61tDS+wcBAvJKREb+FhAQ+6OdnP7CvL7+NjAy+i4qKvv79fT+trCw+w8LCPszLSz+Pjo6+oaCgPPj3d7/083O/0dBQvbKxMb/W1VU/+fj4vcTDQ7/9/Hy+oaCgPPHwcD3X1ta+iokJv6SjI7/r6uq+hYQEPuzraz/U01O/x8bGPrW0NL7BwEC8kpERv4WEBD7o52c/sK8vv42MDL6Lioq+/v19P62sLD7DwsI+zMtLP4+Ojr6hoKA8+Pd3v/Tzc7/R0FC9srExv9bVVT/5+Pi9xMNDv/38fL6hoKA88fBwPdfW1r6KiQm/pKMjv+vq6r6FhAQ+7OtrPw==",
+      "vectorSha256": "c6dabeb4c122e0d81de4e174a2beffebcdcf7bbc9b293cada0eefe166642b1ec",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "16b1697e3790f3286e5dfe95b0e55c8204067927ea701e6082874a3b2e4590f5",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-42": {
+      "vector": "jYwMvsnIyD2DgoI+0M9Pv9/e3r7KyUk/4N9fP6qpKT/Lyso+/Pt7v+LhYT+6uTm/q6qqPtbVVT+Ihwc/vLs7P/Tzc7/8+3s/6Odnv5+enr6enR0/pKMjv5ybGz/JyMi94+LiPpiXFz+8uzu/+vl5P4SDAz/j4uI+4+LivvDvbz+NjAy+ycjIPYOCgj7Qz0+/397evsrJST/g318/qqkpP8vKyj78+3u/4uFhP7q5Ob+rqqo+1tVVP4iHBz+8uzs/9PNzv/z7ez/o52e/n56evp6dHT+koyO/nJsbP8nIyL3j4uI+mJcXP7y7O7/6+Xk/hIMDP+Pi4j7j4uK+8O9vPw==",
+      "vectorSha256": "cffddc88eaa2bc243662863b678fb03471443d4c7c3352106591d126b4319322",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6e8ca01848e4efd4b202f023aaeac3dd06fd0c58ce2ecd73b8cb22fcc1b847f7",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-43": {
+      "vector": "qaiovaOioj7q6Wm/t7a2vv/+/r69vDy+m5qaPvDvb7/f3t4+8/LyPp2cHD719HS+g4KCPoSDA7/a2Vm/9/b2vvz7ez+JiIg9mpkZP97dXb/Qz08/8fBwPQAAgL+DgoI+4uFhv8/Ozj7c21u/lpUVP7KxMT+SkRG//fx8Pvr5eb+pqKi9o6KiPurpab+3tra+//7+vr28PL6bmpo+8O9vv9/e3j7z8vI+nZwcPvX0dL6DgoI+hIMDv9rZWb/39va+/Pt7P4mIiD2amRk/3t1dv9DPTz/x8HA9AACAv4OCgj7i4WG/z87OPtzbW7+WlRU/srExP5KREb/9/Hw++vl5vw==",
+      "vectorSha256": "e6566f060fa49d23984745e70273bfec149a8eaa080dfcbfdd4dd46db33ed768",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "75a80b524068a608b7bc9361a03e1342fd88cc11e78700a00fb312cad8379f03",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-44": {
+      "vector": "iokJv/b1db/Y11c/sbAwPcC/P7+mpSW/mJcXv5CPD78AAIC/jYwMvurpab+6uTk/jo0Nv/f29j729XW/x8bGvt7dXT/6+Xm/hYQEPquqqr6CgQG/6Odnv9nY2D3Y11c/wsFBv46NDb/GxUU/w8LCvtPS0r6/vr4+y8rKPoeGhr6KiQm/9vV1v9jXVz+xsDA9wL8/v6alJb+Ylxe/kI8PvwAAgL+NjAy+6ulpv7q5OT+OjQ2/9/b2Pvb1db/Hxsa+3t1dP/r5eb+FhAQ+q6qqvoKBAb/o52e/2djYPdjXVz/CwUG/jo0Nv8bFRT/DwsK+09LSvr++vj7Lyso+h4aGvg==",
+      "vectorSha256": "f9c8bfd8290ee546c211218a36d5c89acc0d26c8dcbbc8853680b016369022e5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3b05eb85202d3438006e0bdc39bd054eee0390553f0c8deb1f39e24f4bafb25e",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-45": {
+      "vector": "rawsPsvKyr6NjAy+09LSvs3MTD6bmpo+kZAQveTjYz+WlRU/1dRUPs7NTb+enR0/9fR0Pv38fL7Ix0c/mZiYPZCPD7/Avz+/yslJv4mIiL2VlBS+/Pt7P6CfH7+npqY+rKsrP8PCwr7Ix0c/3t1dv6alJT+0szM/xMNDv4eGhj6trCw+y8rKvo2MDL7T0tK+zcxMPpuamj6RkBC95ONjP5aVFT/V1FQ+zs1Nv56dHT/19HQ+/fx8vsjHRz+ZmJg9kI8Pv8C/P7/KyUm/iYiIvZWUFL78+3s/oJ8fv6empj6sqys/w8LCvsjHRz/e3V2/pqUlP7SzMz/Ew0O/h4aGPg==",
+      "vectorSha256": "887fa12f436da3e04d5f07410a8742c4e318b6cdc5c8fdeeb97f431c43adcc55",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "954d6e4b99a67bf1ca9a19ce9e60e38938201b776dfd30a9d54fe311d2d91ea1",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-46": {
+      "vector": "7u1tP6alJT+hoKA89fR0vuDfX7+lpCQ+6+rqPs/Ozr7T0tI+zMtLP+jnZz/DwsK+/fx8PtzbW7+wry8/vbw8vpOSkr7S0VG/7exsvsnIyL3f3t6+lJMTP6uqqr6enR0/wsFBP8fGxr6trCy+0tFRv+DfX7+zsrI+8fBwPZqZGb/u7W0/pqUlP6GgoDz19HS+4N9fv6WkJD7r6uo+z87OvtPS0j7My0s/6OdnP8PCwr79/Hw+3Ntbv7CvLz+9vDy+k5KSvtLRUb/t7Gy+ycjIvd/e3r6UkxM/q6qqvp6dHT/CwUE/x8bGvq2sLL7S0VG/4N9fv7Oysj7x8HA9mpkZvw==",
+      "vectorSha256": "318a5d85bb4f4266a1ad2df83be1368307b4ade92ea949b575e12a021b26023a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f6d282611094ba4cb4e5f34f9f12d7685b17627348c955cee04e6a1710ac8733",
+      "updatedAt": "2025-09-20T22:28:15.446Z"
+    },
+    "motivation-47": {
+      "vector": "trU1P5WUFD7493e/xMNDP4mIiL3GxUW/u7q6vtDPT7+Ihwe/1NNTP8rJST+enR0/0dBQvf/+/j7z8vK+trU1v97dXT+DgoK+9PNzP8TDQz+joqI+g4KCvq6tLb+enR0/5+bmvoyLC7+pqKi9yMdHv7GwMD2Ihwe/+/r6Puno6L22tTU/lZQUPvj3d7/Ew0M/iYiIvcbFRb+7urq+0M9Pv4iHB7/U01M/yslJP56dHT/R0FC9//7+PvPy8r62tTW/3t1dP4OCgr7083M/xMNDP6Oioj6DgoK+rq0tv56dHT/n5ua+jIsLv6moqL3Ix0e/sbAwPYiHB7/7+vo+6ejovQ==",
+      "vectorSha256": "d6fab055ca33145778576d5511d082be56461be882007651e8c0c1d669eda563",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "da9204e1771d51183ce9e4ce79bf4325ee5ff9e1a85f29ce463a751c853cbe71",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "motivation-48": {
+      "vector": "h4aGPsrJST+6uTm/3t1dv/v6+j61tDQ+sbAwvbOysr7Pzs6+g4KCvsnIyL2ZmJi9xsVFv/Tzcz/h4OC8jYwMvuvq6r7v7u4+1dRUPublZT+wry+/2tlZP93cXL7i4WE/mJcXP7u6ur6lpCS+lJMTv6Oioj7KyUk/p6amvujnZ7+HhoY+yslJP7q5Ob/e3V2/+/r6PrW0ND6xsDC9s7Kyvs/Ozr6DgoK+ycjIvZmYmL3GxUW/9PNzP+Hg4LyNjAy+6+rqvu/u7j7V1FQ+5uVlP7CvL7/a2Vk/3dxcvuLhYT+Ylxc/u7q6vqWkJL6UkxO/o6KiPsrJST+npqa+6Odnvw==",
+      "vectorSha256": "e3a04c6e0a0612e2d5fa87e99c7095058b4705dbc7a0db0e0131f11fd54edc37",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a1e42311be967a534c5f73761df97c6e45bb9af228ec64f0cb516b36a8e4560c",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "motivation-49": {
+      "vector": "397evu7tbb/FxEQ+l5aWvru6ur7s62u/xMNDP5OSkr79/Hw+l5aWvr++vj75+Pi9srExP/b1dT+Ihwe/4N9fP6inJz+UkxM/y8rKPqWkJD7Ew0O/yslJv9XUVD6urS0/+vl5v6empj6mpSU/r66uvsvKyr7g31+/iokJP5ybG7/f3t6+7u1tv8XERD6Xlpa+u7q6vuzra7/Ew0M/k5KSvv38fD6Xlpa+v76+Pvn4+L2ysTE/9vV1P4iHB7/g318/qKcnP5STEz/Lyso+paQkPsTDQ7/KyUm/1dRUPq6tLT/6+Xm/p6amPqalJT+vrq6+y8rKvuDfX7+KiQk/nJsbvw==",
+      "vectorSha256": "aea76f2ec17bda31f48cfed7601b61de1b79668c9a54cc5e70fa030b280f21b3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4809985a510ae15b9f5aaf70d8fa3cefd3c9b2941e1b9ad603a9d2544d10c432",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "motivation-50": {
+      "vector": "1NNTv93cXL6gnx+/oaCgPM3MTL7493e/jo0Nv5uamj7Avz8/kI8Pv4eGhj7k42M/19bWvtHQUD3+/X2/qqkpP+zraz+FhAS+1NNTP8C/Pz+OjQ0/0tFRv+blZb/6+Xk/2NdXP/z7ez+gnx8/0dBQPcrJSb+JiIg9nZwcvp+enj7U01O/3dxcvqCfH7+hoKA8zcxMvvj3d7+OjQ2/m5qaPsC/Pz+Qjw+/h4aGPuTjYz/X1ta+0dBQPf79fb+qqSk/7OtrP4WEBL7U01M/wL8/P46NDT/S0VG/5uVlv/r5eT/Y11c//Pt7P6CfHz/R0FA9yslJv4mIiD2dnBy+n56ePg==",
+      "vectorSha256": "4d3092fba8dba4fb073bd43132864116243de5041048a7a3d54386c3df8f6316",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "16643082660439a6df38a1f14a8601d4f56fe9dfc6170dfcebfdcf861b886ca7",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "motivation-51": {
+      "vector": "/Pt7P93cXL6koyM/np0dP7GwMD3Y11e//Pt7v5OSkj7e3V2/h4aGPpuamj62tTU/o6KivqinJz/R0FA91tVVv7SzM7+opyc/yslJv4+Ojj7R0FC94+LivgAAgD/5+Pi9l5aWPsnIyD3w728/nZwcvsjHRz+OjQ0/19bWvp2cHL78+3s/3dxcvqSjIz+enR0/sbAwPdjXV7/8+3u/k5KSPt7dXb+HhoY+m5qaPra1NT+joqK+qKcnP9HQUD3W1VW/tLMzv6inJz/KyUm/j46OPtHQUL3j4uK+AACAP/n4+L2XlpY+ycjIPfDvbz+dnBy+yMdHP46NDT/X1ta+nZwcvg==",
+      "vectorSha256": "eea58ea656f0f3332ef2c8821ac08d6c1eed08ad723993121000468853af12a1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fd64d1ce851402a411a1a6da57d3861526d31ba37947ff70a58cf76ce3c64a6c",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "motivation-52": {
+      "vector": "sK8vv4GAgDvc21u/oJ8fP/HwcD3//v4+5ONjv7++vr7Ew0M/3dxcPpmYmL2npqY+ubi4PaKhIb/U01O/6+rqvpuamr61tDS+srExv//+/j7t7Gw+urk5P6moqL3CwUG/3t1dv+jnZz+lpCQ+hYQEPqinJz+HhoY+srExv5uamj6wry+/gYCAO9zbW7+gnx8/8fBwPf/+/j7k42O/v76+vsTDQz/d3Fw+mZiYvaempj65uLg9oqEhv9TTU7/r6uq+m5qavrW0NL6ysTG///7+Pu3sbD66uTk/qaiovcLBQb/e3V2/6OdnP6WkJD6FhAQ+qKcnP4eGhj6ysTG/m5qaPg==",
+      "vectorSha256": "d35a705136f5cb7a188578df794b5b12decf1bde78c5107d3ff170770823bdd5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "288012cf87bf0e50e19b76a98b2f1645596927bf9ddc751f11f39490d3a127a6",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "friendship-01": {
+      "vector": "09LSPtva2r7U01O/8fBwPaempj7g318/3NtbP/z7e7+Miwu/t7a2PoeGhr6Qjw8/19bWvra1Nb/19HS+jIsLP7q5Ob+RkBA97u1tv5ybGz/c21s/nZwcPtfW1j63trY+wsFBv8fGxj6vrq4+v76+vvPy8j7S0VE/vbw8vtTTUz/T0tI+29ravtTTU7/x8HA9p6amPuDfXz/c21s//Pt7v4yLC7+3trY+h4aGvpCPDz/X1ta+trU1v/X0dL6Miws/urk5v5GQED3u7W2/nJsbP9zbWz+dnBw+19bWPre2tj7CwUG/x8bGPq+urj6/vr6+8/LyPtLRUT+9vDy+1NNTPw==",
+      "vectorSha256": "e9d88a90583b427fefdb7ec7360b9019ee70177c2b431b202830629435906245",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b4491687a9efed023aad5ec74a2561c5238409cded93b5ad1fb1ab50bce868e9",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "friendship-02": {
+      "vector": "o6KiPsPCwj7p6Og9hYQEvuLhYb+7uro+mJcXv/z7ez+Xlpa+sK8vv+blZT++vT2/0M9PP7Oysj7R0FC9pKMjP4aFBT+Qjw8/+/r6PtPS0r6hoKA87exsPre2tj7k42O/2djYvYeGhr75+Pi95ONjP/b1dT+koyM/iokJP4uKij6joqI+w8LCPuno6D2FhAS+4uFhv7u6uj6Ylxe//Pt7P5eWlr6wry+/5uVlP769Pb/Qz08/s7KyPtHQUL2koyM/hoUFP5CPDz/7+vo+09LSvqGgoDzt7Gw+t7a2PuTjY7/Z2Ni9h4aGvvn4+L3k42M/9vV1P6SjIz+KiQk/i4qKPg==",
+      "vectorSha256": "9910c6826022b99c08bdbd0b1abd24824d88d8abcb4689314cece82e5437d7b3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a8b08e6f0fae34fd5a28f221e7ac79d1c2c7be4b829dad0e725e70f1fad1c4a2",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "friendship-03": {
+      "vector": "xMNDv+Pi4j7o52c/8O9vP/Dvb7/l5GS+ubi4PQAAgD/m5WW/h4aGvsbFRb/m5WU/+vl5P9XUVL7g31+/3NtbP4KBAb/j4uK+jo0Nv/v6+r6WlRW/wsFBP4mIiL2npqY+8fBwPdva2r6joqI+397evpuamj6qqSk/8vFxP6yrKz/Ew0O/4+LiPujnZz/w728/8O9vv+XkZL65uLg9AACAP+blZb+Hhoa+xsVFv+blZT/6+Xk/1dRUvuDfX7/c21s/goEBv+Pi4r6OjQ2/+/r6vpaVFb/CwUE/iYiIvaempj7x8HA929ravqOioj7f3t6+m5qaPqqpKT/y8XE/rKsrPw==",
+      "vectorSha256": "90c950ba106d9814fdb9129b9baf903a626b63eba762c145e168ce09cbe8f8e3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1eb8f3f708638bff0d5e1df2fc6510ed3f47394135e077a98749a848a6d4f8d5",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "friendship-04": {
+      "vector": "u7q6PsfGxr6Ihwc/pqUlv9fW1r6koyO/z87OvsC/P7/6+Xk/trU1v//+/r6gnx8/4eDgvN3cXD6BgIC7+/r6PpaVFT/X1tY+7exsPpuamj66uTk/6ulpv6qpKT/Avz8/iIcHv5OSkr6Xlpa+1dRUPvHwcL3Ix0e/+vl5P5iXFz+7uro+x8bGvoiHBz+mpSW/19bWvqSjI7/Pzs6+wL8/v/r5eT+2tTW///7+vqCfHz/h4OC83dxcPoGAgLv7+vo+lpUVP9fW1j7t7Gw+m5qaPrq5OT/q6Wm/qqkpP8C/Pz+Ihwe/k5KSvpeWlr7V1FQ+8fBwvcjHR7/6+Xk/mJcXPw==",
+      "vectorSha256": "ec66009ba0e1e456a8fa0dd52a3542dba8ec2cdc670bbd4e67a26f30d792fed4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ae4ec32d4a2e4c20fc2540cf7c9b7fbecab59da6dc0bd4df3c5b5a9a781cfccb",
+      "updatedAt": "2025-09-20T22:28:15.447Z"
+    },
+    "friendship-05": {
+      "vector": "x8bGvq2sLL62tTU/u7q6vuvq6j7i4WG/nZwcPouKij7g318/iYiIPcrJSb/5+Pg9lpUVv83MTD69vDy+wcBAPNXUVD7My0s/8/LyPuTjY7+Miwu/4+LivqOioj66uTm/s7KyPtPS0j6npqY+2NdXP8PCwr7JyMg9m5qavrKxMb/Hxsa+rawsvra1NT+7urq+6+rqPuLhYb+dnBw+i4qKPuDfXz+JiIg9yslJv/n4+D2WlRW/zcxMPr28PL7BwEA81dRUPszLSz/z8vI+5ONjv4yLC7/j4uK+o6KiPrq5Ob+zsrI+09LSPqempj7Y11c/w8LCvsnIyD2bmpq+srExvw==",
+      "vectorSha256": "b252bc7d5c0478402ea3d5268b8ad309ad130dffc53e086be5fde50aabc0dfa4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4e6ada51ba0f93a2ef881b8f359968819ae5bc0e3a47a823acb4a9eb4f8c5927",
+      "updatedAt": "2025-09-20T22:28:15.448Z"
+    },
+    "friendship-06": {
+      "vector": "6ulpP9jXVz+7uro+sK8vP/Tzcz+3tra++vl5P93cXL6cmxu/2tlZv6alJT/My0s/h4aGvs/Ozr6Pjo4+/v19P6WkJL76+Xm/9/b2voOCgj7Z2Ni9k5KSPoKBAT+DgoI++vl5v97dXb+cmxu/j46OPufm5j7d3Fy+4uFhP87NTT/q6Wk/2NdXP7u6uj6wry8/9PNzP7e2tr76+Xk/3dxcvpybG7/a2Vm/pqUlP8zLSz+Hhoa+z87Ovo+Ojj7+/X0/paQkvvr5eb/39va+g4KCPtnY2L2TkpI+goEBP4OCgj76+Xm/3t1dv5ybG7+Pjo4+5+bmPt3cXL7i4WE/zs1NPw==",
+      "vectorSha256": "a76fc3c8ecf08df610fd14085ca66c43dd82b5316b82e3b754dd57463b365c54",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f4ebaed7f952fc643213d2e55e4ca3fe6b0342a072a4c0a0031132a3b964f0e6",
+      "updatedAt": "2025-09-20T22:28:15.451Z"
+    },
+    "friendship-07": {
+      "vector": "5eRkvvDvbz/Qz08/wL8/v/38fL7Hxsa+jYwMvu7tbb+VlBQ+xMNDP769Pb/5+Pi96ejoPYSDA7+9vDy+/v19v+zra7+amRm/sK8vP4yLC7+fnp4+urk5P/LxcT+Lioq+jYwMvvTzc7/Ew0O/3dxcvoqJCb+urS0/wL8/v9DPT7/l5GS+8O9vP9DPTz/Avz+//fx8vsfGxr6NjAy+7u1tv5WUFD7Ew0M/vr09v/n4+L3p6Og9hIMDv728PL7+/X2/7Otrv5qZGb+wry8/jIsLv5+enj66uTk/8vFxP4uKir6NjAy+9PNzv8TDQ7/d3Fy+iokJv66tLT/Avz+/0M9Pvw==",
+      "vectorSha256": "3646990a524831c273929881e5b7ebbe9585009482168e50c7882e2cd27c4508",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "63f7e720604e6e0992e121708e3e68010a33d73aa7dcf85d6e061e643bd62018",
+      "updatedAt": "2025-09-20T22:28:15.451Z"
+    },
+    "friendship-08": {
+      "vector": "397ePs3MTD6gnx+/vbw8PpybGz+bmpo+8vFxv8fGxj7y8XG/2NdXv/n4+L2amRm/9fR0Pq+urj79/Hw+z87OPpybG7/t7Gw+/Pt7P4iHB7/7+vo+0M9Pv4yLCz+CgQE/3t1dP/Dvb7/x8HA9urk5vwAAgD///v6+mpkZvwAAgD/f3t4+zcxMPqCfH7+9vDw+nJsbP5uamj7y8XG/x8bGPvLxcb/Y11e/+fj4vZqZGb/19HQ+r66uPv38fD7Pzs4+nJsbv+3sbD78+3s/iIcHv/v6+j7Qz0+/jIsLP4KBAT/e3V0/8O9vv/HwcD26uTm/AACAP//+/r6amRm/AACAPw==",
+      "vectorSha256": "be55048ab03762d8900aac716f88f49b210610e605ba3aef57bc54db41f90c26",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b7993097cda607b1071470339eab9fb3329dfd3cbe18c5c0ee088723ff4033ff",
+      "updatedAt": "2025-09-20T22:28:15.451Z"
+    },
+    "friendship-09": {
+      "vector": "+fj4vcvKyj7R0FC9k5KSPpqZGT/Pzs4+7+7uPra1NT/q6Wk/tLMzP6alJb/S0VE/w8LCPsTDQz/l5GQ+9vV1P6WkJD60szM/8O9vP7++vr6Hhoa+hYQEPrCvL7/5+Pi9+/r6PurpaT++vT2/np0dv/z7ez+FhAQ+vr09v+DfXz/5+Pi9y8rKPtHQUL2TkpI+mpkZP8/Ozj7v7u4+trU1P+rpaT+0szM/pqUlv9LRUT/DwsI+xMNDP+XkZD729XU/paQkPrSzMz/w728/v76+voeGhr6FhAQ+sK8vv/n4+L37+vo+6ulpP769Pb+enR2//Pt7P4WEBD6+vT2/4N9fPw==",
+      "vectorSha256": "73e8a67aa0fa9012e85a422baaf4c098e5951c826f462111ed67d70ac40703bb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "70b279a4ccb3bbdaf4d92de8b0e19cfa94d9f7505e902870bef42131fd9021ef",
+      "updatedAt": "2025-09-20T22:28:15.451Z"
+    },
+    "friendship-10": {
+      "vector": "4+Livt7dXb/i4WG/pqUlP5WUFD61tDS+srExPwAAgL/8+3s/5uVlP4OCgr7d3Fw+w8LCPtva2r6wry+/oqEhv6+urj7c21u/+fj4PYmIiL2vrq6+g4KCPqCfHz///v6+l5aWPtva2r7//v6+oJ8fv/Py8r6Qjw+/zs1Nv9jXVz/j4uK+3t1dv+LhYb+mpSU/lZQUPrW0NL6ysTE/AACAv/z7ez/m5WU/g4KCvt3cXD7DwsI+29ravrCvL7+ioSG/r66uPtzbW7/5+Pg9iYiIva+urr6DgoI+oJ8fP//+/r6XlpY+29ravv/+/r6gnx+/8/LyvpCPD7/OzU2/2NdXPw==",
+      "vectorSha256": "7772a3f9d345d3ceeb27e7202a8743b61aaafab151f3052533d0acebfbd392ce",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "47110fd29269d800fdf25f9bb049282fab128f7754a0cf40a5494030433819eb",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-11": {
+      "vector": "ycjIPaOioj6wry8/9/b2vuno6D339va+k5KSPqqpKT+wry8/7+7uvoiHBz+BgIC7lJMTP8XERD6CgQG/2tlZv5OSkj6ZmJg9g4KCvoKBAT/My0u/5eRkvrm4uD2OjQ2/7+7uPqWkJD77+vo++fj4vaKhIT+1tDS+jo0NP6yrK7/JyMg9o6KiPrCvLz/39va+6ejoPff29r6TkpI+qqkpP7CvLz/v7u6+iIcHP4GAgLuUkxM/xcREPoKBAb/a2Vm/k5KSPpmYmD2DgoK+goEBP8zLS7/l5GS+ubi4PY6NDb/v7u4+paQkPvv6+j75+Pi9oqEhP7W0NL6OjQ0/rKsrvw==",
+      "vectorSha256": "1dd6f624eeb9326415d5d05a9066ac1db124f39b638970ce1c9ff644683fe8c5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8ca8d7428e42a4d4d744c37fc9983f13a4895fc01a638b39bb94be70d069c62a",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-12": {
+      "vector": "3Ntbv/38fD6GhQW/hoUFP83MTD6amRk/kZAQvYGAgLuopyc/iokJv8rJSb/X1tY+v76+vgAAgL/q6Wk/q6qqvtbVVT+xsDA9//7+Pr++vj6OjQ0/2djYvdTTU7/b2tq+8fBwvfr5eT/19HS+1NNTP5CPDz+NjAy+7exsPuTjYz/c21u//fx8PoaFBb+GhQU/zcxMPpqZGT+RkBC9gYCAu6inJz+KiQm/yslJv9fW1j6/vr6+AACAv+rpaT+rqqq+1tVVP7GwMD3//v4+v76+Po6NDT/Z2Ni91NNTv9va2r7x8HC9+vl5P/X0dL7U01M/kI8PP42MDL7t7Gw+5ONjPw==",
+      "vectorSha256": "5220d8dbd58009cc284847239fb843fc710ea7050c23d2a11ca40c979bcdf4b3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "129f3dc299cc7b7fd33b1bb55000f455ea85bfafc672164978fc61e9c76e9df1",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-13": {
+      "vector": "j46OPgAAgL/My0u/xMNDv9bVVT/z8vI+xsVFv9rZWT/g318/oqEhP4+Ojj7r6uo+2tlZv5eWlr7Z2Ng9//7+Ps3MTD7o52c/5ONjv8/Ozr7S0VE/vr09v8rJSb/X1tY+oqEhP//+/j61tDS+5+bmPsHAQLz9/Hy+iYiIPba1NT+Pjo4+AACAv8zLS7/Ew0O/1tVVP/Py8j7GxUW/2tlZP+DfXz+ioSE/j46OPuvq6j7a2Vm/l5aWvtnY2D3//v4+zcxMPujnZz/k42O/z87OvtLRUT++vT2/yslJv9fW1j6ioSE///7+PrW0NL7n5uY+wcBAvP38fL6JiIg9trU1Pw==",
+      "vectorSha256": "60e49bcd223a4bf92bc1710aa6d95ea9de09a46a49b70c26e0af60e0c0bb1d85",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a3001a1eeabc1decefd0a3ba135a8dbf99f30e4ce8211bb5d0bf69b97e6088da",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-14": {
+      "vector": "srExP5uamj6hoKC8+/r6Po6NDb/39va+o6Kivuno6D339va+/Pt7v6WkJD7KyUm/2NdXP6moqD3+/X2/vLs7v/79fb/i4WE/mZiYvdTTUz/5+Pg929ravru6ur6trCy+wcBAvOPi4j7q6Wm/8O9vv/HwcL2+vT0/7exsvq+urr6ysTE/m5qaPqGgoLz7+vo+jo0Nv/f29r6joqK+6ejoPff29r78+3u/paQkPsrJSb/Y11c/qaioPf79fb+8uzu//v19v+LhYT+ZmJi91NNTP/n4+D3b2tq+u7q6vq2sLL7BwEC84+LiPurpab/w72+/8fBwvb69PT/t7Gy+r66uvg==",
+      "vectorSha256": "4d2cf22b7838369576408e6f5ae62942d7d0e20df34a0728c490ef911229345f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d8a67dbe3942578e4202941beb8a012201f076e98f49516a7eb80b0878de6254",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-15": {
+      "vector": "srExP7y7Oz+Xlpa+oqEhv7++vj7u7W2/p6amvublZb+wry8/oJ8fv8PCwr7Avz+/6ejoPfPy8j6vrq6+g4KCPuno6D2pqKi9/Pt7v6empj7Avz8/AACAv6alJT/CwUE//fx8vpuamr6TkpI+trU1P83MTD7b2tq+oaCgPI6NDT+ysTE/vLs7P5eWlr6ioSG/v76+Pu7tbb+npqa+5uVlv7CvLz+gnx+/w8LCvsC/P7/p6Og98/LyPq+urr6DgoI+6ejoPamoqL38+3u/p6amPsC/Pz8AAIC/pqUlP8LBQT/9/Hy+m5qavpOSkj62tTU/zcxMPtva2r6hoKA8jo0NPw==",
+      "vectorSha256": "5204ac63eb5954b30d31addc44df23b53b37b0bf57b22022aa426576b6259747",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d8dd5a2faf09560dd7304f208ebc54a08e7502a9df00d2e06059a4da994982c6",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-16": {
+      "vector": "t7a2vqCfHz/KyUk/l5aWPoqJCT/q6Wm/pqUlP6yrK7+xsDC9xMNDP/f29r69vDy+q6qqvtjXV7/r6uq+3t1dv/Lxcb+WlRW/wsFBP8TDQ7+TkpI+vr09P4KBAb+/vr4+5ONjv7Oysr6Ylxe/pKMjP/LxcT+5uLg9s7KyvoqJCb+3tra+oJ8fP8rJST+XlpY+iokJP+rpab+mpSU/rKsrv7GwML3Ew0M/9/b2vr28PL6rqqq+2NdXv+vq6r7e3V2/8vFxv5aVFb/CwUE/xMNDv5OSkj6+vT0/goEBv7++vj7k42O/s7KyvpiXF7+koyM/8vFxP7m4uD2zsrK+iokJvw==",
+      "vectorSha256": "c65135231ce72934675e8d433cb6e415915d27987043ed36d9c2d3af40673e93",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "52cfe4a5c40bd22a7ae14268551445110735e01ea4de3faf0e5334d1f88b533b",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-17": {
+      "vector": "oJ8fv/j3dz+SkRG/lJMTv5CPDz+7urq+q6qqvsXERL7Z2Ni9hoUFv7++vj6Miwu/iIcHv5eWlr77+vo+paQkPrKxMT/7+vo+9/b2Pp6dHT+0szO/rawsvo2MDL79/Hy+mZiYPYqJCb/493e/tLMzv728PD7y8XG/lpUVv7GwMD2gnx+/+Pd3P5KREb+UkxO/kI8PP7u6ur6rqqq+xcREvtnY2L2GhQW/v76+PoyLC7+Ihwe/l5aWvvv6+j6lpCQ+srExP/v6+j739vY+np0dP7SzM7+trCy+jYwMvv38fL6ZmJg9iokJv/j3d7+0szO/vbw8PvLxcb+WlRW/sbAwPQ==",
+      "vectorSha256": "8b2b6792edb67628806c0127798f5d22a2ce23e9c474cba817c2862bcd2496fd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "30fb3736c7515567723daf3a3c5abe94d8bebdce266a6e60893b042697073585",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-18": {
+      "vector": "2NdXv4aFBT/Z2Ni9zMtLv9TTU7+gnx8/iYiIPfTzc7/n5ua+lJMTP769PT+XlpY+hIMDP5iXFz+zsrK+xsVFP8zLSz+npqa+sK8vv8XERL6Pjo4+/fx8PtHQUD3Lyso+rq0tP5STEz/u7W0/vr09P6empj6mpSU/oqEhv+TjYz/Y11e/hoUFP9nY2L3My0u/1NNTv6CfHz+JiIg99PNzv+fm5r6UkxM/vr09P5eWlj6EgwM/mJcXP7Oysr7GxUU/zMtLP6empr6wry+/xcREvo+Ojj79/Hw+0dBQPcvKyj6urS0/lJMTP+7tbT++vT0/p6amPqalJT+ioSG/5ONjPw==",
+      "vectorSha256": "7a40edbe266bc3e57477a33f8279d7ddca313f8325f1dbf0b8e6feaa055e0a80",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "14c2721a16cf880646c9dea5c1cb53e2e5562867a39f86b2d6c9f6dea9d22ff1",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-19": {
+      "vector": "p6amvs7NTT/FxEQ+vbw8Pv/+/j7y8XG/xMNDP/b1db+8uzs/8fBwvaempr7KyUm/1NNTP8PCwj7m5WW/nJsbv+jnZ7+qqSk/1dRUvvv6+j6enR2/yslJP+no6L3f3t6+l5aWPoaFBb+trCw+o6KiPra1NT+RkBC95+bmvouKir6npqa+zs1NP8XERD69vDw+//7+PvLxcb/Ew0M/9vV1v7y7Oz/x8HC9p6amvsrJSb/U01M/w8LCPublZb+cmxu/6Odnv6qpKT/V1FS++/r6Pp6dHb/KyUk/6ejovd/e3r6XlpY+hoUFv62sLD6joqI+trU1P5GQEL3n5ua+i4qKvg==",
+      "vectorSha256": "a873b9cd314d6e59676a5dffd5d98ac92946c79f973a42bbf0987e6bd9682c13",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "56e69897bf07e105dd78561be9b00d320cd465be31e47148a53d95a8da7b465d",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-20": {
+      "vector": "0M9PP8HAQDzy8XE/rawsPtjXVz/Qz0+/xMNDv56dHb/q6Wm/r66uvtva2r7T0tI+5eRkvo+Ojj6TkpK+wL8/v5WUFL7U01O/5uVlv7y7O7/W1VU/n56ePvX0dL6opye/mpkZP4GAgDuvrq6+397evqSjIz+pqKi9v76+vpOSkj7Qz08/wcBAPPLxcT+trCw+2NdXP9DPT7/Ew0O/np0dv+rpab+vrq6+29ravtPS0j7l5GS+j46OPpOSkr7Avz+/lZQUvtTTU7/m5WW/vLs7v9bVVT+fnp4+9fR0vqinJ7+amRk/gYCAO6+urr7f3t6+pKMjP6moqL2/vr6+k5KSPg==",
+      "vectorSha256": "2e8722f08c882051b89695dfdab8e58d43b81c269d1a4378901bf69e73a0014a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e781f895eb181e310b5449b463a35b206d160d22eaa7612ccc805448d17550a4",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-21": {
+      "vector": "trU1vwAAgD+CgQE/iokJP+no6L3Qz08/tLMzP4GAgLvHxsY+5uVlP6qpKT+zsrK+zs1NP5+enr6mpSW/m5qaPry7O7/Qz0+/np0dP5+enj6hoKA8g4KCPqCfH7+VlBQ+pqUlv8nIyD23trY+1tVVP9HQUD2rqqo++Pd3P6empr62tTW/AACAP4KBAT+KiQk/6ejovdDPTz+0szM/gYCAu8fGxj7m5WU/qqkpP7Oysr7OzU0/n56evqalJb+bmpo+vLs7v9DPT7+enR0/n56ePqGgoDyDgoI+oJ8fv5WUFD6mpSW/ycjIPbe2tj7W1VU/0dBQPauqqj7493c/p6amvg==",
+      "vectorSha256": "07ab7c66fe2ae64b33449a9d9622d41a6175eff34ae21c28ede19eaa232e3fb4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "25ffc0c471e7d97fb1f2d453e6582da62218cea782a030922d8cadea86aafb56",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-22": {
+      "vector": "1dRUPuzra7/8+3s/qqkpP5eWlj6OjQ2/kZAQPaKhIb/BwEA8mpkZP6empj6koyO/6ejoPcTDQz/6+Xm/qaiovfX0dD7d3Fw+z87OPsrJST/DwsI+ubi4va6tLb/39vY+kpERv/v6+j6vrq6+/v19P+XkZL7t7Gw+1NNTP/HwcD3V1FQ+7Otrv/z7ez+qqSk/l5aWPo6NDb+RkBA9oqEhv8HAQDyamRk/p6amPqSjI7/p6Og9xMNDP/r5eb+pqKi99fR0Pt3cXD7Pzs4+yslJP8PCwj65uLi9rq0tv/f29j6SkRG/+/r6Pq+urr7+/X0/5eRkvu3sbD7U01M/8fBwPQ==",
+      "vectorSha256": "bc4b95cbc60d017dee028e182f81c5cc2348dbd77613c560d799ec10fd6b25dd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9a0afdd4a539842f81cca92e8ee103759e9bb3e4b07429bd37be54fe639de987",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-23": {
+      "vector": "4N9fv5+enj6cmxu/8/LyvtPS0j7FxES+yslJv8bFRT+CgQE///7+vsPCwr6joqI+srExv7CvL7/6+Xm/sbAwvYaFBT/7+vq+6ulpP6empj66uTm/kZAQvfz7ez/+/X2/6Odnv6qpKb/r6uo+yslJP6empr61tDQ+nJsbP4WEBL7g31+/n56ePpybG7/z8vK+09LSPsXERL7KyUm/xsVFP4KBAT///v6+w8LCvqOioj6ysTG/sK8vv/r5eb+xsDC9hoUFP/v6+r7q6Wk/p6amPrq5Ob+RkBC9/Pt7P/79fb/o52e/qqkpv+vq6j7KyUk/p6amvrW0ND6cmxs/hYQEvg==",
+      "vectorSha256": "eb7733ffe79918f5c61d9b4acbacdc95d97c179ec52556118f5f819d096f12a6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "10a73243b4671be2c0404fa82728037ac241f4a9237bfd010c2bbae45696cd6f",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-24": {
+      "vector": "qqkpP9XUVL6qqSm/trU1P6KhIT/R0FA9//7+vuHg4LyUkxO/wcBAvIyLC7/Pzs6+r66uvv38fL6ysTE/z87OPqOior69vDw+2djYvdrZWb/p6Og9np0dP8vKyr63trY+oJ8fv+Hg4Dzk42O/oJ8fv/X0dD7493e/lZQUvqinJ7+qqSk/1dRUvqqpKb+2tTU/oqEhP9HQUD3//v6+4eDgvJSTE7/BwEC8jIsLv8/Ozr6vrq6+/fx8vrKxMT/Pzs4+o6Kivr28PD7Z2Ni92tlZv+no6D2enR0/y8rKvre2tj6gnx+/4eDgPOTjY7+gnx+/9fR0Pvj3d7+VlBS+qKcnvw==",
+      "vectorSha256": "63f7d04b9695a55f19bf841301c7fd770968c8bc1696c2bffa151875af60fe37",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d4652bdad086407c367e3a4c5460d8b3579772138ece4dad30830e309e046d2c",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-25": {
+      "vector": "AACAv5STEz+dnBw++/r6vqempj6xsDC98O9vv5iXF7+mpSU/qKcnv6uqqj7m5WU/kpERP5KRET+GhQU/9PNzv7q5OT+lpCS+gYCAu8XERD7JyMg9tbQ0vsXERD7R0FA92NdXv7a1NT/i4WG/jYwMPsvKyr7NzEy+trU1P/X0dD4AAIC/lJMTP52cHD77+vq+p6amPrGwML3w72+/mJcXv6alJT+opye/q6qqPublZT+SkRE/kpERP4aFBT/083O/urk5P6WkJL6BgIC7xcREPsnIyD21tDS+xcREPtHQUD3Y11e/trU1P+LhYb+NjAw+y8rKvs3MTL62tTU/9fR0Pg==",
+      "vectorSha256": "98f8b4e0cb1af6cab05ee8738dc877f15df4802b4e05d90f6ad85d79571bf8a5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "00c99341a97a0834d22caaf2c8c8c206dc6b7f988c69988614da0f914d66da9e",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-26": {
+      "vector": "sbAwvfDvbz+Ihwc/oJ8fP728PL6DgoI+/fx8PqyrK7+CgQE/hoUFP8fGxr6joqK+k5KSvrW0ND6dnBw+tbQ0PoSDAz+JiIg93NtbP6yrK7+Ihwc/nJsbP5STE7/i4WG/9/b2vtbVVT+urS0/wcBAPImIiL2GhQU/0M9Pv5CPD7+xsDC98O9vP4iHBz+gnx8/vbw8voOCgj79/Hw+rKsrv4KBAT+GhQU/x8bGvqOior6TkpK+tbQ0Pp2cHD61tDQ+hIMDP4mIiD3c21s/rKsrv4iHBz+cmxs/lJMTv+LhYb/39va+1tVVP66tLT/BwEA8iYiIvYaFBT/Qz0+/kI8Pvw==",
+      "vectorSha256": "30d6d4974388b72d3b8140e141a43f4e0407fc661f7335a1a514220674ae84df",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7af7c3cf68a09f2ac0c24e575b969396c188ed2ac3cd360f42ead68177c21838",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-27": {
+      "vector": "rawsPr28PL65uLi96ulpP8jHRz+OjQ2/nJsbv7GwML2WlRU/oaCgvJSTEz/39vY+pKMjP5ybGz+amRm/l5aWPqKhIb/39va+vLs7v9LRUb+lpCS+r66uPv38fL6NjAy+hIMDv+3sbL7Hxsa+p6amPtHQUD2/vr6+4eDgvOLhYb+trCw+vbw8vrm4uL3q6Wk/yMdHP46NDb+cmxu/sbAwvZaVFT+hoKC8lJMTP/f29j6koyM/nJsbP5qZGb+XlpY+oqEhv/f29r68uzu/0tFRv6WkJL6vrq4+/fx8vo2MDL6EgwO/7exsvsfGxr6npqY+0dBQPb++vr7h4OC84uFhvw==",
+      "vectorSha256": "b97d3308c7e36aa99532a9dc0a85899adb327bd1595ff309ddc41d1550b76329",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "956874f4e339327aca7dc9bdd1cd33a52f4222176bab606e3e624ea986507c0f",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-28": {
+      "vector": "6OdnP9TTU7/l5GQ+x8bGPublZT/KyUm/l5aWPqyrKz+opye/xcREvvTzcz/R0FA95eRkvsLBQb/9/Hw+g4KCPurpab/q6Wm/v76+PpCPDz/My0u/3Ntbv6CfH7/29XW/6+rqvt3cXL7493e/tbQ0Pra1Nb/Lysq+1NNTP5iXF7/o52c/1NNTv+XkZD7HxsY+5uVlP8rJSb+XlpY+rKsrP6inJ7/FxES+9PNzP9HQUD3l5GS+wsFBv/38fD6DgoI+6ulpv+rpab+/vr4+kI8PP8zLS7/c21u/oJ8fv/b1db/r6uq+3dxcvvj3d7+1tDQ+trU1v8vKyr7U01M/mJcXvw==",
+      "vectorSha256": "04dae8f3fe5f1f0d1c4cfaa18d37f4ff7a63b2917eec9218ea73da9377b3c7e9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f3169cb1f21ba5d52c67f986631f9fa00b0bafc71a12300545640496254de934",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-29": {
+      "vector": "+/r6vtzbW7+Hhoa+nJsbP5mYmD3u7W0/9vV1P6moqL3BwEA8gYCAu/r5eb/6+Xk//Pt7v+fm5r7u7W0/8fBwPa2sLL7a2Vk/0dBQPdnY2D2FhAS+lZQUvt7dXb+CgQE/mZiYPe/u7j6SkRE/4uFhv+rpaT/Ix0e/pKMjP6Oioj77+vq+3Ntbv4eGhr6cmxs/mZiYPe7tbT/29XU/qaiovcHAQDyBgIC7+vl5v/r5eT/8+3u/5+bmvu7tbT/x8HA9rawsvtrZWT/R0FA92djYPYWEBL6VlBS+3t1dv4KBAT+ZmJg97+7uPpKRET/i4WG/6ulpP8jHR7+koyM/o6KiPg==",
+      "vectorSha256": "6383eb6ddfb0028686c2603e710c0aff3f9380e62c68045e0e3ac4a06bab43e3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "41125ecd89f6fa75817f03fc0246f6876aec868d6f6d11c089bbc80ff41cd1a8",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-30": {
+      "vector": "oqEhP5qZGT/S0VG/mpkZv/Py8r6EgwO/p6amvqqpKT+Miws/i4qKPqSjI7+fnp6++/r6PuLhYT/7+vq+q6qqvry7O7+SkRE/wcBAvI6NDb+Pjo6+nJsbv/b1db/OzU2/1NNTP6SjI7/6+Xk/1tVVv/v6+r7BwEA8+fj4va2sLD6ioSE/mpkZP9LRUb+amRm/8/LyvoSDA7+npqa+qqkpP4yLCz+Lioo+pKMjv5+enr77+vo+4uFhP/v6+r6rqqq+vLs7v5KRET/BwEC8jo0Nv4+Ojr6cmxu/9vV1v87NTb/U01M/pKMjv/r5eT/W1VW/+/r6vsHAQDz5+Pi9rawsPg==",
+      "vectorSha256": "89014116273dffc1b3195813b0cd6c2794b915f1aa22f12abd8898183b81a88b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d0cc1733433e56d4c5a22e58bef0415522c87e395c320519e92efc1541817095",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-31": {
+      "vector": "paQkPuTjY7/X1tY+pqUlP7i3Nz+NjAy+qKcnP+vq6r67uro+q6qqPtfW1r6JiIg93Ntbv/b1db/f3t4+2NdXP4mIiD2Ylxc/wcBAPJCPD7+opyc/n56evoaFBT+FhAS+j46OPry7O7/FxES+8O9vv/b1dT/39va+5+bmPt3cXL6lpCQ+5ONjv9fW1j6mpSU/uLc3P42MDL6opyc/6+rqvru6uj6rqqo+19bWvomIiD3c21u/9vV1v9/e3j7Y11c/iYiIPZiXFz/BwEA8kI8Pv6inJz+fnp6+hoUFP4WEBL6Pjo4+vLs7v8XERL7w72+/9vV1P/f29r7n5uY+3dxcvg==",
+      "vectorSha256": "729aa0903f8b670180f58adb20e64fcb4472de236a3e67fbe3b49c7ce0530626",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "940eb5d2db6ed345aeaa4a881205b7eb88cb8138d358c26fa3226708fa42b964",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-32": {
+      "vector": "1dRUPoSDA7/Qz0+/ycjIPd3cXL7GxUU/oqEhv+TjY7+4tze/0tFRP8fGxr6cmxs/+Pd3P6CfH7/V1FS+//7+PoOCgr76+Xk/sK8vP+/u7r7Pzs6+vr09P5aVFb+opye/0M9Pv8jHRz/i4WE/2NdXv93cXD6Qjw8/8fBwPezraz/V1FQ+hIMDv9DPT7/JyMg93dxcvsbFRT+ioSG/5ONjv7i3N7/S0VE/x8bGvpybGz/493c/oJ8fv9XUVL7//v4+g4KCvvr5eT+wry8/7+7uvs/Ozr6+vT0/lpUVv6inJ7/Qz0+/yMdHP+LhYT/Y11e/3dxcPpCPDz/x8HA97OtrPw==",
+      "vectorSha256": "45697ad28aea7e37866593e8d68fe26b983e17568efaeb68bfa34fbd71b07dda",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9a3e188c64e22f0e24e84ecdfb3065bf5ffcd7444cde352c18e3f0149bc787f5",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-33": {
+      "vector": "+Pd3P6+urj6FhAS+0dBQvZWUFD6FhAQ+vbw8PqmoqL2vrq6+7exsPqOioj4AAIA/i4qKvvDvbz/Ix0c/8/Lyvvf29j6ysTE/1dRUvsXERL6enR0/gYCAu5aVFT/k42O/ubi4PczLS7/39va+lpUVP5ybG7+EgwM/0dBQPbSzM7/493c/r66uPoWEBL7R0FC9lZQUPoWEBD69vDw+qaiova+urr7t7Gw+o6KiPgAAgD+Lioq+8O9vP8jHRz/z8vK+9/b2PrKxMT/V1FS+xcREvp6dHT+BgIC7lpUVP+TjY7+5uLg9zMtLv/f29r6WlRU/nJsbv4SDAz/R0FA9tLMzvw==",
+      "vectorSha256": "3aab3b35249368918d9b410be024af48837c9d42d0851c5d2f798bac4b0b3dc6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fbab6f7992909775549da8ff5df7e343bdd86567ce7fca0e8b1a42ca32c18626",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-34": {
+      "vector": "397ePpmYmL21tDS+lpUVP4eGhr6qqSm/hoUFv//+/j6ioSG/qqkpP9TTU7+trCy++Pd3P+rpaT+lpCS+trU1P5WUFL7k42M/mJcXP9HQUL2lpCQ+5eRkPoKBAT+bmpq+p6amPrCvL7/JyMi98vFxP93cXD6gnx+/sbAwPYeGhj7f3t4+mZiYvbW0NL6WlRU/h4aGvqqpKb+GhQW///7+PqKhIb+qqSk/1NNTv62sLL7493c/6ulpP6WkJL62tTU/lZQUvuTjYz+Ylxc/0dBQvaWkJD7l5GQ+goEBP5uamr6npqY+sK8vv8nIyL3y8XE/3dxcPqCfH7+xsDA9h4aGPg==",
+      "vectorSha256": "45481a8f3d64ad7dba9987622c21eeb4c2426352e213d18349ca7ff75c6253e0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b77669ca5e2b3dbf2fd4166afbf46bda6df1cb79949cc059a92873f89b3085a1",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-35": {
+      "vector": "6OdnP6qpKb/i4WE/0dBQvZGQED3x8HC9+vl5P4aFBT/m5WU/w8LCvoiHB7/Hxsa+6+rqvtrZWb/s62u/9/b2PujnZz/My0u/+vl5v9fW1j6dnBw+ubi4vc/Ozj6OjQ2/mZiYvYGAgDvj4uI+xcREPvHwcD2vrq6+2djYvd7dXb/o52c/qqkpv+LhYT/R0FC9kZAQPfHwcL36+Xk/hoUFP+blZT/DwsK+iIcHv8fGxr7r6uq+2tlZv+zra7/39vY+6OdnP8zLS7/6+Xm/19bWPp2cHD65uLi9z87OPo6NDb+ZmJi9gYCAO+Pi4j7FxEQ+8fBwPa+urr7Z2Ni93t1dvw==",
+      "vectorSha256": "8783cea2cbdd4d100efeca85ffbd81669997b85404be727d2ce2c9a7041c06d2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f32bf0798478fcc2f24f3c4e45130abdf31a03b59374b3397680b89887547211",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-36": {
+      "vector": "/Pt7P9/e3r6WlRW/m5qaPvDvbz/R0FA9AACAv42MDL7t7Gw+mJcXv7q5Ob/h4OA8g4KCPoeGhr6gnx+/7+7uvuPi4j6wry+/7Otrv/f29r7d3Fy+vLs7P//+/r7BwEA8oqEhP/v6+r6trCw+lJMTP8C/P7+0szM/iYiIvcLBQb/8+3s/397evpaVFb+bmpo+8O9vP9HQUD0AAIC/jYwMvu3sbD6Ylxe/urk5v+Hg4DyDgoI+h4aGvqCfH7/v7u6+4+LiPrCvL7/s62u/9/b2vt3cXL68uzs///7+vsHAQDyioSE/+/r6vq2sLD6UkxM/wL8/v7SzMz+JiIi9wsFBvw==",
+      "vectorSha256": "93ee0d8e390215c6b048c5605089a65eeacb5d75bd7a0fdfed46efe962f6fd51",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fd4835a6f786006e9d342383a05e3044b8280a4264dd4081d04195c920d9771f",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-37": {
+      "vector": "7OtrP+zra7/Ew0M/sK8vv6empj7T0tK+397ePqinJz+vrq6+pKMjv7CvL7+joqK+vbw8vtXUVD6VlBS+zs1Nv5iXF7+OjQ0/gYCAO4SDA7/29XW/y8rKvtrZWT/b2to+kI8Pv8TDQz+dnBw+7+7uvpKREb+qqSm/ycjIvZ+enj7s62s/7Otrv8TDQz+wry+/p6amPtPS0r7f3t4+qKcnP6+urr6koyO/sK8vv6Oior69vDy+1dRUPpWUFL7OzU2/mJcXv46NDT+BgIA7hIMDv/b1db/Lysq+2tlZP9va2j6Qjw+/xMNDP52cHD7v7u6+kpERv6qpKb/JyMi9n56ePg==",
+      "vectorSha256": "80ce8e7c79a7717720423b1ea60140ab61aa3b66cf1da2ae04357ba6b64e60b9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f50ae128a94bb7d3542e2857689a6d1934c6803e054decb638e19344372b73a7",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-38": {
+      "vector": "kZAQvfDvb7+EgwO/AACAP4uKir66uTk/mpkZP/r5eb/Z2Ng9oJ8fP5GQEL37+vq+trU1P7q5Ob/h4OA8jYwMPuHg4Dygnx8/lJMTv7i3Nz/Ix0c/jo0NP8PCwj6pqKg9p6amvqinJ7/Hxsa+yslJv9fW1r6ysTG/zMtLP5CPDz+RkBC98O9vv4SDA78AAIA/i4qKvrq5OT+amRk/+vl5v9nY2D2gnx8/kZAQvfv6+r62tTU/urk5v+Hg4DyNjAw+4eDgPKCfHz+UkxO/uLc3P8jHRz+OjQ0/w8LCPqmoqD2npqa+qKcnv8fGxr7KyUm/19bWvrKxMb/My0s/kI8PPw==",
+      "vectorSha256": "a86e1a37a4f447f39ccd5e6f423fa0520d5cb0e582867e04ae59ae82566d3797",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7b083eff5ddccc038dcf7b41da23839183cf36dbe3c6b08a562c4e1b4a27e5c7",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-39": {
+      "vector": "/v19P4WEBL6Pjo6+v76+Pp2cHL7BwEC87u1tP83MTL6xsDA9wcBAPNXUVL61tDS+urk5v83MTL6TkpK+urk5P/z7ez+Hhoa+iIcHv/38fD7h4OA8zMtLv7m4uL2opye/hIMDv7a1NT/u7W0/g4KCPru6uj7w728//v19P/n4+D3+/X0/hYQEvo+Ojr6/vr4+nZwcvsHAQLzu7W0/zcxMvrGwMD3BwEA81dRUvrW0NL66uTm/zcxMvpOSkr66uTk//Pt7P4eGhr6Ihwe//fx8PuHg4DzMy0u/ubi4vainJ7+EgwO/trU1P+7tbT+DgoI+u7q6PvDvbz/+/X0/+fj4PQ==",
+      "vectorSha256": "2694424a4e36b56108b3ea33fd3f1bc44c7356c17add559f02f1b2d8804b307c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fe6f5caf6c7ef6668581656923665bdcfd5e3c9f831a742c3edaf6a0aef7fe8f",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-40": {
+      "vector": "o6KivtXUVD7t7Gw+8O9vv9XUVL7i4WE/ubi4veHg4Lzi4WE/hoUFP6yrKz+6uTm/+vl5P7++vj7s62u/jYwMvri3N7/Lysq+hoUFv7q5Ob+hoKA8m5qavtTTU7+6uTk/s7KyvuHg4DyurS2/397ePt/e3r6EgwM/xsVFP6WkJD6joqK+1dRUPu3sbD7w72+/1dRUvuLhYT+5uLi94eDgvOLhYT+GhQU/rKsrP7q5Ob/6+Xk/v76+Puzra7+NjAy+uLc3v8vKyr6GhQW/urk5v6GgoDybmpq+1NNTv7q5OT+zsrK+4eDgPK6tLb/f3t4+397evoSDAz/GxUU/paQkPg==",
+      "vectorSha256": "98b6c9a7c54236cdd480f7289ae366db9b502b3a8144b60340550432b49f877f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "579a9d0865f0747cf0c2d523fcaf0a6e244d3d23825916dc538329b748c1e294",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-41": {
+      "vector": "4eDgPMzLSz/Hxsa+xcREvuTjYz/n5uY+sK8vP5aVFT/V1FQ+8O9vv4GAgDvk42M/7Otrv8LBQT+gnx+/1dRUPoKBAT///v6+urk5v5CPDz+xsDA95eRkvoSDA7/s62u/19bWPrm4uD3Pzs6+5uVlvwAAgD+pqKg9l5aWvrOysr7h4OA8zMtLP8fGxr7FxES+5ONjP+fm5j6wry8/lpUVP9XUVD7w72+/gYCAO+TjYz/s62u/wsFBP6CfH7/V1FQ+goEBP//+/r66uTm/kI8PP7GwMD3l5GS+hIMDv+zra7/X1tY+ubi4Pc/Ozr7m5WW/AACAP6moqD2Xlpa+s7Kyvg==",
+      "vectorSha256": "cebd41406981469de74e43e9cb450271e713ef6ff1b84e3387e3b328cdbcdd92",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "83e54e67f1b9d7ca9a0880f10ae0309ac04023c785633e0ab58b4c0dff8a5a53",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-42": {
+      "vector": "nJsbv8bFRb+KiQk/i4qKPuTjYz+1tDS+t7a2vvv6+r6EgwO/i4qKvsLBQT/n5uY+zcxMPsjHRz/h4OC8oaCgvP/+/r6mpSW/z87Ovuzraz+ysTG/lZQUPqWkJL64tze/lpUVv+zra7+cmxu/sbAwvejnZz+rqqo+7OtrP8/Ozj6cmxu/xsVFv4qJCT+Lioo+5ONjP7W0NL63tra++/r6voSDA7+Lioq+wsFBP+fm5j7NzEw+yMdHP+Hg4LyhoKC8//7+vqalJb/Pzs6+7OtrP7KxMb+VlBQ+paQkvri3N7+WlRW/7Otrv5ybG7+xsDC96OdnP6uqqj7s62s/z87OPg==",
+      "vectorSha256": "4a754d731c248b8b41c179b1cd94382d9d737933930448f75cdb1842999161a0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "321dc4a2f16952413e5de0b999e37c7d402d4cf527926b24350a327af3aaf5b3",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-43": {
+      "vector": "1NNTv8TDQz/j4uK+wsFBv9rZWb+Pjo6+1dRUPv38fD7f3t6+iYiIvdPS0r67uro+u7q6PvPy8r6EgwM/tLMzPwAAgL+7uro+7exsvqKhIT/j4uK+vbw8PqqpKT+qqSm/goEBv83MTL7Avz8/lZQUPv38fD6RkBC93Ntbv/n4+D3U01O/xMNDP+Pi4r7CwUG/2tlZv4+Ojr7V1FQ+/fx8Pt/e3r6JiIi909LSvru6uj67uro+8/LyvoSDAz+0szM/AACAv7u6uj7t7Gy+oqEhP+Pi4r69vDw+qqkpP6qpKb+CgQG/zcxMvsC/Pz+VlBQ+/fx8PpGQEL3c21u/+fj4PQ==",
+      "vectorSha256": "a2f138f4822f530fe9e391b4fd930349fda5735e847d8c826a3b64a0d9c1cf1b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "16e1471f135c9a9f48774baeae43c1d900ae62d04797d42b3f66df929f7b128f",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-44": {
+      "vector": "iIcHv/b1db+VlBS+7u1tP728PD7BwEC89/b2vqKhIb+Qjw+/qaioPdbVVT/r6uq+goEBv8HAQLz//v4+nZwcPvz7e7/q6Wk/gYCAu8nIyD3Y11c/lJMTv/79fT/R0FA9//7+Pvf29r6Lioo+9fR0PpiXF7++vT0/xcREvre2tj6Ihwe/9vV1v5WUFL7u7W0/vbw8PsHAQLz39va+oqEhv5CPD7+pqKg91tVVP+vq6r6CgQG/wcBAvP/+/j6dnBw+/Pt7v+rpaT+BgIC7ycjIPdjXVz+UkxO//v19P9HQUD3//v4+9/b2vouKij719HQ+mJcXv769PT/FxES+t7a2Pg==",
+      "vectorSha256": "1bd461b5b5d380ab9d2523cfe74e4f514520dd1ee2aefc8fa8e3b993239c14a8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3c056df6977e422f388aea453f7ebf9302f47f8ceb36fe86bf42a29e34de67ad",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-45": {
+      "vector": "tbQ0vuPi4r6wry8/wsFBv+Pi4r7S0VG/6+rqvpqZGb/n5uY+4+LivpWUFD7Z2Ng96Odnv9zbW7+UkxO/kpERv/Lxcb/493e/tbQ0vuLhYb/GxUU//v19vwAAgD/083O/w8LCPre2tj6sqys/3t1dP+7tbb+Pjo6+19bWvu3sbD61tDS+4+LivrCvLz/CwUG/4+LivtLRUb/r6uq+mpkZv+fm5j7j4uK+lZQUPtnY2D3o52e/3Ntbv5STE7+SkRG/8vFxv/j3d7+1tDS+4uFhv8bFRT/+/X2/AACAP/Tzc7/DwsI+t7a2PqyrKz/e3V0/7u1tv4+Ojr7X1ta+7exsPg==",
+      "vectorSha256": "9a923f9d83f819ba9f68ae3b25d93130220e312aa1b758105751db4b0d859213",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6947d71f47174533b947928d0c1236370704690fe201ff06b0add5ee095c4a9d",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-46": {
+      "vector": "k5KSPoGAgLvPzs4++fj4Pauqqj68uzs/jo0NP/X0dL7T0tK+7exsvs7NTT+Lioq+g4KCvvHwcD2cmxu/u7q6Ps7NTb+fnp4+3NtbP7q5Ob/My0u/zMtLP5aVFb+fnp4+/Pt7P8/Ozr6JiIi96+rqPo2MDL6BgIC7iokJP6uqqr6TkpI+gYCAu8/Ozj75+Pg9q6qqPry7Oz+OjQ0/9fR0vtPS0r7t7Gy+zs1NP4uKir6DgoK+8fBwPZybG7+7uro+zs1Nv5+enj7c21s/urk5v8zLS7/My0s/lpUVv5+enj78+3s/z87OvomIiL3r6uo+jYwMvoGAgLuKiQk/q6qqvg==",
+      "vectorSha256": "2f64df55b6629ee3db1c8613ecd5545dfda83ca76a416206b5ae6edf13b05b23",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a47fb38faaddc6614b62e65d5f8732ae19a7ed231ae535a7fd4c77ba6e7fc455",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-47": {
+      "vector": "pKMjP7SzMz/Qz08/oaCgPPv6+j7R0FA9ycjIvfr5eT+Miwu/5uVlP9DPTz+zsrI+2tlZv4iHBz/S0VE/vr09P62sLD6Ylxe/8/LyvsvKyr6ysTE/wsFBP9zbWz/Ix0e/6OdnP8fGxr6Lioq+ubi4Paempr739va+1tVVP4SDA7+koyM/tLMzP9DPTz+hoKA8+/r6PtHQUD3JyMi9+vl5P4yLC7/m5WU/0M9PP7Oysj7a2Vm/iIcHP9LRUT++vT0/rawsPpiXF7/z8vK+y8rKvrKxMT/CwUE/3NtbP8jHR7/o52c/x8bGvouKir65uLg9p6amvvf29r7W1VU/hIMDvw==",
+      "vectorSha256": "2378e765477dfa2ed7528245a21071fd5770a786d3c89350a744b57f7d4a6fd1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d1d9e782be8673fc3af2e7ac13c3e8de9534434dd8e0ed1cf34e5d8b5642ea3e",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-48": {
+      "vector": "rawsvuno6L3493c/4N9fP9PS0j7083M/x8bGPuLhYb/w728//v19P+3sbL7s62s/zMtLv97dXT+EgwO/sK8vv+vq6r7s62u/5+bmvpWUFL6sqyu/sbAwPYiHB7+2tTU/mpkZP+rpab/S0VG/9/b2PtXUVD6Hhoa+5uVlv+vq6r6trCy+6ejovfj3dz/g318/09LSPvTzcz/HxsY+4uFhv/Dvbz/+/X0/7exsvuzraz/My0u/3t1dP4SDA7+wry+/6+rqvuzra7/n5ua+lZQUvqyrK7+xsDA9iIcHv7a1NT+amRk/6ulpv9LRUb/39vY+1dRUPoeGhr7m5WW/6+rqvg==",
+      "vectorSha256": "229a446bff9fad66569b7800092c6028e58adf7fa340a5ba299ed7903aa62503",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6a71fbefb4f9b10ff7fe62f51aee3e28450a466d2a853cdacc0b17bd9a5e0d45",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-49": {
+      "vector": "4eDgvJ+enj76+Xm/5+bmPoGAgDvm5WW/lpUVP4SDAz/v7u6+6+rqPquqqr7u7W2/vLs7v9/e3j6enR2/np0dv/79fb+GhQW/xMNDv+jnZz/HxsY+yslJP4OCgr7b2to+3t1dv4+Ojr6JiIg96Odnv7W0ND65uLg9hIMDP/r5eT/h4OC8n56ePvr5eb/n5uY+gYCAO+blZb+WlRU/hIMDP+/u7r7r6uo+q6qqvu7tbb+8uzu/397ePp6dHb+enR2//v19v4aFBb/Ew0O/6OdnP8fGxj7KyUk/g4KCvtva2j7e3V2/j46OvomIiD3o52e/tbQ0Prm4uD2EgwM/+vl5Pw==",
+      "vectorSha256": "76705ae5ba6a40d588b07898f1df6f3d402d1a6c55b5dc0c0cb2a45970a095fa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7ca703b9800dcac144ba550922b73131013d1ef3b1e45fb6115c880c968bc1fc",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "friendship-50": {
+      "vector": "oJ8fv+zraz/X1ta+AACAv9PS0r6opyc/np0dP4OCgj62tTW/+vl5P42MDD7HxsY+iYiIPcC/Pz+SkRG/ycjIvZybGz/7+vo++/r6PpqZGb+ZmJi93dxcvoyLCz/y8XG/tbQ0vvX0dL6trCw+1NNTv66tLb/e3V0/jo0Nv46NDT+gnx+/7OtrP9fW1r4AAIC/09LSvqinJz+enR0/g4KCPra1Nb/6+Xk/jYwMPsfGxj6JiIg9wL8/P5KREb/JyMi9nJsbP/v6+j77+vo+mpkZv5mYmL3d3Fy+jIsLP/Lxcb+1tDS+9fR0vq2sLD7U01O/rq0tv97dXT+OjQ2/jo0NPw==",
+      "vectorSha256": "51870e327b7cd6a52e7ac719b3db3bd13f667a1e1108d76322f894b801b5a829",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "30f54a004bd3cea025fc91b188df3773cdbebe337664c5076961951629ee39c6",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "music-01": {
+      "vector": "vLs7P4GAgLu0szM/1NNTv7e2tr6Hhoa+7exsPv/+/j7Y11c/lpUVP56dHT+CgQG/9/b2PoiHB7+Ihwc/o6KiPvX0dL6SkRG/uLc3v7++vr7m5WW/rawsPt7dXT+KiQm/mJcXv+rpab/U01O/1NNTP8LBQT+amRm/jYwMvq2sLL68uzs/gYCAu7SzMz/U01O/t7a2voeGhr7t7Gw+//7+PtjXVz+WlRU/np0dP4KBAb/39vY+iIcHv4iHBz+joqI+9fR0vpKREb+4tze/v76+vublZb+trCw+3t1dP4qJCb+Ylxe/6ulpv9TTU7/U01M/wsFBP5qZGb+NjAy+rawsvg==",
+      "vectorSha256": "ff76746402400301ec3ce7529b12f7e52cfe988f6a959487f37f425c3ccaab2e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dd7fd916525e9dbfebcace3fbd3cc3a8613724500d95ee3b340b16e9e0336e6a",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "music-02": {
+      "vector": "r66uPujnZ7+SkRG/r66uPuDfXz++vT2/ycjIvQAAgL+8uzu/lZQUvpGQEL3s62s/jIsLP6GgoDzv7u6+8vFxP7m4uL2CgQG/29ravuDfX7+OjQ0/oJ8fP4SDAz+ioSE/09LSvrKxMT/DwsI+zs1Nv4SDA7/KyUk/397ePpiXF7+vrq4+6Odnv5KREb+vrq4+4N9fP769Pb/JyMi9AACAv7y7O7+VlBS+kZAQvezraz+Miws/oaCgPO/u7r7y8XE/ubi4vYKBAb/b2tq+4N9fv46NDT+gnx8/hIMDP6KhIT/T0tK+srExP8PCwj7OzU2/hIMDv8rJST/f3t4+mJcXvw==",
+      "vectorSha256": "0d6570816c77995d0dbac3a83d3541d571530865d09bfcfe7aeace193e385a54",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ab0c37abef217300226d7bf5c58244f8743f4910c6cfc1d04bd8b0193ee4b734",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "music-03": {
+      "vector": "uLc3v8LBQT+amRk/5+bmvoaFBT+ysTE/np0dv8C/P7+FhAS+ycjIPZaVFb/Ix0c/pqUlv/Lxcb/CwUE/sbAwvdva2j7KyUm/pKMjP7e2tr7FxEQ+7exsvsC/Pz/493c/+/r6Pt3cXD7T0tI+j46OvvDvb7/KyUk/w8LCvrSzM7+4tze/wsFBP5qZGT/n5ua+hoUFP7KxMT+enR2/wL8/v4WEBL7JyMg9lpUVv8jHRz+mpSW/8vFxv8LBQT+xsDC929raPsrJSb+koyM/t7a2vsXERD7t7Gy+wL8/P/j3dz/7+vo+3dxcPtPS0j6Pjo6+8O9vv8rJST/DwsK+tLMzvw==",
+      "vectorSha256": "bf47f58fc0353cd7cdd5d7d368eaabca91dba6dd98a135c856250f1f99102a55",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "24e0cc46c2d831206f8c35e32d07e07ab61bd1529862dffbbe9bb45c08e44f26",
+      "updatedAt": "2025-09-20T22:28:15.452Z"
+    },
+    "music-04": {
+      "vector": "sK8vP+fm5r6WlRU//v19P6alJb/g31+/2tlZv6GgoDy8uzs///7+vtrZWb+2tTW/19bWPqalJT/T0tI+jo0NP8/Ozj6urS0/jYwMPr++vr6vrq6+hYQEvt/e3j6cmxs/6+rqvpaVFb/x8HA9oqEhP+Hg4LyzsrI+j46OPs/Ozr6wry8/5+bmvpaVFT/+/X0/pqUlv+DfX7/a2Vm/oaCgPLy7Oz///v6+2tlZv7a1Nb/X1tY+pqUlP9PS0j6OjQ0/z87OPq6tLT+NjAw+v76+vq+urr6FhAS+397ePpybGz/r6uq+lpUVv/HwcD2ioSE/4eDgvLOysj6Pjo4+z87Ovg==",
+      "vectorSha256": "5afdc13ec80ba83b96cab16489994e63bc98c4f1e95bad6642d6cc7b18d17a1b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d746cafe2d101382dd401325b5d2b4c6b3d69150546fb7cd453587d07caca34c",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-05": {
+      "vector": "19bWvt7dXb+qqSm/p6amvsvKyj6Qjw+/mpkZP728PD7X1tY+z87OvtXUVL6Ylxc/vr09P8jHR7+gnx8/9/b2PuHg4DzR0FA919bWvr++vj7o52c/v76+vt7dXT+Hhoa+qKcnP+jnZz/5+Pg99/b2Puno6D3z8vK+vbw8vpuamj7X1ta+3t1dv6qpKb+npqa+y8rKPpCPD7+amRk/vbw8PtfW1j7Pzs6+1dRUvpiXFz++vT0/yMdHv6CfHz/39vY+4eDgPNHQUD3X1ta+v76+PujnZz+/vr6+3t1dP4eGhr6opyc/6OdnP/n4+D339vY+6ejoPfPy8r69vDy+m5qaPg==",
+      "vectorSha256": "376c2f01cdde8122df2f4755ce90ea324bc4de22df21f3e36daf757b2a483d51",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4a112b56b238cc97b54c65cbde1ccfbd83864aaff350ee5ed3f38fbd8e4368a6",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-06": {
+      "vector": "goEBv//+/r7Hxsa+gYCAu9va2j6cmxs/4N9fv9TTUz/Ix0c/zMtLP6SjI7/Qz08/qKcnv8PCwr7Y11c//v19P7u6ur7NzEy+sK8vP/HwcL3i4WG/zs1Nv9va2r60szO/7+7uvpybGz+6uTk/zMtLv46NDT/Z2Ni9urk5P/f29r6CgQG///7+vsfGxr6BgIC729raPpybGz/g31+/1NNTP8jHRz/My0s/pKMjv9DPTz+opye/w8LCvtjXVz/+/X0/u7q6vs3MTL6wry8/8fBwveLhYb/OzU2/29ravrSzM7/v7u6+nJsbP7q5OT/My0u/jo0NP9nY2L26uTk/9/b2vg==",
+      "vectorSha256": "6feae5301f7b3a5a58e4652f97ea0c66b18acf464289dd09276b118c08846e8c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3f404e7fb6cd10e9e3e52ee72c4febfe5166d7780f19492644cddc1ac672dc42",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-07": {
+      "vector": "wsFBv5ybG7+3trY+9fR0PqinJ7/o52c/2tlZP6CfH7/n5ua++fj4PeblZb+xsDC9srExP7KxMb+JiIg95eRkPvTzcz+7urq+3dxcvsXERD6pqKg91tVVP7CvLz+HhoY+6OdnP+jnZ7/FxES+yslJv8XERD7a2Vk/rawsPuXkZD7CwUG/nJsbv7e2tj719HQ+qKcnv+jnZz/a2Vk/oJ8fv+fm5r75+Pg95uVlv7GwML2ysTE/srExv4mIiD3l5GQ+9PNzP7u6ur7d3Fy+xcREPqmoqD3W1VU/sK8vP4eGhj7o52c/6Odnv8XERL7KyUm/xcREPtrZWT+trCw+5eRkPg==",
+      "vectorSha256": "4f2e8e9a319fd9c20198f0cd3b556daf8678d2d4032140577c4f2de1f1d0a4ac",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1f32ad9e2cf3ec30468f0d7ad827889cf95164988aead7a1f30c671b98ec959c",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-08": {
+      "vector": "sK8vv8LBQb+fnp4+q6qqPpeWlr7v7u4+/fx8vvb1db+trCw+goEBv4OCgr7t7Gy++/r6PoOCgj6Ylxc/jYwMvoSDA7/Lysq+zcxMvrW0NL67uro+ubi4PayrK7/z8vK+qqkpv/X0dL6fnp4+wL8/v9nY2L3Pzs6+pqUlv/Py8j6wry+/wsFBv5+enj6rqqo+l5aWvu/u7j79/Hy+9vV1v62sLD6CgQG/g4KCvu3sbL77+vo+g4KCPpiXFz+NjAy+hIMDv8vKyr7NzEy+tbQ0vru6uj65uLg9rKsrv/Py8r6qqSm/9fR0vp+enj7Avz+/2djYvc/Ozr6mpSW/8/LyPg==",
+      "vectorSha256": "390c482fd08413c132fce74e089116de20f94d067061b73925a0c0533ec0c2db",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "281fa7aa5abb6005953f5f62bea0cb6e3e4d6669ae8b2a432b61a720724c2dbc",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-09": {
+      "vector": "5eRkvquqqr7o52c/oaCgPLi3N7+fnp4+kZAQverpaT+0szO/8/LyvqOior6TkpK+ubi4vcPCwr6fnp4+AACAv7a1NT/x8HC95uVlv7GwML3Pzs6+6ulpv+DfXz/X1tY+sK8vv/f29j69vDw++vl5P/38fL6dnBy+pqUlv/r5eT/l5GS+q6qqvujnZz+hoKA8uLc3v5+enj6RkBC96ulpP7SzM7/z8vK+o6KivpOSkr65uLi9w8LCvp+enj4AAIC/trU1P/HwcL3m5WW/sbAwvc/Ozr7q6Wm/4N9fP9fW1j6wry+/9/b2Pr28PD76+Xk//fx8vp2cHL6mpSW/+vl5Pw==",
+      "vectorSha256": "7757314da73cf0f25712a74890485c39e01fb0dbc36aef7987ad4499702b9cb7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6355f38224a77bf42643575b744fa700da780d7a4c0befb528bd97fc606c2dfc",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-10": {
+      "vector": "8vFxP6yrK7/Avz8/wL8/P+fm5r7//v6+6+rqvt3cXD6mpSU/j46Ovp2cHD7BwEA84+LivomIiL3R0FA99PNzv6yrKz/R0FC909LSvo+Ojj719HS+gYCAu52cHD6koyM/9PNzP5+enj7Ew0M/0dBQPQAAgD+DgoI+2NdXv6moqD3y8XE/rKsrv8C/Pz/Avz8/5+bmvv/+/r7r6uq+3dxcPqalJT+Pjo6+nZwcPsHAQDzj4uK+iYiIvdHQUD3083O/rKsrP9HQUL3T0tK+j46OPvX0dL6BgIC7nZwcPqSjIz/083M/n56ePsTDQz/R0FA9AACAP4OCgj7Y11e/qaioPQ==",
+      "vectorSha256": "abd314fdc62cf5aaac607597c38dc6b6f6d663034a193d497facdbf752b8b300",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f82adfdf4640459bd25c938147778606d5794ba3617f93d1f9a7e186ffa0148a",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-11": {
+      "vector": "6OdnPwAAgL+RkBA9u7q6vp+enr7+/X2/t7a2vpCPD7/Ew0M/yMdHv5WUFL7Avz8/jo0NP7KxMT/OzU0/xMNDP7Oysj6amRm/v76+Pp+enj76+Xk/8/LyPomIiD3g318/7exsvp2cHL7d3Fy+lpUVP8vKyj6NjAy+xsVFP8vKyj7o52c/AACAv5GQED27urq+n56evv79fb+3tra+kI8Pv8TDQz/Ix0e/lZQUvsC/Pz+OjQ0/srExP87NTT/Ew0M/s7KyPpqZGb+/vr4+n56ePvr5eT/z8vI+iYiIPeDfXz/t7Gy+nZwcvt3cXL6WlRU/y8rKPo2MDL7GxUU/y8rKPg==",
+      "vectorSha256": "bddef0e33a6d5813df811e1936e138158edfc773d85c358c5144abb087d1a697",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f300845158015238e11c6ddfc6d8e6e1ac33afa7fcbc88ef626c64cab26ee2b2",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-12": {
+      "vector": "o6KivoWEBD7493e/jIsLP+DfXz+UkxM/p6amvtDPTz+gnx8/y8rKPv/+/r76+Xk/7u1tv87NTT+Ylxc/1dRUvqCfHz///v4+mJcXP769PT+WlRU/zs1NP46NDT/Ew0M/j46OPq2sLD6Pjo4+/Pt7P/v6+r7R0FA9kpERP/79fb+joqK+hYQEPvj3d7+Miws/4N9fP5STEz+npqa+0M9PP6CfHz/Lyso+//7+vvr5eT/u7W2/zs1NP5iXFz/V1FS+oJ8fP//+/j6Ylxc/vr09P5aVFT/OzU0/jo0NP8TDQz+Pjo4+rawsPo+Ojj78+3s/+/r6vtHQUD2SkRE//v19vw==",
+      "vectorSha256": "766269e7cba4041396ebbaf6debcdb99efd1bd7a4fd64306a6f9ebf148a86561",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "579004c5efc956e7cfb240fc09e6cb65cfbfcbdecae6c6e1a395a3fd4186c801",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-13": {
+      "vector": "0dBQvejnZ7+9vDw+urk5P9/e3j7n5ua+9vV1P4KBAT+amRk/4+LiPqmoqL38+3u/uLc3v7CvLz/Lyso+gYCAO5CPDz/V1FS+kZAQvaqpKb/19HQ+m5qaPpSTE7+npqY+hoUFv4yLC7+Qjw8/7exsvoOCgr7BwEC89PNzvwAAgD/R0FC96Odnv728PD66uTk/397ePufm5r729XU/goEBP5qZGT/j4uI+qaiovfz7e7+4tze/sK8vP8vKyj6BgIA7kI8PP9XUVL6RkBC9qqkpv/X0dD6bmpo+lJMTv6empj6GhQW/jIsLv5CPDz/t7Gy+g4KCvsHAQLz083O/AACAPw==",
+      "vectorSha256": "7bf0545178f0938729d6b27eada81e83052919efbe14de47c34acaea67bd3e31",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "790c97dcb746fac0ccb8750224d7b280c7657b2b9ea636a93d3ac7625f7e06ff",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-14": {
+      "vector": "2djYPaempj7S0VE/kI8Pv8zLSz/i4WE/tLMzv56dHb/l5GQ+hoUFP6Oioj7l5GS+6ulpv/X0dL7a2Vm/gYCAO4qJCT/T0tI+qaiovcvKyj7OzU2/z87Ovr++vj7j4uK+6ulpv6uqqr7h4OA8y8rKPs/Ozj7W1VU/n56ePp2cHL7Z2Ng9p6amPtLRUT+Qjw+/zMtLP+LhYT+0szO/np0dv+XkZD6GhQU/o6KiPuXkZL7q6Wm/9fR0vtrZWb+BgIA7iokJP9PS0j6pqKi9y8rKPs7NTb/Pzs6+v76+PuPi4r7q6Wm/q6qqvuHg4DzLyso+z87OPtbVVT+fnp4+nZwcvg==",
+      "vectorSha256": "0a6ac745caa30d482d0adc60362cdd25e1d8ccf6c634f3723531b596d4ccde00",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8da9e838e5f026319cc2a8630b611380c4b475b2194caf470b5583b2b3eaa76c",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-15": {
+      "vector": "6+rqPouKir7Hxsa+o6KivtXUVL7KyUk/zcxMPrCvLz/7+vo+3t1dP93cXD4AAIA/nZwcPvHwcD3n5ua+9PNzP+Pi4j7h4OA8vbw8vvHwcD3X1ta+9fR0vq2sLD7b2tq+h4aGvrCvLz+Pjo6+mpkZv9rZWT8AAIC/ubi4Pbq5Ob/r6uo+i4qKvsfGxr6joqK+1dRUvsrJST/NzEw+sK8vP/v6+j7e3V0/3dxcPgAAgD+dnBw+8fBwPefm5r7083M/4+LiPuHg4Dy9vDy+8fBwPdfW1r719HS+rawsPtva2r6Hhoa+sK8vP4+Ojr6amRm/2tlZPwAAgL+5uLg9urk5vw==",
+      "vectorSha256": "0336855e7e50e1e0dc7cf26417272c57cc641422099d37221e0aa4e303e3d287",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ba5d4e5765e499d7beee9bff938746f9b88368874a6195495ed75c33ec008b23",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-16": {
+      "vector": "jo0NP/79fT+enR0/qaiovZqZGT+hoKC88O9vP8HAQLy9vDw+6ejovZCPD7+TkpK++fj4vdva2j7b2to+mZiYvcC/P7+pqKg98fBwPd7dXb/a2Vk/jo0Nv87NTb+WlRW/kpERv7y7O7+9vDw++Pd3v7Oysr65uLg9xcREvpqZGb+OjQ0//v19P56dHT+pqKi9mpkZP6GgoLzw728/wcBAvL28PD7p6Oi9kI8Pv5OSkr75+Pi929raPtva2j6ZmJi9wL8/v6moqD3x8HA93t1dv9rZWT+OjQ2/zs1Nv5aVFb+SkRG/vLs7v728PD7493e/s7Kyvrm4uD3FxES+mpkZvw==",
+      "vectorSha256": "d59ef841d7c284abf976a75acde13609acbba78be25035b9a7592fbb9944bf1e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c6fece75cc7df77e9771385b70b6b676208a8711ec39193537229704538b6733",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-17": {
+      "vector": "7+7uvr69Pb/19HS+tLMzP8C/Pz++vT0/yslJP8HAQLz29XU/0dBQvbGwML2fnp6+pKMjP8zLSz/8+3s/w8LCPsbFRb/HxsY+mpkZP8bFRb/Qz0+/0M9Pv9HQUL2FhAS+kZAQvYiHBz/Hxsa+19bWPqempr7083O/lpUVv6GgoDzv7u6+vr09v/X0dL60szM/wL8/P769PT/KyUk/wcBAvPb1dT/R0FC9sbAwvZ+enr6koyM/zMtLP/z7ez/DwsI+xsVFv8fGxj6amRk/xsVFv9DPT7/Qz0+/0dBQvYWEBL6RkBC9iIcHP8fGxr7X1tY+p6amvvTzc7+WlRW/oaCgPA==",
+      "vectorSha256": "31a002ecbba28cc2d2af45712ab7b100fab836801dee5fe6691a92f043e52966",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "442161d9dfdee47efa797a58d1e5fdb01db1cc1d1818796f7bc34eb556063582",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-18": {
+      "vector": "5ONjv9zbWz+urS2/urk5v7W0ND7h4OA8sK8vv8LBQT+XlpY+gYCAu9jXVz+ysTE/rKsrP+/u7j7p6Og98vFxv/f29r6cmxs/lJMTP6uqqj7k42O/wL8/P/Py8j7t7Gy+4N9fv728PD7083O/o6KivsHAQDz+/X0/paQkvsXERL7k42O/3NtbP66tLb+6uTm/tbQ0PuHg4Dywry+/wsFBP5eWlj6BgIC72NdXP7KxMT+sqys/7+7uPuno6D3y8XG/9/b2vpybGz+UkxM/q6qqPuTjY7/Avz8/8/LyPu3sbL7g31+/vbw8PvTzc7+joqK+wcBAPP79fT+lpCS+xcREvg==",
+      "vectorSha256": "c8754e77222af9b651b8d30feed97bdd1de30f3242935d54e6c8c2887c18ff2c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0eed2923968328e0a57febd8d5bb8e0742cdc9aa0edfbc621097065781fe6b67",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-19": {
+      "vector": "p6amPrCvL7/KyUm/r66uvrm4uL2GhQU/oJ8fv/Dvbz+WlRW/m5qaPoKBAb8AAIA/3t1dP/79fT+pqKi94+LiPszLSz+enR0/jYwMPoqJCT///v4+1dRUPt/e3j6lpCS+lZQUPrSzMz/u7W0/ycjIvZaVFb+enR0/pqUlP5mYmD2npqY+sK8vv8rJSb+vrq6+ubi4vYaFBT+gnx+/8O9vP5aVFb+bmpo+goEBvwAAgD/e3V0//v19P6moqL3j4uI+zMtLP56dHT+NjAw+iokJP//+/j7V1FQ+397ePqWkJL6VlBQ+tLMzP+7tbT/JyMi9lpUVv56dHT+mpSU/mZiYPQ==",
+      "vectorSha256": "45ce9039f0a957643aa4c340754f7a794aa3f7ff7a73fa5e718adb1b33412c01",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a9281b5474c230f735a63fffeefe75b8e5ce91c4bf9ab76b92d9f67335ced289",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-20": {
+      "vector": "8O9vP8HAQLzz8vK+h4aGPvz7e7+1tDS+k5KSvpOSkj7NzEy+//7+vtXUVD7NzEy+np0dP/38fL7j4uK+rawsvoGAgLva2Vk/5eRkPpKREb/s62s/l5aWvomIiL2xsDC9hYQEvuDfXz+OjQ2/zcxMvrGwMD3q6Wk/iYiIvYyLC7/w728/wcBAvPPy8r6HhoY+/Pt7v7W0NL6TkpK+k5KSPs3MTL7//v6+1dRUPs3MTL6enR0//fx8vuPi4r6trCy+gYCAu9rZWT/l5GQ+kpERv+zraz+Xlpa+iYiIvbGwML2FhAS+4N9fP46NDb/NzEy+sbAwPerpaT+JiIi9jIsLvw==",
+      "vectorSha256": "4eab927b62dafbbc6f1827ce49a978288f7e1caa97d75f834ee8f4bba7549ccf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f77e43a102695ba466409a66ce60476a7fec9c37f55a777a6fef396685f4773a",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-21": {
+      "vector": "0tFRP769PT/d3Fy+8/LyvtTTUz/8+3u/w8LCPp6dHb+OjQ2/lpUVP9zbW7+Xlpa+6ulpv8PCwr6WlRU/rq0tP5mYmD3T0tK+29raPqSjI7/5+Pg90tFRv/z7e7/HxsY+1dRUvt3cXL78+3u/r66uPp2cHL6zsrI+oaCgvKqpKb/S0VE/vr09P93cXL7z8vK+1NNTP/z7e7/DwsI+np0dv46NDb+WlRU/3Ntbv5eWlr7q6Wm/w8LCvpaVFT+urS0/mZiYPdPS0r7b2to+pKMjv/n4+D3S0VG//Pt7v8fGxj7V1FS+3dxcvvz7e7+vrq4+nZwcvrOysj6hoKC8qqkpvw==",
+      "vectorSha256": "8e8cb2ff0d826a5216d14621e420f092efa1e42816fd69ab79d9611355ab90e2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e8de6443e902b03139ca125a0b4fcad6894bb62e8f1702b1656402ab6cac7d2b",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-22": {
+      "vector": "7exsvo6NDb+RkBA9r66uvvX0dL6FhAS+wcBAvLCvLz+koyM/vbw8Pv38fL7X1tY+iokJP6WkJL7V1FS+wL8/P8nIyL3BwEC80M9PP7SzMz+fnp4+6OdnP7i3N7/h4OA8rq0tP6WkJD6+vT2/7+7uPv79fT+Miws/u7q6vpaVFb/t7Gy+jo0Nv5GQED2vrq6+9fR0voWEBL7BwEC8sK8vP6SjIz+9vDw+/fx8vtfW1j6KiQk/paQkvtXUVL7Avz8/ycjIvcHAQLzQz08/tLMzP5+enj7o52c/uLc3v+Hg4DyurS0/paQkPr69Pb/v7u4+/v19P4yLCz+7urq+lpUVvw==",
+      "vectorSha256": "c76d0e06a563dcb3ef225489371e5c26bb6a566f1cfea41813a39f23f15e0998",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "62398454616f7ed7d19760b5c46b65df737ee7d9a7f32483d69421bbfec55135",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-23": {
+      "vector": "0M9Pv6GgoDyMiws/mpkZv/79fb+3tra+oqEhP9fW1r7X1tY+0M9Pv+no6L2koyO/1tVVv+LhYT/o52e/k5KSvuLhYT/493c/i4qKvsTDQz+qqSk/5ONjv8PCwj7a2Vm/1tVVP66tLb+DgoI+5eRkvtXUVL7R0FA93Ntbv+Pi4j7Qz0+/oaCgPIyLCz+amRm//v19v7e2tr6ioSE/19bWvtfW1j7Qz0+/6ejovaSjI7/W1VW/4uFhP+jnZ7+TkpK+4uFhP/j3dz+Lioq+xMNDP6qpKT/k42O/w8LCPtrZWb/W1VU/rq0tv4OCgj7l5GS+1dRUvtHQUD3c21u/4+LiPg==",
+      "vectorSha256": "2f7bbf369ca088e6ad9b04c7904697d0450119c3fdde46eeaf64c456c3dfc459",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1882c5330152d04ab518712e15f00c5bf0fb5de1d40eb013ea29a063658612b8",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-24": {
+      "vector": "xsVFv7u6ur6RkBA91NNTP5mYmD23trY+ycjIPbe2tj6TkpI+oaCgvPr5eT/Lyso+kZAQPcXERL7s62u/o6Kivvj3dz+CgQG/i4qKvq2sLD61tDQ+mJcXv7++vj6ZmJi98O9vP+LhYT+Xlpa+hIMDP4eGhr7T0tI+xMNDv8rJST/GxUW/u7q6vpGQED3U01M/mZiYPbe2tj7JyMg9t7a2PpOSkj6hoKC8+vl5P8vKyj6RkBA9xcREvuzra7+joqK++Pd3P4KBAb+Lioq+rawsPrW0ND6Ylxe/v76+PpmYmL3w728/4uFhP5eWlr6EgwM/h4aGvtPS0j7Ew0O/yslJPw==",
+      "vectorSha256": "9990c10508721e7b9ba37c8e6271d4487711de3c3d9dcee1fe564395c4d36828",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1d5184e989ad8cada47dfcb284670a57fb3f5d959634af76f7f05ac15eb41ee4",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-25": {
+      "vector": "yMdHP5+enr6cmxu/sbAwvejnZz+dnBw+6+rqvtbVVT/8+3u/m5qaPvLxcT/s62u/jIsLP7Oysr76+Xk/k5KSvoaFBb+npqY+xsVFv+3sbL7X1ta+iIcHP/v6+j7u7W0/h4aGvrW0ND7j4uK+vr09P/Lxcb/a2Vk/mZiYPc3MTL7Ix0c/n56evpybG7+xsDC96OdnP52cHD7r6uq+1tVVP/z7e7+bmpo+8vFxP+zra7+Miws/s7Kyvvr5eT+TkpK+hoUFv6empj7GxUW/7exsvtfW1r6Ihwc/+/r6Pu7tbT+Hhoa+tbQ0PuPi4r6+vT0/8vFxv9rZWT+ZmJg9zcxMvg==",
+      "vectorSha256": "981799ec93f0c3a7e19619121a6f64671476361b1999f27708d2682f04c5f802",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e358327af39345ea02a6f80ac553fc5b3da91d624ac3bef65e9647de07ec8966",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-26": {
+      "vector": "ubi4Pfr5eT/19HS+kI8Pv6GgoDzv7u6+yMdHv5eWlr6ioSG/n56ePqGgoDwAAIC/yMdHP56dHT/T0tI+5uVlP8bFRT+wry+/kI8PP5STEz/My0u/paQkPvDvbz+gnx+/hoUFv6Oior7Z2Ng9wcBAPNXUVL7p6Og9vr09v6empr65uLg9+vl5P/X0dL6Qjw+/oaCgPO/u7r7Ix0e/l5aWvqKhIb+fnp4+oaCgPAAAgL/Ix0c/np0dP9PS0j7m5WU/xsVFP7CvL7+Qjw8/lJMTP8zLS7+lpCQ+8O9vP6CfH7+GhQW/o6KivtnY2D3BwEA81dRUvuno6D2+vT2/p6amvg==",
+      "vectorSha256": "0ace2aa2f9a39f28340ca5d4de11d9ec24f291e52df4e3d27018ab13cbb08adf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8bfc613882441c5a2fa78200e3ceb4f2e228c7c91a94f7303d578d81658e2156",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-27": {
+      "vector": "kpERP6yrK7/e3V2/5ONjv4KBAb/T0tI+9fR0vuLhYT/CwUG/l5aWPrGwMD2xsDA99vV1P8jHRz/q6Wm/trU1v4iHB7+HhoY+3t1dP4qJCb+bmpq+/fx8vouKij60szM/29ravtfW1j7Y11c/7OtrP+/u7r6dnBw+lpUVP4qJCb+SkRE/rKsrv97dXb/k42O/goEBv9PS0j719HS+4uFhP8LBQb+XlpY+sbAwPbGwMD329XU/yMdHP+rpab+2tTW/iIcHv4eGhj7e3V0/iokJv5uamr79/Hy+i4qKPrSzMz/b2tq+19bWPtjXVz/s62s/7+7uvp2cHD6WlRU/iokJvw==",
+      "vectorSha256": "98d695e5da28ed56d214468360a6b2fcc581e9d176eb1123adfa87a6265f2d6d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c82a110e3fb461f01fa58585fae30b253ca1ee3b5960a2d949b5ebf54493ca3b",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-28": {
+      "vector": "zMtLP+Hg4DzR0FA9wL8/v66tLT+bmpq+3dxcvsnIyD26uTm/mZiYvbSzMz/i4WG/tbQ0Pry7Oz+xsDC9m5qavp2cHL6xsDC95+bmPomIiL3HxsY+tbQ0vu7tbT/+/X0/lZQUvrOysr7KyUm/9vV1P66tLT+DgoK+mZiYPe/u7r7My0s/4eDgPNHQUD3Avz+/rq0tP5uamr7d3Fy+ycjIPbq5Ob+ZmJi9tLMzP+LhYb+1tDQ+vLs7P7GwML2bmpq+nZwcvrGwML3n5uY+iYiIvcfGxj61tDS+7u1tP/79fT+VlBS+s7KyvsrJSb/29XU/rq0tP4OCgr6ZmJg97+7uvg==",
+      "vectorSha256": "e180cdc2d4cde3a8674e7977f43798312f1357bef696365b2c5fd6caa591d47d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e5838620d659648c2376d90f96dd7a596c7ab977b169f6fe6d531bfad65f8944",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-29": {
+      "vector": "n56ePry7Oz+RkBC9yMdHv+TjYz/a2Vm/wcBAPIiHB7+OjQ0/vbw8PuHg4LyYlxe/qKcnP9HQUL2ioSE/t7a2PqGgoLzT0tK+yMdHv9nY2L2Hhoa+4uFhv/38fD7s62s/sbAwvYyLC7+xsDA9ubi4PamoqD3V1FQ+9fR0vo2MDD6fnp4+vLs7P5GQEL3Ix0e/5ONjP9rZWb/BwEA8iIcHv46NDT+9vDw+4eDgvJiXF7+opyc/0dBQvaKhIT+3trY+oaCgvNPS0r7Ix0e/2djYvYeGhr7i4WG//fx8Puzraz+xsDC9jIsLv7GwMD25uLg9qaioPdXUVD719HS+jYwMPg==",
+      "vectorSha256": "5ae1bd42149dfff5701102ec2a3eb96e29b686ceb7337e2dd9be3aa23a42c654",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a7dd7b1cf113813cc6977c34d379d0ad7d4b1c725e0f9ff57a3a858b8a9a6191",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-30": {
+      "vector": "1dRUvu3sbD6SkRG/8/LyvqqpKb/W1VW/uLc3v/X0dD6fnp6+/Pt7v8/Ozr7n5uY+8O9vv7y7O7/BwEA819bWPv79fT/Qz08/h4aGPp+enr7a2Vm/+/r6Pv79fT/+/X2/qqkpP6moqD3Qz08/zcxMvublZb/r6uq+5eRkvoSDAz/V1FS+7exsPpKREb/z8vK+qqkpv9bVVb+4tze/9fR0Pp+enr78+3u/z87Ovufm5j7w72+/vLs7v8HAQDzX1tY+/v19P9DPTz+HhoY+n56evtrZWb/7+vo+/v19P/79fb+qqSk/qaioPdDPTz/NzEy+5uVlv+vq6r7l5GS+hIMDPw==",
+      "vectorSha256": "4d398693ba5e46cd3546ff5a6a7738d30a888fa78259a18757a369de304c0dac",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "659d37432b15249e58024cb9082281b5fee7a15813befe01d48ae7660d4563c1",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-31": {
+      "vector": "rq0tP9rZWb+xsDA91tVVv//+/r6zsrK+yMdHv56dHT+4tze/+/r6PoeGhj7k42O/paQkvsfGxj6wry8/9vV1v4OCgr79/Hy+5+bmPrm4uL3b2to+v76+PtTTU7/l5GQ+nJsbv/Py8r7V1FS+ycjIvcrJST/NzEw+29ravsjHR7+urS0/2tlZv7GwMD3W1VW///7+vrOysr7Ix0e/np0dP7i3N7/7+vo+h4aGPuTjY7+lpCS+x8bGPrCvLz/29XW/g4KCvv38fL7n5uY+ubi4vdva2j6/vr4+1NNTv+XkZD6cmxu/8/LyvtXUVL7JyMi9yslJP83MTD7b2tq+yMdHvw==",
+      "vectorSha256": "2e0ca6c53ab1c1efae5bbce352bf62365d0a7171f6c903c0505a7f440740862b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d613851540531cce24bea10e6bb1d7055f60b974b6af169c32436573e499491c",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-32": {
+      "vector": "i4qKPtva2r7U01M/lZQUvpKRET/Z2Ng9wcBAPKSjIz+opye//v19v5KRET/083M/iokJP7++vj7Ix0c/+vl5P8rJSb+enR0/4+LiPpOSkr64tzc/ubi4PbCvL7+BgIC76OdnP/Py8r6zsrI+mZiYPfTzcz+gnx8/zcxMvvTzc7+Lioo+29ravtTTUz+VlBS+kpERP9nY2D3BwEA8pKMjP6inJ7/+/X2/kpERP/Tzcz+KiQk/v76+PsjHRz/6+Xk/yslJv56dHT/j4uI+k5KSvri3Nz+5uLg9sK8vv4GAgLvo52c/8/LyvrOysj6ZmJg99PNzP6CfHz/NzEy+9PNzvw==",
+      "vectorSha256": "462c3585ce516ce54c797ac17cd99ad8ad9e1864ede5876e2ea24a7157525424",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a249e96dc88d81d12c01c8f9c4afe3fc1bceb85bdb8b287ff343ac89f9cf6606",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-33": {
+      "vector": "t7a2PqalJb/k42O/5uVlv9HQUL3b2to+iYiIvbSzM7/S0VG/jYwMPgAAgD/Ew0M/hYQEPomIiD2/vr6+jIsLv+Hg4Dz493c/hIMDP7u6uj75+Pi96ulpv4aFBT/8+3u/goEBv62sLD7u7W0/l5aWPv79fT+XlpY+vLs7P/r5eT+3trY+pqUlv+TjY7/m5WW/0dBQvdva2j6JiIi9tLMzv9LRUb+NjAw+AACAP8TDQz+FhAQ+iYiIPb++vr6Miwu/4eDgPPj3dz+EgwM/u7q6Pvn4+L3q6Wm/hoUFP/z7e7+CgQG/rawsPu7tbT+XlpY+/v19P5eWlj68uzs/+vl5Pw==",
+      "vectorSha256": "16434de92d36d954b74fd77860e5c9fe0a2b6fd1dcd7ab24c6cda8f759669196",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ad2d0e0d79b677261791ffe19088503a83fbc1ae700bc2023f95f6a5fea5ddfc",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-34": {
+      "vector": "jYwMPp2cHL75+Pg9qKcnv7e2tj6lpCS+0dBQvfLxcT+0szM/5uVlv4eGhr79/Hw+pKMjP9LRUb+RkBC9sK8vv9rZWb/GxUU/wL8/P5iXF7/q6Wm/hYQEvoKBAb+Qjw+/jo0Nv/79fb/j4uI+rq0tP8LBQT+TkpI+iokJv66tLT+NjAw+nZwcvvn4+D2opye/t7a2PqWkJL7R0FC98vFxP7SzMz/m5WW/h4aGvv38fD6koyM/0tFRv5GQEL2wry+/2tlZv8bFRT/Avz8/mJcXv+rpab+FhAS+goEBv5CPD7+OjQ2//v19v+Pi4j6urS0/wsFBP5OSkj6KiQm/rq0tPw==",
+      "vectorSha256": "358f450c6954da03bf659c79ae2aacbe9d29c901e24c1b4d517dc87f97dac31b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "916c8f2cad6b79f8d90d5e9fd1177b2813e2df340b6f3f383901b8d6e0a43bd6",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-35": {
+      "vector": "+/r6Pt3cXL6mpSU/ycjIvaqpKb/b2tq+6OdnP/b1dT/493c/5eRkvpiXFz/o52c/6ejovY6NDb/Y11e/8vFxP8TDQz/b2tq+g4KCvpmYmD3d3Fy+jYwMPuno6L2+vT2/mZiYveblZT+2tTW/8O9vP6alJT+1tDQ+pKMjv6+urr77+vo+3dxcvqalJT/JyMi9qqkpv9va2r7o52c/9vV1P/j3dz/l5GS+mJcXP+jnZz/p6Oi9jo0Nv9jXV7/y8XE/xMNDP9va2r6DgoK+mZiYPd3cXL6NjAw+6ejovb69Pb+ZmJi95uVlP7a1Nb/w728/pqUlP7W0ND6koyO/r66uvg==",
+      "vectorSha256": "1cba07895e529ca559dd308528c184bc84b0adbe20a3b5a720edca79bed028c7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "be64d2732b49f3fafb63cbf3713914f8e1495f896491712176f225f7d2962e54",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-36": {
+      "vector": "k5KSvri3Nz/Y11e/3t1dv9bVVT/Z2Ng9x8bGPvb1dT+BgIC7t7a2vrW0NL7a2Vm/7+7uPp6dHT/S0VG/9vV1v4iHB7/OzU2/oaCgPLCvLz+HhoY+vbw8PublZb+amRk/qqkpP8fGxj7Lysq+jYwMvtDPTz/U01O/z87OPsfGxr6TkpK+uLc3P9jXV7/e3V2/1tVVP9nY2D3HxsY+9vV1P4GAgLu3tra+tbQ0vtrZWb/v7u4+np0dP9LRUb/29XW/iIcHv87NTb+hoKA8sK8vP4eGhj69vDw+5uVlv5qZGT+qqSk/x8bGPsvKyr6NjAy+0M9PP9TTU7/Pzs4+x8bGvg==",
+      "vectorSha256": "33a831cadad9892cfd5c47f45748d6768bb595db077724c0665771fed845e62e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5bdb1411ea8db1fa7f526913bbce17053c1982d7a1970dccd4b14d6ee716b34e",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-37": {
+      "vector": "srExv5STEz+urS0/xcREvoaFBb/+/X2/19bWPpSTEz+Miwu/09LSPtDPTz/8+3u/kZAQPa2sLD77+vq+29ravsLBQT/Hxsa+n56ePoqJCb+joqI+8fBwvfz7e7/NzEw+hoUFv/38fL7i4WE/0tFRP4eGhr6bmpo+oaCgvKOioj6ysTG/lJMTP66tLT/FxES+hoUFv/79fb/X1tY+lJMTP4yLC7/T0tI+0M9PP/z7e7+RkBA9rawsPvv6+r7b2tq+wsFBP8fGxr6fnp4+iokJv6Oioj7x8HC9/Pt7v83MTD6GhQW//fx8vuLhYT/S0VE/h4aGvpuamj6hoKC8o6KiPg==",
+      "vectorSha256": "397398ad1310d6d985777e11e90ae8c5450df4bc26fe5d7c152317450b5c1c86",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "27c9d6673d01b5c93ab4e70284954149e04ea73ba87802993d60f0e85ea67da8",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-38": {
+      "vector": "iYiIvZqZGb/u7W0///7+vuvq6r7Hxsa+goEBP/j3dz+TkpI+uLc3v4mIiD3w72+/qKcnP7i3Nz+4tzc/u7q6Ps7NTT+npqY+mZiYvf/+/j6GhQU/9fR0PtXUVL7GxUW/ycjIPauqqr7NzEy+397ePtrZWT/q6Wk/jYwMvuTjY7+JiIi9mpkZv+7tbT///v6+6+rqvsfGxr6CgQE/+Pd3P5OSkj64tze/iYiIPfDvb7+opyc/uLc3P7i3Nz+7uro+zs1NP6empj6ZmJi9//7+PoaFBT/19HQ+1dRUvsbFRb/JyMg9q6qqvs3MTL7f3t4+2tlZP+rpaT+NjAy+5ONjvw==",
+      "vectorSha256": "8098150b6be958156d8b406b53b0020e88056ad95f215e20399bb214a4346365",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7733f640454ec0fba4248808d3dbdbaee6a976bfc29e651d8c5566b7ecf46e0e",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-39": {
+      "vector": "oqEhv6uqqj6qqSk/6Odnv4iHBz+SkRE/rawsPtzbWz/5+Pg9pqUlv9LRUb+wry8/7u1tv7y7O7/n5uY+xcREPp6dHb8AAIA/4eDgPMTDQz+EgwO/kI8PP7i3N7/k42O/lJMTP/79fb/Ix0c/9vV1P/Dvbz/U01O///7+PvDvbz+ioSG/q6qqPqqpKT/o52e/iIcHP5KRET+trCw+3NtbP/n4+D2mpSW/0tFRv7CvLz/u7W2/vLs7v+fm5j7FxEQ+np0dvwAAgD/h4OA8xMNDP4SDA7+Qjw8/uLc3v+TjY7+UkxM//v19v8jHRz/29XU/8O9vP9TTU7///v4+8O9vPw==",
+      "vectorSha256": "c87543304ae694cf6fa20369973f5bd61737648b2b873fb1b9f1deb886db5587",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2faad40cc3c895ed8f2d17d70922b99831ff83e13ec7240ec901e3faf716bff7",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-40": {
+      "vector": "6Odnv//+/r6koyO/s7Kyvo2MDL68uzs/9/b2PtHQUL3Pzs4+iIcHv4yLC7+BgIC7yMdHP5OSkj6urS0/lJMTP8TDQ7/j4uK+jo0Nv8bFRb+Lioq+g4KCPp2cHL7U01M/jo0NP4eGhr7//v6+jo0Nv87NTT+5uLg9k5KSvtHQUD3o52e///7+vqSjI7+zsrK+jYwMvry7Oz/39vY+0dBQvc/Ozj6Ihwe/jIsLv4GAgLvIx0c/k5KSPq6tLT+UkxM/xMNDv+Pi4r6OjQ2/xsVFv4uKir6DgoI+nZwcvtTTUz+OjQ0/h4aGvv/+/r6OjQ2/zs1NP7m4uD2TkpK+0dBQPQ==",
+      "vectorSha256": "1ea0717b5916a4440ecdff665b1fc331bc8509ce4b6edc0f428c0e6f88541d26",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0c402e536eddbd79b33c3a7fe3a4d6c91e47391d5da06ce9c65e4039e68b5b86",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-41": {
+      "vector": "l5aWvu7tbT/l5GS+xcREvs3MTD6dnBw+zMtLP728PD6vrq6+7u1tv9rZWb/19HQ+hoUFP+jnZ7/Lysq+7u1tv8/Ozj6enR2/u7q6vu3sbD6JiIi9tLMzv+DfXz///v4+9fR0vtrZWT/DwsI+5eRkPuno6L0AAIA/yMdHv9bVVT+Xlpa+7u1tP+XkZL7FxES+zcxMPp2cHD7My0s/vbw8Pq+urr7u7W2/2tlZv/X0dD6GhQU/6Odnv8vKyr7u7W2/z87OPp6dHb+7urq+7exsPomIiL20szO/4N9fP//+/j719HS+2tlZP8PCwj7l5GQ+6ejovQAAgD/Ix0e/1tVVPw==",
+      "vectorSha256": "55028c3210780fedfabcbd33e8c7f36cc6a5ea02163b3b3ccc7693c4148d9140",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5af663679993e5975409139ec20c4d09b331519d7726efbf61ecb09c71ff1cea",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-42": {
+      "vector": "0dBQvZKREb+ioSE/5ONjv/X0dD7i4WG/xsVFP4aFBT+/vr4+iIcHP//+/j6TkpI+8vFxv+3sbL76+Xk/y8rKPri3Nz+koyO/mJcXP4KBAb/s62s/1dRUPomIiD3KyUm/8/LyvtTTU7/V1FS+iokJv/r5eb+xsDA9paQkPo6NDT/R0FC9kpERv6KhIT/k42O/9fR0PuLhYb/GxUU/hoUFP7++vj6Ihwc///7+PpOSkj7y8XG/7exsvvr5eT/Lyso+uLc3P6SjI7+Ylxc/goEBv+zraz/V1FQ+iYiIPcrJSb/z8vK+1NNTv9XUVL6KiQm/+vl5v7GwMD2lpCQ+jo0NPw==",
+      "vectorSha256": "0f8a6b112fc1809178302978bcfbd0e6e260b6b850969e971b717e824f80d081",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7937d00e9e0fe2c2afc3bfa40762fcb2db2ecb3ff59a881b4316653b038594c6",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-43": {
+      "vector": "kZAQvfb1dT+fnp4+3NtbP5+enr7v7u6+vbw8PpqZGT+amRk/7+7uPouKij7d3Fy+qKcnP52cHL7l5GQ+yMdHP4KBAb/o52c/1NNTP42MDL7x8HA97exsvgAAgD/Ew0M//v19P4mIiL2Pjo6+wL8/P7y7Oz/t7Gy+v76+Pq+urr6RkBC99vV1P5+enj7c21s/n56evu/u7r69vDw+mpkZP5qZGT/v7u4+i4qKPt3cXL6opyc/nZwcvuXkZD7Ix0c/goEBv+jnZz/U01M/jYwMvvHwcD3t7Gy+AACAP8TDQz/+/X0/iYiIvY+Ojr7Avz8/vLs7P+3sbL6/vr4+r66uvg==",
+      "vectorSha256": "e928ffed44c149382425ce7bf96b315f02fe0ee06c102378976a834bd232f0ad",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7bfaa7ed584497ccccbba264d36c9ce33ff3e96e8762ffe1fe775cdfdd62af54",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-44": {
+      "vector": "h4aGPoOCgr6CgQG/oaCgPKyrK7/U01O/7+7uPry7Oz+Ihwe/3t1dv46NDb/c21u/z87OPpGQED2VlBQ+19bWPtXUVD6ioSE/zs1NP46NDT/u7W2/lZQUvtjXV7+KiQm/rKsrv4iHBz/f3t6+h4aGPqalJT+qqSm/v76+vo2MDD6HhoY+g4KCvoKBAb+hoKA8rKsrv9TTU7/v7u4+vLs7P4iHB7/e3V2/jo0Nv9zbW7/Pzs4+kZAQPZWUFD7X1tY+1dRUPqKhIT/OzU0/jo0NP+7tbb+VlBS+2NdXv4qJCb+sqyu/iIcHP9/e3r6HhoY+pqUlP6qpKb+/vr6+jYwMPg==",
+      "vectorSha256": "16187a1ea111895ae3a3cbaef8b0dd74e6176af0679287e20edc2783bcc4e521",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a15f3f822a16bbdd3c113912b38492b59ad0e6c6096d143b2ac348a1d22b5091",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-45": {
+      "vector": "1tVVv7e2tj7My0s/vr09v8XERL6joqK+2djYPeTjY7+trCw+n56ePpaVFb/Pzs4+2tlZP8XERD6trCw+/fx8voSDA7/d3Fw+o6Kivri3N7+rqqo+tbQ0PoaFBb/HxsY+/fx8vvn4+L2ZmJi9mJcXv769PT+opye/8vFxP9jXV7/W1VW/t7a2PszLSz++vT2/xcREvqOior7Z2Ng95ONjv62sLD6fnp4+lpUVv8/Ozj7a2Vk/xcREPq2sLD79/Hy+hIMDv93cXD6joqK+uLc3v6uqqj61tDQ+hoUFv8fGxj79/Hy++fj4vZmYmL2Ylxe/vr09P6inJ7/y8XE/2NdXvw==",
+      "vectorSha256": "01abda97071bd32a12bf02af090c562bba20815d341454e209cb5d8ec304465d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "15ade52167578d0e95a735b3ec9895603e9b5724aa963db160707634de2cf814",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-46": {
+      "vector": "4+Livs3MTL66uTm/r66uvgAAgL+8uzu/0M9Pv+Pi4j6UkxO/09LSvuno6L3CwUE/ycjIvevq6r6Miws/4N9fv/Py8j75+Pi93dxcPrq5OT/493e/o6KiPsrJST+HhoY+wsFBv8HAQDzc21u/2NdXv6uqqj6zsrK+3t1dv83MTL7j4uK+zcxMvrq5Ob+vrq6+AACAv7y7O7/Qz0+/4+LiPpSTE7/T0tK+6ejovcLBQT/JyMi96+rqvoyLCz/g31+/8/LyPvn4+L3d3Fw+urk5P/j3d7+joqI+yslJP4eGhj7CwUG/wcBAPNzbW7/Y11e/q6qqPrOysr7e3V2/zcxMvg==",
+      "vectorSha256": "c2476ea0fada27b1d6a5d9eb945694b901f7eca3a441fe8c2847bb50e4fc6c38",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "47662354002218b8364b71e07345c510bc709bdc04a8e4a11f811214aa531166",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-47": {
+      "vector": "jIsLP5eWlr6mpSW/sK8vv7CvLz///v4+9vV1v8/Ozr6OjQ0/xMNDv7Oysj739vY+9/b2vvX0dD6KiQm/j46Ovq+urr7493c/2tlZv4WEBD7v7u4+3t1dP7SzMz+CgQE/np0dP7GwMD3My0u/g4KCPo2MDL6Xlpa+29ravuvq6r6Miws/l5aWvqalJb+wry+/sK8vP//+/j729XW/z87Ovo6NDT/Ew0O/s7KyPvf29j739va+9fR0PoqJCb+Pjo6+r66uvvj3dz/a2Vm/hYQEPu/u7j7e3V0/tLMzP4KBAT+enR0/sbAwPczLS7+DgoI+jYwMvpeWlr7b2tq+6+rqvg==",
+      "vectorSha256": "1e3e1d7dcdef3f90b7437ce33f12cfa9b59f9bc32a94447d6a1d146c92deb772",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c55a2d28d7bf054cc61eacbd429e3b5c54fb1390bbeed9c0ce851aa06e5a4945",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-48": {
+      "vector": "rq0tP6+urj7l5GS+//7+voKBAT+HhoY+vr09v5GQED2joqK+zs1NP//+/r6hoKC8kpERP769PT/JyMg9zMtLP5qZGT/Ew0O/trU1v8HAQLyYlxc/jYwMPvTzcz+NjAy+AACAv5GQED24tze/yMdHv/LxcT+UkxM/lJMTP6CfHz+urS0/r66uPuXkZL7//v6+goEBP4eGhj6+vT2/kZAQPaOior7OzU0///7+vqGgoLySkRE/vr09P8nIyD3My0s/mpkZP8TDQ7+2tTW/wcBAvJiXFz+NjAw+9PNzP42MDL4AAIC/kZAQPbi3N7/Ix0e/8vFxP5STEz+UkxM/oJ8fPw==",
+      "vectorSha256": "125534852c2aaccc91e509cb595ee86b87f495697734f297f61e2362de72cfb4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d6ab6340c0a1218457e6407dc8de8ce5cc1e257ecb91f96e0084241cf8c9c9cf",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-49": {
+      "vector": "xcREvpCPDz+VlBS+xsVFP7++vj7b2tq+zs1Nv+LhYb+4tzc/1dRUvvLxcT/a2Vm/oaCgPNva2r7Ew0M/vLs7v7q5Ob/y8XG/paQkvquqqr7NzEy+hYQEvoiHBz+0szO/nZwcvrm4uD3w72+/jYwMPvTzc7+/vr4+p6amPtLRUb/FxES+kI8PP5WUFL7GxUU/v76+Ptva2r7OzU2/4uFhv7i3Nz/V1FS+8vFxP9rZWb+hoKA829ravsTDQz+8uzu/urk5v/Lxcb+lpCS+q6qqvs3MTL6FhAS+iIcHP7SzM7+dnBy+ubi4PfDvb7+NjAw+9PNzv7++vj6npqY+0tFRvw==",
+      "vectorSha256": "f2ac56e04f02c55df5dfb6c209f5cb9edfc5ea21b246d816ed7342cd38125011",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "67c76de2af49190fdb65f8138249e12223076b55666fc3266c8b089106afa917",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "music-50": {
+      "vector": "3NtbP7GwMD37+vq+2djYvbSzM7/f3t4+2djYvY+Ojr7o52e/4+LiPoSDAz+hoKC85uVlv9LRUb+WlRW/qaiovbe2tr7w72+/qaiovdXUVL65uLi96ejoPeXkZL64tze/hYQEvoGAgLu/vr4+hIMDv5CPDz/NzEw+9PNzP+zra7/c21s/sbAwPfv6+r7Z2Ni9tLMzv9/e3j7Z2Ni9j46OvujnZ7/j4uI+hIMDP6GgoLzm5WW/0tFRv5aVFb+pqKi9t7a2vvDvb7+pqKi91dRUvrm4uL3p6Og95eRkvri3N7+FhAS+gYCAu7++vj6EgwO/kI8PP83MTD7083M/7Otrvw==",
+      "vectorSha256": "c39777f5b48bd19ff9258446744e11ef80da6e6208dc0fad1c9cc4462b837247",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ed85417226b7725c0cb8c17d0d17357552087565748e63246f7faf3ec799f90a",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-02": {
+      "vector": "AACAP+rpab/X1ta+o6KiPoKBAb+trCw+goEBv+Pi4j6xsDC9wL8/v+rpab+rqqq+oJ8fv9HQUL3BwEA81NNTv+TjY7/083M/397ePvr5eb/CwUG/z87OPoiHB7///v4+7+7uPsTDQz/Ew0O/oaCgPPr5eb/x8HA96Odnv+rpaT8AAIA/6ulpv9fW1r6joqI+goEBv62sLD6CgQG/4+LiPrGwML3Avz+/6ulpv6uqqr6gnx+/0dBQvcHAQDzU01O/5ONjv/Tzcz/f3t4++vl5v8LBQb/Pzs4+iIcHv//+/j7v7u4+xMNDP8TDQ7+hoKA8+vl5v/HwcD3o52e/6ulpPw==",
+      "vectorSha256": "fd2d52aa03ac006feb5680f2e2668bda9c76120cdb0b36e55833dca2124980d6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ff0b4aa83f953fb87a200b55307981160ef9b7031fb33cbfbbe11e8203870cf4",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-03": {
+      "vector": "qKcnv5ybG7/Z2Ni9g4KCvpiXF7/d3Fw+2NdXv+DfXz/083M/4eDgPJmYmD3h4OA8jo0NP+blZT+joqK+rq0tP9LRUT/Z2Ni99fR0PpOSkr7OzU2/3dxcPvj3dz/8+3s/ycjIvbq5Ob/T0tI+5+bmPtfW1r7v7u4+g4KCPoOCgr6opye/nJsbv9nY2L2DgoK+mJcXv93cXD7Y11e/4N9fP/Tzcz/h4OA8mZiYPeHg4DyOjQ0/5uVlP6Oior6urS0/0tFRP9nY2L319HQ+k5KSvs7NTb/d3Fw++Pd3P/z7ez/JyMi9urk5v9PS0j7n5uY+19bWvu/u7j6DgoI+g4KCvg==",
+      "vectorSha256": "09bcd82833e64c59220e1d42a18ff200b4b18cf985223e1ea859e0b408c503cd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2c32725f349b14eff9838983c6f257d6e8729e5b199bfbfd7323b4b94abba05f",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-05": {
+      "vector": "pqUlP6qpKT/Hxsa+xsVFv52cHL6CgQE/rKsrP+Hg4DzIx0e/q6qqvuPi4r6EgwO/zMtLP8nIyL2dnBw+tLMzP4qJCb+opye/6OdnP+Pi4j6JiIi96ejovZeWlr7k42M/qaioPeno6D2DgoI+zMtLv9LRUb/t7Gy+6ulpP8PCwj6mpSU/qqkpP8fGxr7GxUW/nZwcvoKBAT+sqys/4eDgPMjHR7+rqqq+4+LivoSDA7/My0s/ycjIvZ2cHD60szM/iokJv6inJ7/o52c/4+LiPomIiL3p6Oi9l5aWvuTjYz+pqKg96ejoPYOCgj7My0u/0tFRv+3sbL7q6Wk/w8LCPg==",
+      "vectorSha256": "2fa19280ba06641e9575ec0f47f3e169a2f7c429633cbe20a609a51dc13d82ef",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d2d44e1d6cc0d5831c55473ee57393d93b2cf3b877715af18a8ea01a1762f4b0",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-07": {
+      "vector": "9PNzP4eGhj7d3Fy+9PNzP7++vr7BwEA8u7q6Pq+urj7t7Gw+/v19v6yrKz/n5ua+jo0NP+/u7r6GhQU/5eRkvujnZz/m5WU/7OtrP46NDT+amRm/paQkvpWUFD7Avz+/9fR0vqinJ7/FxES+3Ntbv6GgoDzp6Oi9jIsLv7y7O7/083M/h4aGPt3cXL7083M/v76+vsHAQDy7uro+r66uPu3sbD7+/X2/rKsrP+fm5r6OjQ0/7+7uvoaFBT/l5GS+6OdnP+blZT/s62s/jo0NP5qZGb+lpCS+lZQUPsC/P7/19HS+qKcnv8XERL7c21u/oaCgPOno6L2Miwu/vLs7vw==",
+      "vectorSha256": "08aa62cc7b6a696d50788a6fde409effe20b6b0e1c7f9c9b9ea7b5b2f70766fd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f9a164f95081aeab9d01d546c644c263f3f2f5c6336b9220612c671282713a22",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-08": {
+      "vector": "nJsbP+vq6r6bmpo++Pd3P7a1NT/NzEy+zcxMvsnIyL2CgQE/nJsbv4iHBz+mpSW/k5KSPpiXF7/Ix0e/7exsvvDvb7/9/Hy+j46OvtXUVL6NjAy+/fx8vqCfHz+JiIg9+Pd3v+blZT/l5GQ+8/LyPtLRUT+zsrK+zcxMvuTjY7+cmxs/6+rqvpuamj7493c/trU1P83MTL7NzEy+ycjIvYKBAT+cmxu/iIcHP6alJb+TkpI+mJcXv8jHR7/t7Gy+8O9vv/38fL6Pjo6+1dRUvo2MDL79/Hy+oJ8fP4mIiD3493e/5uVlP+XkZD7z8vI+0tFRP7Oysr7NzEy+5ONjvw==",
+      "vectorSha256": "10ae945e8e957c0e29f645ae5067c4befa5aeb83ead86e28754a8b52d4ee54e5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cd45a6fbda666673c032c32da4341c6208605c656e60cf8804f29cbce853660e",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-09": {
+      "vector": "vr09v7a1Nb+pqKi9/fx8voSDAz/Ew0O/6Odnv5mYmD2hoKC88/LyvpWUFL6FhAS+iokJv8/Ozr7T0tI+1NNTv4qJCb/+/X2/5ONjP/r5eb///v6+/v19P6Oior7GxUW/8O9vv7KxMb/Hxsa+g4KCvri3Nz+gnx8/7u1tP8TDQ7++vT2/trU1v6moqL39/Hy+hIMDP8TDQ7/o52e/mZiYPaGgoLzz8vK+lZQUvoWEBL6KiQm/z87OvtPS0j7U01O/iokJv/79fb/k42M/+vl5v//+/r7+/X0/o6KivsbFRb/w72+/srExv8fGxr6DgoK+uLc3P6CfHz/u7W0/xMNDvw==",
+      "vectorSha256": "9dcc655be2d1b35f6dfa81c1499ff9cbd12454c736251205c3aecfdf11334ef1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "21257560c11e0c897d436d6f3b4cb4163b01f10340fe571d08274e5fdbcff61e",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-11": {
+      "vector": "/v19P/v6+r6joqK+/fx8PtfW1j7Avz8/y8rKvpWUFL7n5ua+9vV1v62sLD7493e/lZQUPrKxMT+5uLi9h4aGPri3N7+enR0/gYCAO8HAQLyNjAw+1NNTv7m4uD2rqqq+xsVFv+vq6r77+vo+7Otrv8TDQ7/m5WU/r66uPsLBQT/+/X0/+/r6vqOior79/Hw+19bWPsC/Pz/Lysq+lZQUvufm5r729XW/rawsPvj3d7+VlBQ+srExP7m4uL2HhoY+uLc3v56dHT+BgIA7wcBAvI2MDD7U01O/ubi4Pauqqr7GxUW/6+rqvvv6+j7s62u/xMNDv+blZT+vrq4+wsFBPw==",
+      "vectorSha256": "8083bc973d4c02aab16ebd4dbbb6dc870cad6598cc2452c838e1d03392779367",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fe41579fb5df4d6d4605950492d874a124ce807e91168b551d45be0a1ef2abe0",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-12": {
+      "vector": "1dRUPurpaT/T0tI+9vV1v/38fL7+/X0/g4KCvq2sLL6sqyu/rawsvpSTE7/k42O/kI8Pv9HQUL3q6Wk/9fR0Pr69PT/n5uY+wsFBP6qpKb+VlBS+pKMjP6uqqr4AAIA//v19P/b1dT/NzEw+j46OPpKREb/Qz08/hoUFP+TjY7/V1FQ+6ulpP9PS0j729XW//fx8vv79fT+DgoK+rawsvqyrK7+trCy+lJMTv+TjY7+Qjw+/0dBQverpaT/19HQ+vr09P+fm5j7CwUE/qqkpv5WUFL6koyM/q6qqvgAAgD/+/X0/9vV1P83MTD6Pjo4+kpERv9DPTz+GhQU/5ONjvw==",
+      "vectorSha256": "93afcb4475fbc4a570988497f3dc98d5e1bebbe53af639e7c032e7aeabbed82f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9af4b40560fe5f6a2a6a360e3879f49edeb9e02b6dd155fffefa99a337e7c20e",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-13": {
+      "vector": "4N9fP9LRUT8AAIA/6ejoPfX0dD79/Hy+mZiYPZqZGT+GhQU/2NdXP7i3Nz/8+3s/v76+vtrZWT+FhAS+xMNDv/v6+j7w728/m5qaPrOysr7R0FA9ycjIvYiHBz/k42M/hYQEPo+Ojr7My0s/vLs7v4mIiL2OjQ2/0dBQvfDvbz/g318/0tFRPwAAgD/p6Og99fR0Pv38fL6ZmJg9mpkZP4aFBT/Y11c/uLc3P/z7ez+/vr6+2tlZP4WEBL7Ew0O/+/r6PvDvbz+bmpo+s7KyvtHQUD3JyMi9iIcHP+TjYz+FhAQ+j46OvszLSz+8uzu/iYiIvY6NDb/R0FC98O9vPw==",
+      "vectorSha256": "53b709a54b44f5f5cc49199cfa143c4d3a0a7427fd617059360204630aff141b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "efe8ff8e9e6089ccc2ebdbfd50ec6f1ebef7a6538673c3f1905ce522773979f7",
+      "updatedAt": "2025-09-20T22:28:15.453Z"
+    },
+    "travel-14": {
+      "vector": "5uVlv+zra7/OzU2/jo0Nv+fm5r6Ylxc/pqUlP6empr6mpSW/hYQEvtDPT7/X1tY+yMdHP4eGhj729XU/09LSPpKRET/q6Wk/oJ8fv8fGxr6CgQE/iokJP+LhYb+fnp4+y8rKvqCfH7+lpCS+kpERv7SzM7/R0FA9/fx8vtfW1r7m5WW/7Otrv87NTb+OjQ2/5+bmvpiXFz+mpSU/p6amvqalJb+FhAS+0M9Pv9fW1j7Ix0c/h4aGPvb1dT/T0tI+kpERP+rpaT+gnx+/x8bGvoKBAT+KiQk/4uFhv5+enj7Lysq+oJ8fv6WkJL6SkRG/tLMzv9HQUD39/Hy+19bWvg==",
+      "vectorSha256": "cf5bb04cc0888130cfaa33e85c67fcd308d28c641a3e8f1797c0aa0efd027153",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0d0a193946cbd2562d6f18b5e3a1fab4c8f4304ec0c40fa74d306b372686604a",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-15": {
+      "vector": "7exsvoaFBb+CgQG/qqkpv9jXVz/k42M/iYiIveLhYb/b2to+1tVVP4WEBD6urS2/09LSPtzbWz+trCw+2tlZv62sLD7+/X2/kpERv6inJ7+TkpK+qqkpv4iHBz+FhAS+3Ntbv+/u7r7083M/m5qavu3sbD7x8HA9nJsbv+3sbD7t7Gy+hoUFv4KBAb+qqSm/2NdXP+TjYz+JiIi94uFhv9va2j7W1VU/hYQEPq6tLb/T0tI+3NtbP62sLD7a2Vm/rawsPv79fb+SkRG/qKcnv5OSkr6qqSm/iIcHP4WEBL7c21u/7+7uvvTzcz+bmpq+7exsPvHwcD2cmxu/7exsPg==",
+      "vectorSha256": "6073c1076b5798561489dc022ba29d2bfc0329892313a04958463784da9ff987",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "623d3f2bebf1770fb6ea9029b4ed95139501372c5b2bc36f1244f9599d87329d",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-16": {
+      "vector": "rawsPuLhYT/493e/pKMjv/r5eb/DwsI+jIsLv/j3d7+NjAy+xcREPuPi4r78+3u/jIsLP8vKyj7//v4+oJ8fv9fW1j6Qjw+/9vV1v+7tbT/19HS+rKsrv4qJCb+enR2/4+LiPp2cHL6joqI+yslJP/X0dL7FxEQ+zcxMPtDPTz+trCw+4uFhP/j3d7+koyO/+vl5v8PCwj6Miwu/+Pd3v42MDL7FxEQ+4+Livvz7e7+Miws/y8rKPv/+/j6gnx+/19bWPpCPD7/29XW/7u1tP/X0dL6sqyu/iokJv56dHb/j4uI+nZwcvqOioj7KyUk/9fR0vsXERD7NzEw+0M9PPw==",
+      "vectorSha256": "b5bb196bcb93891739f05ac99317eee020cbf51b5d1d12bc6780654aa572725f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "95f0042e03b03a046e984702c5b2bf30b53805f6612a3b31b86ca8e4619899e7",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-17": {
+      "vector": "r66uPpOSkr6vrq4+s7KyvoKBAT/h4OA84+LiPuTjYz/9/Hw+tbQ0vtHQUD2GhQW/yslJP/Dvb7/Avz+/k5KSPrW0ND6EgwO/zcxMvp6dHT+0szO/1NNTv46NDb+sqys/19bWPv/+/j7Y11e/q6qqvrSzM7/m5WU/rKsrv5ybG7+vrq4+k5KSvq+urj6zsrK+goEBP+Hg4Dzj4uI+5ONjP/38fD61tDS+0dBQPYaFBb/KyUk/8O9vv8C/P7+TkpI+tbQ0PoSDA7/NzEy+np0dP7SzM7/U01O/jo0Nv6yrKz/X1tY+//7+PtjXV7+rqqq+tLMzv+blZT+sqyu/nJsbvw==",
+      "vectorSha256": "470dea3904dc7260039ac1a4cbe8e79a43ca7e12a57e4868fedd45c1a1d037d0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ab5bab53c083b8f19f69863de40820a4963e66ce261639d5b5bf145526f22a32",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-19": {
+      "vector": "AACAv97dXb/U01M/lZQUvoGAgLukoyM/iIcHv9rZWT/Z2Ng96Odnv/v6+r6FhAS+t7a2vsLBQb+vrq6+j46Ovr28PD6SkRE/7exsPvX0dL77+vo+srExP8/Ozj6zsrI+4N9fv/Py8r739vY+vbw8vvz7ez+4tze/rawsPqyrKz8AAIC/3t1dv9TTUz+VlBS+gYCAu6SjIz+Ihwe/2tlZP9nY2D3o52e/+/r6voWEBL63tra+wsFBv6+urr6Pjo6+vbw8PpKRET/t7Gw+9fR0vvv6+j6ysTE/z87OPrOysj7g31+/8/Lyvvf29j69vDy+/Pt7P7i3N7+trCw+rKsrPw==",
+      "vectorSha256": "b9eddebd3095c739956c3b3f64aa62ec050cd4d1dfcb7a70dc5e93bfc6354568",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0011e96d7fd13cec8d0c416f521f545c97c89d61bed8b3ac1043bd68fd2495d5",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-20": {
+      "vector": "iIcHP5WUFL7b2to+7OtrP6alJT+HhoY+9/b2Pv38fL6UkxO/0M9PP//+/j7Z2Ng9i4qKPpuamr6enR2/9vV1P/X0dL7S0VG/7+7uPtTTUz+4tzc//Pt7P9bVVb+pqKg9oJ8fv6WkJD7i4WE/wcBAPMLBQT+trCy+s7KyvsnIyL2Ihwc/lZQUvtva2j7s62s/pqUlP4eGhj739vY+/fx8vpSTE7/Qz08///7+PtnY2D2Lioo+m5qavp6dHb/29XU/9fR0vtLRUb/v7u4+1NNTP7i3Nz/8+3s/1tVVv6moqD2gnx+/paQkPuLhYT/BwEA8wsFBP62sLL6zsrK+ycjIvQ==",
+      "vectorSha256": "377ecc5b90197d56b4c8c3582f790455958f8c98174b8c7a472504203a10c76a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c36db6f5d2a1bd6036e7bf8da25931fa6117bbe9dbfd158a3094f081e06a5373",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-21": {
+      "vector": "7u1tP/Py8r68uzu/8/LyPvHwcD37+vo+paQkvq2sLD6BgIC7g4KCPpSTEz/5+Pi91NNTP6Oioj6JiIg94N9fv+3sbD6GhQU/5uVlP+/u7r7JyMg9gYCAu52cHD6dnBy+3Ntbv4qJCT+5uLi99/b2vvX0dD7k42O/vbw8PsrJSb/u7W0/8/Lyvry7O7/z8vI+8fBwPfv6+j6lpCS+rawsPoGAgLuDgoI+lJMTP/n4+L3U01M/o6KiPomIiD3g31+/7exsPoaFBT/m5WU/7+7uvsnIyD2BgIC7nZwcPp2cHL7c21u/iokJP7m4uL339va+9fR0PuTjY7+9vDw+yslJvw==",
+      "vectorSha256": "18fa1611850b3dba0d6c69ccaebf3b399270f984be17fc3ee4efdb29edb18374",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f64322bc87be6b957fa0c970e9a888109dc2f2448c7f936c12c474429e0e971b",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-22": {
+      "vector": "srExv66tLT+gnx8/tbQ0PsrJSb+Pjo4+r66uvsrJST/u7W0/g4KCvt7dXb/My0u/v76+Po+Ojr66uTm/1NNTv66tLb+rqqo+8vFxvwAAgD+Miws/y8rKPuzraz+WlRW/4eDgvLKxMb+trCy+g4KCvsbFRT+ioSE/8/LyvvTzc7+ysTG/rq0tP6CfHz+1tDQ+yslJv4+Ojj6vrq6+yslJP+7tbT+DgoK+3t1dv8zLS7+/vr4+j46Ovrq5Ob/U01O/rq0tv6uqqj7y8XG/AACAP4yLCz/Lyso+7OtrP5aVFb/h4OC8srExv62sLL6DgoK+xsVFP6KhIT/z8vK+9PNzvw==",
+      "vectorSha256": "99d1150d4a09361cfc3e864ba63f0a888fa3264daa109a039a3ce5c04017e1aa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "27d6cf961ba354e4f65f111aaf5c231629aa07ffc5b2f5357c276a5fe2d04306",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-23": {
+      "vector": "4N9fP+no6D3k42O/oJ8fP8/Ozr6Lioo+kpERv9TTU7/S0VE/yslJv5mYmL2JiIg9goEBv4GAgLvd3Fy+urk5P4uKij7Qz0+/ubi4veXkZD79/Hw+6ejoPYqJCb+DgoI++/r6vpuamr7r6uo+m5qaPouKir6EgwO/sbAwveHg4Dzg318/6ejoPeTjY7+gnx8/z87OvouKij6SkRG/1NNTv9LRUT/KyUm/mZiYvYmIiD2CgQG/gYCAu93cXL66uTk/i4qKPtDPT7+5uLi95eRkPv38fD7p6Og9iokJv4OCgj77+vq+m5qavuvq6j6bmpo+i4qKvoSDA7+xsDC94eDgPA==",
+      "vectorSha256": "1017bcea535622c68188a49fdcef3ffcbb894cbb0f11346d7e29643211c45b89",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ef8e0ecf4ca23716e81b76883f7f64dca218749c9f8e3ba04159baa65d3e7a83",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-24": {
+      "vector": "kI8Pv/v6+j68uzu/+/r6vufm5j6bmpq+lZQUPq+urj7KyUk/vLs7P+no6D2Ylxc/lZQUPublZT+amRm/q6qqPo2MDL7Z2Ng9/v19P6WkJL7FxEQ+19bWPsXERD7V1FQ+1tVVP/n4+D36+Xm/1tVVv/z7ez/U01M/9PNzv6inJz+Qjw+/+/r6Pry7O7/7+vq+5+bmPpuamr6VlBQ+r66uPsrJST+8uzs/6ejoPZiXFz+VlBQ+5uVlP5qZGb+rqqo+jYwMvtnY2D3+/X0/paQkvsXERD7X1tY+xcREPtXUVD7W1VU/+fj4Pfr5eb/W1VW//Pt7P9TTUz/083O/qKcnPw==",
+      "vectorSha256": "44215a7f5fd88f0bb4533632f247e5e051fd6a53bc4b53899fd15a39053d4bc2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "38be2241b95992abe4dd8ecb92f233aa6e8dfe6b98b5989aea8f0315fde906d3",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-25": {
+      "vector": "hYQEvoGAgLvj4uI+3NtbP6uqqj7q6Wk/AACAP6SjIz+KiQm/pqUlv/LxcT/Pzs6+mJcXP/Lxcb+TkpK+jo0NP5qZGb+wry8/3Ntbv6uqqr7R0FC9+fj4vdDPT7/8+3u/r66uvri3Nz+DgoI+vLs7v6empj7s62s/yslJP/Tzc7+FhAS+gYCAu+Pi4j7c21s/q6qqPurpaT8AAIA/pKMjP4qJCb+mpSW/8vFxP8/Ozr6Ylxc/8vFxv5OSkr6OjQ0/mpkZv7CvLz/c21u/q6qqvtHQUL35+Pi90M9Pv/z7e7+vrq6+uLc3P4OCgj68uzu/p6amPuzraz/KyUk/9PNzvw==",
+      "vectorSha256": "69dcbf69c19d96c80d82f769e961fa0878e9aadabb376d15f767dfd9aa05cb4d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6f7fb8edaaf4ffd13b2df84ccb075bc633d712557970180254dba022a9f5e406",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-26": {
+      "vector": "wsFBv9LRUb/f3t6+hoUFP87NTT+7urq+6Odnv5mYmL3OzU2/1tVVv5aVFb+dnBy+9/b2PpybGz/e3V2/pqUlv+fm5j6Miwu/3t1dP8TDQ7/s62s/k5KSvuHg4DzX1ta+mpkZP9rZWb+Qjw8/w8LCPqCfHz/l5GQ+3dxcPoeGhr7CwUG/0tFRv9/e3r6GhQU/zs1NP7u6ur7o52e/mZiYvc7NTb/W1VW/lpUVv52cHL739vY+nJsbP97dXb+mpSW/5+bmPoyLC7/e3V0/xMNDv+zraz+TkpK+4eDgPNfW1r6amRk/2tlZv5CPDz/DwsI+oJ8fP+XkZD7d3Fw+h4aGvg==",
+      "vectorSha256": "75fb335f16c0c7ada62078f4c1af5046836dbfb53e9502b9c7948cf64ee3c2de",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1f1748c2e6510c761915356cbdcd112db93aee1ef55b834acc13c7b0cf9c9b5e",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-27": {
+      "vector": "0M9PP4KBAb/q6Wk/9vV1v6uqqr6pqKi9np0dP6SjIz/OzU2/pqUlv7i3N7+5uLg919bWvqWkJL6TkpI+397evvTzc7+3tra+u7q6vvX0dD7NzEy+xMNDP6KhIb+RkBC9xcREPvn4+D3l5GQ+4eDgvNjXVz+Pjo6+6ulpP5qZGb/Qz08/goEBv+rpaT/29XW/q6qqvqmoqL2enR0/pKMjP87NTb+mpSW/uLc3v7m4uD3X1ta+paQkvpOSkj7f3t6+9PNzv7e2tr67urq+9fR0Ps3MTL7Ew0M/oqEhv5GQEL3FxEQ++fj4PeXkZD7h4OC82NdXP4+Ojr7q6Wk/mpkZvw==",
+      "vectorSha256": "9c899c5c90b12f39800fc6c8b752c18010232ca82429233050a935ae75b8b0bd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e73ff4055575ced1192d248b4a6ba4480652519e66e12f7b988f9c7ceb5cf433",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-29": {
+      "vector": "gYCAO6KhIb/U01M/lpUVP9HQUL37+vq+8O9vP8HAQDygnx+/vr09v4qJCb+gnx+/19bWvoeGhj6BgIA76Odnv/n4+L3f3t4+6OdnP/79fb+Lioo+sbAwvZGQEL2sqyu/6+rqPrW0NL7l5GQ+lpUVP6CfH7/8+3s/goEBP7e2tj6BgIA7oqEhv9TTUz+WlRU/0dBQvfv6+r7w728/wcBAPKCfH7++vT2/iokJv6CfH7/X1ta+h4aGPoGAgDvo52e/+fj4vd/e3j7o52c//v19v4uKij6xsDC9kZAQvayrK7/r6uo+tbQ0vuXkZD6WlRU/oJ8fv/z7ez+CgQE/t7a2Pg==",
+      "vectorSha256": "a562e170f5b997ee9b07e4f17bbec66ab3835c1759ffce5dbc97d9587e6bbb03",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "802fe9ca7941f78130213b304aa1800c70b7f301a27a7b2aba699cca30fdc0ad",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-31": {
+      "vector": "paQkPoGAgDvz8vI+hIMDv5aVFT/19HQ+vLs7P42MDD7k42M/xcREvpKREb/8+3u/np0dP6inJz+Hhoa+u7q6Pvf29r7v7u4+2djYPaalJT/R0FA97+7uvsnIyD2dnBy+oJ8fv5iXFz+0szO/iYiIvZ6dHT+2tTW/AACAv/HwcD2lpCQ+gYCAO/Py8j6EgwO/lpUVP/X0dD68uzs/jYwMPuTjYz/FxES+kpERv/z7e7+enR0/qKcnP4eGhr67uro+9/b2vu/u7j7Z2Ng9pqUlP9HQUD3v7u6+ycjIPZ2cHL6gnx+/mJcXP7SzM7+JiIi9np0dP7a1Nb8AAIC/8fBwPQ==",
+      "vectorSha256": "3667e2ebcb097e2014eac616be8941d835b3cfccd474539a4524455b133cffcb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9480bc3eca9edd91f1673702ced35eae42bb8dd286448c6c30cb2677ce250087",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-32": {
+      "vector": "7+7uPrCvL7++vT2/lJMTv6qpKb/U01M//Pt7v9va2r7U01M/zs1NP62sLD7493e/3NtbP+blZT/z8vI+19bWvu7tbT+Lioq+kI8PP7GwML2npqa+0dBQvaCfH7+trCy+8/LyvsTDQz8AAIC/oJ8fv8nIyD2cmxu/mpkZP7Oysj7v7u4+sK8vv769Pb+UkxO/qqkpv9TTUz/8+3u/29ravtTTUz/OzU0/rawsPvj3d7/c21s/5uVlP/Py8j7X1ta+7u1tP4uKir6Qjw8/sbAwvaempr7R0FC9oJ8fv62sLL7z8vK+xMNDPwAAgL+gnx+/ycjIPZybG7+amRk/s7KyPg==",
+      "vectorSha256": "7ae16da9a496a63481569d8f7e92bf3cb67cdab4f41baec51390c7cf78ab1bb3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bb2821362be90249e9e69504edf2bc4af65dc77a5679306a43e100308c32ccac",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-33": {
+      "vector": "j46OPgAAgD+ioSE/29raPpSTE7+mpSW/zs1Nv9DPT7+pqKg9wcBAPMPCwr7c21s/1tVVP/r5eT/l5GS+srExP4+Ojr6rqqq+trU1v62sLL7Ew0O/29ravsTDQ7+mpSU/4N9fP5uamj7493e/s7KyPsHAQLzS0VG/wcBAPOno6D2Pjo4+AACAP6KhIT/b2to+lJMTv6alJb/OzU2/0M9Pv6moqD3BwEA8w8LCvtzbWz/W1VU/+vl5P+XkZL6ysTE/j46Ovquqqr62tTW/rawsvsTDQ7/b2tq+xMNDv6alJT/g318/m5qaPvj3d7+zsrI+wcBAvNLRUb/BwEA86ejoPQ==",
+      "vectorSha256": "147a2556dac43f4459fd49a4221411fdfca9f56ccc8ed4839473328c40b135ca",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a3ffd0b6362d19188a814fedeafc63d85c55256a1e491ed2efa604ac7e17818e",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-35": {
+      "vector": "nJsbP5uamr7m5WW/xsVFv/r5eb/R0FA9s7KyPuXkZD729XW/6Odnv7CvL7/k42O/wcBAvKWkJD6hoKC86ejovZaVFT++vT0/yslJP/LxcT+WlRW/7OtrP/HwcL3My0u/p6amvu/u7j7GxUU/4eDgPLm4uD2Pjo6+5eRkPsPCwj6cmxs/m5qavublZb/GxUW/+vl5v9HQUD2zsrI+5eRkPvb1db/o52e/sK8vv+TjY7/BwEC8paQkPqGgoLzp6Oi9lpUVP769PT/KyUk/8vFxP5aVFb/s62s/8fBwvczLS7+npqa+7+7uPsbFRT/h4OA8ubi4PY+Ojr7l5GQ+w8LCPg==",
+      "vectorSha256": "ff558c5c755236ca562da1905dcf1ea16b01e14e2974dc8c72240d150b661a5e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cd590d1d0386ac9c050c280e7e947d71cadee4f835f5781a56bbe2838b5c9cb0",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-36": {
+      "vector": "hYQEvoWEBD7U01M/29raPuTjY7+Ylxe/u7q6PsLBQT+pqKi9uLc3v728PD75+Pg9qqkpv6uqqj7y8XG/q6qqvt/e3r6WlRW/8O9vP7GwMD36+Xk/paQkPs/Ozj7U01M/w8LCPrm4uD2BgIC7x8bGPs/Ozj6wry8/yslJv4aFBT+FhAS+hYQEPtTTUz/b2to+5ONjv5iXF7+7uro+wsFBP6moqL24tze/vbw8Pvn4+D2qqSm/q6qqPvLxcb+rqqq+397evpaVFb/w728/sbAwPfr5eT+lpCQ+z87OPtTTUz/DwsI+ubi4PYGAgLvHxsY+z87OPrCvLz/KyUm/hoUFPw==",
+      "vectorSha256": "025001b5a5932dbf4441b1a49ffe62fe7e42102fd4e9015a5151e4e46e4c84b6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6f90e9b60e34aee07524978f2baa07554835f785fc94b3e9b08b7fb1b3d71bc2",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-37": {
+      "vector": "p6amPtbVVb/OzU2/vLs7P728PD6EgwO/kZAQPePi4r7T0tI+urk5P9jXV7+pqKg9j46Ovp6dHT/Z2Ng9+Pd3P5WUFD6Lioo+paQkvoeGhr63tra+i4qKvuDfX7/o52c/iokJv/j3d7+UkxM/zs1NP+no6L3i4WE/09LSvrKxMT+npqY+1tVVv87NTb+8uzs/vbw8PoSDA7+RkBA94+LivtPS0j66uTk/2NdXv6moqD2Pjo6+np0dP9nY2D3493c/lZQUPouKij6lpCS+h4aGvre2tr6Lioq+4N9fv+jnZz+KiQm/+Pd3v5STEz/OzU0/6ejoveLhYT/T0tK+srExPw==",
+      "vectorSha256": "05bee6938a0c590126c751733ffd99ae454928084db487b5f8a865dff8ed9c93",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a91519dd973e8447b4dc148a5cce8dfb92a26b5e525d10f33b04c9e671f04bd8",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-40": {
+      "vector": "9PNzP9XUVD75+Pi95uVlP4aFBb+RkBC99vV1P5mYmD3p6Og97OtrP5qZGT/q6Wm/kpERP8bFRT/493e/7+7uPoqJCT/t7Gw+7+7uvu/u7j62tTW/2djYveDfXz+VlBS+0M9PP9/e3r7o52e/j46OPtTTU7+1tDQ+9fR0vqmoqD3083M/1dRUPvn4+L3m5WU/hoUFv5GQEL329XU/mZiYPeno6D3s62s/mpkZP+rpab+SkRE/xsVFP/j3d7/v7u4+iokJP+3sbD7v7u6+7+7uPra1Nb/Z2Ni94N9fP5WUFL7Qz08/397evujnZ7+Pjo4+1NNTv7W0ND719HS+qaioPQ==",
+      "vectorSha256": "ae292b609724a090b2b28e22ab8ec1f37c38a0a4ef41c170f6e2d1206c80d6db",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f99a70f23d7bfa898ef5cc0bc8e204bbc49d44bb2572ef6de7480ca31696618a",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-41": {
+      "vector": "1dRUPq+urr7Ew0O/+/r6PsbFRT+ysTE/9PNzv8C/P7/493c/+Pd3P/38fL6VlBS+mJcXP9jXV7+Xlpa+1NNTvwAAgL/My0s/jo0Nv9jXVz+dnBw+7u1tP/Py8r79/Hy+w8LCPoWEBL6OjQ2/8/LyPv38fD7U01M/8vFxv7i3N7/V1FQ+r66uvsTDQ7/7+vo+xsVFP7KxMT/083O/wL8/v/j3dz/493c//fx8vpWUFL6Ylxc/2NdXv5eWlr7U01O/AACAv8zLSz+OjQ2/2NdXP52cHD7u7W0/8/Lyvv38fL7DwsI+hYQEvo6NDb/z8vI+/fx8PtTTUz/y8XG/uLc3vw==",
+      "vectorSha256": "870198cf94047c2a910c8533ad8ff1c5ae1132540d3afc6a258e31a311bb8799",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9a541ebee2d80620fbfb606dcb145a1600e539eb93f64360b06f39bc9fe90724",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-43": {
+      "vector": "uLc3P+TjY7/8+3u/jo0Nv9TTUz/j4uI+qKcnP8C/Pz+rqqo+l5aWPoyLC7/c21s/ubi4vZCPD7+trCy+/fx8vp2cHD6Miws/7u1tP9PS0j6+vT0/29raPoqJCT+RkBA9goEBP8vKyj7g31+/s7KyvoGAgDvy8XE/rq0tP+blZb+4tzc/5ONjv/z7e7+OjQ2/1NNTP+Pi4j6opyc/wL8/P6uqqj6XlpY+jIsLv9zbWz+5uLi9kI8Pv62sLL79/Hy+nZwcPoyLCz/u7W0/09LSPr69PT/b2to+iokJP5GQED2CgQE/y8rKPuDfX7+zsrK+gYCAO/LxcT+urS0/5uVlvw==",
+      "vectorSha256": "0c44c8500069c59b57d6b572c3cf80abad09dc3b769d81f1aed1cac0e192e273",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "db0e0239e9b8d3dfaaa53aed74386a6093c5f6b4deb6c484c0b2105380f8d60d",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-44": {
+      "vector": "kZAQvefm5j79/Hw+8vFxP9HQUD3R0FA98/LyPo2MDL7083M/5eRkPv38fL6koyO/+/r6vp+enr4AAIA/3t1dv93cXD7493e/+vl5P9DPTz+Pjo6+oJ8fP56dHT/GxUW/xcREvuXkZL7Qz08/mZiYvcvKyr6CgQG/x8bGvrq5Ob+RkBC95+bmPv38fD7y8XE/0dBQPdHQUD3z8vI+jYwMvvTzcz/l5GQ+/fx8vqSjI7/7+vq+n56evgAAgD/e3V2/3dxcPvj3d7/6+Xk/0M9PP4+Ojr6gnx8/np0dP8bFRb/FxES+5eRkvtDPTz+ZmJi9y8rKvoKBAb/Hxsa+urk5vw==",
+      "vectorSha256": "4c584f8bc0e8b4c4245c97ce1d1da0ebaf860c35c2d386320d7dcd3abcb82476",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7bb99ff88686bc6ef99c602e4158ff119b04fce75ccfce1d6763e7764d3f4e23",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-46": {
+      "vector": "9vV1P4qJCT+TkpK+nZwcPtHQUD3a2Vk/uLc3P4SDA7+KiQm/i4qKvt3cXD6CgQE/5uVlP+/u7j7Qz0+/kZAQPa6tLb+2tTU/t7a2PtTTU7/X1tY+qqkpP5qZGT/f3t6+m5qaPr++vj6/vr4+n56ePuDfX7+BgIC7zMtLv/j3d7/29XU/iokJP5OSkr6dnBw+0dBQPdrZWT+4tzc/hIMDv4qJCb+Lioq+3dxcPoKBAT/m5WU/7+7uPtDPT7+RkBA9rq0tv7a1NT+3trY+1NNTv9fW1j6qqSk/mpkZP9/e3r6bmpo+v76+Pr++vj6fnp4+4N9fv4GAgLvMy0u/+Pd3vw==",
+      "vectorSha256": "9f0291484cf8f65e00760e4bca957df93a0a28645f04e7a6176c3f0d83249cbe",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fac45b9386ecdb3e3b5d9bc0f2bb188429daad16b5d4cc48a6afafa7107f1a04",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-47": {
+      "vector": "o6Kivs7NTT/Ix0c/k5KSPpybG7+DgoI+p6amvvf29r6cmxs/y8rKPt3cXD7FxES+nZwcPufm5j6GhQU/+/r6vp2cHL7Ix0c/rKsrv6KhIb/q6Wk/oaCgPKKhIb+bmpo+19bWPoiHBz/f3t4+9/b2vqCfHz+NjAy+g4KCvtbVVb+joqK+zs1NP8jHRz+TkpI+nJsbv4OCgj6npqa+9/b2vpybGz/Lyso+3dxcPsXERL6dnBw+5+bmPoaFBT/7+vq+nZwcvsjHRz+sqyu/oqEhv+rpaT+hoKA8oqEhv5uamj7X1tY+iIcHP9/e3j739va+oJ8fP42MDL6DgoK+1tVVvw==",
+      "vectorSha256": "5dfc1c320f5a58c183b93600030b6c55c38481b02a6ecc5b31bcf7e9fe46d00b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "57e6e3a432a05642cdb29b6793b9c2416ce32a2ff4822fa6b5c3b742cf6e5f15",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-48": {
+      "vector": "oaCgvKmoqL3t7Gy+t7a2vsXERL7Qz08/+vl5P7W0NL6hoKC8uLc3v7m4uL2OjQ0/yMdHP8PCwj7R0FC9n56ePsC/P7/Z2Ng9/Pt7v9jXVz+dnBw+y8rKPv79fb+enR2/jo0NP4GAgDvj4uI+i4qKPu7tbT/HxsY+r66uPpGQED2hoKC8qaiove3sbL63tra+xcREvtDPTz/6+Xk/tbQ0vqGgoLy4tze/ubi4vY6NDT/Ix0c/w8LCPtHQUL2fnp4+wL8/v9nY2D38+3u/2NdXP52cHD7Lyso+/v19v56dHb+OjQ0/gYCAO+Pi4j6Lioo+7u1tP8fGxj6vrq4+kZAQPQ==",
+      "vectorSha256": "b146ef6bf88934f144f1304ba644e6af96558053a7032967cd0c0940b0af1952",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7d75625267e7fc697d2474c6e3b079a7208d02eb93b20131c680b8a2f6b1ab84",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-49": {
+      "vector": "3dxcPuno6L3v7u6+y8rKPsHAQDzU01M/t7a2PpeWlr6WlRU/mZiYPa6tLT+6uTk/np0dP87NTT+Ylxe/paQkvoSDAz+hoKA8oaCgPL++vr739vY+jo0NP+7tbb/k42M/trU1P5WUFD7OzU2/+/r6PpCPD7/493c/zMtLv7i3N7/d3Fw+6ejove/u7r7Lyso+wcBAPNTTUz+3trY+l5aWvpaVFT+ZmJg9rq0tP7q5OT+enR0/zs1NP5iXF7+lpCS+hIMDP6GgoDyhoKA8v76+vvf29j6OjQ0/7u1tv+TjYz+2tTU/lZQUPs7NTb/7+vo+kI8Pv/j3dz/My0u/uLc3vw==",
+      "vectorSha256": "560549c54600a3cca6a0eb1cb7356b4210d6a4a766ffc125af82703ce0637abe",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9b7144b281e9ad5aca89d6dccee6346bc1828250bdc609f1da9219be38fb1a24",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "travel-50": {
+      "vector": "ycjIvdzbWz/39vY+xsVFP8zLS7+1tDQ+hIMDv/b1db/q6Wk/v76+PgAAgL/T0tK++vl5v8TDQ7+GhQW/3dxcvuzraz+opye/o6KiPomIiL2xsDA9pKMjP+rpab/c21u/wL8/v7W0NL7W1VU/4uFhP/38fD6lpCS+kpERP8TDQ7/JyMi93NtbP/f29j7GxUU/zMtLv7W0ND6EgwO/9vV1v+rpaT+/vr4+AACAv9PS0r76+Xm/xMNDv4aFBb/d3Fy+7OtrP6inJ7+joqI+iYiIvbGwMD2koyM/6ulpv9zbW7/Avz+/tbQ0vtbVVT/i4WE//fx8PqWkJL6SkRE/xMNDvw==",
+      "vectorSha256": "454f30406c2c41baa4c105256f99122a87bebe5df6f379440973d23c561a78a5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "73edbde21a963e05f4af004b031e3d64f52ca87785d10b122069eaf09f6bc81e",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-01": {
+      "vector": "tLMzP5STEz/Avz+/vr09P/38fL6amRm/3NtbP+3sbD7U01O/j46OPra1Nb/w72+/zcxMPry7Oz/T0tI+5ONjv8jHR7+koyM/5+bmvqKhIb+cmxu/zcxMvqGgoLyhoKC8wcBAvKinJ7+NjAy+29ravt/e3j7Pzs4+jYwMvtnY2L20szM/lJMTP8C/P7++vT0//fx8vpqZGb/c21s/7exsPtTTU7+Pjo4+trU1v/Dvb7/NzEw+vLs7P9PS0j7k42O/yMdHv6SjIz/n5ua+oqEhv5ybG7/NzEy+oaCgvKGgoLzBwEC8qKcnv42MDL7b2tq+397ePs/Ozj6NjAy+2djYvQ==",
+      "vectorSha256": "9937d49dc519302429020e0b1f726535fbb044c924e77f707fe6ad9376df3407",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d9c920de6033ed9d16a3250899ddb40e1cd1462f32667d7d7e2c6e49b7b36e72",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-02": {
+      "vector": "xcREPqKhIT/Z2Ng9g4KCvp2cHL7c21u/1tVVv5aVFT+gnx+/+vl5v6inJ7/Ix0e//Pt7v4eGhj6amRk/trU1v4WEBD7Z2Ng92djYPZmYmD3493e/19bWPt/e3r7p6Og9/v19P6alJb/k42O/8vFxP8fGxr7Ew0O/mZiYPdjXVz/FxEQ+oqEhP9nY2D2DgoK+nZwcvtzbW7/W1VW/lpUVP6CfH7/6+Xm/qKcnv8jHR7/8+3u/h4aGPpqZGT+2tTW/hYQEPtnY2D3Z2Ng9mZiYPfj3d7/X1tY+397evuno6D3+/X0/pqUlv+TjY7/y8XE/x8bGvsTDQ7+ZmJg92NdXPw==",
+      "vectorSha256": "d60d008cca9f7a512ca59a7f7f1e465e0e081badc05dde98d1bd5804536eb53a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "98d08d5f6c1215ca30032c1c02a1cc25908d8d8904b5488efe2d0ef84e1e89eb",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-03": {
+      "vector": "9vV1v8TDQz+qqSk/jo0Nv8zLS7/083M/yMdHP+7tbb/FxES+4+LiPqGgoDze3V2/s7KyPoWEBD6ysTE/zMtLP62sLL7r6uo+lZQUvuvq6r7Z2Ni92NdXP7u6uj7Avz8/np0dv+rpab/y8XG/vbw8vrq5OT+0szO/hIMDP7++vj729XW/xMNDP6qpKT+OjQ2/zMtLv/Tzcz/Ix0c/7u1tv8XERL7j4uI+oaCgPN7dXb+zsrI+hYQEPrKxMT/My0s/rawsvuvq6j6VlBS+6+rqvtnY2L3Y11c/u7q6PsC/Pz+enR2/6ulpv/Lxcb+9vDy+urk5P7SzM7+EgwM/v76+Pg==",
+      "vectorSha256": "664ea1ea210945e239bc1f81bc848f0bb24af590108ccc09f3d28aa6e9810386",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "05e1d4391af9e30967b88211ac90d8e56aba6d4572ebaedf310b0768dc26c1af",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-04": {
+      "vector": "iokJv4WEBD6Miws/j46OPtTTUz/FxES+3t1dP7GwML3x8HC9oJ8fv+LhYT/19HS+7exsvtjXVz+8uzs/wsFBv+TjYz/HxsY+0dBQvcXERL6wry+//fx8PpOSkj7k42O/rKsrv9nY2D3s62s/kZAQvYiHBz+xsDA9oJ8fP8PCwr6KiQm/hYQEPoyLCz+Pjo4+1NNTP8XERL7e3V0/sbAwvfHwcL2gnx+/4uFhP/X0dL7t7Gy+2NdXP7y7Oz/CwUG/5ONjP8fGxj7R0FC9xcREvrCvL7/9/Hw+k5KSPuTjY7+sqyu/2djYPezraz+RkBC9iIcHP7GwMD2gnx8/w8LCvg==",
+      "vectorSha256": "50275651635dc257b8054c4637dab7193f3ebd75a0c8bf49a36a89c7569b94bb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3b90c5a3e967ee7a7830f06162ebdd1ff1b17967289fa40e2a8df57bc385cf4f",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-05": {
+      "vector": "4N9fP5OSkj66uTm//v19v8bFRb/e3V2/j46OPtva2j6urS2/mJcXP6inJ7/Avz8/gYCAO+3sbD69vDw+AACAv/b1db+opye/vr09P4GAgDukoyM/yMdHv52cHL6ZmJg9urk5P7y7O7+Lioq+5uVlP8TDQz+pqKi91NNTP8LBQb/g318/k5KSPrq5Ob/+/X2/xsVFv97dXb+Pjo4+29raPq6tLb+Ylxc/qKcnv8C/Pz+BgIA77exsPr28PD4AAIC/9vV1v6inJ7++vT0/gYCAO6SjIz/Ix0e/nZwcvpmYmD26uTk/vLs7v4uKir7m5WU/xMNDP6moqL3U01M/wsFBvw==",
+      "vectorSha256": "cd25e8b4f982431d56c4927068b5daef33cb1d0d093148693711118d6335c992",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "efa423011d11a3b629cb2cdf809d9700052cde80d11c6c89dc225df2e175e91f",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-06": {
+      "vector": "gYCAu+3sbL6ZmJg9xMNDv9fW1j7Ew0O/zMtLv4+Ojj7S0VG/p6amvvn4+D3W1VU/urk5P5qZGT+JiIg9hYQEvsjHR7+GhQW/vLs7P6WkJD7My0s/9/b2vtTTUz+Lioq+iokJP+zraz+trCw+jo0Nv97dXT/n5uY+2tlZP62sLD6BgIC77exsvpmYmD3Ew0O/19bWPsTDQ7/My0u/j46OPtLRUb+npqa++fj4PdbVVT+6uTk/mpkZP4mIiD2FhAS+yMdHv4aFBb+8uzs/paQkPszLSz/39va+1NNTP4uKir6KiQk/7OtrP62sLD6OjQ2/3t1dP+fm5j7a2Vk/rawsPg==",
+      "vectorSha256": "31ccc7c2d9ce417b9da5df594df3ad7b4b366d6fb6f1e604f4720639af6f5d7c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7f62891eb51e1aa317568feadccc886f1c3ddd94e542e95dc4f59539eeb9ec95",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-07": {
+      "vector": "vLs7P7m4uD3o52c/paQkvtva2r7Y11e/hYQEPo+Ojj7V1FQ+6ulpP4eGhr6gnx+/pqUlv/v6+j7l5GS+9fR0PqGgoLzn5ua+3dxcvqCfHz/Y11e/lZQUvtDPTz+ysTG/zMtLv5STE7+KiQm/09LSvouKir7b2to+9PNzP7y7O7+8uzs/ubi4PejnZz+lpCS+29ravtjXV7+FhAQ+j46OPtXUVD7q6Wk/h4aGvqCfH7+mpSW/+/r6PuXkZL719HQ+oaCgvOfm5r7d3Fy+oJ8fP9jXV7+VlBS+0M9PP7KxMb/My0u/lJMTv4qJCb/T0tK+i4qKvtva2j7083M/vLs7vw==",
+      "vectorSha256": "438bdf5384386282801351bba91340846278a7b3a471657e0010cf8d9420e7c4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dd8bf36b491490a39af45e302dbe639e7d4664cf146de7271a363b4b5db6f922",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-08": {
+      "vector": "19bWPvb1dT+koyO/09LSvr69Pb+Ylxe/5eRkvpaVFb+0szM/vLs7P8jHRz/HxsY+3dxcPsnIyD2GhQW/1NNTv6qpKb+CgQG/mZiYve7tbT+cmxu/9vV1v5qZGT/5+Pg9z87OPsTDQ7/CwUG/+vl5P9va2j6DgoI+zMtLP6GgoLzX1tY+9vV1P6SjI7/T0tK+vr09v5iXF7/l5GS+lpUVv7SzMz+8uzs/yMdHP8fGxj7d3Fw+ycjIPYaFBb/U01O/qqkpv4KBAb+ZmJi97u1tP5ybG7/29XW/mpkZP/n4+D3Pzs4+xMNDv8LBQb/6+Xk/29raPoOCgj7My0s/oaCgvA==",
+      "vectorSha256": "db076f5cc70237e14b97a586314e0513d0030f45a4bf10574275f6134d4d6faa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b5fa2e4b21346335d9dde3b19b8c3d162b3f76f63205cc8fb31e1ffcb6a0e57d",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-09": {
+      "vector": "jo0NvwAAgL+opyc/q6qqvublZb/r6uq+v76+vq6tLb8AAIC/iYiIPbKxMb/S0VG/iokJv9XUVL7Lyso+7OtrP5WUFD65uLi9oqEhv5qZGb/Z2Ng90M9PP728PD7n5ua+k5KSvtTTUz/9/Hy+yslJv5ybG7+Miwu/9fR0voiHB7+OjQ2/AACAv6inJz+rqqq+5uVlv+vq6r6/vr6+rq0tvwAAgL+JiIg9srExv9LRUb+KiQm/1dRUvsvKyj7s62s/lZQUPrm4uL2ioSG/mpkZv9nY2D3Qz08/vbw8Pufm5r6TkpK+1NNTP/38fL7KyUm/nJsbv4yLC7/19HS+iIcHvw==",
+      "vectorSha256": "70f6df3be06d3bcf90ae3e798c96815cf62b66a60de73df4dcdb42165d1443d9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3900d3550d455029008827173b65b2f592742f338de797465be9601b323a613c",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-10": {
+      "vector": "yslJv/v6+r7CwUE/397evqinJz/7+vo+yslJP7CvLz+Ihwe/9PNzv+jnZz+dnBw+3NtbP5uamr6Ihwe/g4KCvrW0ND7NzEy+iYiIvdPS0r76+Xk/urk5P7KxMb++vT0/9fR0vpaVFT+mpSU/yMdHP7a1Nb+Lioq+ubi4vYKBAb/KyUm/+/r6vsLBQT/f3t6+qKcnP/v6+j7KyUk/sK8vP4iHB7/083O/6OdnP52cHD7c21s/m5qavoiHB7+DgoK+tbQ0Ps3MTL6JiIi909LSvvr5eT+6uTk/srExv769PT/19HS+lpUVP6alJT/Ix0c/trU1v4uKir65uLi9goEBvw==",
+      "vectorSha256": "ac2c6d0995e21b57a8d21302c1954ff7e15d1cc387fb7e53e3e5a06624bf636d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1b41e048d3bee4d73c06f393ed593c5f9666774bfcdc27de61cad2e3255d743f",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-11": {
+      "vector": "iYiIvcTDQ7/Z2Ni96+rqPrGwML2Ihwe/qaiovdrZWb+urS0/l5aWPszLSz/u7W2/6Odnv4KBAb/5+Pi92djYPeblZT/Y11c/0M9PP8bFRb/Y11e/iIcHP8bFRb/Y11e/2NdXv7W0NL7NzEy+sbAwPZOSkr7R0FC96Odnv/Lxcb+JiIi9xMNDv9nY2L3r6uo+sbAwvYiHB7+pqKi92tlZv66tLT+XlpY+zMtLP+7tbb/o52e/goEBv/n4+L3Z2Ng95uVlP9jXVz/Qz08/xsVFv9jXV7+Ihwc/xsVFv9jXV7/Y11e/tbQ0vs3MTL6xsDA9k5KSvtHQUL3o52e/8vFxvw==",
+      "vectorSha256": "4995416ade9c70633264c43bd2deeed17746208eec442c19561e17c1b9fe180f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "771e72ba7a3c7513d6a5e5090c3f708df2ebe71d14c31d14146966855b790c07",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-12": {
+      "vector": "1NNTP8C/P7+opyc/paQkPvj3d7/DwsK+xMNDP9/e3r7e3V2/6+rqvublZb+CgQG/3dxcvu/u7j6rqqq+7exsPtbVVT+WlRU/1NNTv+TjYz/b2tq+5+bmPt/e3j67uro+jYwMPuTjYz/X1ta+goEBv5KREb/Lysq+pKMjP6uqqr7U01M/wL8/v6inJz+lpCQ++Pd3v8PCwr7Ew0M/397evt7dXb/r6uq+5uVlv4KBAb/d3Fy+7+7uPquqqr7t7Gw+1tVVP5aVFT/U01O/5ONjP9va2r7n5uY+397ePru6uj6NjAw+5ONjP9fW1r6CgQG/kpERv8vKyr6koyM/q6qqvg==",
+      "vectorSha256": "9ce73b77eb1dc5aa09d307cc478fdae8478eee868261b75eb25c2c7f59c6e412",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e920d394044fe14811450d3f64bb559deaca16f149b9b7ae91f14a3f374dd155",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-13": {
+      "vector": "np0dP6KhIT+qqSm/3t1dP5KREb/U01O/8fBwvZybGz+8uzs/+Pd3v7CvL7/Ix0c/0M9PP8fGxr6OjQ2/2tlZv4eGhj6fnp4+/v19v7W0NL7k42M/wsFBP5KREb/Ew0O/+vl5v/79fb+wry8/rKsrP8rJSb+wry+/pKMjv8XERD6enR0/oqEhP6qpKb/e3V0/kpERv9TTU7/x8HC9nJsbP7y7Oz/493e/sK8vv8jHRz/Qz08/x8bGvo6NDb/a2Vm/h4aGPp+enj7+/X2/tbQ0vuTjYz/CwUE/kpERv8TDQ7/6+Xm//v19v7CvLz+sqys/yslJv7CvL7+koyO/xcREPg==",
+      "vectorSha256": "a729b158ade84e0111a253858d7cd897793b9e4b368612f83ffed810e5c266b2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ced02bee371678cddd0428e3e74e3913a1a70169f1e0371e0301d7d51b282e98",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-14": {
+      "vector": "19bWPtzbWz+RkBA9lJMTP+jnZz+2tTW/n56ePqmoqD26uTm/0M9PP8nIyD3//v6+tLMzP9bVVT+JiIg9np0dv6alJb/Qz0+/nZwcPrGwML3Pzs4+vbw8vqKhIb/HxsY+zcxMPry7Oz+fnp6+AACAv9jXV7+OjQ2/+Pd3v8nIyD3X1tY+3NtbP5GQED2UkxM/6OdnP7a1Nb+fnp4+qaioPbq5Ob/Qz08/ycjIPf/+/r60szM/1tVVP4mIiD2enR2/pqUlv9DPT7+dnBw+sbAwvc/Ozj69vDy+oqEhv8fGxj7NzEw+vLs7P5+enr4AAIC/2NdXv46NDb/493e/ycjIPQ==",
+      "vectorSha256": "c246452cbf3a76e71e3f2361c26857bd5d5bb1624b72173d10ec4d7e036b9edf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b5ed84c9f325a78a23e78c40d9ea88312d18937ab3682fb199dd58001439048c",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-15": {
+      "vector": "xMNDv+TjY7+DgoI++fj4vd7dXT+JiIi9trU1P5KRET++vT2/m5qaPqKhIT/My0s/yslJv4+Ojj6trCw+x8bGPoaFBT+cmxu/zcxMPsC/P7/Z2Ni9t7a2vpqZGT+8uzs/pqUlv+no6D25uLi909LSvr++vr7V1FQ+qaiovdnY2L3Ew0O/5ONjv4OCgj75+Pi93t1dP4mIiL22tTU/kpERP769Pb+bmpo+oqEhP8zLSz/KyUm/j46OPq2sLD7HxsY+hoUFP5ybG7/NzEw+wL8/v9nY2L23tra+mpkZP7y7Oz+mpSW/6ejoPbm4uL3T0tK+v76+vtXUVD6pqKi92djYvQ==",
+      "vectorSha256": "ee224c4acf170f57eada14ea24e44caaa1ec715dc08db784fcb8acd542ba15f8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1e0ea070ee77dac821a6d0e51ba395b1c23299207252ccdd2d8e744b509a7572",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-16": {
+      "vector": "2djYvZybGz+ioSG///7+PvDvb7/d3Fw+paQkPufm5r7y8XE/sK8vP/X0dL6+vT0/nJsbv87NTT+gnx8/qaioPQAAgL+urS2/vLs7v//+/j7w728/8vFxP+/u7r6urS2/w8LCPsLBQT+Pjo4+w8LCvvn4+L29vDw+5uVlP8fGxr7Z2Ni9nJsbP6KhIb///v4+8O9vv93cXD6lpCQ+5+bmvvLxcT+wry8/9fR0vr69PT+cmxu/zs1NP6CfHz+pqKg9AACAv66tLb+8uzu///7+PvDvbz/y8XE/7+7uvq6tLb/DwsI+wsFBP4+Ojj7DwsK++fj4vb28PD7m5WU/x8bGvg==",
+      "vectorSha256": "d996ebeddce2e30ac2716ffca107ba9d20d7f54b61b03a89bee7dcf2c085a1a0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "72cd2fbf089b9446f8d761de32e6cf8a002922bff7f84429b0e0a34f7097f24e",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-17": {
+      "vector": "/fx8Pp+enj6Qjw+/vbw8vu3sbD6trCw+nJsbv7SzM7+NjAw+zcxMvqalJT/JyMi90M9PP4WEBL6Lioq+j46OPoGAgDvu7W2/l5aWPsnIyL2mpSW/2djYvd7dXb+Qjw8/iYiIvfv6+j7d3Fy+mZiYPdDPTz+Qjw8/nJsbv56dHT/9/Hw+n56ePpCPD7+9vDy+7exsPq2sLD6cmxu/tLMzv42MDD7NzEy+pqUlP8nIyL3Qz08/hYQEvouKir6Pjo4+gYCAO+7tbb+XlpY+ycjIvaalJb/Z2Ni93t1dv5CPDz+JiIi9+/r6Pt3cXL6ZmJg90M9PP5CPDz+cmxu/np0dPw==",
+      "vectorSha256": "f4d8a4c19bd4d72abe4709e1b4fc683da47322e989831b210ccd7190bb379cc7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9fa738689d9532269166d273e76f5da38009a5732d7211c777be6489e7c732ce",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-18": {
+      "vector": "ycjIPfb1dT+HhoY+lpUVP8fGxj7DwsK+wcBAPNLRUb/o52e/k5KSPp+enj66uTk/kI8PP5WUFL729XU/1dRUvouKij6UkxM/j46OvtPS0j6Miws/rKsrv6Oioj7d3Fy+n56evqempr6CgQE/lpUVv4GAgLv//v4++Pd3v+TjYz/JyMg99vV1P4eGhj6WlRU/x8bGPsPCwr7BwEA80tFRv+jnZ7+TkpI+n56ePrq5OT+Qjw8/lZQUvvb1dT/V1FS+i4qKPpSTEz+Pjo6+09LSPoyLCz+sqyu/o6KiPt3cXL6fnp6+p6amvoKBAT+WlRW/gYCAu//+/j7493e/5ONjPw==",
+      "vectorSha256": "b0e8afb61d901f2136cc9237b74928c4ecf29e51ccc45e56aa5ef9db9d72ad3a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8cfaa1cab14f81170ca4a7dcc76dfa65a2c95cb4c52aa8645856c0357fbf04f1",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-20": {
+      "vector": "goEBv4iHBz+vrq4+rKsrP+DfX7/083O/ubi4PYWEBD6UkxM/oaCgvKmoqL2FhAS+1tVVv7GwMD2UkxM/5ONjP7m4uL2bmpo+v76+PvPy8j7My0s/kpERP8XERL7My0u/5uVlP/HwcD2fnp4+8fBwvd/e3r6/vr6+vr09P/b1db+CgQG/iIcHP6+urj6sqys/4N9fv/Tzc7+5uLg9hYQEPpSTEz+hoKC8qaiovYWEBL7W1VW/sbAwPZSTEz/k42M/ubi4vZuamj6/vr4+8/LyPszLSz+SkRE/xcREvszLS7/m5WU/8fBwPZ+enj7x8HC9397evr++vr6+vT0/9vV1vw==",
+      "vectorSha256": "0945e3354f97f19b73314668e4d5afbe8f9c3a4b29fa05e8c721c047f65c03c0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3fc3abd510068b90c97d756f1585c9f174a6afbce5c8671af287a7784850de05",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-21": {
+      "vector": "yMdHP/v6+r6BgIC7tbQ0PoyLCz+urS0/rawsPsbFRT+lpCS+qKcnP7W0ND7b2to+8fBwPZKRET/i4WE/hIMDP42MDL6Miws/wcBAPI+Ojr7d3Fw+gYCAO5eWlr7a2Vk/qqkpP769PT+CgQE/xcREPpCPD7+wry8/0M9Pv+no6D3Ix0c/+/r6voGAgLu1tDQ+jIsLP66tLT+trCw+xsVFP6WkJL6opyc/tbQ0Ptva2j7x8HA9kpERP+LhYT+EgwM/jYwMvoyLCz/BwEA8j46Ovt3cXD6BgIA7l5aWvtrZWT+qqSk/vr09P4KBAT/FxEQ+kI8Pv7CvLz/Qz0+/6ejoPQ==",
+      "vectorSha256": "92f994b3bb5a61dff426c073d90f5e61e3a6d7dfd1b40589557c5f1973bc0a12",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e3417f96c5d695e26bd396b687c8f0c16ec5815c9b805aecd4dec09838d7188e",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-22": {
+      "vector": "7Otrv/Dvb7/5+Pg909LSvs3MTL6fnp6+v76+PpiXFz/Ix0c/p6amPuDfXz/Y11e/jYwMvr++vr6koyM/4eDgPJeWlr66uTk/6ulpv5CPDz+urS2/kpERv6CfHz+Ylxc/1tVVP7u6uj6sqys/h4aGvuDfXz/Qz0+/t7a2Pu/u7j7s62u/8O9vv/n4+D3T0tK+zcxMvp+enr6/vr4+mJcXP8jHRz+npqY+4N9fP9jXV7+NjAy+v76+vqSjIz/h4OA8l5aWvrq5OT/q6Wm/kI8PP66tLb+SkRG/oJ8fP5iXFz/W1VU/u7q6PqyrKz+Hhoa+4N9fP9DPT7+3trY+7+7uPg==",
+      "vectorSha256": "eed61aa66c68ec35e04318b9e20d8f3440818b32dc38e8f9513f470449b9e5f3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0a088f4b6658afcbe3a9ef146e50d1835adc0bc72937cfcbeaaed55eef18adbb",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-23": {
+      "vector": "5+bmvujnZ7/l5GQ+sbAwPe3sbL6enR2/9fR0vo6NDT+ysTG/AACAP+TjYz/My0u/9fR0Po+Ojj6BgIC7ycjIvbCvL7+qqSm/jYwMPpeWlj7T0tI+AACAP7++vj6NjAw+tbQ0PoeGhr7s62s/19bWvp6dHT/My0s/uLc3v97dXb/n5ua+6Odnv+XkZD6xsDA97exsvp6dHb/19HS+jo0NP7KxMb8AAIA/5ONjP8zLS7/19HQ+j46OPoGAgLvJyMi9sK8vv6qpKb+NjAw+l5aWPtPS0j4AAIA/v76+Po2MDD61tDQ+h4aGvuzraz/X1ta+np0dP8zLSz+4tze/3t1dvw==",
+      "vectorSha256": "29fd970f059e5d69a2c0ff8bf523a20e3845b170e2a5a817c0b5fabe93259b39",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "460c9c85623161c627fff11a9ea37f73282b91a5b4ffaf91965ef54acee52411",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-24": {
+      "vector": "/v19P42MDL6+vT2/iYiIvcLBQb/39vY+wL8/P8zLS7/9/Hy+9/b2Pr69PT+GhQW/n56ePqalJb/7+vq+ubi4Pfr5eb+Ylxc/qKcnv5WUFL60szM/mJcXv5eWlj6EgwM/h4aGvvHwcL3Lyso+vbw8PrOysr7HxsY+kI8Pv4SDA7/+/X0/jYwMvr69Pb+JiIi9wsFBv/f29j7Avz8/zMtLv/38fL739vY+vr09P4aFBb+fnp4+pqUlv/v6+r65uLg9+vl5v5iXFz+opye/lZQUvrSzMz+Ylxe/l5aWPoSDAz+Hhoa+8fBwvcvKyj69vDw+s7KyvsfGxj6Qjw+/hIMDvw==",
+      "vectorSha256": "99c4b7e421cd545bf0713872981a49aaafcf4f4d1b46d42d138e89eb0472e025",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fe6e21771fbddf1a60bdde3da72d418b03cb2c6dd934a5c15e78b29753b1383e",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-25": {
+      "vector": "9fR0Prq5Ob+OjQ0/4uFhv8XERD6mpSU/uLc3P7CvLz/39va+0M9PP7q5Ob/X1ta+trU1v+fm5r6NjAy+8fBwvZybGz+bmpq+kpERv5ybGz+trCy+urk5v9zbW7/n5uY+7+7uPtfW1r6OjQ2/trU1P//+/r7i4WG/o6KivqalJb/19HQ+urk5v46NDT/i4WG/xcREPqalJT+4tzc/sK8vP/f29r7Qz08/urk5v9fW1r62tTW/5+bmvo2MDL7x8HC9nJsbP5uamr6SkRG/nJsbP62sLL66uTm/3Ntbv+fm5j7v7u4+19bWvo6NDb+2tTU///7+vuLhYb+joqK+pqUlvw==",
+      "vectorSha256": "aad4aecc26cd7f5ca7bd3379a9bb3ec023a65fe2f9452a5ccb7308b34d20bed3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9e23c60f98d2dbd742e7234a25466e78cd5937cd6a2312b9bb4a39da400f572d",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-26": {
+      "vector": "2djYvejnZ7+SkRE/rKsrv7u6ur79/Hy+nJsbv5OSkj6/vr4+gYCAu42MDL7c21u/1tVVP+LhYT///v6+5eRkPsHAQDyjoqK+6+rqPrW0ND7c21u/iIcHP/f29j6EgwO/sK8vP6Oioj7d3Fy+goEBv9HQUL3g31+/jIsLP6qpKb/Z2Ni96Odnv5KRET+sqyu/u7q6vv38fL6cmxu/k5KSPr++vj6BgIC7jYwMvtzbW7/W1VU/4uFhP//+/r7l5GQ+wcBAPKOior7r6uo+tbQ0PtzbW7+Ihwc/9/b2PoSDA7+wry8/o6KiPt3cXL6CgQG/0dBQveDfX7+Miws/qqkpvw==",
+      "vectorSha256": "dc3614f063df4c68900de9dc3131c8b0c2766638ea08fbb41b53b3f2993fb5b7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "720cc82a516032a4af7f6e12eaf0409c8157ba9612c3bd3ed7a8643f7910c52b",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-27": {
+      "vector": "hYQEvqSjIz+dnBw+q6qqPqWkJD729XU/urk5v8fGxr7j4uK+5eRkvqmoqL2dnBw+4N9fP4eGhj6GhQU/kpERv4yLCz+ioSG/zs1NP+no6D3a2Vk/iYiIPa2sLL7OzU2/r66uvtjXVz+dnBw++vl5v/HwcL2Ihwe/9fR0PvTzc7+FhAS+pKMjP52cHD6rqqo+paQkPvb1dT+6uTm/x8bGvuPi4r7l5GS+qaiovZ2cHD7g318/h4aGPoaFBT+SkRG/jIsLP6KhIb/OzU0/6ejoPdrZWT+JiIg9rawsvs7NTb+vrq6+2NdXP52cHD76+Xm/8fBwvYiHB7/19HQ+9PNzvw==",
+      "vectorSha256": "d5067c90211ced0bd431cc4f2d4a0465b18b75f521905f12d1ad702bcf1de295",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6fd193aa94fa234e47637593efa1c237c52fe68eec886a1954eb9303783c9e06",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-28": {
+      "vector": "nZwcPoKBAb/29XW/7u1tv8XERL6vrq6+1NNTv8zLSz/Ix0e/+fj4vczLS7+enR0/zMtLP728PD7Ix0c/0M9PP/r5eb/Pzs6+/fx8PuHg4LympSW/np0dP4aFBb/U01O/6ulpv+fm5j6trCy+pqUlP+/u7r6amRk/jYwMPoWEBD6dnBw+goEBv/b1db/u7W2/xcREvq+urr7U01O/zMtLP8jHR7/5+Pi9zMtLv56dHT/My0s/vbw8PsjHRz/Qz08/+vl5v8/Ozr79/Hw+4eDgvKalJb+enR0/hoUFv9TTU7/q6Wm/5+bmPq2sLL6mpSU/7+7uvpqZGT+NjAw+hYQEPg==",
+      "vectorSha256": "27976a189dec98c73b862aca3295222765bf4f5945675269e7d7d591fcedc2ad",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "933f0509675416e51c701acee597e3e7034c9f7c2dce3d160bb96ad244cc9190",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-29": {
+      "vector": "8/LyvqOior60szO/hoUFP83MTL6KiQk/j46OPtjXVz+mpSU/v76+voSDA7/o52c/y8rKPra1Nb/h4OC8oaCgPN7dXb+zsrK+wL8/P/LxcT/7+vo+lJMTv+zraz/q6Wm/jo0Nv6KhIb+OjQ2/wL8/v/Py8j6HhoY+j46OvpOSkj7z8vK+o6KivrSzM7+GhQU/zcxMvoqJCT+Pjo4+2NdXP6alJT+/vr6+hIMDv+jnZz/Lyso+trU1v+Hg4LyhoKA83t1dv7Oysr7Avz8/8vFxP/v6+j6UkxO/7OtrP+rpab+OjQ2/oqEhv46NDb/Avz+/8/LyPoeGhj6Pjo6+k5KSPg==",
+      "vectorSha256": "4187cb0f605dc9376d047e328bb031a9c70d5724ad869c400404bc1e260ba2c6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "435726c266c4a3ebd2503ef3b2257c821153dff8be36f50b392f3920bca15ca4",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-30": {
+      "vector": "kpERP4eGhr6Pjo6+yslJP6GgoDzz8vK+6Odnv4WEBL6KiQk/wL8/P6GgoDzf3t6+vr09P/Tzcz/8+3s/xsVFP5STEz+pqKg9zs1NP9DPT7+FhAS+uLc3P4eGhr7X1tY+pqUlP//+/r6Pjo6+7Otrv/Py8r719HQ+/v19v8HAQLySkRE/h4aGvo+Ojr7KyUk/oaCgPPPy8r7o52e/hYQEvoqJCT/Avz8/oaCgPN/e3r6+vT0/9PNzP/z7ez/GxUU/lJMTP6moqD3OzU0/0M9Pv4WEBL64tzc/h4aGvtfW1j6mpSU///7+vo+Ojr7s62u/8/LyvvX0dD7+/X2/wcBAvA==",
+      "vectorSha256": "9faad8e2c8617cee2ca3d69b1e1a83644fedb10a62ef35922641ea8d9aa07445",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c85e5ce482430c6fc4df8248def9fde2c98ae6186fdb5eb5d2405c0a439e017e",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-31": {
+      "vector": "h4aGPuHg4DzS0VE/5+bmPpybG7+ZmJi9vbw8PrKxMT+xsDC9p6amvqmoqD3R0FC9j46OvrKxMb+EgwM/6ejoPeLhYT/f3t6+rq0tv62sLL7Avz+/urk5P/HwcD2+vT2/8vFxv5iXF7+opye/+fj4PdnY2D3s62u/jIsLv87NTb+HhoY+4eDgPNLRUT/n5uY+nJsbv5mYmL29vDw+srExP7GwML2npqa+qaioPdHQUL2Pjo6+srExv4SDAz/p6Og94uFhP9/e3r6urS2/rawsvsC/P7+6uTk/8fBwPb69Pb/y8XG/mJcXv6inJ7/5+Pg92djYPezra7+Miwu/zs1Nvw==",
+      "vectorSha256": "aa61407a2c0d2a1a85272758d0b4869ec48695e3805a85fde7753f8ea5408fbb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a183e8b9327697d87a568a795c27c18ef048296a20dc872107342c8f8d0a3a19",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-32": {
+      "vector": "8vFxP8LBQb/U01O/k5KSPtTTUz+Pjo6+AACAv8fGxr7493e/x8bGvrW0ND66uTm/kZAQPcbFRb+vrq4+sK8vP7q5Ob/g318/29ravv38fD7Avz+/zcxMvvv6+r6SkRG/s7KyvoOCgr65uLi9sbAwvf38fD6mpSW/lJMTv7SzMz/y8XE/wsFBv9TTU7+TkpI+1NNTP4+Ojr4AAIC/x8bGvvj3d7/Hxsa+tbQ0Prq5Ob+RkBA9xsVFv6+urj6wry8/urk5v+DfXz/b2tq+/fx8PsC/P7/NzEy++/r6vpKREb+zsrK+g4KCvrm4uL2xsDC9/fx8PqalJb+UkxO/tLMzPw==",
+      "vectorSha256": "cb8794a6e461293c745dfa540204c292aad85aad89086da9a934ee23e748bbc1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f81f16a4e95c004e044e9623841dabd723ef499f20664137535f747a9f2d36d9",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-33": {
+      "vector": "lZQUPs7NTT/e3V0/3dxcPvPy8r76+Xk/lpUVv/j3dz+0szO/4N9fv728PL63trY++/r6PqKhIT+wry+/6ulpP9PS0r6VlBQ+x8bGPv/+/r7GxUW/goEBP5+enr6dnBw+zMtLv7q5OT+/vr4+4N9fP7SzM7+Lioo+/v19P/38fD6VlBQ+zs1NP97dXT/d3Fw+8/Lyvvr5eT+WlRW/+Pd3P7SzM7/g31+/vbw8vre2tj77+vo+oqEhP7CvL7/q6Wk/09LSvpWUFD7HxsY+//7+vsbFRb+CgQE/n56evp2cHD7My0u/urk5P7++vj7g318/tLMzv4uKij7+/X0//fx8Pg==",
+      "vectorSha256": "f09e589628d9bb56c6ebc00a880d9b6c9d0939a821b23afbf56be742766f301b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "92e6ee9b43fc35fb261068adbed028f44b92b1401dc058931adcafef26a2fe9f",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-34": {
+      "vector": "r66uPvDvbz+7uro+9fR0vpaVFT/v7u6+1NNTP+TjY7+zsrK+hoUFv+Hg4DzJyMi9paQkPoaFBb+wry+/q6qqvvf29r6zsrK+hoUFv5qZGb/+/X2/rawsvqGgoLygnx8/2djYPYqJCb/l5GQ+29raPpmYmD3b2to+w8LCvtTTU7+vrq4+8O9vP7u6uj719HS+lpUVP+/u7r7U01M/5ONjv7Oysr6GhQW/4eDgPMnIyL2lpCQ+hoUFv7CvL7+rqqq+9/b2vrOysr6GhQW/mpkZv/79fb+trCy+oaCgvKCfHz/Z2Ng9iokJv+XkZD7b2to+mZiYPdva2j7DwsK+1NNTvw==",
+      "vectorSha256": "ecd913c5645a9d2314de677e8e32c121d98944fd1599b466d43e289801a91696",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "abf7ae61ca44e90e533d8373943d285542533d33016a7dcf8d3b9cb689b64f16",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-35": {
+      "vector": "z87OPqSjIz+XlpY+0M9Pv4iHBz/x8HA91NNTP9/e3r7w72+/9PNzP+rpaT+CgQG/8O9vP4aFBT/FxEQ+jIsLv4aFBb+npqa+uLc3v/z7ez+EgwO/vbw8PsfGxj6KiQk/ycjIPY6NDT+9vDy+09LSPsjHRz/NzEw++vl5v6inJz/Pzs4+pKMjP5eWlj7Qz0+/iIcHP/HwcD3U01M/397evvDvb7/083M/6ulpP4KBAb/w728/hoUFP8XERD6Miwu/hoUFv6empr64tze//Pt7P4SDA7+9vDw+x8bGPoqJCT/JyMg9jo0NP728PL7T0tI+yMdHP83MTD76+Xm/qKcnPw==",
+      "vectorSha256": "ab893a3af1a19c64a10e2ea7975253b6ccfac1559b4978b691e40e2fc06a16b5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b3d1a518c387e94808f9f43ff7c2983a3d5624fd3e97b1c48cc668b4e39903d3",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-36": {
+      "vector": "6ejove/u7j7My0u/oaCgvLm4uD3Pzs6+5uVlP/b1dT/h4OA86ejovcbFRT+npqa+397evuHg4DyJiIi9sbAwPdbVVb/U01O/nJsbv6empr6hoKC8h4aGPtfW1j7g31+/xMNDv/v6+r6OjQ0/sbAwPaKhIb+wry8/oJ8fv/Lxcb/p6Oi97+7uPszLS7+hoKC8ubi4Pc/Ozr7m5WU/9vV1P+Hg4Dzp6Oi9xsVFP6empr7f3t6+4eDgPImIiL2xsDA91tVVv9TTU7+cmxu/p6amvqGgoLyHhoY+19bWPuDfX7/Ew0O/+/r6vo6NDT+xsDA9oqEhv7CvLz+gnx+/8vFxvw==",
+      "vectorSha256": "1f99b61fec2dd741d7df8d065c0fc97d2913f6d55bc476906b30b08b2940e141",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "71bb1a7d8b4cf2fa8371e25648837785151632567da1b5101e41c6852fd73007",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-37": {
+      "vector": "oqEhv8nIyL3Ew0M/r66uvq6tLb/z8vI+4+Livru6uj7Avz+/g4KCPqalJb+Qjw8/s7KyvpGQEL3q6Wm/+vl5P/z7e7/083O/p6amvsXERL6WlRW//fx8vujnZz+KiQk/jIsLP6KhIT/Qz08/6+rqvre2tr6mpSU/oaCgPOrpab+ioSG/ycjIvcTDQz+vrq6+rq0tv/Py8j7j4uK+u7q6PsC/P7+DgoI+pqUlv5CPDz+zsrK+kZAQverpab/6+Xk//Pt7v/Tzc7+npqa+xcREvpaVFb/9/Hy+6OdnP4qJCT+Miws/oqEhP9DPTz/r6uq+t7a2vqalJT+hoKA86ulpvw==",
+      "vectorSha256": "06762e0156de70d29d6e240760bc9067648d395c08560c67c9cbef4b4225daa9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2f73e15429bc47ae20a02dc7537b0bfc020656673560f3c4c5d0e74552d2820b",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-38": {
+      "vector": "7Otrv+XkZD6joqI+8O9vP46NDT+npqa+jo0NP9zbWz/b2to+hoUFv6KhIT/h4OC8nZwcvoGAgDvKyUm/h4aGPoqJCb+0szO/j46OvsXERL6zsrI+yMdHv56dHT/FxES+5uVlP5WUFL6+vT0/u7q6vv38fD7i4WG/8O9vvwAAgD/s62u/5eRkPqOioj7w728/jo0NP6empr6OjQ0/3NtbP9va2j6GhQW/oqEhP+Hg4LydnBy+gYCAO8rJSb+HhoY+iokJv7SzM7+Pjo6+xcREvrOysj7Ix0e/np0dP8XERL7m5WU/lZQUvr69PT+7urq+/fx8PuLhYb/w72+/AACAPw==",
+      "vectorSha256": "f78476e253174c7a19da24db35aaaea9a651730897c683287f8bc8230c530514",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0a9ca8f7c656c6edb63dd07c6c801ba13b265c67ac1cce67f26dde519f0f08ff",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-39": {
+      "vector": "vr09v6CfHz/w72+/8O9vP46NDT/o52e/29raPsrJSb/39va+zcxMPqOior63trY+zcxMvqinJ7/Pzs4+8/Lyvv79fT+vrq4+6ulpv6alJT+cmxu/+fj4vefm5j7JyMg9g4KCvquqqj6DgoK+x8bGPr++vj6fnp4+3dxcvoOCgj6+vT2/oJ8fP/Dvb7/w728/jo0NP+jnZ7/b2to+yslJv/f29r7NzEw+o6Kivre2tj7NzEy+qKcnv8/Ozj7z8vK+/v19P6+urj7q6Wm/pqUlP5ybG7/5+Pi95+bmPsnIyD2DgoK+q6qqPoOCgr7HxsY+v76+Pp+enj7d3Fy+g4KCPg==",
+      "vectorSha256": "3dd2cc2f3b5f08f2bc0fc72094b7a9ae2fb4e1c5e5975c34e5e4d189adea015d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "21cf08f7c60cb61b429957ad662cb343feab0bd23270b98c5faa5fb1afa764a0",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-40": {
+      "vector": "zcxMvrCvLz/OzU0/1dRUvuDfXz/9/Hy+1NNTv+/u7j7u7W2/7u1tv8rJSb+cmxs/7+7uvvr5eb+Ihwe/4+LiPq6tLb+FhAQ+rKsrv+TjYz/Z2Ni95+bmPv38fL7d3Fy+x8bGvu7tbT/z8vK+5ONjv+DfXz+koyM/kpERv+zraz/NzEy+sK8vP87NTT/V1FS+4N9fP/38fL7U01O/7+7uPu7tbb/u7W2/yslJv5ybGz/v7u6++vl5v4iHB7/j4uI+rq0tv4WEBD6sqyu/5ONjP9nY2L3n5uY+/fx8vt3cXL7Hxsa+7u1tP/Py8r7k42O/4N9fP6SjIz+SkRG/7OtrPw==",
+      "vectorSha256": "890b4b6258f18ac15de32f2ca13306bb3888b94e8eb1bd26e4e26c433d2c7df0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "66d7e665ef6016bb09091bcd44033cb829902af172b960644ef6430eefd137f5",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "humor-41": {
+      "vector": "sbAwPb28PD7i4WE/xcREPq6tLb/39va+4+LiPrm4uD26uTm/tbQ0PoSDAz/w728/5+bmPsLBQb+BgIA7w8LCPsLBQb/7+vo+3t1dP+TjY7/w72+/9vV1v62sLL7r6uo+kI8PP9bVVT+Hhoa+29raPu3sbD7083O/29raPpiXFz+xsDA9vbw8PuLhYT/FxEQ+rq0tv/f29r7j4uI+ubi4Pbq5Ob+1tDQ+hIMDP/Dvbz/n5uY+wsFBv4GAgDvDwsI+wsFBv/v6+j7e3V0/5ONjv/Dvb7/29XW/rawsvuvq6j6Qjw8/1tVVP4eGhr7b2to+7exsPvTzc7/b2to+mJcXPw==",
+      "vectorSha256": "fc1f6763f05ed3daa5129d5ca79e895d15ac8d4032c21e6cfb6215c28454caa7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8597f0982942b88b2396c1f7b91f80b01fbeee0e08056abac7ea5eb69d06b6cb",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "humor-42": {
+      "vector": "ubi4PdfW1r6cmxu/7+7uPvz7ez+cmxs/qKcnv8rJST+pqKg9lpUVv8LBQb/FxEQ+lpUVPwAAgD/7+vq+sbAwvc/Ozr6XlpY+mZiYvcrJST/Qz0+/wcBAPKmoqL3f3t4+iokJP/38fD6xsDC9srExv62sLL6xsDA9u7q6vu3sbD65uLg919bWvpybG7/v7u4+/Pt7P5ybGz+opye/yslJP6moqD2WlRW/wsFBv8XERD6WlRU/AACAP/v6+r6xsDC9z87OvpeWlj6ZmJi9yslJP9DPT7/BwEA8qaiovd/e3j6KiQk//fx8PrGwML2ysTG/rawsvrGwMD27urq+7exsPg==",
+      "vectorSha256": "d937b247a95d969bc797fa3deb9e150448e69ea060186a2dda90c871c21d1d70",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8b4a32bbfdcd2ce48a351f98caff417a4ca576e4188175b7c49f7a276a85519d",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "humor-43": {
+      "vector": "+Pd3P5uamr7y8XE/AACAP/n4+D2hoKA8kpERP8bFRT/DwsI+5+bmvp6dHb/R0FC9tLMzP4KBAb+2tTW/2NdXP9LRUT/Ix0c/l5aWvqSjIz+amRm/1tVVv6moqD2Ylxc/wcBAvNPS0j7HxsY+hYQEPvTzcz/Pzs4++Pd3P4yLC7/493c/m5qavvLxcT8AAIA/+fj4PaGgoDySkRE/xsVFP8PCwj7n5ua+np0dv9HQUL20szM/goEBv7a1Nb/Y11c/0tFRP8jHRz+Xlpa+pKMjP5qZGb/W1VW/qaioPZiXFz/BwEC809LSPsfGxj6FhAQ+9PNzP8/Ozj7493c/jIsLvw==",
+      "vectorSha256": "10378d3bf22bb05624462ec7ae07b485839d5a6b6813af8b2a05fb3a928b629c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fb59f8ff8f82c8e2b0463179d93f25ebe8e35ad133158acb7eb4b190f9b3fb3a",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "humor-44": {
+      "vector": "nZwcPrm4uL3W1VW/nJsbv8LBQT+8uzs/j46OvtjXVz/g318/pqUlP5mYmD2Xlpa+8/Lyvvn4+L36+Xk/rawsPv/+/r7Y11c/mZiYPaqpKb+0szM/nJsbv4aFBT/T0tI+/v19v6moqD2Ylxc/kpERP7CvLz/Avz+/397ePvDvbz+dnBw+ubi4vdbVVb+cmxu/wsFBP7y7Oz+Pjo6+2NdXP+DfXz+mpSU/mZiYPZeWlr7z8vK++fj4vfr5eT+trCw+//7+vtjXVz+ZmJg9qqkpv7SzMz+cmxu/hoUFP9PS0j7+/X2/qaioPZiXFz+SkRE/sK8vP8C/P7/f3t4+8O9vPw==",
+      "vectorSha256": "53b269f52c415e1e3110974f5ec1643ed935363a42dfa66254bb1211d7f51e86",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "93741532e0dd5cebefd2895a4370fc9540eb892bd932c2b4018acbc8d720b7f7",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "humor-45": {
+      "vector": "zcxMPpCPDz+lpCQ++/r6PuXkZL7KyUm/6OdnP5WUFL7U01O/2NdXv6GgoDzW1VU/2NdXv4mIiL2bmpq+8O9vP6qpKT/e3V2/7u1tP52cHD69vDy+jo0NP9va2r6koyM/1NNTP66tLb/X1tY+9PNzP42MDD4AAIA/+Pd3P9jXV7/NzEw+kI8PP6WkJD77+vo+5eRkvsrJSb/o52c/lZQUvtTTU7/Y11e/oaCgPNbVVT/Y11e/iYiIvZuamr7w728/qqkpP97dXb/u7W0/nZwcPr28PL6OjQ0/29ravqSjIz/U01M/rq0tv9fW1j7083M/jYwMPgAAgD/493c/2NdXvw==",
+      "vectorSha256": "bd45eef0646ff70c891eba2b1ecf9da446c8c2328bd929ae8c354514e953c7d6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "99c794be631bf36d161482ea147759f7d411f69368c649d1e929b5f991fffb14",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "humor-46": {
+      "vector": "np0dv9PS0j6vrq4+mZiYPfn4+L2xsDC9lZQUPpCPDz+pqKi9oqEhv66tLT+lpCS+7+7uvvDvb7/19HS+lZQUvoqJCT+xsDA93dxcPsrJSb/S0VE/pqUlP6CfH7+sqys/uLc3v7++vr6Ylxc/i4qKvqSjIz/OzU0/nZwcvoiHBz+enR2/09LSPq+urj6ZmJg9+fj4vbGwML2VlBQ+kI8PP6moqL2ioSG/rq0tP6WkJL7v7u6+8O9vv/X0dL6VlBS+iokJP7GwMD3d3Fw+yslJv9LRUT+mpSU/oJ8fv6yrKz+4tze/v76+vpiXFz+Lioq+pKMjP87NTT+dnBy+iIcHPw==",
+      "vectorSha256": "0fa07e59481cffc10987feaed94811431a5227960506462ae408aa8b9879ebb9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "31b4ab89707a92c7752fd66b4408616dc4859b1be8d230d52450cb5dd1e66cc3",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "humor-49": {
+      "vector": "oJ8fv728PD7f3t6+2tlZv+7tbb+Qjw+/19bWPtbVVb/X1tY+19bWvsTDQz/Pzs4+oaCgPLy7Oz/JyMg9397ePoeGhr7Ew0M/iYiIPfr5eb+5uLg9q6qqPv38fL60szM/j46OPs7NTT/+/X2/pqUlP6GgoLyHhoa+1tVVv8vKyj6gnx+/vbw8Pt/e3r7a2Vm/7u1tv5CPD7/X1tY+1tVVv9fW1j7X1ta+xMNDP8/Ozj6hoKA8vLs7P8nIyD3f3t4+h4aGvsTDQz+JiIg9+vl5v7m4uD2rqqo+/fx8vrSzMz+Pjo4+zs1NP/79fb+mpSU/oaCgvIeGhr7W1VW/y8rKPg==",
+      "vectorSha256": "177f2039c629b88cbd8520a738ea869e5caad5a129a70525e3b0f11b8925c914",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "309748130938b515b54ae1b382dd8cb75ee188038baa60d9a3e601d27d5e15b2",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-01": {
+      "vector": "rawsPq2sLD7z8vI+6ejoPc/Ozj7FxES+2tlZP5aVFT/d3Fy+8fBwPcnIyL3R0FA9rKsrv4uKij7m5WW/7Otrv5CPD7+GhQU//fx8Pvv6+r7k42M/t7a2vr69PT+RkBC9397ePoWEBD6EgwO/np0dP7Oysj7t7Gw+sK8vv/j3dz+trCw+rawsPvPy8j7p6Og9z87OPsXERL7a2Vk/lpUVP93cXL7x8HA9ycjIvdHQUD2sqyu/i4qKPublZb/s62u/kI8Pv4aFBT/9/Hw++/r6vuTjYz+3tra+vr09P5GQEL3f3t4+hYQEPoSDA7+enR0/s7KyPu3sbD6wry+/+Pd3Pw==",
+      "vectorSha256": "2c5e4c6361d2a4bb2b9819b41ca57890d524d0e6061a6b45a2720d247e8d624c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9595bc8eb367ecca648773862aa20d0a38c29f41f152de7bb7903eceac9d28fb",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-02": {
+      "vector": "rq0tv5mYmD2fnp6+7exsPtTTU7/j4uK+jYwMvoqJCb/t7Gw+3dxcPpiXFz+XlpY+0dBQvaWkJL6wry8/4eDgPP/+/r6BgIA7p6amPrm4uL3Lyso+3Ntbv6empj77+vo+sK8vv9PS0j76+Xk/8/LyvrKxMT/b2tq+rq0tP8PCwr6urS2/mZiYPZ+enr7t7Gw+1NNTv+Pi4r6NjAy+iokJv+3sbD7d3Fw+mJcXP5eWlj7R0FC9paQkvrCvLz/h4OA8//7+voGAgDunpqY+ubi4vcvKyj7c21u/p6amPvv6+j6wry+/09LSPvr5eT/z8vK+srExP9va2r6urS0/w8LCvg==",
+      "vectorSha256": "146cd3d9e7504d119851dfef2539136b775f61e512052f9ef495c03f3b7e377b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2989589d16476e3b9d9bcba5796bd7834080a974b212a9be28b4fc43d849d64f",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-03": {
+      "vector": "6ulpP6yrKz+amRm/paQkvqCfH7+NjAy+lJMTP9zbW7+urS2/19bWPqOioj7d3Fw+1dRUPoeGhr7r6uo+s7Kyvv38fL7S0VG/kI8Pv4eGhj6Ihwc/pqUlv9zbW7/19HS+2tlZv6inJ7+urS2/x8bGvt3cXL7Z2Ni9lZQUPt7dXb/q6Wk/rKsrP5qZGb+lpCS+oJ8fv42MDL6UkxM/3Ntbv66tLb/X1tY+o6KiPt3cXD7V1FQ+h4aGvuvq6j6zsrK+/fx8vtLRUb+Qjw+/h4aGPoiHBz+mpSW/3Ntbv/X0dL7a2Vm/qKcnv66tLb/Hxsa+3dxcvtnY2L2VlBQ+3t1dvw==",
+      "vectorSha256": "a4a696b6f01cae1b60c7f57247dfd03a2705c9984b5dbe244e5508898f0f64ab",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f4d5336b306ec91229b5a89b9a5eba53601738a1c32d1261132c294e64729211",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-04": {
+      "vector": "oaCgvPX0dL6DgoK+6ulpv6qpKb+rqqo+hoUFv8vKyj7e3V0/8O9vP+no6L3493c/9fR0PurpaT/7+vo+uLc3v6CfHz+CgQG/kI8Pv8C/P7+4tzc/mpkZv/v6+r7g318/h4aGvvz7e7+9vDy+vLs7P6WkJD7KyUm/sbAwPf/+/j6hoKC89fR0voOCgr7q6Wm/qqkpv6uqqj6GhQW/y8rKPt7dXT/w728/6ejovfj3dz/19HQ+6ulpP/v6+j64tze/oJ8fP4KBAb+Qjw+/wL8/v7i3Nz+amRm/+/r6vuDfXz+Hhoa+/Pt7v728PL68uzs/paQkPsrJSb+xsDA9//7+Pg==",
+      "vectorSha256": "70906032ec66d06a6f79cfe913a960eeb5e62e568b5cc3550a689a2f2cbb2deb",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7d615f0b2baa3db2eef771fb9ef4be24cf3f3820db3341ef5e0268dd941b85bf",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-05": {
+      "vector": "2tlZP8nIyD23tra+t7a2vouKij6Miws/r66uvp6dHT+2tTU/j46OPqalJb+amRm/srExv/b1dT+mpSW/g4KCvpuamr6vrq4+8O9vv8PCwr7Z2Ng9paQkPtnY2D2+vT2/7exsvrGwML3W1VW/4+LiPpCPD7+/vr4++fj4vbq5Ob/a2Vk/ycjIPbe2tr63tra+i4qKPoyLCz+vrq6+np0dP7a1NT+Pjo4+pqUlv5qZGb+ysTG/9vV1P6alJb+DgoK+m5qavq+urj7w72+/w8LCvtnY2D2lpCQ+2djYPb69Pb/t7Gy+sbAwvdbVVb/j4uI+kI8Pv7++vj75+Pi9urk5vw==",
+      "vectorSha256": "d37c92edd8341a6a5f7e986d9903616bc9a3e19e93181ca72073d1cd65193ed6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ec8c5252a2c554cedaa32d3327fa2d5f59ab084f8d948d21627a15b838af7023",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-06": {
+      "vector": "y8rKvtPS0j7o52e/iokJP8rJST/Avz8/397evufm5r6UkxO/jo0NP/n4+D2amRm/7exsPrCvLz+Lioq+1NNTP6Oior6hoKA8jIsLv7a1NT+GhQW/k5KSPo2MDL7t7Gw+kpERP9zbWz/29XW/v76+vvr5eb+JiIi9r66uvpiXFz/Lysq+09LSPujnZ7+KiQk/yslJP8C/Pz/f3t6+5+bmvpSTE7+OjQ0/+fj4PZqZGb/t7Gw+sK8vP4uKir7U01M/o6KivqGgoDyMiwu/trU1P4aFBb+TkpI+jYwMvu3sbD6SkRE/3NtbP/b1db+/vr6++vl5v4mIiL2vrq6+mJcXPw==",
+      "vectorSha256": "f21218e2251d5c0b872dee5e1b469b1e64c4b9d22901bf8766f75b34aa61f3a9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4db40cc4e4df484636c68f339dd75de957823ada3da46e9dc8ed0550037754cb",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-07": {
+      "vector": "1NNTv9rZWb+xsDC9trU1P4yLCz/b2tq+rKsrP7y7Oz/29XW/6ejoPcvKyr739va+jYwMPszLSz+WlRU/kI8PP7KxMT+Lioo+srExv9XUVL7OzU2/jIsLP7CvL7/U01M/y8rKPrq5OT+rqqq+0M9PP6CfHz/DwsK+jo0Nv4yLC7/U01O/2tlZv7GwML22tTU/jIsLP9va2r6sqys/vLs7P/b1db/p6Og9y8rKvvf29r6NjAw+zMtLP5aVFT+Qjw8/srExP4uKij6ysTG/1dRUvs7NTb+Miws/sK8vv9TTUz/Lyso+urk5P6uqqr7Qz08/oJ8fP8PCwr6OjQ2/jIsLvw==",
+      "vectorSha256": "cecd43c5b4437757f72e74669dcaed3258c52c3c001b5cbaff0933af3d982925",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "16137adac549d5dd058e4d4291e5cac7d8a2276519c528e9b2dc55e7cf4f393a",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-08": {
+      "vector": "pKMjv8HAQLyBgIA7zcxMPqSjIz/S0VE/8vFxP4yLCz/r6uo+t7a2Pvv6+j6dnBw+6+rqPrq5Ob/My0s///7+vry7Oz/OzU2//v19P+DfXz/g31+/8O9vP7e2tr7y8XG/x8bGvrq5OT+7uro+gYCAO/X0dL6mpSW/o6Kivuno6L2koyO/wcBAvIGAgDvNzEw+pKMjP9LRUT/y8XE/jIsLP+vq6j63trY++/r6Pp2cHD7r6uo+urk5v8zLSz///v6+vLs7P87NTb/+/X0/4N9fP+DfX7/w728/t7a2vvLxcb/Hxsa+urk5P7u6uj6BgIA79fR0vqalJb+joqK+6ejovQ==",
+      "vectorSha256": "af23f3c2c3c233467eb1fdae79b7941bdfbcf45c833f150de1ce137ed1519be2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2e7e8099d1e8f8c5baadbe93ba23e540dd19feef10f752074edcae80612d5771",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-09": {
+      "vector": "u7q6PoiHBz/Y11c/5ONjv769Pb/19HQ+gYCAO93cXD6Pjo4+paQkPr28PL7x8HA9l5aWPpeWlj7NzEy+goEBv9bVVb/Y11c/tLMzv+/u7r6qqSk/kI8Pv5KREb/Ew0O/xsVFv9bVVb+VlBQ+iIcHv6moqL3l5GQ+wsFBv+Pi4r67uro+iIcHP9jXVz/k42O/vr09v/X0dD6BgIA73dxcPo+Ojj6lpCQ+vbw8vvHwcD2XlpY+l5aWPs3MTL6CgQG/1tVVv9jXVz+0szO/7+7uvqqpKT+Qjw+/kpERv8TDQ7/GxUW/1tVVv5WUFD6Ihwe/qaioveXkZD7CwUG/4+Livg==",
+      "vectorSha256": "d1d78b3876164fef113a6eeaa760cbcc455b9ad25d72861a2f766910676917d7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "aec3eb0e219e809ba3946887a5a5663f15eb2644d438371e1d15923c759c1f47",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-10": {
+      "vector": "u7q6vp+enr6OjQ0/oqEhv5KRET/7+vo+8O9vP+rpab/y8XG/pqUlPwAAgD+Qjw8/xcREvomIiD27urq+sK8vv9fW1j7BwEA8/Pt7v5KREb/z8vK+3Ntbv9LRUT/k42M/29ravpmYmL3d3Fw+//7+PsC/Pz++vT0/p6amvr++vj67urq+n56evo6NDT+ioSG/kpERP/v6+j7w728/6ulpv/Lxcb+mpSU/AACAP5CPDz/FxES+iYiIPbu6ur6wry+/19bWPsHAQDz8+3u/kpERv/Py8r7c21u/0tFRP+TjYz/b2tq+mZiYvd3cXD7//v4+wL8/P769PT+npqa+v76+Pg==",
+      "vectorSha256": "aac9b1e5f51fcee6a601c3ba8b66ad396de01b48dc29037f3d547e84243d104c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5158c62fc8bef70b07d2ffc767885128b58102374312e8f149769bbfdfde56af",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-11": {
+      "vector": "tbQ0Pri3N7+Miws/np0dP7GwML3T0tI+hoUFv6inJz+/vr4+u7q6Pq6tLT+npqY+w8LCPuno6D2mpSU/wL8/P5ybGz/Ew0O/h4aGvsXERL6Miwu/vr09P5CPD7+4tzc/5+bmPre2tr6Ylxe/mpkZv+rpaT/i4WG/tbQ0vt7dXT+1tDQ+uLc3v4yLCz+enR0/sbAwvdPS0j6GhQW/qKcnP7++vj67uro+rq0tP6empj7DwsI+6ejoPaalJT/Avz8/nJsbP8TDQ7+Hhoa+xcREvoyLC7++vT0/kI8Pv7i3Nz/n5uY+t7a2vpiXF7+amRm/6ulpP+LhYb+1tDS+3t1dPw==",
+      "vectorSha256": "68e21051eea38f763c15a32caea2e377cfcae537055a18791c691dd4d1dbfbfe",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9624c5ce7ab43dd3afaed6a9b08ed2dfcd1e5e673ade38dbb9523433f40f69ee",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-12": {
+      "vector": "8O9vv5qZGT/h4OC8srExP9bVVT/BwEC8qqkpP728PD6lpCS+09LSPtnY2D3GxUW/5ONjP5qZGT/HxsY+7OtrP4KBAb/W1VU/oqEhv8XERD6WlRU/4N9fP4iHB7+Ylxc/4N9fv9PS0r7U01M/kpERP9nY2D3l5GS+//7+vry7Oz/w72+/mpkZP+Hg4LyysTE/1tVVP8HAQLyqqSk/vbw8PqWkJL7T0tI+2djYPcbFRb/k42M/mpkZP8fGxj7s62s/goEBv9bVVT+ioSG/xcREPpaVFT/g318/iIcHv5iXFz/g31+/09LSvtTTUz+SkRE/2djYPeXkZL7//v6+vLs7Pw==",
+      "vectorSha256": "f675d91b57ee278319890f739d9f59ee3e433b142f5e016c702a60a4dbd63245",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "08cc7cd8ea7ed4976bb48d1df1ccb1f53fea2f98caef3ccb104be9c88d6340dd",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-13": {
+      "vector": "l5aWPsXERD7Ix0c/np0dv6alJb+4tzc/vbw8vvr5eT/My0s/oJ8fv5CPDz/x8HA9xcREvvDvb7/Z2Ni9x8bGvtva2j719HQ+nJsbP6CfHz/5+Pi9z87Ovs/Ozj6/vr6+ubi4Pbm4uL339va+4N9fv4qJCT/z8vI+u7q6Pvr5eb+XlpY+xcREPsjHRz+enR2/pqUlv7i3Nz+9vDy++vl5P8zLSz+gnx+/kI8PP/HwcD3FxES+8O9vv9nY2L3Hxsa+29raPvX0dD6cmxs/oJ8fP/n4+L3Pzs6+z87OPr++vr65uLg9ubi4vff29r7g31+/iokJP/Py8j67uro++vl5vw==",
+      "vectorSha256": "affe8731c5ca7fb2ec497ceacb070b1c614cc4cc66073ef4741fb667317cdfcf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a598e3312ddb68fce530c7876708724eb69ecdcf704cb3508b744210c4bcae03",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-14": {
+      "vector": "nZwcPuXkZL6OjQ0/tbQ0PpKRET+Pjo4+j46OPuDfX7+qqSk/5ONjv8nIyD2WlRU///7+vsfGxr6VlBQ+//7+vvTzcz+fnp4+2NdXP+XkZD6ioSG/5+bmPouKij7v7u6+6Odnv/r5eT/+/X0/vr09P+vq6r7W1VW/6ejoPYmIiD2dnBw+5eRkvo6NDT+1tDQ+kpERP4+Ojj6Pjo4+4N9fv6qpKT/k42O/ycjIPZaVFT///v6+x8bGvpWUFD7//v6+9PNzP5+enj7Y11c/5eRkPqKhIb/n5uY+i4qKPu/u7r7o52e/+vl5P/79fT++vT0/6+rqvtbVVb/p6Og9iYiIPQ==",
+      "vectorSha256": "9548a4a08c6edcc636e48af2a735a0b705d790266e1c5ce2a3eccaa577e2b74e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9363c696c8a3a310d40e8cca404e9240f9a7eb9c2fb9a2440cfcfede45158e88",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-15": {
+      "vector": "vbw8PsXERD6Pjo6+6ulpP4uKij6CgQE/jo0Nv/Py8r6Ylxc/3t1dP5GQED3Pzs6+y8rKvuzra7+ioSE/1NNTv5STE7/NzEy+x8bGPtfW1r7y8XE/+vl5P9va2j719HS+lZQUvri3Nz/BwEA8pqUlv/z7ez/g31+/gYCAO/X0dD69vDw+xcREPo+Ojr7q6Wk/i4qKPoKBAT+OjQ2/8/LyvpiXFz/e3V0/kZAQPc/Ozr7Lysq+7Otrv6KhIT/U01O/lJMTv83MTL7HxsY+19bWvvLxcT/6+Xk/29raPvX0dL6VlBS+uLc3P8HAQDympSW//Pt7P+DfX7+BgIA79fR0Pg==",
+      "vectorSha256": "350de91b4f2d4b0934eee268816bd932a5c0022307bf8fb36e50665047205a3a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "97985cf4a2c03943cbee844c4d0ad0163666b14af8fcb6616ddb812dfd10809e",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-16": {
+      "vector": "+vl5v5OSkj7+/X0/ubi4PcvKyr6pqKg90tFRv7KxMT/m5WU/nZwcvrKxMT/c21s/5eRkvsHAQLzNzEw+1dRUvo+Ojj7Lysq+tbQ0PpSTE7/f3t6+3NtbP7y7Oz+6uTk/vr09P+rpaT+wry+/o6KiPpGQEL3T0tI+s7KyvvX0dD76+Xm/k5KSPv79fT+5uLg9y8rKvqmoqD3S0VG/srExP+blZT+dnBy+srExP9zbWz/l5GS+wcBAvM3MTD7V1FS+j46OPsvKyr61tDQ+lJMTv9/e3r7c21s/vLs7P7q5OT++vT0/6ulpP7CvL7+joqI+kZAQvdPS0j6zsrK+9fR0Pg==",
+      "vectorSha256": "614b8de47ea22c3e5e440dc6ea8b8435a6a049cc630a4d7d06ccbce7f7931c5c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "03a4fe8b4d8a17d8f26cd8ed637e9965a34d963648eddddcdef428a87bb4539e",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-17": {
+      "vector": "5+bmPsHAQLyysTE/7Otrv7q5Ob/GxUU/s7Kyvv79fT+amRk/hYQEPry7Oz+6uTk/4uFhP+TjY7/l5GQ+zcxMvrm4uL3Z2Ni90M9PP97dXb+FhAQ+6+rqvvLxcT/HxsY+oJ8fP8C/Pz+KiQk/+/r6PtbVVb+trCy+8O9vP9zbWz/n5uY+wcBAvLKxMT/s62u/urk5v8bFRT+zsrK+/v19P5qZGT+FhAQ+vLs7P7q5OT/i4WE/5ONjv+XkZD7NzEy+ubi4vdnY2L3Qz08/3t1dv4WEBD7r6uq+8vFxP8fGxj6gnx8/wL8/P4qJCT/7+vo+1tVVv62sLL7w728/3NtbPw==",
+      "vectorSha256": "00171ced120710b67eb21941de3f35de837f5433d5ccaed8114693aa8dd314e6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b97ed80a23e253fecc90dddcf00e9c667472e7119045f8b1cfdfc4be156af7ed",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-18": {
+      "vector": "sK8vv8LBQb+8uzs/np0dv+XkZL6wry8//v19P769Pb+9vDy+rawsPqCfHz+zsrI+8vFxv6empj4AAIC/2NdXP+Hg4DzCwUE/r66uvtPS0r7y8XE/kI8PP5eWlr7k42O/hYQEvoWEBL7j4uK+j46OvsC/P7+RkBC9//7+Puzraz+wry+/wsFBv7y7Oz+enR2/5eRkvrCvLz/+/X0/vr09v728PL6trCw+oJ8fP7Oysj7y8XG/p6amPgAAgL/Y11c/4eDgPMLBQT+vrq6+09LSvvLxcT+Qjw8/l5aWvuTjY7+FhAS+hYQEvuPi4r6Pjo6+wL8/v5GQEL3//v4+7OtrPw==",
+      "vectorSha256": "954adc013f59ec5c3196b4955e65b4f353bdaf9f98342c64e2c2c9b0f24098f8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "281fdd3163d7fe216895cfac07a900eb83e0544bf8c75a0e6f6f475c207bbff5",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-19": {
+      "vector": "wsFBv46NDT/n5ua+6+rqPqalJb+amRm/paQkvqGgoDzKyUm/9/b2PoyLCz+VlBQ+6+rqPo2MDL6OjQ0/kpERP5qZGb/+/X0/4eDgPNjXV7/v7u6+oJ8fP/Py8r7q6Wk/3t1dP/Py8j7s62u/paQkvs7NTT+lpCQ+iIcHP9rZWb/CwUG/jo0NP+fm5r7r6uo+pqUlv5qZGb+lpCS+oaCgPMrJSb/39vY+jIsLP5WUFD7r6uo+jYwMvo6NDT+SkRE/mpkZv/79fT/h4OA82NdXv+/u7r6gnx8/8/LyvurpaT/e3V0/8/LyPuzra7+lpCS+zs1NP6WkJD6Ihwc/2tlZvw==",
+      "vectorSha256": "bcec210a20398cbb55ae0ee5081639911eac0b473a6f6206e26ff1b844e3ec15",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1fc646ba2d336b821bbdc592ba6ec6c833fe831444cf43f4eebc0a6be694c313",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-20": {
+      "vector": "AACAv8nIyL2GhQU/rawsPszLSz+7uro+s7Kyvquqqj77+vo++Pd3P87NTb/My0u/8/LyPpiXFz/CwUG/2tlZP9HQUL25uLg9y8rKvsPCwj67uro+l5aWvufm5r6Ylxc/y8rKPs/Ozr6BgIA71tVVP5WUFL7Ew0M/7exsPo+Ojr4AAIC/ycjIvYaFBT+trCw+zMtLP7u6uj6zsrK+q6qqPvv6+j7493c/zs1Nv8zLS7/z8vI+mJcXP8LBQb/a2Vk/0dBQvbm4uD3Lysq+w8LCPru6uj6Xlpa+5+bmvpiXFz/Lyso+z87OvoGAgDvW1VU/lZQUvsTDQz/t7Gw+j46Ovg==",
+      "vectorSha256": "b37040d7b4f8cd98f351db53b054c43863bb9627a9fb97c827c571f1d238b03f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0073c295e5ae53aabefb191abccb1fec798b4db0ae5a46cbb24c80ea6de19d5c",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-21": {
+      "vector": "yslJv5WUFL66uTk/yslJP5OSkj7Y11e/oJ8fP//+/j7j4uI+6+rqPoqJCb+TkpI+gYCAO8PCwj7l5GQ+8/Lyvre2tr6koyM/hoUFv46NDT++vT2/3dxcPoSDA7++vT0/q6qqPtjXVz/d3Fy+srExv8PCwr6FhAS+srExv5ybG7/KyUm/lZQUvrq5OT/KyUk/k5KSPtjXV7+gnx8///7+PuPi4j7r6uo+iokJv5OSkj6BgIA7w8LCPuXkZD7z8vK+t7a2vqSjIz+GhQW/jo0NP769Pb/d3Fw+hIMDv769PT+rqqo+2NdXP93cXL6ysTG/w8LCvoWEBL6ysTG/nJsbvw==",
+      "vectorSha256": "eb01e3028cfce7d1591ffccf31767db027d083d0a00ab62ae828a24dc0fb8553",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1b6ddce4a414cfbfb8ba3ba480b09c4352d13dc6219b3edeaaeb64274f6f2732",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-22": {
+      "vector": "5eRkvo+Ojj6VlBS+AACAv+zraz+ioSG/mJcXP6moqL3j4uK+z87Ovri3Nz+xsDA95uVlP6qpKb/m5WU/3dxcPpybGz+enR2/oqEhP8/Ozj7i4WG/6ulpP9DPT7+enR2/kpERv5ybG7+DgoI+1tVVP6moqL2vrq4+rKsrv5qZGb/l5GS+j46OPpWUFL4AAIC/7OtrP6KhIb+Ylxc/qaiovePi4r7Pzs6+uLc3P7GwMD3m5WU/qqkpv+blZT/d3Fw+nJsbP56dHb+ioSE/z87OPuLhYb/q6Wk/0M9Pv56dHb+SkRG/nJsbv4OCgj7W1VU/qaiova+urj6sqyu/mpkZvw==",
+      "vectorSha256": "0ee1ccc4f5bfb35032951d91f78456173f68f34bb948b6d03dfdf60ebb32462c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "63a36d00f52fcb75474cdb85f22bf29bcd31d0b30ff418313732a0ea75ab2a33",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-23": {
+      "vector": "jIsLP7i3Nz+opyc/i4qKvtDPTz+Ylxe/zcxMvpSTEz+lpCQ+6+rqPq2sLL7CwUG/lJMTv7y7Oz+GhQW/w8LCPquqqj6EgwO/6Odnv46NDb/OzU0/srExv4aFBb++vT2/3Ntbv5ybG7++vT2/ycjIPZ6dHb+GhQU/t7a2Po+Ojr6Miws/uLc3P6inJz+Lioq+0M9PP5iXF7/NzEy+lJMTP6WkJD7r6uo+rawsvsLBQb+UkxO/vLs7P4aFBb/DwsI+q6qqPoSDA7/o52e/jo0Nv87NTT+ysTG/hoUFv769Pb/c21u/nJsbv769Pb/JyMg9np0dv4aFBT+3trY+j46Ovg==",
+      "vectorSha256": "f0894a063b4afe8c8f59bdd52938190766ae8fc23b351de48aeb480fc47b03c1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c5dbd35de73466c994ba6a1f36dd3db0aa3e0c39e6273d211232218c31c2ad5c",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-24": {
+      "vector": "5+bmPpmYmD21tDQ+19bWPuDfXz/6+Xk/qqkpv6GgoDzBwEC8i4qKvrq5Ob+0szM/8/LyvsvKyj7R0FA92NdXv/Dvb7+TkpI+paQkvs/Ozr61tDS+zMtLv5WUFD6VlBS+u7q6PqOior7v7u4++vl5P4+Ojj7Z2Ni9q6qqvqGgoLzn5uY+mZiYPbW0ND7X1tY+4N9fP/r5eT+qqSm/oaCgPMHAQLyLioq+urk5v7SzMz/z8vK+y8rKPtHQUD3Y11e/8O9vv5OSkj6lpCS+z87OvrW0NL7My0u/lZQUPpWUFL67uro+o6Kivu/u7j76+Xk/j46OPtnY2L2rqqq+oaCgvA==",
+      "vectorSha256": "32b5608b1a7c35f1c68f03009bfa4ab81ede8e0559d39e88d90176f10c81525a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b98996b5effc2b827e5d23d943b2861408a46b4c691a926dae57bbfca372557d",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-25": {
+      "vector": "iYiIvePi4r7l5GS+8/LyPra1Nb+ysTE/0tFRP+blZT+CgQG/zcxMvo+Ojj6vrq6+zMtLv8TDQ7/Ix0e/lZQUvpCPDz/X1ta+vLs7P5eWlj6Pjo4+6+rqvrSzMz+dnBy+9/b2vpaVFb+joqK+pqUlP4iHB7+3tra+2tlZv5uamj6JiIi94+LivuXkZL7z8vI+trU1v7KxMT/S0VE/5uVlP4KBAb/NzEy+j46OPq+urr7My0u/xMNDv8jHR7+VlBS+kI8PP9fW1r68uzs/l5aWPo+Ojj7r6uq+tLMzP52cHL739va+lpUVv6Oior6mpSU/iIcHv7e2tr7a2Vm/m5qaPg==",
+      "vectorSha256": "0a3fcea12a0cbf3c08f01487bc93b6fd43637be9f2544b43649d015ed13738d2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "774763bc25d8e8f23f66a3541a1e1c6dc74adda5a345d96c423557d23c5213a6",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-26": {
+      "vector": "yMdHv7e2tr7s62s/+vl5v5eWlr79/Hw+yslJv5mYmD2EgwM/7u1tv5KREb+7uro+sbAwva+urj6Xlpa+j46OvsfGxr6hoKC8xcREvvLxcb/k42M/8O9vP9XUVD6Qjw+/7Otrv5uamj61tDQ+vLs7v9fW1j6joqK+sbAwPeblZb/Ix0e/t7a2vuzraz/6+Xm/l5aWvv38fD7KyUm/mZiYPYSDAz/u7W2/kpERv7u6uj6xsDC9r66uPpeWlr6Pjo6+x8bGvqGgoLzFxES+8vFxv+TjYz/w728/1dRUPpCPD7/s62u/m5qaPrW0ND68uzu/19bWPqOior6xsDA95uVlvw==",
+      "vectorSha256": "306de5c6f2bdd8a9ba0fb26ac44bd9a0861fd29026add0776b4ab8f9e38e71ee",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1c52f5035a9f1b89c10937ae7aab5a5c4e7d6707f1f79a380aa69622b557850d",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-27": {
+      "vector": "j46OvpeWlj7My0u/mZiYPbOysr6Lioo+lpUVv7i3N7+koyM/nJsbv9zbW7/S0VG/q6qqPsC/Pz+ysTE/srExP7Oysj7FxES+xMNDP/n4+L2xsDA9m5qaPri3N7+6uTm/paQkPs7NTb/g318/kI8Pv/Lxcb+0szO/kI8PP7i3Nz+Pjo6+l5aWPszLS7+ZmJg9s7KyvouKij6WlRW/uLc3v6SjIz+cmxu/3Ntbv9LRUb+rqqo+wL8/P7KxMT+ysTE/s7KyPsXERL7Ew0M/+fj4vbGwMD2bmpo+uLc3v7q5Ob+lpCQ+zs1Nv+DfXz+Qjw+/8vFxv7SzM7+Qjw8/uLc3Pw==",
+      "vectorSha256": "d213cf5385767ffb087e095e65725360908716a1e0e334690bb1d13c2deac674",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5ca51a8953a23524d1321217aadfd8d8ac67e17085a624239419ef380726c7db",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-28": {
+      "vector": "2tlZP62sLL6NjAy+6ulpP/LxcT/u7W0/2tlZP9XUVL60szM/8O9vP/b1dT8AAIC///7+vp2cHL79/Hy+5+bmvtHQUL26uTk/wsFBP9bVVT/a2Vm/s7KyvoSDA7/5+Pg9urk5v8vKyj75+Pg91NNTP9PS0r7Avz8/mZiYPauqqj7a2Vk/rawsvo2MDL7q6Wk/8vFxP+7tbT/a2Vk/1dRUvrSzMz/w728/9vV1PwAAgL///v6+nZwcvv38fL7n5ua+0dBQvbq5OT/CwUE/1tVVP9rZWb+zsrK+hIMDv/n4+D26uTm/y8rKPvn4+D3U01M/09LSvsC/Pz+ZmJg9q6qqPg==",
+      "vectorSha256": "f899297dd3b2684b19b1411b5ae203c43347914fa744b17331b5941242eba4c8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ec6a6ef4f8f6ec65d9f7fa00406c604679dce0ea13533e8f23b28fe94bdf89aa",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-29": {
+      "vector": "qqkpv5mYmD3l5GQ+2NdXP8vKyj7u7W2/xMNDP8jHR7+BgIC7zs1Nv769PT+ZmJi9uLc3v/j3dz/X1ta+xsVFv5qZGT/Y11e/2NdXv5STE7/R0FA9vbw8PvX0dD7DwsK+jIsLP9XUVD7k42O/vr09P8jHRz+Ylxc/0dBQPeblZT+qqSm/mZiYPeXkZD7Y11c/y8rKPu7tbb/Ew0M/yMdHv4GAgLvOzU2/vr09P5mYmL24tze/+Pd3P9fW1r7GxUW/mpkZP9jXV7/Y11e/lJMTv9HQUD29vDw+9fR0PsPCwr6Miws/1dRUPuTjY7++vT0/yMdHP5iXFz/R0FA95uVlPw==",
+      "vectorSha256": "092bae296b44c84707235ea3fd126b66dd0ae6968e13be2a59a189b4fbefebf7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2b899cebb209e11c7f19de7624fb4a1dcc14143686979e4fc59a0edee3cb86f2",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-30": {
+      "vector": "h4aGPqyrK7/s62u/l5aWPv79fT+TkpK+9PNzv6CfHz+VlBQ+6Odnv4SDA7/R0FA96Odnv4yLC7+Lioo+v76+vsLBQb+sqyu/mJcXv+Pi4j6Pjo4+6+rqvouKir4AAIA/0tFRv7m4uL3m5WW/7exsvoSDAz+urS2/n56ePp6dHb+HhoY+rKsrv+zra7+XlpY+/v19P5OSkr7083O/oJ8fP5WUFD7o52e/hIMDv9HQUD3o52e/jIsLv4uKij6/vr6+wsFBv6yrK7+Ylxe/4+LiPo+Ojj7r6uq+i4qKvgAAgD/S0VG/ubi4veblZb/t7Gy+hIMDP66tLb+fnp4+np0dvw==",
+      "vectorSha256": "df5dbc28b92372af1ed963e6d70b508528fd1f00eabdec839939eede41593709",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a12a0aa5fe5b06cf920c3e860c3aa2501f2a34b8a3455dff17740d62c129a731",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-31": {
+      "vector": "8/Lyvuno6D26uTk/4N9fv7CvL7+mpSU/vLs7P+jnZ7+BgIC78/Lyvr69PT+joqI+4eDgvN/e3j6RkBC9t7a2PpGQED3My0u/nJsbP8XERL7i4WE/zs1Nv4aFBT+4tzc/wsFBv+vq6r7Ix0e/kI8Pv/38fD6fnp4+4eDgvNXUVL7z8vK+6ejoPbq5OT/g31+/sK8vv6alJT+8uzs/6Odnv4GAgLvz8vK+vr09P6Oioj7h4OC8397ePpGQEL23trY+kZAQPczLS7+cmxs/xcREvuLhYT/OzU2/hoUFP7i3Nz/CwUG/6+rqvsjHR7+Qjw+//fx8Pp+enj7h4OC81dRUvg==",
+      "vectorSha256": "4c2a0a555e819f3daefab1cad7bcc6506677729cd3243e3664e63fe8e634f30d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "438edc1028d2dd0c7f43dea87cb77bad841acd67f019c2db1f451c389fa77c65",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-32": {
+      "vector": "wcBAvJ+enj7//v4+6OdnP5aVFT/Pzs6+k5KSPpybGz+5uLg9trU1P4OCgj6pqKi9wL8/v5aVFb+0szM/o6KivtrZWb+xsDA9o6KiPo6NDT/DwsI+/Pt7v+7tbb/e3V0/jo0Nv6Oior6trCw+srExP4WEBL6RkBC9trU1P8rJSb/BwEC8n56ePv/+/j7o52c/lpUVP8/Ozr6TkpI+nJsbP7m4uD22tTU/g4KCPqmoqL3Avz+/lpUVv7SzMz+joqK+2tlZv7GwMD2joqI+jo0NP8PCwj78+3u/7u1tv97dXT+OjQ2/o6Kivq2sLD6ysTE/hYQEvpGQEL22tTU/yslJvw==",
+      "vectorSha256": "62f31e9788693fd8e698c1a81b12643d0d1494cefe7ea9c8c5fb938d1db9b551",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7ea7bff3ca4ca4cd8bdaa0752035d9571385a8c6b00209ee395795d86f7bda1b",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-33": {
+      "vector": "g4KCPpqZGT/Z2Ni9mJcXP769PT/Pzs4+19bWvsrJST/V1FS+0tFRv+TjY7+9vDy+1NNTv4aFBb/x8HC9397ePqmoqD3DwsK+p6amPs7NTb+UkxO/o6KiPu7tbb/DwsI+zs1NP6moqD3i4WG/2tlZP4yLC7/l5GS+iIcHP7W0ND6DgoI+mpkZP9nY2L2Ylxc/vr09P8/Ozj7X1ta+yslJP9XUVL7S0VG/5ONjv728PL7U01O/hoUFv/HwcL3f3t4+qaioPcPCwr6npqY+zs1Nv5STE7+joqI+7u1tv8PCwj7OzU0/qaioPeLhYb/a2Vk/jIsLv+XkZL6Ihwc/tbQ0Pg==",
+      "vectorSha256": "44e3e4e8b2a4325e95e1b4319f443113e6671f8f52756b33601f9b90e09ac9a7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a0cc72cbdeb34ae465170e68163d78b78a4fa91936a809b0e68a0fec3a63c396",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-34": {
+      "vector": "rawsvpiXFz/i4WE/rq0tv9PS0j7083M///7+Pra1NT+JiIi9lpUVP9XUVL7V1FQ+tLMzP6inJ7/c21u/l5aWPrKxMb/o52c/urk5v/z7ez/Pzs6+6ejoPfDvb7+wry8/paQkPo6NDT/u7W0/8O9vv6SjI7/n5ua+iIcHP4eGhr6trCy+mJcXP+LhYT+urS2/09LSPvTzcz///v4+trU1P4mIiL2WlRU/1dRUvtXUVD60szM/qKcnv9zbW7+XlpY+srExv+jnZz+6uTm//Pt7P8/Ozr7p6Og98O9vv7CvLz+lpCQ+jo0NP+7tbT/w72+/pKMjv+fm5r6Ihwc/h4aGvg==",
+      "vectorSha256": "7246c6e67d7f9c10fde5b62dc518f49b445e1085dd88da8efe5065449288db8d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6acbf029b4f9bfda77ca659ad92c12a527f323fd4c8e08d794c6f6082e46c35e",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-35": {
+      "vector": "g4KCPv79fT+pqKg9h4aGvrSzM7/z8vI+h4aGPtTTUz+wry8/+vl5P6empj6WlRW/rq0tv728PD6CgQE/iYiIvd/e3j6/vr6+h4aGvoqJCb/5+Pi9urk5P5ybG7+npqY+ycjIPcvKyj68uzu/goEBv7i3N7+TkpK+xMNDP9TTU7+DgoI+/v19P6moqD2Hhoa+tLMzv/Py8j6HhoY+1NNTP7CvLz/6+Xk/p6amPpaVFb+urS2/vbw8PoKBAT+JiIi9397ePr++vr6Hhoa+iokJv/n4+L26uTk/nJsbv6empj7JyMg9y8rKPry7O7+CgQG/uLc3v5OSkr7Ew0M/1NNTvw==",
+      "vectorSha256": "9a8b8e782c7197f4fc38eef0186e3605ea21808f7f3c6adb1481b7479e64ad70",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a0fe8a5e26bca1e9d7fca9352997c077b7505e3b70dc32a98cb2223f245be116",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-37": {
+      "vector": "8fBwPe7tbb/Lyso+srExP728PD7X1tY+4N9fP+zraz/p6Og9wcBAPLa1Nb+gnx8/AACAv/HwcL3r6uq+qqkpv/LxcT/U01M/x8bGvvv6+r7R0FA9sK8vP769Pb/OzU0/0tFRv9TTUz/k42M/gYCAO9XUVD4AAIA/+vl5P+fm5r7x8HA97u1tv8vKyj6ysTE/vbw8PtfW1j7g318/7OtrP+no6D3BwEA8trU1v6CfHz8AAIC/8fBwvevq6r6qqSm/8vFxP9TTUz/Hxsa++/r6vtHQUD2wry8/vr09v87NTT/S0VG/1NNTP+TjYz+BgIA71dRUPgAAgD/6+Xk/5+bmvg==",
+      "vectorSha256": "9e6e5db395ebca72485940e458c6698b1e8361da2d8d2fb8e2c6bc8d3e4d8164",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8709b2d897b5eff58e8125cf0078452bf8e94e4186d721e617e9f1809afffc46",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-38": {
+      "vector": "ubi4vb69Pb+JiIi9w8LCPtTTU7+ZmJi9s7KyvqalJb/i4WE/5ONjv4WEBL6TkpK+tLMzP5uamj7Qz08/qKcnP97dXT+opye/goEBv/n4+D3g318/7u1tv7i3N7+1tDS++/r6Prq5Ob+ysTE/iokJv4uKir6JiIi93dxcPp2cHD65uLi9vr09v4mIiL3DwsI+1NNTv5mYmL2zsrK+pqUlv+LhYT/k42O/hYQEvpOSkr60szM/m5qaPtDPTz+opyc/3t1dP6inJ7+CgQG/+fj4PeDfXz/u7W2/uLc3v7W0NL77+vo+urk5v7KxMT+KiQm/i4qKvomIiL3d3Fw+nZwcPg==",
+      "vectorSha256": "6e8d9e1dfa40fdaa496548fd60a4bf23c01dd337e8b1595f83f3f68159ad415f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "742177b01676532df00e6f5bd9a6e7d3ee2c3f8fef092469be23d83b5d779b93",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-39": {
+      "vector": "xsVFv6yrK7/u7W0/7u1tv7CvLz+DgoI+5uVlP5OSkr76+Xm/iIcHP4WEBD7HxsY+qKcnP8zLS7+fnp6+7u1tP4KBAT+WlRU/mpkZP4aFBb+KiQk/jIsLP8vKyr61tDQ+lpUVv+zra7+Lioq+/fx8vs3MTL6ioSE/goEBvwAAgL/GxUW/rKsrv+7tbT/u7W2/sK8vP4OCgj7m5WU/k5KSvvr5eb+Ihwc/hYQEPsfGxj6opyc/zMtLv5+enr7u7W0/goEBP5aVFT+amRk/hoUFv4qJCT+Miws/y8rKvrW0ND6WlRW/7Otrv4uKir79/Hy+zcxMvqKhIT+CgQG/AACAvw==",
+      "vectorSha256": "6cfc0545accb061c1253faf31f5edb47da9e2bcf1119ba916f6e91352b01f7bd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1d2af609d7a0f25b03c390b1d31a58f6c0cacc3dc4c54d96350a5d6066d03f00",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-40": {
+      "vector": "mJcXP/79fT+EgwO/zs1Nv//+/j7My0s/t7a2Ps7NTT/d3Fw+5+bmPuDfXz++vT2/pKMjv62sLD7R0FA9hoUFP/v6+j6joqI+8O9vP83MTL7f3t4+yslJP7m4uD3a2Vk/tbQ0Pp6dHT+enR0/uLc3P4KBAT+Ihwc/yMdHP7++vj6Ylxc//v19P4SDA7/OzU2///7+PszLSz+3trY+zs1NP93cXD7n5uY+4N9fP769Pb+koyO/rawsPtHQUD2GhQU/+/r6PqOioj7w728/zcxMvt/e3j7KyUk/ubi4PdrZWT+1tDQ+np0dP56dHT+4tzc/goEBP4iHBz/Ix0c/v76+Pg==",
+      "vectorSha256": "e0e97716b4a96b787e0f1dd198c84e5c19dd8f34c99a7705a3fe52afb8ed6987",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cbfe3e19bfe5ade69bb9ef212e9586c2bea8f766b7e48bec96cecedbc0c3e3af",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-41": {
+      "vector": "x8bGPt3cXD7BwEC81tVVv+zraz/t7Gy+/fx8vpKRET/GxUW/5uVlP7Oysr7//v4+7u1tv8/Ozj6RkBA9oqEhv4aFBb+npqa+9fR0PvX0dD7FxES+y8rKvujnZ7+Qjw+/lZQUvomIiL2zsrK+oqEhP9va2j6ZmJi9+vl5P8TDQz/HxsY+3dxcPsHAQLzW1VW/7OtrP+3sbL79/Hy+kpERP8bFRb/m5WU/s7Kyvv/+/j7u7W2/z87OPpGQED2ioSG/hoUFv6empr719HQ+9fR0PsXERL7Lysq+6Odnv5CPD7+VlBS+iYiIvbOysr6ioSE/29raPpmYmL36+Xk/xMNDPw==",
+      "vectorSha256": "da46dea38600ee04ee6557c2173b87bdd1675194322a5b9659be0ffe05ef9c02",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b19b7e15f56260c81df253bf09b3842f3d569e9e674d0c386d7753d0b676fce1",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-42": {
+      "vector": "7+7uvp+enj7l5GQ+vbw8vsrJST/Ix0c/srExv4SDAz+WlRU/l5aWPurpab+wry+/gYCAu4aFBT+0szO/o6KiPu7tbb+2tTW/vr09v9nY2D3j4uI+xMNDP8rJST+dnBw+ubi4PcrJSb+ioSG///7+vsnIyD3DwsI++fj4vcvKyr7v7u6+n56ePuXkZD69vDy+yslJP8jHRz+ysTG/hIMDP5aVFT+XlpY+6ulpv7CvL7+BgIC7hoUFP7SzM7+joqI+7u1tv7a1Nb++vT2/2djYPePi4j7Ew0M/yslJP52cHD65uLg9yslJv6KhIb///v6+ycjIPcPCwj75+Pi9y8rKvg==",
+      "vectorSha256": "0f01b804a9f5d9013bbb31f2b383c8243be582e6d715368d8c3321799e4ad23d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "44a79c68e4e327c1caa50b287fc226a80925218db8e1e4938b1b2f408cb0704d",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-43": {
+      "vector": "np0dv728PL6Miws/29ravvb1db+vrq6+u7q6PtjXV7+Pjo4+k5KSPpOSkj7083M/k5KSvpGQED3u7W2/rawsPoyLCz/e3V2/1dRUPtHQUD3Pzs6+rawsPoqJCb/e3V2/x8bGPp2cHL7JyMi9o6KiPvz7ez/c21u/rKsrP/HwcD2enR2/vbw8voyLCz/b2tq+9vV1v6+urr67uro+2NdXv4+Ojj6TkpI+k5KSPvTzcz+TkpK+kZAQPe7tbb+trCw+jIsLP97dXb/V1FQ+0dBQPc/Ozr6trCw+iokJv97dXb/HxsY+nZwcvsnIyL2joqI+/Pt7P9zbW7+sqys/8fBwPQ==",
+      "vectorSha256": "0c9d55b33715cd3f064c5b45f245d7edb2cd8d1f3f197d13e24995f352baf032",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3168c5490554ae14a3a4a4f95b840995c5119a864c953b11b16c73a8fd12d587",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-44": {
+      "vector": "6ulpP9DPTz/h4OA86OdnP+LhYb/s62s/0dBQvY6NDT+5uLg9hoUFP5ybG7+trCy+trU1v/f29j7NzEw+6ejoPa2sLD6zsrI+wL8/v9zbW7+UkxO/pqUlP8zLSz+UkxO/4+LiPsnIyD2Lioq+19bWPru6ur7W1VW/7u1tP5GQED3q6Wk/0M9PP+Hg4Dzo52c/4uFhv+zraz/R0FC9jo0NP7m4uD2GhQU/nJsbv62sLL62tTW/9/b2Ps3MTD7p6Og9rawsPrOysj7Avz+/3Ntbv5STE7+mpSU/zMtLP5STE7/j4uI+ycjIPYuKir7X1tY+u7q6vtbVVb/u7W0/kZAQPQ==",
+      "vectorSha256": "a3cf375f81d029c4e8ddb468e7305c21cc32639c129d8c8c9fbcd87d802dda8a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f4e783f30ff579c68bc2326a25bd998e95ac201236d2e536b88c5db55115f684",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-45": {
+      "vector": "yslJv6alJb+Pjo4+2djYvdzbWz+urS0/hYQEvvv6+j6sqyu//Pt7P6+urr6GhQU/8vFxv9TTU7+gnx+/ycjIvba1NT/u7W0/5uVlv/n4+D2Lioq+sK8vv/Tzc7+gnx8/vr09P4qJCb+EgwM/wL8/v6empr7r6uq+n56evpWUFD7KyUm/pqUlv4+Ojj7Z2Ni93NtbP66tLT+FhAS++/r6PqyrK7/8+3s/r66uvoaFBT/y8XG/1NNTv6CfH7/JyMi9trU1P+7tbT/m5WW/+fj4PYuKir6wry+/9PNzv6CfHz++vT0/iokJv4SDAz/Avz+/p6amvuvq6r6fnp6+lZQUPg==",
+      "vectorSha256": "6573345723f46464803d14132de02304cf76cdc24cc6ee9c3edac539d87619a4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1b2da372edd66fbe2afd54c207163073daf60d8f5d2806cfde3bc12056455892",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-46": {
+      "vector": "5uVlv9zbW7+koyO/6Odnv769PT/+/X2/8fBwva+urr6OjQ0/0M9Pv56dHT+JiIg90tFRPwAAgD+Xlpa+4+Livs/Ozj7//v6+k5KSvvz7ez/19HQ+lZQUvoWEBD7w728/AACAP5CPD7+TkpK+wcBAvNrZWb+bmpo+/v19v6+urr7m5WW/3Ntbv6SjI7/o52e/vr09P/79fb/x8HC9r66uvo6NDT/Qz0+/np0dP4mIiD3S0VE/AACAP5eWlr7j4uK+z87OPv/+/r6TkpK+/Pt7P/X0dD6VlBS+hYQEPvDvbz8AAIA/kI8Pv5OSkr7BwEC82tlZv5uamj7+/X2/r66uvg==",
+      "vectorSha256": "c361ce45d6fb655d27bc175bec4f8dbae2b2a86f7d27e7a658166986cae34c78",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0d122e0cde017854c618ce88e8ff5a47b3405bfd9e6d90f7ff385b7e13a60154",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-47": {
+      "vector": "qqkpP9TTU7+3tra+hYQEPrSzM7+0szO/0M9Pv83MTD7Pzs4+hIMDv/Dvb7+enR2/+vl5v56dHb+6uTm/o6KiPtXUVL66uTm/5uVlv8zLS7++vT0/6Odnv8TDQz+BgIA7pKMjP6qpKb/y8XG//fx8PoWEBL6ZmJg9goEBP9LRUb+qqSk/1NNTv7e2tr6FhAQ+tLMzv7SzM7/Qz0+/zcxMPs/Ozj6EgwO/8O9vv56dHb/6+Xm/np0dv7q5Ob+joqI+1dRUvrq5Ob/m5WW/zMtLv769PT/o52e/xMNDP4GAgDukoyM/qqkpv/Lxcb/9/Hw+hYQEvpmYmD2CgQE/0tFRvw==",
+      "vectorSha256": "84ba85c60f33bb1e61935eef564d5eec11e0415137bba487ae5ec936da4f22d9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d416529026261899b33e0831033123a865230d1ade0ce180d12b079f6f89c017",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-48": {
+      "vector": "9/b2PrGwML2VlBS+1tVVv5eWlr6WlRW/9/b2vpybG7+gnx+/yMdHv/HwcD2GhQU/jo0NP/Py8j739va+1NNTP+no6D38+3s/jYwMvt/e3j7s62s/gYCAO/j3d7/d3Fy+4eDgvPb1db+9vDy+vr09P9bVVT/w728/paQkvq+urj739vY+sbAwvZWUFL7W1VW/l5aWvpaVFb/39va+nJsbv6CfH7/Ix0e/8fBwPYaFBT+OjQ0/8/LyPvf29r7U01M/6ejoPfz7ez+NjAy+397ePuzraz+BgIA7+Pd3v93cXL7h4OC89vV1v728PL6+vT0/1tVVP/Dvbz+lpCS+r66uPg==",
+      "vectorSha256": "d0e08d338c22fc562f32f0131bc4e1aa02f364030e5b2ec9eff87901f791dc9d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "bd7a6d155a354232301c87c2c6bc42e98efd6eb7f58004647c0568deeaf76bab",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "money-49": {
+      "vector": "o6KivsPCwj65uLg9vbw8Pvb1dT+/vr4+wsFBv9XUVL6lpCS+1dRUPufm5j6fnp4+kZAQvff29r6Pjo4+5ONjv5OSkj7OzU2/4+Livu3sbD7FxES+lJMTv+rpab/JyMg9mJcXv8LBQb+npqY+vbw8vuLhYT+amRm/oaCgvJWUFD6joqK+w8LCPrm4uD29vDw+9vV1P7++vj7CwUG/1dRUvqWkJL7V1FQ+5+bmPp+enj6RkBC99/b2vo+Ojj7k42O/k5KSPs7NTb/j4uK+7exsPsXERL6UkxO/6ulpv8nIyD2Ylxe/wsFBv6empj69vDy+4uFhP5qZGb+hoKC8lZQUPg==",
+      "vectorSha256": "d0584b92753d47ab854718f417f6b36be7e2d5bf7761ed7c3c340cfb2e2d7f3b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "57b08b97faaf1f656b9ab9a77b42a30ea419479d67360b8c341fa968f0337d92",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-01": {
+      "vector": "AACAv8/Ozj729XW/kI8Pv7u6ur7R0FA9k5KSvrCvLz+sqyu//v19P/Py8r7c21u/1tVVP4KBAb/Ew0M/p6amvqCfH7+CgQG/rKsrv6alJb+Miwu/rKsrP6KhIb/v7u4+qKcnP7y7Oz/FxES+1NNTv/v6+r77+vq+8vFxP7q5OT8AAIC/z87OPvb1db+Qjw+/u7q6vtHQUD2TkpK+sK8vP6yrK7/+/X0/8/LyvtzbW7/W1VU/goEBv8TDQz+npqa+oJ8fv4KBAb+sqyu/pqUlv4yLC7+sqys/oqEhv+/u7j6opyc/vLs7P8XERL7U01O/+/r6vvv6+r7y8XE/urk5Pw==",
+      "vectorSha256": "5c9947339b11879e0eeaf505baafcb6980c816a32c30d2fe457d7d8e29b0101f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "00b3053851865bd72afe4312ea3fe156303f2a2d3ad52fbbd3dd67164141f8dc",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-02": {
+      "vector": "2djYvbOysj739vY+z87OPpeWlj6RkBC90tFRP/X0dD7d3Fw+/Pt7v5+enj7NzEy+2tlZv7W0NL7f3t4+8fBwPcrJSb+0szM/lJMTP9va2j79/Hy++/r6vurpab/y8XG/iYiIPa2sLL7Avz+/wsFBP/Tzc7/8+3s/09LSPuTjY7/Z2Ni9s7KyPvf29j7Pzs4+l5aWPpGQEL3S0VE/9fR0Pt3cXD78+3u/n56ePs3MTL7a2Vm/tbQ0vt/e3j7x8HA9yslJv7SzMz+UkxM/29raPv38fL77+vq+6ulpv/Lxcb+JiIg9rawsvsC/P7/CwUE/9PNzv/z7ez/T0tI+5ONjvw==",
+      "vectorSha256": "50b573a45978e8cc6c915acfe917668c33f578f9a2253248a216932446e37506",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "72acbdb3a57be89e9b02a7661369b7871bd9c9b660410b07886a20e006fdb40e",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-03": {
+      "vector": "y8rKvqGgoDzl5GQ+0tFRP6alJb/JyMg9xcREPoeGhr7i4WE/6+rqPqKhIT/39vY+srExv66tLb/z8vK+mJcXP6qpKT/y8XG/hYQEPuno6L2npqY+hYQEPtDPTz+6uTm/8/Lyvvj3dz/a2Vm/6OdnP5OSkr4AAIA/mZiYvfr5eT/Lysq+oaCgPOXkZD7S0VE/pqUlv8nIyD3FxEQ+h4aGvuLhYT/r6uo+oqEhP/f29j6ysTG/rq0tv/Py8r6Ylxc/qqkpP/Lxcb+FhAQ+6ejovaempj6FhAQ+0M9PP7q5Ob/z8vK++Pd3P9rZWb/o52c/k5KSvgAAgD+ZmJi9+vl5Pw==",
+      "vectorSha256": "4ed6bb7d81e2f6b5b19aadcb5b57309c13e0284c4fb6eb7e51ff08b16668fee7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4d829ce82d8c985ef0bad0bd272943cbd4079071a990e72343fb13f35bff76fc",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-04": {
+      "vector": "9vV1v5aVFb/i4WG/0dBQPa+urj7Ew0M/pqUlv/z7e7/OzU2/xsVFv6inJz+8uzu/oJ8fv9PS0j7DwsI+gYCAu6CfHz/+/X0/6OdnP/HwcL3+/X0/oJ8fv+DfX7+vrq4+9fR0PvHwcL20szM/kI8PP5CPD7+amRk/0M9Pv83MTD729XW/lpUVv+LhYb/R0FA9r66uPsTDQz+mpSW//Pt7v87NTb/GxUW/qKcnP7y7O7+gnx+/09LSPsPCwj6BgIC7oJ8fP/79fT/o52c/8fBwvf79fT+gnx+/4N9fv6+urj719HQ+8fBwvbSzMz+Qjw8/kI8Pv5qZGT/Qz0+/zcxMPg==",
+      "vectorSha256": "10c77c0d3f6217b283ea6991cc69fcf125d246d947dcc4ff2765c27ca4212748",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "05350f86abe12d02191dd32230b4b07fcffef378fe3010ab9e78d9c738cc1899",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-05": {
+      "vector": "9vV1P/LxcT+WlRU/rq0tP9rZWT/V1FQ+h4aGPp6dHb+7urq+5+bmPoKBAb/m5WU/iYiIPZybGz+cmxu/+Pd3P6GgoDympSU/s7KyvtPS0r6pqKi9zMtLv7u6ur6FhAS+vLs7v6uqqr6lpCS+xMNDv9PS0j7g318/w8LCvt7dXb/29XU/8vFxP5aVFT+urS0/2tlZP9XUVD6HhoY+np0dv7u6ur7n5uY+goEBv+blZT+JiIg9nJsbP5ybG7/493c/oaCgPKalJT+zsrK+09LSvqmoqL3My0u/u7q6voWEBL68uzu/q6qqvqWkJL7Ew0O/09LSPuDfXz/DwsK+3t1dvw==",
+      "vectorSha256": "061b2e7aa7ab73b90288e4e11f512bef39f1ac758635146b2f231c503b12b976",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "faf8cad6ec9aa13151b93ff288cd32fb82d2534b751a516f22556b1eb4ef4f11",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-06": {
+      "vector": "sK8vP5STE7+6uTm/r66uPuTjY7/5+Pg9kI8PP6KhIb+FhAS+y8rKvuPi4j7X1ta++vl5v4eGhj7k42O//fx8vs3MTD7083O/nJsbv46NDb/JyMi9q6qqPsbFRb+5uLi9hoUFP9/e3j6bmpo+xcREPo+Ojj7T0tK+qqkpP728PD6wry8/lJMTv7q5Ob+vrq4+5ONjv/n4+D2Qjw8/oqEhv4WEBL7Lysq+4+LiPtfW1r76+Xm/h4aGPuTjY7/9/Hy+zcxMPvTzc7+cmxu/jo0Nv8nIyL2rqqo+xsVFv7m4uL2GhQU/397ePpuamj7FxEQ+j46OPtPS0r6qqSk/vbw8Pg==",
+      "vectorSha256": "69e42b2f6d572ecfc0a016af8e05ae62cf362cb79346e15e80b492c72ae935da",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d73623ab0e8fc72f6f4db84a03a10e609906323973aa1d74c2b7a698a34bd497",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-07": {
+      "vector": "1tVVP6KhIT+9vDw+tLMzv9nY2L24tzc/4N9fv7m4uL35+Pi9i4qKvr++vj6CgQG/rq0tv5ybG7+0szO/jo0NP+rpaT/X1tY+nJsbP/HwcL2npqa+w8LCPpiXFz/Y11c/mJcXv/38fL6/vr4+qqkpv83MTL7CwUE//v19v+Hg4LzW1VU/oqEhP728PD60szO/2djYvbi3Nz/g31+/ubi4vfn4+L2Lioq+v76+PoKBAb+urS2/nJsbv7SzM7+OjQ0/6ulpP9fW1j6cmxs/8fBwvaempr7DwsI+mJcXP9jXVz+Ylxe//fx8vr++vj6qqSm/zcxMvsLBQT/+/X2/4eDgvA==",
+      "vectorSha256": "43d0ce84ecbc78437e156fa23e1b6fe3ec13711d97355ab122d9e01a28da1519",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ead0972672db1074705daf3f293226c6f4b5cd7856b0cbeb3460af2b66e0017c",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-08": {
+      "vector": "/Pt7P6Oioj6opyc/0tFRP/Py8j7CwUG/q6qqvs3MTD6WlRU/wcBAvJeWlr6cmxs/urk5v7e2tr7OzU0/vLs7P6SjIz+8uzu/ycjIvYyLCz/V1FS+k5KSPru6uj6joqK+o6KiPpuamr7FxEQ+qaiovbe2tj6Xlpa+09LSvpuamj78+3s/o6KiPqinJz/S0VE/8/LyPsLBQb+rqqq+zcxMPpaVFT/BwEC8l5aWvpybGz+6uTm/t7a2vs7NTT+8uzs/pKMjP7y7O7/JyMi9jIsLP9XUVL6TkpI+u7q6PqOior6joqI+m5qavsXERD6pqKi9t7a2PpeWlr7T0tK+m5qaPg==",
+      "vectorSha256": "bcf5c08abcccb1811c3b495a27898ae2ebc2d1db3481c7c9b66a9948013c4f3b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fda8d3e8bc1f5599ca7e5acd2352e6ddd12273c565a4ae57a8599875ad5a4ba6",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-09": {
+      "vector": "u7q6Ps/Ozr6DgoK+6OdnP5mYmD339vY+u7q6Pu/u7j7Y11e/uLc3v+zra7/m5WW/qKcnP5eWlr7n5ua+urk5v5GQEL2WlRW/8O9vv6+urj6fnp6+yMdHP9HQUD3W1VU/3NtbP+zraz/o52c/6OdnP6CfH7/h4OA82tlZP9HQUL27uro+z87OvoOCgr7o52c/mZiYPff29j67uro+7+7uPtjXV7+4tze/7Otrv+blZb+opyc/l5aWvufm5r66uTm/kZAQvZaVFb/w72+/r66uPp+enr7Ix0c/0dBQPdbVVT/c21s/7OtrP+jnZz/o52c/oJ8fv+Hg4Dza2Vk/0dBQvQ==",
+      "vectorSha256": "2d353f50c1081abf12503f65c560edf866d520b74c9ee560a4988d50498de485",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ae4c5ff389bdaebb14240a0dd35a46237b3508ab58e386eaedf5f3f33083ec79",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-10": {
+      "vector": "3Ntbv/LxcT+EgwM/hIMDv9fW1r7R0FA93NtbP5WUFL79/Hy+397evpOSkr6ysTG/9fR0vqinJz/e3V2/8/LyvuLhYb+TkpI+0M9Pv66tLb/b2to+8fBwPeblZb+opyc/qKcnv6KhIT+Ylxc/8vFxP7u6uj77+vq+lpUVP8jHR7/c21u/8vFxP4SDAz+EgwO/19bWvtHQUD3c21s/lZQUvv38fL7f3t6+k5KSvrKxMb/19HS+qKcnP97dXb/z8vK+4uFhv5OSkj7Qz0+/rq0tv9va2j7x8HA95uVlv6inJz+opye/oqEhP5iXFz/y8XE/u7q6Pvv6+r6WlRU/yMdHvw==",
+      "vectorSha256": "29ff65ca3979d66e3fee8329ca1f2bad642ef099ea439662b3e87ed59ea69f2f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "12f8c13e4a86ed6d60485b2761d311430fa41829b6870dd32cd0cbf8ae41ca1c",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-11": {
+      "vector": "jo0NP7a1NT+joqI+qaiovff29r7X1tY+oJ8fv6+urr7t7Gy+wsFBv8bFRb+Miws/xcREPrW0NL7l5GQ+tbQ0PvX0dL68uzs/tLMzP7KxMb/Lysq+yMdHP4KBAT/l5GS+1tVVv7a1Nb/m5WU//v19P4GAgDvo52e/qaiovY6NDb+OjQ0/trU1P6Oioj6pqKi99/b2vtfW1j6gnx+/r66uvu3sbL7CwUG/xsVFv4yLCz/FxEQ+tbQ0vuXkZD61tDQ+9fR0vry7Oz+0szM/srExv8vKyr7Ix0c/goEBP+XkZL7W1VW/trU1v+blZT/+/X0/gYCAO+jnZ7+pqKi9jo0Nvw==",
+      "vectorSha256": "7d30736c40181620f053b84cdbe061568dccac5c62ef9ab2ddb9398199009b2c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c6daa87542b53054621f1dc598699c9661ddd9274de3c0631525f2fe800c7539",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-12": {
+      "vector": "7u1tP769PT/b2tq+mpkZv8jHR7+XlpY+1tVVv/r5eb+7uro+urk5P/X0dD6cmxs/+Pd3P4yLC7/o52c/1tVVP8nIyD3u7W0/hIMDP93cXD7w728/iokJv6+urr6koyM/jo0Nv42MDL7T0tK+vbw8PtfW1j6npqa+lJMTP8HAQDzu7W0/vr09P9va2r6amRm/yMdHv5eWlj7W1VW/+vl5v7u6uj66uTk/9fR0PpybGz/493c/jIsLv+jnZz/W1VU/ycjIPe7tbT+EgwM/3dxcPvDvbz+KiQm/r66uvqSjIz+OjQ2/jYwMvtPS0r69vDw+19bWPqempr6UkxM/wcBAPA==",
+      "vectorSha256": "8493e7765b00bdce36f5fea3eb422fd2326b166be20aac1ecba92a2b53c7741c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f6de49331ca51503aedc9ecdfb3af3ea8cf6c19bf73b54d1396e4b97b556c981",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-13": {
+      "vector": "vbw8PuTjY7/T0tK+6ulpP+XkZD7BwEA8hYQEvuvq6r6TkpI+9PNzv9zbW7+JiIi90tFRP/HwcL24tzc/wsFBP+/u7j7p6Og9mpkZv9XUVL7q6Wk/u7q6vsPCwr7h4OC8qqkpP56dHb+hoKA8qKcnv+XkZL7CwUG/g4KCPuPi4j69vDw+5ONjv9PS0r7q6Wk/5eRkPsHAQDyFhAS+6+rqvpOSkj7083O/3Ntbv4mIiL3S0VE/8fBwvbi3Nz/CwUE/7+7uPuno6D2amRm/1dRUvurpaT+7urq+w8LCvuHg4LyqqSk/np0dv6GgoDyopye/5eRkvsLBQb+DgoI+4+LiPg==",
+      "vectorSha256": "b01c7413670cfc8a3a360f38b093009f6cfc1c1a74bcaa571446cd7c7567aeef",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "970e4bf49c816f45a4061277e878dbe0bb8e3365f4514f7cd431822c631fa0b8",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-14": {
+      "vector": "hYQEvo+Ojj7Avz8/m5qavqyrK7+urS2/iokJP8LBQT+Miwu/s7Kyvuzraz+urS0/jYwMvrOysr6OjQ2/o6KivsLBQb+SkRG/1dRUvrq5Ob/29XU/k5KSvvr5eT+FhAQ+zcxMPvf29r7083O/iIcHv5qZGb+Qjw8/z87Ovt3cXL6FhAS+j46OPsC/Pz+bmpq+rKsrv66tLb+KiQk/wsFBP4yLC7+zsrK+7OtrP66tLT+NjAy+s7Kyvo6NDb+joqK+wsFBv5KREb/V1FS+urk5v/b1dT+TkpK++vl5P4WEBD7NzEw+9/b2vvTzc7+Ihwe/mpkZv5CPDz/Pzs6+3dxcvg==",
+      "vectorSha256": "47841527a3f46cb4920ab18c965cfca05df51dc9da5667cd58c94cf1ce6b4b5d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6fa3df592a29c4e03a53f5d66e5339571f376523fa5bfc909942063c33c74c64",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-15": {
+      "vector": "nJsbv8LBQT/BwEA8+Pd3P6GgoDzl5GS+rKsrv+vq6j6Ihwc/7+7uPuHg4DyZmJg97exsPpuamr7o52e/9PNzv+fm5j7y8XG/xMNDP8TDQz+JiIi92tlZv9/e3j78+3s/sK8vP9XUVD6joqI+5ONjP6empj7v7u4+3t1dv6empr6cmxu/wsFBP8HAQDz493c/oaCgPOXkZL6sqyu/6+rqPoiHBz/v7u4+4eDgPJmYmD3t7Gw+m5qavujnZ7/083O/5+bmPvLxcb/Ew0M/xMNDP4mIiL3a2Vm/397ePvz7ez+wry8/1dRUPqOioj7k42M/p6amPu/u7j7e3V2/p6amvg==",
+      "vectorSha256": "8b5061e96ead629d29f022307395a0abdd6b22d429ccae7e38423feeef66f5f2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "32e081fb82632abac3bb83899d590c06b907e1e17713b7fdd79aa8f1a9bb1156",
+      "updatedAt": "2025-09-20T22:28:15.456Z"
+    },
+    "family-16": {
+      "vector": "y8rKvq2sLL7NzEy+oaCgvIiHBz/19HS+wL8/P8bFRT+Lioq+srExv8LBQT/T0tK+6+rqvrm4uL2UkxM/zs1NP7SzM7+GhQU/o6Kivru6ur6urS2/8O9vP7W0ND7Lysq+6ulpv52cHL7Lysq+2NdXv7m4uD3Qz08/o6KiPuno6D3Lysq+rawsvs3MTL6hoKC8iIcHP/X0dL7Avz8/xsVFP4uKir6ysTG/wsFBP9PS0r7r6uq+ubi4vZSTEz/OzU0/tLMzv4aFBT+joqK+u7q6vq6tLb/w728/tbQ0PsvKyr7q6Wm/nZwcvsvKyr7Y11e/ubi4PdDPTz+joqI+6ejoPQ==",
+      "vectorSha256": "2ae4a9d9f9d9300c3a4064170e8e476677fa2b92267add0f3c05af6cc31546e8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4d6a667dc361dfe25d27e04b4574c9e626c2575129f7964d0b6c4d148be7a88e",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-17": {
+      "vector": "goEBP/38fD6koyM/5uVlv7u6uj6opye/r66uPvPy8r6gnx8/oaCgPMvKyr67urq+h4aGvvLxcT+ZmJg9vr09v/b1dT/083M/2djYvYSDA7+joqK+5ONjv6yrKz+/vr4+AACAP+rpaT/OzU0/oJ8fP+jnZz+WlRW/jo0Nv8jHR7+CgQE//fx8PqSjIz/m5WW/u7q6PqinJ7+vrq4+8/LyvqCfHz+hoKA8y8rKvru6ur6Hhoa+8vFxP5mYmD2+vT2/9vV1P/Tzcz/Z2Ni9hIMDv6Oior7k42O/rKsrP7++vj4AAIA/6ulpP87NTT+gnx8/6OdnP5aVFb+OjQ2/yMdHvw==",
+      "vectorSha256": "59d9e42274c4e98be7fdce9ded455600603fbf2617f659c080ecc97524e152cc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c09fd10dae2cab43cf824d515ef88921faf9723e570ed5affff4e6cff335391c",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-18": {
+      "vector": "xcREPsPCwr79/Hw+5ONjv5WUFD7DwsI+rawsvpqZGT/7+vo+yMdHv/79fT+rqqo+mZiYPerpaT+GhQW/rawsPqCfHz+Miws/sbAwPa6tLb/Qz0+/trU1v9/e3j7z8vK+29raPtnY2D2Miws/np0dv8zLS7+qqSm/m5qavrGwMD3FxEQ+w8LCvv38fD7k42O/lZQUPsPCwj6trCy+mpkZP/v6+j7Ix0e//v19P6uqqj6ZmJg96ulpP4aFBb+trCw+oJ8fP4yLCz+xsDA9rq0tv9DPT7+2tTW/397ePvPy8r7b2to+2djYPYyLCz+enR2/zMtLv6qpKb+bmpq+sbAwPQ==",
+      "vectorSha256": "3561684ba0d24da8180d7115a870fa6c24ad3068eadb400feeb025c3751ebda4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "984f9f0e92b06accbe1cfeaa89f43d95cfc585291825b743b68dc5311a2b5985",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-19": {
+      "vector": "gYCAu9va2j7CwUG/zMtLP4yLCz/BwEC8/v19P4KBAT+RkBC9rq0tP/Lxcb+Xlpa+4eDgPO/u7r7Avz8/5+bmvtbVVb+GhQW/3dxcvvb1dT+RkBA94uFhv62sLD7Avz8/xsVFv/Dvbz/Ix0e/3t1dv6qpKT/W1VU/yslJv97dXT+BgIC729raPsLBQb/My0s/jIsLP8HAQLz+/X0/goEBP5GQEL2urS0/8vFxv5eWlr7h4OA87+7uvsC/Pz/n5ua+1tVVv4aFBb/d3Fy+9vV1P5GQED3i4WG/rawsPsC/Pz/GxUW/8O9vP8jHR7/e3V2/qqkpP9bVVT/KyUm/3t1dPw==",
+      "vectorSha256": "c4cc0e610cf9aa2f5d5ab90d12f45bbbd7d6b9b449ad588f67e6e101ba26fdae",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7fb61fe5c57efec07bd6075a8344df46153d64fa840f95df1df71c11d4ea1bee",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-20": {
+      "vector": "n56ePvTzcz+UkxO/kZAQPZqZGT+OjQ2/n56evuPi4j6sqyu/0M9Pv4aFBT/NzEy+s7KyvtfW1r6RkBC9hoUFP+zra7+RkBA9iIcHv83MTL6VlBS+y8rKvqCfHz+JiIg9pqUlP/b1dT+/vr4+rawsvt7dXT/BwEC8r66uPpiXF7+fnp4+9PNzP5STE7+RkBA9mpkZP46NDb+fnp6+4+LiPqyrK7/Qz0+/hoUFP83MTL6zsrK+19bWvpGQEL2GhQU/7Otrv5GQED2Ihwe/zcxMvpWUFL7Lysq+oJ8fP4mIiD2mpSU/9vV1P7++vj6trCy+3t1dP8HAQLyvrq4+mJcXvw==",
+      "vectorSha256": "cb6b90a6202a3c400c5362658dbbfd0afbc3b5cae9a3b04928fe3b43458cd983",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a7f93684cc3958b82a18c266534a7bc20a843c666d4dcf88d2faaf6aee7eab34",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-21": {
+      "vector": "zs1NP8XERD6EgwO/2djYvfPy8r7My0u/iYiIvcTDQ7/V1FQ+9fR0vq+urj7X1ta+yMdHP4qJCb+qqSm/j46OPuLhYT+xsDA98O9vP4eGhj6xsDC9p6amPvDvb7/s62u/2tlZP9LRUT+bmpo+gYCAO/z7ez/a2Vk/8fBwvYOCgj7OzU0/xcREPoSDA7/Z2Ni98/LyvszLS7+JiIi9xMNDv9XUVD719HS+r66uPtfW1r7Ix0c/iokJv6qpKb+Pjo4+4uFhP7GwMD3w728/h4aGPrGwML2npqY+8O9vv+zra7/a2Vk/0tFRP5uamj6BgIA7/Pt7P9rZWT/x8HC9g4KCPg==",
+      "vectorSha256": "b165b23a64cedaa3cb1ad032867b3132375458ac1a5b1295dca22f88d3284bfa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e6983e72431a771e9a61ab4ae33b2ba3f085f7a17aa9080aece8a680fdec78a0",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-22": {
+      "vector": "wL8/P6inJ7+SkRG/5uVlP4mIiD3d3Fw+w8LCPvr5eT+Pjo4+x8bGvpOSkj7Qz0+/lZQUPvDvb7+qqSk/+fj4vaqpKb/My0s/uLc3v/r5eT+FhAQ+vr09P7e2tr6ysTG/rq0tv+jnZz+lpCQ+gYCAu5eWlj7c21s/sbAwvYqJCT/Avz8/qKcnv5KREb/m5WU/iYiIPd3cXD7DwsI++vl5P4+Ojj7Hxsa+k5KSPtDPT7+VlBQ+8O9vv6qpKT/5+Pi9qqkpv8zLSz+4tze/+vl5P4WEBD6+vT0/t7a2vrKxMb+urS2/6OdnP6WkJD6BgIC7l5aWPtzbWz+xsDC9iokJPw==",
+      "vectorSha256": "76ddefad4cc3f65d5ae1904ceea2f3ef31f5af384cf599000bbff8b74585d7f3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "df2c37f2889bb0fca34ea4189208d4702be524fc90de522729f3947fa5ed7ac4",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-23": {
+      "vector": "8O9vPwAAgL/My0u/q6qqvtPS0j68uzu/zcxMvo6NDT+VlBS+3t1dP4iHBz+Pjo6+l5aWPtfW1j7DwsI+29ravpCPD7/Qz08/m5qavu7tbb/q6Wk/oJ8fP+Pi4j6rqqo+srExP7a1NT+wry+/3dxcvpWUFL6/vr4+y8rKPomIiD3w728/AACAv8zLS7+rqqq+09LSPry7O7/NzEy+jo0NP5WUFL7e3V0/iIcHP4+Ojr6XlpY+19bWPsPCwj7b2tq+kI8Pv9DPTz+bmpq+7u1tv+rpaT+gnx8/4+LiPquqqj6ysTE/trU1P7CvL7/d3Fy+lZQUvr++vj7Lyso+iYiIPQ==",
+      "vectorSha256": "d0b7f788cf7c6431853ee5b1185dd3a1acb120c236e06cca607a66105c671103",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f7001a55b42266c66deec35ca5b5b04938e75909f4cfb8aad8da28646dafb288",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-24": {
+      "vector": "qaioPbGwMD3Ew0O/6ejoPeblZT+WlRW/r66uPqinJz/5+Pi9+/r6vvr5eT/My0u/xcREvtTTU7+ysTG/oJ8fP+blZb/JyMi9oJ8fvwAAgD/o52c/29raPvHwcD3V1FS+lZQUPr28PD6pqKi9vr09v/38fL6DgoK+1dRUvsvKyr6pqKg9sbAwPcTDQ7/p6Og95uVlP5aVFb+vrq4+qKcnP/n4+L37+vq++vl5P8zLS7/FxES+1NNTv7KxMb+gnx8/5uVlv8nIyL2gnx+/AACAP+jnZz/b2to+8fBwPdXUVL6VlBQ+vbw8PqmoqL2+vT2//fx8voOCgr7V1FS+y8rKvg==",
+      "vectorSha256": "bcc70496454ffaf8d33c4f6224977161267cfeb99a5b0643d1be503e961c13d0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8a851e8ef235abd37041fc1a671627cf0d7330fff3b6876592977521605f654d",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-25": {
+      "vector": "AACAv+blZb+wry+/s7KyPtTTU7/GxUW/rq0tv+LhYT/U01M/vLs7P7q5OT/o52e/u7q6vouKij6BgIC7//7+vpSTEz+VlBS+ubi4vYGAgDvk42O/6+rqvvf29j6+vT2/zMtLP8jHR7/FxEQ++fj4vbKxMb+EgwO/09LSvqKhIT8AAIC/5uVlv7CvL7+zsrI+1NNTv8bFRb+urS2/4uFhP9TTUz+8uzs/urk5P+jnZ7+7urq+i4qKPoGAgLv//v6+lJMTP5WUFL65uLi9gYCAO+TjY7/r6uq+9/b2Pr69Pb/My0s/yMdHv8XERD75+Pi9srExv4SDA7/T0tK+oqEhPw==",
+      "vectorSha256": "32bea48fe166333ee2b80f08d5498f72147db8cb65145c765e56a6b803788170",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "000d28ac161d29f0e9dddc0c51a27f40c96d74800e45bd21e51c9870273e4bd0",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-26": {
+      "vector": "n56evrW0NL6EgwM/+Pd3v6empr7s62u/p6amvq6tLb/s62u/vbw8PqOior7t7Gw+o6KivqmoqD22tTU/6Odnv6empj6bmpo+hYQEPpmYmL3CwUG/4eDgPO3sbD7r6uo+4+LiPvv6+r7s62u/8fBwvZ2cHD6gnx+/4N9fv/Tzcz+fnp6+tbQ0voSDAz/493e/p6amvuzra7+npqa+rq0tv+zra7+9vDw+o6Kivu3sbD6joqK+qaioPba1NT/o52e/p6amPpuamj6FhAQ+mZiYvcLBQb/h4OA87exsPuvq6j7j4uI++/r6vuzra7/x8HC9nZwcPqCfH7/g31+/9PNzPw==",
+      "vectorSha256": "42a62dc7380f6c76b47ea25789328daf0e20ac3d96979f642b398c443e83d614",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5869c104560a56290a97579d578ada0ca9a690761f839dbab8410a78933010f9",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-27": {
+      "vector": "/fx8vvv6+j68uzs/k5KSPpybGz/n5uY+w8LCPru6uj6Ylxe/+fj4PerpaT+6uTm/jYwMPo+Ojr6sqyu/xcREvr28PL6GhQU//fx8vuno6D2Lioq+wcBAPJuamr7n5uY+ubi4ve7tbb+5uLi9jIsLv9nY2D2Ihwe/AACAv83MTD79/Hy++/r6Pry7Oz+TkpI+nJsbP+fm5j7DwsI+u7q6PpiXF7/5+Pg96ulpP7q5Ob+NjAw+j46OvqyrK7/FxES+vbw8voaFBT/9/Hy+6ejoPYuKir7BwEA8m5qavufm5j65uLi97u1tv7m4uL2Miwu/2djYPYiHB78AAIC/zcxMPg==",
+      "vectorSha256": "ce5e231b2a3983afa986efa1e5a82eefef193dc039a9e6f0b6d4d81337998f7e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "60bedda4cdb9b0ae348ff423915c2a6768c2608e5d8159b97409743a8d3c0099",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-28": {
+      "vector": "2djYveXkZL7u7W2/uLc3v8bFRb/39vY+trU1P8LBQb+wry+/z87OPpKREb/Y11c/8/LyvsvKyj7l5GS+n56evp6dHb/d3Fw+yMdHP7CvLz/j4uI+2NdXP8LBQT/h4OA87u1tPwAAgL/CwUE/mJcXv93cXL6Ylxc/4N9fP5KRET/Z2Ni95eRkvu7tbb+4tze/xsVFv/f29j62tTU/wsFBv7CvL7/Pzs4+kpERv9jXVz/z8vK+y8rKPuXkZL6fnp6+np0dv93cXD7Ix0c/sK8vP+Pi4j7Y11c/wsFBP+Hg4Dzu7W0/AACAv8LBQT+Ylxe/3dxcvpiXFz/g318/kpERPw==",
+      "vectorSha256": "6e7406be43193cb515f4518d349a330873b1beecef8e843cc5dbcafd9900a9fd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "726309241dbdda1f28b337eb43b26358319be3d7b8ebe083f600e03464cbefc8",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-29": {
+      "vector": "lpUVP728PD7GxUU/7+7uPqinJ7/k42M/uLc3v7CvLz+fnp6+1NNTP4qJCb/k42M/i4qKPrm4uD3z8vK+gYCAO8C/P7+qqSk/8vFxP+/u7r7W1VU/v76+vvHwcL3c21u/kI8Pv4SDA7/Ew0M/v76+vvf29r6trCw+7+7uvt3cXD6WlRU/vbw8PsbFRT/v7u4+qKcnv+TjYz+4tze/sK8vP5+enr7U01M/iokJv+TjYz+Lioo+ubi4PfPy8r6BgIA7wL8/v6qpKT/y8XE/7+7uvtbVVT+/vr6+8fBwvdzbW7+Qjw+/hIMDv8TDQz+/vr6+9/b2vq2sLD7v7u6+3dxcPg==",
+      "vectorSha256": "f51c419b829cbf30d678d2d14ebc964f43c608a1af2a59614c1bf2efb5785f0b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ca97e2bb2cf124d758e93bf1a28b438020d4f844ea507812383ee1504295449b",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-30": {
+      "vector": "6+rqvpeWlj7t7Gy+4+Livru6uj7X1tY+s7KyPpeWlr7KyUm/2djYPbKxMT+VlBS++Pd3P8bFRT/l5GS+k5KSvs/Ozr6Ihwe/rq0tP9/e3r6JiIg95eRkPvn4+D2vrq4+sbAwveXkZD77+vo+1NNTP+3sbD7h4OC86+rqPu/u7j7r6uq+l5aWPu3sbL7j4uK+u7q6PtfW1j6zsrI+l5aWvsrJSb/Z2Ng9srExP5WUFL7493c/xsVFP+XkZL6TkpK+z87OvoiHB7+urS0/397evomIiD3l5GQ++fj4Pa+urj6xsDC95eRkPvv6+j7U01M/7exsPuHg4Lzr6uo+7+7uPg==",
+      "vectorSha256": "25db085cf3f49690d075123ddf0ae530084051e02fc31b327c3ff3961aa1b9ec",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "45a56247aeb5ac5a1b8dd86dfbe2635b4c3cd648889c8fab7a9cbee99d7cbabb",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-31": {
+      "vector": "9PNzP4iHBz+RkBA90dBQvf/+/r6bmpo+l5aWPv/+/r7Y11c/gYCAu93cXD7u7W2/1dRUPquqqj7Z2Ni9uLc3P52cHL6enR2/7exsvrq5Ob+SkRG/l5aWvre2tr7S0VG/kpERP8/Ozr6amRk/jo0Nv9LRUT/19HQ+8O9vv7SzMz/083M/iIcHP5GQED3R0FC9//7+vpuamj6XlpY+//7+vtjXVz+BgIC73dxcPu7tbb/V1FQ+q6qqPtnY2L24tzc/nZwcvp6dHb/t7Gy+urk5v5KREb+Xlpa+t7a2vtLRUb+SkRE/z87OvpqZGT+OjQ2/0tFRP/X0dD7w72+/tLMzPw==",
+      "vectorSha256": "d0698a47072a69e30c9f7effdcff0133415665e7d193bf3cf20f07a013046c17",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f9c3847940a6a540eb7f9b099aaa72db6c316223375a5217c84ccc39e89e08d9",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-32": {
+      "vector": "xsVFv+Pi4r7n5ua+6+rqvrKxMT+fnp4+l5aWPpmYmL2dnBw+sK8vP+XkZL6XlpY+mZiYPZ2cHL7a2Vk/oJ8fP/38fL6+vT2/k5KSvu/u7r7z8vI+nZwcPtTTU7+Ihwc/oJ8fP46NDT+7urq+oaCgPNnY2D2xsDA9t7a2Pt7dXT/GxUW/4+Livufm5r7r6uq+srExP5+enj6XlpY+mZiYvZ2cHD6wry8/5eRkvpeWlj6ZmJg9nZwcvtrZWT+gnx8//fx8vr69Pb+TkpK+7+7uvvPy8j6dnBw+1NNTv4iHBz+gnx8/jo0NP7u6ur6hoKA82djYPbGwMD23trY+3t1dPw==",
+      "vectorSha256": "2dee54cbdba547405e99455e83eca7eae75e3f287e4a241ee58f11504d92d100",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1d474645d8a7a57693d763a5896ceccf60215b44bc9316c3cfc651828d85adee",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-33": {
+      "vector": "m5qaPra1Nb+4tzc/sbAwvYSDAz/493e/7u1tP+jnZz+GhQW/6ulpv5ybGz+pqKg929raPoyLC7/Z2Ng9z87OvtXUVL7i4WG/3dxcPpeWlr7o52e/nJsbv+Pi4r7KyUk/6OdnP4mIiL2/vr4+srExP4SDA7/083O/8fBwPcnIyL2bmpo+trU1v7i3Nz+xsDC9hIMDP/j3d7/u7W0/6OdnP4aFBb/q6Wm/nJsbP6moqD3b2to+jIsLv9nY2D3Pzs6+1dRUvuLhYb/d3Fw+l5aWvujnZ7+cmxu/4+LivsrJST/o52c/iYiIvb++vj6ysTE/hIMDv/Tzc7/x8HA9ycjIvQ==",
+      "vectorSha256": "29bc9a0287f03681bc115df6710867412ec5d7ce1e0c2e3ba2f1fbdaa6badcfc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a625db7ac104f6f33d0bcd8ab63a8d4c650f9b5a0c3247e4f377afd83e068773",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-34": {
+      "vector": "0dBQPbe2tr6FhAQ+AACAP5iXF7+Ylxe/7+7uvuvq6r7OzU0/sK8vv/v6+j78+3u/g4KCPrKxMb/R0FA9z87OPpiXF7+SkRE/iokJv4aFBT+koyO/6ejovYOCgr7Avz+/0tFRP+Pi4j7l5GQ+rKsrPwAAgD+enR2/v76+vpGQEL3R0FA9t7a2voWEBD4AAIA/mJcXv5iXF7/v7u6+6+rqvs7NTT+wry+/+/r6Pvz7e7+DgoI+srExv9HQUD3Pzs4+mJcXv5KRET+KiQm/hoUFP6SjI7/p6Oi9g4KCvsC/P7/S0VE/4+LiPuXkZD6sqys/AACAP56dHb+/vr6+kZAQvQ==",
+      "vectorSha256": "bcd02cf042c7c2ba72e97738cb35b80e631ede3b8bbd230c5012994e5aa3cd64",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "865290ff34344445e628be02a02786b334c83bc22e715f20e8b89cd5ff31507b",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-35": {
+      "vector": "y8rKvra1Nb+RkBC9ubi4vd/e3r7+/X2/hIMDv/f29r6WlRW/6Odnv8XERD68uzs/n56evre2tj62tTW/xsVFP/Py8r6opyc/hoUFv4aFBb/Lysq+ubi4vbi3Nz+1tDS+kI8PP4mIiL2qqSm/9fR0vufm5j7+/X2/nJsbv9va2j7Lysq+trU1v5GQEL25uLi9397evv79fb+EgwO/9/b2vpaVFb/o52e/xcREPry7Oz+fnp6+t7a2Pra1Nb/GxUU/8/LyvqinJz+GhQW/hoUFv8vKyr65uLi9uLc3P7W0NL6Qjw8/iYiIvaqpKb/19HS+5+bmPv79fb+cmxu/29raPg==",
+      "vectorSha256": "a7be7fc67c430c8262071580cf2e340a181c9211bb8a7d13eaaee77d614ec345",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4d257b7448013e42350c98dd58ad25e243d33d3d4d74db69c7772b61b90132b6",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-36": {
+      "vector": "mpkZv7e2tj6hoKA8mZiYPeTjYz/q6Wk/4N9fP7KxMb/t7Gy+4eDgPIOCgr6KiQk/rKsrP4yLC7+8uzs/zs1NP+blZb/a2Vm/6ulpP7W0NL6GhQU/kI8Pv4uKir6mpSU/iYiIveblZT/Pzs4+u7q6Pvz7e7/DwsI+wcBAvIyLC7+amRm/t7a2PqGgoDyZmJg95ONjP+rpaT/g318/srExv+3sbL7h4OA8g4KCvoqJCT+sqys/jIsLv7y7Oz/OzU0/5uVlv9rZWb/q6Wk/tbQ0voaFBT+Qjw+/i4qKvqalJT+JiIi95uVlP8/Ozj67uro+/Pt7v8PCwj7BwEC8jIsLvw==",
+      "vectorSha256": "3e7db88bdea7887049cc7f2249063cf82ddcce51215213148cf6db6d812b76d4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "33ad8289f1f4ef2762835fc4d53adde60d13f469c2385dd277f2b3ae02b07e3a",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-37": {
+      "vector": "vr09v6GgoLz39vY+nJsbv5WUFD6WlRW//Pt7v9va2j7s62s/mJcXP9TTU7+EgwO/qqkpP/HwcD3n5uY+s7Kyvru6ur7f3t4+/fx8PsnIyL37+vq+vbw8PgAAgD/V1FS+6Odnv/LxcT/o52e/w8LCPq+urr6UkxM/6Odnv8rJSb++vT2/oaCgvPf29j6cmxu/lZQUPpaVFb/8+3u/29raPuzraz+Ylxc/1NNTv4SDA7+qqSk/8fBwPefm5j6zsrK+u7q6vt/e3j79/Hw+ycjIvfv6+r69vDw+AACAP9XUVL7o52e/8vFxP+jnZ7/DwsI+r66uvpSTEz/o52e/yslJvw==",
+      "vectorSha256": "ef5509a67752f098dfed28fad77703fb28aaba34be99377ed29226057014a9a5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "217dbd32923502b6f5cb163ed487b95351b79f734197ff650cf80cb054c90c1b",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-38": {
+      "vector": "x8bGvqSjIz+/vr6+2NdXP/Dvbz+pqKi9+/r6Pq+urj6fnp4+r66uvublZb/p6Og9uLc3P4KBAb+Ihwe/6ejoPbW0NL6EgwM/mZiYvbCvLz/5+Pg91dRUPri3Nz+BgIA77exsPufm5j7OzU0/5+bmPublZT+UkxO/iIcHv/X0dD7Hxsa+pKMjP7++vr7Y11c/8O9vP6moqL37+vo+r66uPp+enj6vrq6+5uVlv+no6D24tzc/goEBv4iHB7/p6Og9tbQ0voSDAz+ZmJi9sK8vP/n4+D3V1FQ+uLc3P4GAgDvt7Gw+5+bmPs7NTT/n5uY+5uVlP5STE7+Ihwe/9fR0Pg==",
+      "vectorSha256": "5cfdf05d18633cd33fb0fe09c2dc849f50c8c950b075c842afcf4522f288c13d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4ed150ebf775beaba7540d8edb3f3c8e69c176d78f9adb809db9e6b9f2363c9e",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-39": {
+      "vector": "4eDgPPb1db/NzEy+5uVlP6+urj7NzEw+0tFRv9/e3r739va+2djYPdnY2L3r6uq+l5aWvry7Oz+JiIi9mpkZP6uqqr6Pjo4+7u1tP6uqqr7Lyso+qaiovauqqr6gnx+/wsFBP5KRET/l5GQ+pKMjv7CvLz/BwEC8397evqGgoDzh4OA89vV1v83MTL7m5WU/r66uPs3MTD7S0VG/397evvf29r7Z2Ng92djYvevq6r6Xlpa+vLs7P4mIiL2amRk/q6qqvo+Ojj7u7W0/q6qqvsvKyj6pqKi9q6qqvqCfH7/CwUE/kpERP+XkZD6koyO/sK8vP8HAQLzf3t6+oaCgPA==",
+      "vectorSha256": "33e962ce8859619834b8be56d3fdc3882736667086e4b109a0c1f8df40221e6b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "830566f2ab991748428d72455add77cc55a3f655b2755530e0c89c2ed77e4882",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-40": {
+      "vector": "x8bGvr++vr7z8vI+2NdXP6KhIb+xsDC9i4qKPr28PL6pqKi929ravuHg4LzGxUU//fx8Pr28PL7q6Wk/vbw8vpeWlr6hoKA8//7+vpiXF7+Ylxc/kZAQvcnIyL2urS2/h4aGPs7NTT/JyMg99vV1v/n4+L20szO/pqUlv9va2j7Hxsa+v76+vvPy8j7Y11c/oqEhv7GwML2Lioo+vbw8vqmoqL3b2tq+4eDgvMbFRT/9/Hw+vbw8vurpaT+9vDy+l5aWvqGgoDz//v6+mJcXv5iXFz+RkBC9ycjIva6tLb+HhoY+zs1NP8nIyD329XW/+fj4vbSzM7+mpSW/29raPg==",
+      "vectorSha256": "9664ea99df7bcd484807fa665919b9dbf9b73b1acd3e6d5420e536d0decdde4a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4e50bceb2f7aa26875497ce29f68f4685a824034cb7b7329a1e68c0570262db6",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-41": {
+      "vector": "l5aWPpeWlj61tDQ+//7+PqalJb/JyMg9qaiovYyLCz/m5WW/o6KiPs/Ozr6/vr4+oJ8fP7q5Ob+Pjo6+v76+vqCfH7+rqqq++Pd3v9PS0r6Xlpa+zs1NP5aVFb/Ew0O/4N9fv42MDD65uLg95eRkPoWEBD7My0u/3Ntbv5ybGz+XlpY+l5aWPrW0ND7//v4+pqUlv8nIyD2pqKi9jIsLP+blZb+joqI+z87Ovr++vj6gnx8/urk5v4+Ojr6/vr6+oJ8fv6uqqr7493e/09LSvpeWlr7OzU0/lpUVv8TDQ7/g31+/jYwMPrm4uD3l5GQ+hYQEPszLS7/c21u/nJsbPw==",
+      "vectorSha256": "ea00446e1997edf56a86c64d5fcc992accaeefb24471cdfdc44954b4e48b65da",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a5a596bf2d8c75c50da84cafcf235c503055044b5ae6351e10918b9c901a12cd",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-42": {
+      "vector": "ubi4PfTzcz/Ix0e/AACAP8jHRz+Pjo6+2djYvZiXF7+ysTE/lpUVP8zLS7+BgIA7pqUlP9TTU7+GhQW/9/b2vo6NDb/5+Pi90M9Pv7m4uL25uLi9l5aWPrq5OT+rqqq+1NNTP9PS0r7OzU2/oaCgvKWkJL6gnx+/6Odnv6Oior65uLg99PNzP8jHR78AAIA/yMdHP4+Ojr7Z2Ni9mJcXv7KxMT+WlRU/zMtLv4GAgDumpSU/1NNTv4aFBb/39va+jo0Nv/n4+L3Qz0+/ubi4vbm4uL2XlpY+urk5P6uqqr7U01M/09LSvs7NTb+hoKC8paQkvqCfH7/o52e/o6Kivg==",
+      "vectorSha256": "709449fe43b5aecb8d7cce5a57513c34facf46b85c3e9734d4608f9b50a16b70",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8bf91cffe35c7234d8ca1a80d2163d423970187474a5dc55e94b197d6b300c57",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-43": {
+      "vector": "29ravsvKyr6sqyu/oqEhv6qpKT+CgQG/yMdHP7u6ur75+Pi9xMNDv/v6+j7JyMg919bWPpGQED2Ylxc/nZwcvsbFRb+hoKA83t1dv+/u7r6DgoK+0tFRP5WUFL6rqqo+m5qaPoqJCT/DwsI+o6KiPr28PL6koyO/j46Ovvf29j7b2tq+y8rKvqyrK7+ioSG/qqkpP4KBAb/Ix0c/u7q6vvn4+L3Ew0O/+/r6PsnIyD3X1tY+kZAQPZiXFz+dnBy+xsVFv6GgoDze3V2/7+7uvoOCgr7S0VE/lZQUvquqqj6bmpo+iokJP8PCwj6joqI+vbw8vqSjI7+Pjo6+9/b2Pg==",
+      "vectorSha256": "c16f922ee3d028b954db20704f22294856c3e7f9d73b15c9d35c7e6c9c963b48",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "494d2a2fd43fe351701ebe8cb584cb6c1d8211445fe86daaa6c4b0a8682e5cbd",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-44": {
+      "vector": "4eDgPJCPD7+WlRW/0tFRP7a1Nb+ysTG/oaCgPLKxMT+Qjw+/sK8vP+fm5j6xsDA9w8LCvoGAgLv39va+n56ePsTDQz+npqa+x8bGPt3cXD6KiQm/6+rqPqempj6joqI+j46OPqGgoLyKiQm/oJ8fP728PD6cmxu/k5KSPvf29j7h4OA8kI8Pv5aVFb/S0VE/trU1v7KxMb+hoKA8srExP5CPD7+wry8/5+bmPrGwMD3DwsK+gYCAu/f29r6fnp4+xMNDP6empr7HxsY+3dxcPoqJCb/r6uo+p6amPqOioj6Pjo4+oaCgvIqJCb+gnx8/vbw8PpybG7+TkpI+9/b2Pg==",
+      "vectorSha256": "5b1ad41e062a548a2cd103da979a5ecf5e7ceb6b52aabe45dbd814a564c20b1a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "833835e8252782d838d7b9854f7f42a7e156b19b3bbaa9a8a37d3bcf9732a4bd",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-45": {
+      "vector": "6+rqPquqqj7Pzs6+1dRUPtLRUb+XlpY+19bWPsjHRz/+/X0/h4aGvquqqj6urS0/4+Livru6uj6UkxO/mJcXP83MTD7b2tq+zs1Nv+jnZz+rqqq+trU1P6moqD2UkxM/sbAwPaqpKb+Pjo6+3dxcPsXERD6+vT0///7+PqWkJL7r6uo+q6qqPs/Ozr7V1FQ+0tFRv5eWlj7X1tY+yMdHP/79fT+Hhoa+q6qqPq6tLT/j4uK+u7q6PpSTE7+Ylxc/zcxMPtva2r7OzU2/6OdnP6uqqr62tTU/qaioPZSTEz+xsDA9qqkpv4+Ojr7d3Fw+xcREPr69PT///v4+paQkvg==",
+      "vectorSha256": "526c8738172c994e57daac6b24f9eecff5d0c53fb6ff40b14934b0acc13cf621",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "baaa4c9a17a5b5e3fe5eaad647ae36cb994919f355da8ac9852b5c9b98debf6b",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-46": {
+      "vector": "1dRUvpybG7/Z2Ni99vV1v+jnZ7+DgoK+rawsvoiHB7/u7W0/19bWPpiXF7+mpSW/m5qaPpSTE7/f3t6+4uFhP9DPTz/DwsK+u7q6vq+urj7s62u/s7Kyvu7tbT+amRm/6Odnv6WkJL7e3V0/p6amvqGgoDyMiws/0tFRP9HQUD3V1FS+nJsbv9nY2L329XW/6Odnv4OCgr6trCy+iIcHv+7tbT/X1tY+mJcXv6alJb+bmpo+lJMTv9/e3r7i4WE/0M9PP8PCwr67urq+r66uPuzra7+zsrK+7u1tP5qZGb/o52e/paQkvt7dXT+npqa+oaCgPIyLCz/S0VE/0dBQPQ==",
+      "vectorSha256": "09be582df19b4eb65d28a70618868f465fd958964eea177bbac225a6e8449f34",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "653272050c5f6a3cf6b5342da63648f0e74f51ab0a53f6330c6bee5682c5e886",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-47": {
+      "vector": "x8bGvtXUVD6opyc/u7q6PpGQEL37+vo+ycjIvbi3N7+Ihwe/7u1tP7KxMb/Avz8/nZwcvu/u7j7W1VU/2tlZv42MDL7Avz8/q6qqPoKBAT+lpCQ+4N9fP56dHT+KiQk/09LSPr69Pb/u7W2/jo0NP6GgoDy7urq+ubi4PcrJST/Hxsa+1dRUPqinJz+7uro+kZAQvfv6+j7JyMi9uLc3v4iHB7/u7W0/srExv8C/Pz+dnBy+7+7uPtbVVT/a2Vm/jYwMvsC/Pz+rqqo+goEBP6WkJD7g318/np0dP4qJCT/T0tI+vr09v+7tbb+OjQ0/oaCgPLu6ur65uLg9yslJPw==",
+      "vectorSha256": "7c7473c4ceab8f2bde65504f2dda118eb713813a1f2dda195013a26a31edcf6e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4e9ad3ae7bbe73243cf627df6cbbea136edfaac094efcec4b42109c682518be4",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-48": {
+      "vector": "AACAv4qJCT+0szO/iYiIve7tbb/f3t6+nJsbP6+urr6BgIC7w8LCvtHQUL2dnBw+0M9PP8jHRz+trCy+397ePtLRUT+4tzc/trU1v7GwML3h4OC8mJcXP/X0dD69vDw+g4KCPsnIyL38+3s/29raPtPS0j7s62u/9/b2vvn4+D0AAIC/iokJP7SzM7+JiIi97u1tv9/e3r6cmxs/r66uvoGAgLvDwsK+0dBQvZ2cHD7Qz08/yMdHP62sLL7f3t4+0tFRP7i3Nz+2tTW/sbAwveHg4LyYlxc/9fR0Pr28PD6DgoI+ycjIvfz7ez/b2to+09LSPuzra7/39va++fj4PQ==",
+      "vectorSha256": "44df791b291dd03fd5eb3420cb0494b5ae5c41ec99014647ce61d8f17b2f3a66",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "00c426770948cd547f4f7993e7e36ab7e8db257a7ccb9e97a073fdb6b40a428f",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-49": {
+      "vector": "9vV1P42MDD7493e/oaCgPJuamj729XU/6Odnv7y7Oz/X1ta+hoUFP+LhYb+DgoK+0dBQvY+Ojr6qqSk///7+Pu7tbT/n5uY+09LSvs7NTT/b2tq+vr09v4uKir6/vr6+397ePqGgoDyqqSm/qKcnv4GAgDuBgIA7lpUVv62sLD729XU/jYwMPvj3d7+hoKA8m5qaPvb1dT/o52e/vLs7P9fW1r6GhQU/4uFhv4OCgr7R0FC9j46OvqqpKT///v4+7u1tP+fm5j7T0tK+zs1NP9va2r6+vT2/i4qKvr++vr7f3t4+oaCgPKqpKb+opye/gYCAO4GAgDuWlRW/rawsPg==",
+      "vectorSha256": "d164beda32b2575641c23b31b2aca40987fbbc005e7b3fd6ad9146a5d9fff825",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fa910482a6fa0cdd4ac20f5f795cd4bff6b94be649215d50b7822b2c80803595",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "family-50": {
+      "vector": "ycjIPaGgoLzf3t6+v76+PtXUVL7W1VW/4+Livrq5OT/f3t6+pKMjP6KhIT+BgIC7hIMDP+zra7+/vr6+urk5P4GAgDvb2tq+397evpWUFL6FhAQ+o6KiPv38fD6+vT0/4eDgvKempr6enR2/p6amvouKir7a2Vk/7Otrv4qJCT/JyMg9oaCgvN/e3r6/vr4+1dRUvtbVVb/j4uK+urk5P9/e3r6koyM/oqEhP4GAgLuEgwM/7Otrv7++vr66uTk/gYCAO9va2r7f3t6+lZQUvoWEBD6joqI+/fx8Pr69PT/h4OC8p6amvp6dHb+npqa+i4qKvtrZWT/s62u/iokJPw==",
+      "vectorSha256": "22867621bcb62cf69ef2917d1a1543da05d26f9befb2ee816622d97d41758a90",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8c7d48af651547dc48d1d07fc10a50dc8049486d90a89fde7c5631565dec0ac4",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "love-01": {
+      "vector": "n56evtDPTz/NzEy+urk5P/79fT+ioSG/pKMjv//+/j64tzc/+/r6Ppuamr6DgoI+5uVlv/v6+r7n5uY+sbAwPdXUVD6Lioq+h4aGPrm4uD2joqI+xsVFv/z7ez/493e/v76+Pq2sLD75+Pg9jo0NP/Lxcb/m5WU/i4qKPtbVVb+fnp6+0M9PP83MTL66uTk//v19P6KhIb+koyO///7+Pri3Nz/7+vo+m5qavoOCgj7m5WW/+/r6vufm5j6xsDA91dRUPouKir6HhoY+ubi4PaOioj7GxUW//Pt7P/j3d7+/vr4+rawsPvn4+D2OjQ0/8vFxv+blZT+Lioo+1tVVvw==",
+      "vectorSha256": "de2afca37abd49acac7e96f5b3eefb26b19ec27e1ad8764b7ac0d06f01b76cc1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "58e766dcfe2f2ebfdbbe59a00d41b9859a5da18ba81dfd04af958fc607f2a215",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "love-02": {
+      "vector": "vr09P7q5Ob+CgQG/zMtLP5ybG7+gnx+/iIcHv8jHR7/e3V2/+vl5P+3sbD7W1VW/9PNzP/n4+L22tTU/jo0NP7Oysj7f3t4+k5KSvsrJSb///v4+srExv83MTD67uro+kpERv6qpKT/g31+/g4KCPry7Oz+qqSk/z87OPpOSkj6+vT0/urk5v4KBAb/My0s/nJsbv6CfH7+Ihwe/yMdHv97dXb/6+Xk/7exsPtbVVb/083M/+fj4vba1NT+OjQ0/s7KyPt/e3j6TkpK+yslJv//+/j6ysTG/zcxMPru6uj6SkRG/qqkpP+DfX7+DgoI+vLs7P6qpKT/Pzs4+k5KSPg==",
+      "vectorSha256": "82a5a9cb5c6d7abf607f4537c32be463864224e1aaf58c224313433d477e8b84",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "de233fe532303c1c11fc9d15f970dac6acb75b1bbf2799ae37d410a0ddd4b3a4",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "love-03": {
+      "vector": "o6KivqKhIT/n5uY+9fR0PqmoqL38+3s/1NNTv8nIyL3R0FC9oaCgvLa1Nb/OzU0/8fBwPZWUFD7z8vK+ycjIPbOysr7Lysq+lJMTv8jHR7/29XU/rawsvoOCgj6HhoY+9vV1v7i3N7/Ew0O/xcREPq+urr7NzEy+wsFBP9bVVT+joqK+oqEhP+fm5j719HQ+qaiovfz7ez/U01O/ycjIvdHQUL2hoKC8trU1v87NTT/x8HA9lZQUPvPy8r7JyMg9s7KyvsvKyr6UkxO/yMdHv/b1dT+trCy+g4KCPoeGhj729XW/uLc3v8TDQ7/FxEQ+r66uvs3MTL7CwUE/1tVVPw==",
+      "vectorSha256": "394fe68ada293f9a6aa30e19e24179fb3dc5248c9c9480dabbc755af1df4fbba",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "57d0b99e75fd1673797d25e68792438c534d361cfa6aa0a105241e985466e0ea",
+      "updatedAt": "2025-09-20T22:28:15.457Z"
+    },
+    "love-04": {
+      "vector": "h4aGvpuamr7Ix0e/+fj4vdLRUb/q6Wk/0M9PP+/u7j6zsrK+1NNTP4mIiL2OjQ0/srExP83MTL7h4OC8l5aWPtTTUz+lpCQ+tbQ0PsPCwr6Ihwe/srExv5aVFb+Lioq++/r6vpeWlr76+Xk/9/b2PoaFBT/Ix0e/+/r6Pq6tLb+Hhoa+m5qavsjHR7/5+Pi90tFRv+rpaT/Qz08/7+7uPrOysr7U01M/iYiIvY6NDT+ysTE/zcxMvuHg4LyXlpY+1NNTP6WkJD61tDQ+w8LCvoiHB7+ysTG/lpUVv4uKir77+vq+l5aWvvr5eT/39vY+hoUFP8jHR7/7+vo+rq0tvw==",
+      "vectorSha256": "e8fea027968e4316060d091b38c1482fdf41b187440876881dbb39c083f6c619",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5e591c7017f4e7bb53e977c6d8667ca5e994964f3c27355d415afcbdc21cbe29",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-05": {
+      "vector": "8vFxv6Oior62tTW/5ONjP/v6+j7Z2Ni9l5aWPtrZWT+BgIC7jIsLv9TTUz/f3t6+ubi4Pe3sbD6VlBS+vr09v//+/r62tTU/5ONjP9nY2L3m5WW/ycjIPYOCgr7r6uq+h4aGvrGwML2UkxM/lZQUvr28PL7X1tY+g4KCvt7dXT/y8XG/o6Kivra1Nb/k42M/+/r6PtnY2L2XlpY+2tlZP4GAgLuMiwu/1NNTP9/e3r65uLg97exsPpWUFL6+vT2///7+vra1NT/k42M/2djYveblZb/JyMg9g4KCvuvq6r6Hhoa+sbAwvZSTEz+VlBS+vbw8vtfW1j6DgoK+3t1dPw==",
+      "vectorSha256": "3720431a7182267965ab267e6ec345b0793ba7e1993648f2cc814e79cd43f537",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "075725f1be72a5ec7f3ae9488b9d6d2140daf1720d8c5f455e7ac96d68b55fee",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-06": {
+      "vector": "4N9fP/v6+j6Pjo4+s7Kyvvn4+L2qqSk/k5KSPuPi4r6wry8/+vl5v4KBAT/m5WW/l5aWPsvKyj7b2tq+vbw8vrKxMT+joqI+mZiYvcTDQ7+SkRE/srExv8bFRT+hoKC8lZQUvu/u7r7OzU0/pqUlv4aFBT/x8HC9jo0Nv/38fD7g318/+/r6Po+Ojj6zsrK++fj4vaqpKT+TkpI+4+LivrCvLz/6+Xm/goEBP+blZb+XlpY+y8rKPtva2r69vDy+srExP6Oioj6ZmJi9xMNDv5KRET+ysTG/xsVFP6GgoLyVlBS+7+7uvs7NTT+mpSW/hoUFP/HwcL2OjQ2//fx8Pg==",
+      "vectorSha256": "619b716dd5c7fff964573675c582992a1b89ad8ba8414f6d264e59cad69ffee3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "efbea35370d4a447d703c00da5b24968d8a8761ec827e27d6d44e62dc278399f",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-07": {
+      "vector": "v76+vtrZWb+gnx8/urk5v/38fL7//v6+1dRUPvz7ez+qqSm/mJcXv+TjYz/R0FC95eRkvtzbWz+ioSG/rKsrP/HwcL2lpCS+rawsvoeGhr7S0VG/wL8/v+rpab+8uzs/tLMzP9va2r7y8XE/6ejoPeno6D20szO/+vl5P+DfX7+/vr6+2tlZv6CfHz+6uTm//fx8vv/+/r7V1FQ+/Pt7P6qpKb+Ylxe/5ONjP9HQUL3l5GS+3NtbP6KhIb+sqys/8fBwvaWkJL6trCy+h4aGvtLRUb/Avz+/6ulpv7y7Oz+0szM/29ravvLxcT/p6Og96ejoPbSzM7/6+Xk/4N9fvw==",
+      "vectorSha256": "b34781de337f0170391a4e8a188821697e2b185b42b89f970cf777a38aee39aa",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5013cf2360409afd2b34f17963ed2fd5786b6a5e17200bddd949f88e8e26fc10",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-08": {
+      "vector": "lpUVv/X0dL7CwUE/sK8vv/Dvbz+CgQG/ubi4Pfn4+D3BwEC8u7q6vp2cHL6lpCQ+5eRkvpiXFz+FhAS+xcREPru6ur6qqSm/2tlZv4SDA7/6+Xm/7+7uvpCPD7/NzEy+o6KivsbFRb/S0VE/8O9vv8fGxr7x8HC909LSvv79fT+WlRW/9fR0vsLBQT+wry+/8O9vP4KBAb+5uLg9+fj4PcHAQLy7urq+nZwcvqWkJD7l5GS+mJcXP4WEBL7FxEQ+u7q6vqqpKb/a2Vm/hIMDv/r5eb/v7u6+kI8Pv83MTL6joqK+xsVFv9LRUT/w72+/x8bGvvHwcL3T0tK+/v19Pw==",
+      "vectorSha256": "6a7e1587b793802224ed352e9bf54e7542103bd8952da73fb696aadf4c19f6d6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3561e028f73f8b8f7e516c9463cb6f98512b133e03443866571de8084e784bfe",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-09": {
+      "vector": "+vl5P6WkJD7W1VU/n56ePrW0NL729XU/9vV1P6alJb/q6Wm//Pt7v9jXVz+Ylxc/r66uPru6ur7c21u/AACAv5eWlj67uro+n56evoaFBT/Pzs4+gYCAu7CvLz+fnp4+lJMTv4+Ojr7w728/0dBQPa2sLL63tra+yMdHP4+Ojr76+Xk/paQkPtbVVT+fnp4+tbQ0vvb1dT/29XU/pqUlv+rpab/8+3u/2NdXP5iXFz+vrq4+u7q6vtzbW78AAIC/l5aWPru6uj6fnp6+hoUFP8/Ozj6BgIC7sK8vP5+enj6UkxO/j46OvvDvbz/R0FA9rawsvre2tr7Ix0c/j46Ovg==",
+      "vectorSha256": "3fb3a0255cb9689dd78c0b6adc32a6172fb01bd5396b6e0f296a997f39a5cef3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "fc94eaa769fafa2d0b02ebcbab511200a5ae58c2b37fd7a7365cf7866a52e35c",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-10": {
+      "vector": "gYCAO/j3dz/v7u4+kZAQvaCfH7+JiIi9pKMjP9XUVD6vrq4+7exsvtzbW7+2tTW/0M9Pv5STE7/NzEy+v76+vu3sbL76+Xk/yslJP4uKir7Ew0M/xcREvqalJb/JyMg9z87OPsnIyD2mpSW/2tlZP8/Ozr6koyM/wcBAvLa1Nb+BgIA7+Pd3P+/u7j6RkBC9oJ8fv4mIiL2koyM/1dRUPq+urj7t7Gy+3Ntbv7a1Nb/Qz0+/lJMTv83MTL6/vr6+7exsvvr5eT/KyUk/i4qKvsTDQz/FxES+pqUlv8nIyD3Pzs4+ycjIPaalJb/a2Vk/z87OvqSjIz/BwEC8trU1vw==",
+      "vectorSha256": "852087d5730db8f0ab2b1b7a37cb8e56ce4cf5a92c63dec6e27c7f2dd809eb14",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "80fbbb7b3077d19aab6212251836665062fce45de1672d8cb38c2dec4cd17e25",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-11": {
+      "vector": "urk5P4iHB7/S0VG/1tVVv9HQUD2Ihwe/tbQ0PoOCgj61tDS+4+LiPru6uj61tDS+kpERv93cXL7w728/kI8Pv7m4uL3f3t6+mJcXv8HAQLy4tze/pKMjv8C/Pz+1tDQ+x8bGPvTzcz+lpCS+5uVlv+vq6j7Pzs6+9PNzP+7tbb+6uTk/iIcHv9LRUb/W1VW/0dBQPYiHB7+1tDQ+g4KCPrW0NL7j4uI+u7q6PrW0NL6SkRG/3dxcvvDvbz+Qjw+/ubi4vd/e3r6Ylxe/wcBAvLi3N7+koyO/wL8/P7W0ND7HxsY+9PNzP6WkJL7m5WW/6+rqPs/Ozr7083M/7u1tvw==",
+      "vectorSha256": "9d7d32b76b9664be1cfd5db612faaf267317bd8965780ad75afc4dd38f405de8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dc3c1715863c96a069b8ae693764f7387448347e242edf96b1f96b0dba4cf909",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-12": {
+      "vector": "6OdnP+blZb+sqyu/3NtbP83MTD6rqqo+hIMDv/j3d7/z8vI+x8bGPvDvb7+Qjw+/tLMzP/X0dL6urS0/hoUFP4GAgDvR0FA9rKsrP9jXVz+8uzu/gYCAu+7tbT/j4uI+kI8PP+Hg4Dyrqqo+np0dP+DfX7+sqyu/zMtLP/HwcD3o52c/5uVlv6yrK7/c21s/zcxMPquqqj6EgwO/+Pd3v/Py8j7HxsY+8O9vv5CPD7+0szM/9fR0vq6tLT+GhQU/gYCAO9HQUD2sqys/2NdXP7y7O7+BgIC77u1tP+Pi4j6Qjw8/4eDgPKuqqj6enR0/4N9fv6yrK7/My0s/8fBwPQ==",
+      "vectorSha256": "af694818508d8fa4793181367fe805f68134bfb1bf3d1b16e2b03066bfc7e732",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f30d2aed99aa3e04bcb10838d961d6c28086d5eb227ff6b8c783aace102ae587",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-13": {
+      "vector": "jIsLP93cXL7KyUm/kZAQvfb1dT8AAIC/vLs7v/v6+r7q6Wm/6Odnv5ybG7+cmxs/urk5P7W0ND6Lioq+q6qqvqmoqD2RkBA9mpkZv/X0dD7q6Wm/lpUVv9rZWb+TkpK+8fBwvcfGxr6sqys/rq0tv5KREb/Lyso+9PNzv/Tzcz+Miws/3dxcvsrJSb+RkBC99vV1PwAAgL+8uzu/+/r6vurpab/o52e/nJsbv5ybGz+6uTk/tbQ0PouKir6rqqq+qaioPZGQED2amRm/9fR0Purpab+WlRW/2tlZv5OSkr7x8HC9x8bGvqyrKz+urS2/kpERv8vKyj7083O/9PNzPw==",
+      "vectorSha256": "c21676783522adfcf37bcd208de31f0a0909ace8d166969a453299c2ac2b2b7b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "c5641b7bfa0022410b0c32cddc965d558a84339e0b35135b784ed52937b206f9",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-14": {
+      "vector": "3dxcvsnIyL23tra+tbQ0vsC/Pz+WlRU/mJcXv8TDQ7/CwUE/+/r6vrGwML26uTk/iIcHP/38fL68uzu/0tFRP5uamj6zsrI+h4aGPrSzM7/19HS+uLc3v7++vr7j4uI+rKsrv5CPDz+wry+/rKsrv4yLC7/T0tK+uLc3v+3sbD7d3Fy+ycjIvbe2tr61tDS+wL8/P5aVFT+Ylxe/xMNDv8LBQT/7+vq+sbAwvbq5OT+Ihwc//fx8vry7O7/S0VE/m5qaPrOysj6HhoY+tLMzv/X0dL64tze/v76+vuPi4j6sqyu/kI8PP7CvL7+sqyu/jIsLv9PS0r64tze/7exsPg==",
+      "vectorSha256": "1c74d2275fb31eb4edafe02ccf6432157b2a72e85f5d62667664d151c752cd56",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "64735269dfca341ee0417adcc36022e8a6aca126612450b82ac7282a3a4b249d",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-15": {
+      "vector": "mZiYveDfX7+qqSm/srExv9rZWT/493c/n56evpOSkr77+vq+09LSvtrZWT+6uTk///7+PpqZGb/y8XE/29ravublZb/DwsK+gYCAO6moqD3a2Vk/urk5P769Pb/c21s/lpUVv6WkJD7i4WG/p6amPqGgoDzY11e/0tFRP9nY2L2ZmJi94N9fv6qpKb+ysTG/2tlZP/j3dz+fnp6+k5KSvvv6+r7T0tK+2tlZP7q5OT///v4+mpkZv/LxcT/b2tq+5uVlv8PCwr6BgIA7qaioPdrZWT+6uTk/vr09v9zbWz+WlRW/paQkPuLhYb+npqY+oaCgPNjXV7/S0VE/2djYvQ==",
+      "vectorSha256": "faec8615817272363f92a43865c8d94e349deb68b85d4b44ffdbc07d6cce8664",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "76102b27ecfb585b414becdcbf33f8490d4f808aecdc21ed35940fa98214e872",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-16": {
+      "vector": "z87OPqyrKz+1tDQ+9/b2vsnIyL3r6uq+//7+PpeWlj7GxUU/qqkpP9PS0j76+Xm/2NdXv/f29r7l5GQ+5ONjv5KRET/l5GS+x8bGPrGwMD3V1FQ+7OtrP8jHRz/f3t6+vr09v/Dvb7+Ihwe/lZQUvo6NDb+koyM/vLs7v9LRUT/Pzs4+rKsrP7W0ND739va+ycjIvevq6r7//v4+l5aWPsbFRT+qqSk/09LSPvr5eb/Y11e/9/b2vuXkZD7k42O/kpERP+XkZL7HxsY+sbAwPdXUVD7s62s/yMdHP9/e3r6+vT2/8O9vv4iHB7+VlBS+jo0Nv6SjIz+8uzu/0tFRPw==",
+      "vectorSha256": "bc80fadd8fa76666fde42960c01622f4ce47e5a7711d84241924c982b136052d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b3d596427345bfa5e2d4b40314429c0ec863b1859af5e34821083c6d39d122e8",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-17": {
+      "vector": "srExP4qJCb+npqa+zcxMPsnIyL0AAIA/4+Livvn4+D2BgIC7iYiIPZmYmD3Ew0M/6ulpP6WkJL7o52c/nZwcPoyLC7+CgQE/+fj4PdDPT7/Hxsa+rq0tP4KBAT/w72+/g4KCvtXUVD7OzU0/1NNTP42MDD7X1tY+4+Livvz7ez+ysTE/iokJv6empr7NzEw+ycjIvQAAgD/j4uK++fj4PYGAgLuJiIg9mZiYPcTDQz/q6Wk/paQkvujnZz+dnBw+jIsLv4KBAT/5+Pg90M9Pv8fGxr6urS0/goEBP/Dvb7+DgoK+1dRUPs7NTT/U01M/jYwMPtfW1j7j4uK+/Pt7Pw==",
+      "vectorSha256": "8a82505516b832286e887e817dc44c934b74f5b5fce81045e22317bb5d1e78ba",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d83b569973ff478f7f8889e1f46bf3933ac08f184ed6c0085f9ae6e991b547fd",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-18": {
+      "vector": "0dBQPefm5r6ioSG/k5KSvqmoqD2trCy+4N9fv9fW1r6bmpo+u7q6Pv79fT/39va+7+7uPsC/P7+Miws/yMdHP9PS0r6TkpK+vLs7P9PS0j79/Hy+0M9PP4WEBL61tDS+x8bGPvLxcT/j4uK+2NdXP5STEz/c21u/zcxMPsvKyj7R0FA95+bmvqKhIb+TkpK+qaioPa2sLL7g31+/19bWvpuamj67uro+/v19P/f29r7v7u4+wL8/v4yLCz/Ix0c/09LSvpOSkr68uzs/09LSPv38fL7Qz08/hYQEvrW0NL7HxsY+8vFxP+Pi4r7Y11c/lJMTP9zbW7/NzEw+y8rKPg==",
+      "vectorSha256": "a5ce129e9b342dbb1894a9ce45050c70c49c8fe9aaf2d2d6c6b3b7708f416f7e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "86462f5b8a6a104aa6aefe42bb20c5e34b5bddb460e76f69b1f847ebc91299b2",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-19": {
+      "vector": "srExP7W0ND7083O/m5qaPqWkJD6FhAS+7Otrv52cHD7T0tI+4eDgvMbFRT+lpCQ+t7a2vufm5j7i4WG/qKcnP/n4+L2ZmJg9kpERP8TDQz+Ihwc/09LSvu3sbL6cmxu/srExP7u6ur7//v6+oqEhP6WkJL6hoKC8kI8PP7e2tj6ysTE/tbQ0PvTzc7+bmpo+paQkPoWEBL7s62u/nZwcPtPS0j7h4OC8xsVFP6WkJD63tra+5+bmPuLhYb+opyc/+fj4vZmYmD2SkRE/xMNDP4iHBz/T0tK+7exsvpybG7+ysTE/u7q6vv/+/r6ioSE/paQkvqGgoLyQjw8/t7a2Pg==",
+      "vectorSha256": "245de3ee867e3896bbf425048313b52abfd0d163753cc19b25c04240e150c1da",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d89606a6946f0a93b47ce29452b90fd37089c8e1c34b6232d85140d06b7dc7ad",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-20": {
+      "vector": "z87OPsnIyL3i4WG/9vV1v8rJSb+WlRW/np0dP8XERD7i4WE/3NtbP8rJST/W1VW/4+LiPri3Nz+RkBC9srExv6yrK7++vT0/+vl5v728PL6enR0/pKMjP6+urr77+vq+rq0tP8/Ozr6sqyu/kI8Pv8jHR7/My0s/ycjIPZ2cHL7Pzs4+ycjIveLhYb/29XW/yslJv5aVFb+enR0/xcREPuLhYT/c21s/yslJP9bVVb/j4uI+uLc3P5GQEL2ysTG/rKsrv769PT/6+Xm/vbw8vp6dHT+koyM/r66uvvv6+r6urS0/z87OvqyrK7+Qjw+/yMdHv8zLSz/JyMg9nZwcvg==",
+      "vectorSha256": "21db52171c7dedf506d0099386bdbca048e2ff7bf69f08bd81bb85735cb0f30e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b3730f051b35ce98f0ede415b8db7b272ade0368ced15441d64c2a381ce58c6c",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-21": {
+      "vector": "vbw8Ppuamr7R0FA9n56evvf29r7k42O/g4KCvvr5eT+KiQm/2NdXP42MDL7r6uo+yMdHP7SzM7/s62u/mpkZP+LhYT+koyO/1NNTv9rZWT/GxUW/paQkvvDvb7+Lioo+q6qqPq+urj7c21u/+vl5v5+enr7+/X0/1NNTP//+/r69vDw+m5qavtHQUD2fnp6+9/b2vuTjY7+DgoK++vl5P4qJCb/Y11c/jYwMvuvq6j7Ix0c/tLMzv+zra7+amRk/4uFhP6SjI7/U01O/2tlZP8bFRb+lpCS+8O9vv4uKij6rqqo+r66uPtzbW7/6+Xm/n56evv79fT/U01M///7+vg==",
+      "vectorSha256": "55f7867aa04ca7191eadbfdcdc2ca3702308159e23d40686b4513b90b41a38ba",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "97598658420e5ffc3beb6ebae3260accf02e16ec1d6b08a2aaab120358fee940",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-22": {
+      "vector": "iYiIPZCPDz+amRk//fx8Puno6L0AAIC/np0dP7y7O7+KiQm/3dxcvoeGhj7Qz0+/+fj4vbKxMT/OzU0/7exsvru6ur6gnx8/t7a2Pre2tj6joqK+zcxMvuTjYz+EgwM/nJsbP5uamj6GhQU/s7KyPvLxcT/T0tI+AACAv7q5Ob+JiIg9kI8PP5qZGT/9/Hw+6ejovQAAgL+enR0/vLs7v4qJCb/d3Fy+h4aGPtDPT7/5+Pi9srExP87NTT/t7Gy+u7q6vqCfHz+3trY+t7a2PqOior7NzEy+5ONjP4SDAz+cmxs/m5qaPoaFBT+zsrI+8vFxP9PS0j4AAIC/urk5vw==",
+      "vectorSha256": "ed310c2074ca6d6b737a1336c2a3415beec56a049a32a11b7dae1f1d1f93735f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "88c7cc9f7100ce223b64a11870d8e66251cfadad5766f1c1cda6c2acf8b40023",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-23": {
+      "vector": "rawsvsrJST+ioSG/q6qqPtHQUL2fnp4+hoUFv7e2tr6rqqq+2tlZP7SzMz/Pzs6+0tFRv8XERL6ioSG/9vV1v62sLL7y8XE/urk5P56dHb/p6Og9/v19P//+/j6koyO/zcxMPre2tr7s62s/trU1P/r5eb/BwEC89PNzv5GQED2trCy+yslJP6KhIb+rqqo+0dBQvZ+enj6GhQW/t7a2vquqqr7a2Vk/tLMzP8/Ozr7S0VG/xcREvqKhIb/29XW/rawsvvLxcT+6uTk/np0dv+no6D3+/X0///7+PqSjI7/NzEw+t7a2vuzraz+2tTU/+vl5v8HAQLz083O/kZAQPQ==",
+      "vectorSha256": "11b0e1c7a5005e648490d823a19785ae487b91526bbf2da693243d6c9b385ebf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6ae42faa79a73d5255ecd94c17672f056af8dc318efebf2e9952f5da037e0684",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-24": {
+      "vector": "r66uvu/u7j7+/X2//fx8PujnZz/W1VU/zs1Nv769PT/FxES+k5KSvsbFRb+koyO/pqUlv7KxMb/NzEw+kpERP8C/P7/BwEA8ubi4PaKhIb+qqSm/29ravoGAgLu8uzu/9/b2vqyrKz+qqSk/kZAQvczLS7/CwUE/9vV1v6alJb+vrq6+7+7uPv79fb/9/Hw+6OdnP9bVVT/OzU2/vr09P8XERL6TkpK+xsVFv6SjI7+mpSW/srExv83MTD6SkRE/wL8/v8HAQDy5uLg9oqEhv6qpKb/b2tq+gYCAu7y7O7/39va+rKsrP6qpKT+RkBC9zMtLv8LBQT/29XW/pqUlvw==",
+      "vectorSha256": "881e449c27efbe96219d0e9340b807489ce96df928f819e71918cfc1a9d6a539",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "54bb019ff3ea19de675b1d2e2d2799c820818b2f2b497f2242d5d47b1ae0052d",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-25": {
+      "vector": "n56ePoGAgLvDwsI+p6amvo6NDT/Qz0+//Pt7v6uqqj6KiQk/9fR0PpeWlr6DgoK+rawsvujnZz+UkxM/sK8vv8PCwr7NzEy+09LSPvPy8j6+vT2/2tlZv6+urr6SkRG/tLMzP9jXVz/Ix0e/lZQUvri3N7+qqSm/wcBAvMjHRz+fnp4+gYCAu8PCwj6npqa+jo0NP9DPT7/8+3u/q6qqPoqJCT/19HQ+l5aWvoOCgr6trCy+6OdnP5STEz+wry+/w8LCvs3MTL7T0tI+8/LyPr69Pb/a2Vm/r66uvpKREb+0szM/2NdXP8jHR7+VlBS+uLc3v6qpKb/BwEC8yMdHPw==",
+      "vectorSha256": "4ef2f77583859f68502f52daf2c9f1baf561de503d28ea1abdcba46145ef3d04",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a77fb056c61802aac49e5a5f6af3c9284f66b4bc21135437d9eb1c6d242b7ee3",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-26": {
+      "vector": "jYwMPu7tbT+DgoK+4N9fv4SDAz/Ew0M///7+vqOior7W1VW//fx8PrKxMT+3tra+oqEhv4+Ojj7j4uK+6ulpP5WUFL6amRk/xcREPra1Nb+4tzc/s7Kyvv38fL6vrq6+mpkZP5aVFT/m5WU/2NdXP//+/j6GhQW/9PNzP4yLCz+NjAw+7u1tP4OCgr7g31+/hIMDP8TDQz///v6+o6KivtbVVb/9/Hw+srExP7e2tr6ioSG/j46OPuPi4r7q6Wk/lZQUvpqZGT/FxEQ+trU1v7i3Nz+zsrK+/fx8vq+urr6amRk/lpUVP+blZT/Y11c///7+PoaFBb/083M/jIsLPw==",
+      "vectorSha256": "0fb0c758902024d1d9056fa219281c06913600de261741fa5a633ba26d70f251",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "91f65f10c1e14057159fd8522fa347f46dcc9825db536054cccaf2ebbf3df9c5",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-27": {
+      "vector": "u7q6vtTTUz+npqa+5+bmPsHAQLyCgQG//fx8Pvr5eT+4tzc/xcREPrSzM7+BgIA7oJ8fv9/e3r6hoKA829raPu/u7r7w72+/wcBAPKyrK7+RkBA9qqkpP+rpab/T0tK+4uFhP4aFBb+mpSU/3t1dP7u6ur6+vT2/mJcXv9bVVT+7urq+1NNTP6empr7n5uY+wcBAvIKBAb/9/Hw++vl5P7i3Nz/FxEQ+tLMzv4GAgDugnx+/397evqGgoDzb2to+7+7uvvDvb7/BwEA8rKsrv5GQED2qqSk/6ulpv9PS0r7i4WE/hoUFv6alJT/e3V0/u7q6vr69Pb+Ylxe/1tVVPw==",
+      "vectorSha256": "3ecd763259094da9ba75f9f913ef11e2bbca453a97ceb12f90ac8831430965ef",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "51e956b97e3f9ffcdb982680304882b64408812a84d40b4bf03dd2ee512134ea",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-28": {
+      "vector": "vLs7v8HAQDze3V2/n56evpmYmL24tzc/+/r6PublZb/My0s/5ONjP5+enj7t7Gy+8fBwPaOior6Ihwc/qqkpP5uamj7Pzs6+3Ntbv7a1Nb/My0u/19bWvqyrKz/+/X2/9vV1v+blZT+fnp6+uLc3P5iXF7+bmpq+6ulpP8PCwj68uzu/wcBAPN7dXb+fnp6+mZiYvbi3Nz/7+vo+5uVlv8zLSz/k42M/n56ePu3sbL7x8HA9o6KivoiHBz+qqSk/m5qaPs/Ozr7c21u/trU1v8zLS7/X1ta+rKsrP/79fb/29XW/5uVlP5+enr64tzc/mJcXv5uamr7q6Wk/w8LCPg==",
+      "vectorSha256": "49451048810e353b9991d49ceefa200c8ecf240d4b90772ef8861b460af2a8ed",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "2281115876dbbe0de5f1a7628757c3d4a64c12251a4ad50105f258db3459f4b0",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-29": {
+      "vector": "5+bmvuvq6j7My0u/7+7uPqWkJD7Pzs6+np0dP+LhYT/Z2Ng9lpUVv9/e3r7My0s/srExv5WUFD7083M/qKcnP9HQUL3u7W0/0tFRv+jnZ7/Qz08/mZiYPcPCwr6Lioo+6+rqPra1Nb+Ihwc/yslJP4qJCb/083M/kZAQvZGQEL3n5ua+6+rqPszLS7/v7u4+paQkPs/Ozr6enR0/4uFhP9nY2D2WlRW/397evszLSz+ysTG/lZQUPvTzcz+opyc/0dBQve7tbT/S0VG/6Odnv9DPTz+ZmJg9w8LCvouKij7r6uo+trU1v4iHBz/KyUk/iokJv/Tzcz+RkBC9kZAQvQ==",
+      "vectorSha256": "4417b237c4b054f966f326f3d186a0beaffa215809e98b645544c9cc8d80f5f9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "46ba1abb944ccef08d3548e52792f9d379f6170ce7894fa2ba25c3e43bf97b7b",
+      "updatedAt": "2025-09-20T22:28:15.458Z"
+    },
+    "love-30": {
+      "vector": "jYwMPsrJSb+gnx+/iIcHP6+urj7d3Fy+5eRkvsrJSb/X1tY+oqEhP8XERL7W1VW/+/r6vpGQEL21tDS+s7KyPre2tj7+/X2/srExv6GgoDzOzU0/2tlZP7a1NT+Hhoa+6OdnP728PD6koyM/paQkPtrZWb+EgwM/oqEhP7++vj6NjAw+yslJv6CfH7+Ihwc/r66uPt3cXL7l5GS+yslJv9fW1j6ioSE/xcREvtbVVb/7+vq+kZAQvbW0NL6zsrI+t7a2Pv79fb+ysTG/oaCgPM7NTT/a2Vk/trU1P4eGhr7o52c/vbw8PqSjIz+lpCQ+2tlZv4SDAz+ioSE/v76+Pg==",
+      "vectorSha256": "742427226ac99ae71b374f28163c9e15e6f0e4f0e37cc350477badb1857ce3da",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "911b30c3ab64631bb5d06715417b69acad012782e6ecda5ef397d19413c1d0af",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-31": {
+      "vector": "m5qavru6ur6HhoY+p6amPqyrKz/FxEQ+6ejoPezra7+TkpK+8O9vv+TjY7/f3t4+2NdXv+XkZD7U01M/j46OvvTzcz8AAIC/t7a2Pr69Pb+9vDy+rawsPrq5OT/y8XE/5uVlP8C/P7/m5WW/sK8vv/X0dL7OzU0/ubi4vfHwcD2bmpq+u7q6voeGhj6npqY+rKsrP8XERD7p6Og97Otrv5OSkr7w72+/5ONjv9/e3j7Y11e/5eRkPtTTUz+Pjo6+9PNzPwAAgL+3trY+vr09v728PL6trCw+urk5P/LxcT/m5WU/wL8/v+blZb+wry+/9fR0vs7NTT+5uLi98fBwPQ==",
+      "vectorSha256": "a6923068c1a4985aec378df6f26e477236d00c9186339632905700e537437fa8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5951a1a9d5988e0a5b080eb7149ce95cf900ad216895dcf8f2200d2861e67487",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-32": {
+      "vector": "iokJv6uqqj6UkxO/o6Kivra1NT/BwEC85uVlP5eWlj75+Pi9zcxMvpqZGb+trCy+k5KSPo6NDT+fnp4+oJ8fP5GQEL3V1FQ+0dBQPbOysj6Ylxe/5+bmPt/e3j6OjQ2/5uVlP9DPT7/X1ta+i4qKvvDvb7+DgoK+9/b2Pry7Oz+KiQm/q6qqPpSTE7+joqK+trU1P8HAQLzm5WU/l5aWPvn4+L3NzEy+mpkZv62sLL6TkpI+jo0NP5+enj6gnx8/kZAQvdXUVD7R0FA9s7KyPpiXF7/n5uY+397ePo6NDb/m5WU/0M9Pv9fW1r6Lioq+8O9vv4OCgr739vY+vLs7Pw==",
+      "vectorSha256": "00ec981a4054c469a238a0e25c98ccc1180428407c2c44c7b6971507d9237a26",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3baa3657da7ef2a57066336aa4c6a7cf7b9a86ac34b9b739f2184a5d085fbddd",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-33": {
+      "vector": "4eDgvOjnZz+sqys/t7a2PoyLCz+koyM/rq0tv8vKyj7f3t4+trU1P5qZGb/Avz+/rq0tv/X0dD6joqI+wcBAPK+urj7BwEA8p6amPvn4+D3My0s/n56ePuvq6j6lpCQ+19bWPvr5eb/GxUW/hIMDP6qpKT/KyUk/1dRUPrGwMD3h4OC86OdnP6yrKz+3trY+jIsLP6SjIz+urS2/y8rKPt/e3j62tTU/mpkZv8C/P7+urS2/9fR0PqOioj7BwEA8r66uPsHAQDynpqY++fj4PczLSz+fnp4+6+rqPqWkJD7X1tY++vl5v8bFRb+EgwM/qqkpP8rJST/V1FQ+sbAwPQ==",
+      "vectorSha256": "d9d73df3ebcc49f4a8e03e3e97af01ab80f6d770e4c1c64b04b7662dd4018cb8",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7cf3d5adc5d129b2b7da3320299ea881ab81a98fe5a7ba94b5031dc1d4e49a85",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-34": {
+      "vector": "09LSPuDfXz+3trY+6Odnv/Py8j7083O/i4qKvvn4+L2qqSm/6ejovYWEBD7Avz8/v76+PgAAgL+VlBQ+4+LiPouKij7DwsK+yMdHv87NTT/29XU/+/r6vpWUFD7Pzs4+q6qqvqGgoLyQjw+/wL8/v46NDb/S0VE/qaiovfv6+r7T0tI+4N9fP7e2tj7o52e/8/LyPvTzc7+Lioq++fj4vaqpKb/p6Oi9hYQEPsC/Pz+/vr4+AACAv5WUFD7j4uI+i4qKPsPCwr7Ix0e/zs1NP/b1dT/7+vq+lZQUPs/Ozj6rqqq+oaCgvJCPD7/Avz+/jo0Nv9LRUT+pqKi9+/r6vg==",
+      "vectorSha256": "c402eca41550d3e7b9d34df52a176c4976a914283e57a18db232176648dba5ba",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b4efad0cbc065d702b7190dfaf0092b8a24f1ce6fa4192b3557d382039e87541",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-35": {
+      "vector": "x8bGPqGgoLzx8HC9pKMjv42MDD7g31+/rawsPq6tLT/n5ua+urk5P97dXb+hoKA809LSvoeGhj7T0tI+yMdHv5OSkj719HQ+8fBwvYuKij6joqK+l5aWPp6dHb/V1FS+sbAwPfz7ez/d3Fw+/fx8vuTjY7+Lioq+7u1tP87NTT/HxsY+oaCgvPHwcL2koyO/jYwMPuDfX7+trCw+rq0tP+fm5r66uTk/3t1dv6GgoDzT0tK+h4aGPtPS0j7Ix0e/k5KSPvX0dD7x8HC9i4qKPqOior6XlpY+np0dv9XUVL6xsDA9/Pt7P93cXD79/Hy+5ONjv4uKir7u7W0/zs1NPw==",
+      "vectorSha256": "7a5890ffdfa4894eb0abf359989c3727091ba84bf5301fc4649850e224745f95",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b17d782e911095d646dc11824ba1b41ca49e78a257a5316585fd9b600e5df6e6",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-36": {
+      "vector": "4eDgPNHQUL3w72+/o6KiPry7O7+enR2/1tVVP5iXFz+/vr6+paQkPpCPDz/Z2Ni9trU1v+no6L2/vr6+09LSvuvq6r6hoKA89/b2vufm5r7KyUm/+fj4PejnZz++vT2/8O9vP83MTL6Ylxc/zs1Nv+LhYT/Lysq+g4KCPvHwcL3h4OA80dBQvfDvb7+joqI+vLs7v56dHb/W1VU/mJcXP7++vr6lpCQ+kI8PP9nY2L22tTW/6ejovb++vr7T0tK+6+rqvqGgoDz39va+5+bmvsrJSb/5+Pg96OdnP769Pb/w728/zcxMvpiXFz/OzU2/4uFhP8vKyr6DgoI+8fBwvQ==",
+      "vectorSha256": "d40676723c129a2c15d317531e7f9b410481b87259973e28827399540fe29b90",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "837908a82231eacb5094c7722571504b458242461b8ff321f766cb19f04da078",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-37": {
+      "vector": "hIMDv9jXV7/DwsI+qKcnv7Oysr7p6Og91tVVv4eGhj6+vT2/lJMTv6qpKb+npqa+vr09P7a1NT/+/X2/kpERv4eGhr6cmxs/0M9Pv6alJb/Avz8/wsFBP6GgoLyIhwc/6ulpv7Oysr7a2Vm/kZAQvZ2cHL6trCy+0tFRv9DPTz+EgwO/2NdXv8PCwj6opye/s7Kyvuno6D3W1VW/h4aGPr69Pb+UkxO/qqkpv6empr6+vT0/trU1P/79fb+SkRG/h4aGvpybGz/Qz0+/pqUlv8C/Pz/CwUE/oaCgvIiHBz/q6Wm/s7KyvtrZWb+RkBC9nZwcvq2sLL7S0VG/0M9PPw==",
+      "vectorSha256": "df0f6a7e74bd19cfaa69c2f5424ee8874204700b71718036b78ea84f2017d950",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3e14b02c538e15a121362b56deda01375ecd182ddfe07dc30b53137b6c6a17e7",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-39": {
+      "vector": "vr09P4qJCT/h4OC86+rqvrCvLz+Xlpa+rawsPsbFRT+joqI+z87Ovry7Oz/d3Fw+5ONjP9/e3r6VlBQ+6+rqPpCPDz+9vDw++/r6vrCvLz/CwUE/4uFhv5+enj7q6Wm/rq0tv/j3d7/DwsI+nZwcPra1Nb+FhAS+5ONjP+TjY7++vT0/iokJP+Hg4Lzr6uq+sK8vP5eWlr6trCw+xsVFP6Oioj7Pzs6+vLs7P93cXD7k42M/397evpWUFD7r6uo+kI8PP728PD77+vq+sK8vP8LBQT/i4WG/n56ePurpab+urS2/+Pd3v8PCwj6dnBw+trU1v4WEBL7k42M/5ONjvw==",
+      "vectorSha256": "402d3d8ea4a7773acde441b8fc033edda6fc9a88f98cc8fafea376545b034e7f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "dec47c45d75a95e2a84cdd9bf14892bac79741d7e00fa70b2904b093256ff10e",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-40": {
+      "vector": "rKsrP6GgoDyLioq+rq0tP4eGhr6amRk/5+bmPtXUVL7m5WU/sbAwveHg4Dz19HQ+x8bGPtva2j729XW/+Pd3v9/e3j78+3s/8/LyvouKij7i4WG/397evv38fL7u7W2/k5KSvvDvbz+Pjo4+rKsrv+3sbD7JyMg9n56evrm4uL2sqys/oaCgPIuKir6urS0/h4aGvpqZGT/n5uY+1dRUvublZT+xsDC94eDgPPX0dD7HxsY+29raPvb1db/493e/397ePvz7ez/z8vK+i4qKPuLhYb/f3t6+/fx8vu7tbb+TkpK+8O9vP4+Ojj6sqyu/7exsPsnIyD2fnp6+ubi4vQ==",
+      "vectorSha256": "498884b021828c127c351112eac87a220fa6bb73b32c0449dc8685bcbeed950a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d5825dd65eccb965f27a839eb1b60504b7fd43a20f4860095bf7a32a9d8c5874",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-41": {
+      "vector": "trU1P8XERL7s62u/p6amvtPS0j7n5uY+9fR0vouKij6CgQG/jYwMvvf29r6sqys/hYQEvv38fL7S0VE/hoUFv42MDL6dnBy+xsVFv/Tzc7/d3Fy+yMdHP4GAgLuqqSm/4eDgvI6NDb+xsDC9wL8/P4OCgj6pqKi9iYiIPaSjI7+2tTU/xcREvuzra7+npqa+09LSPufm5j719HS+i4qKPoKBAb+NjAy+9/b2vqyrKz+FhAS+/fx8vtLRUT+GhQW/jYwMvp2cHL7GxUW/9PNzv93cXL7Ix0c/gYCAu6qpKb/h4OC8jo0Nv7GwML3Avz8/g4KCPqmoqL2JiIg9pKMjvw==",
+      "vectorSha256": "5bc6b6fff4024c18c853db33df1a99371f65858beeda0fd3f0628231c9d34776",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "da670a56b4b961a23f6e42d56f60e83d6e6c1d0664e37f2b7c397adfa075882e",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-42": {
+      "vector": "AACAv7i3N7+3tra+sbAwPby7O7/Y11e/hYQEvq6tLT+0szO/t7a2vqWkJD6hoKC8nJsbP/v6+r7s62s/9vV1v46NDb/GxUW/7OtrP4KBAT8AAIA/hYQEPtnY2L27uro+t7a2vo6NDT+4tzc/+vl5P9bVVb/JyMi95eRkPu3sbL4AAIC/uLc3v7e2tr6xsDA9vLs7v9jXV7+FhAS+rq0tP7SzM7+3tra+paQkPqGgoLycmxs/+/r6vuzraz/29XW/jo0Nv8bFRb/s62s/goEBPwAAgD+FhAQ+2djYvbu6uj63tra+jo0NP7i3Nz/6+Xk/1tVVv8nIyL3l5GQ+7exsvg==",
+      "vectorSha256": "fee37d5ccc55d0a02d417a8660687aea44eadf56ec71decdd8ef5468498cec9c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0024528522146fd62652947dcd41f505391df5c0ff9072ae52c6dbfc15739c62",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-43": {
+      "vector": "j46OvujnZ7+dnBy+h4aGvv/+/j7Lysq+vr09P5eWlr6ioSE/xcREPq6tLT/9/Hy+5uVlv5KRET+lpCQ+3t1dv+/u7r7Avz8/3dxcPtva2j6dnBy+0tFRP9rZWb+0szM/z87OPsnIyD24tzc/xsVFP/38fD6Ylxe/kZAQPa6tLb+Pjo6+6Odnv52cHL6Hhoa+//7+PsvKyr6+vT0/l5aWvqKhIT/FxEQ+rq0tP/38fL7m5WW/kpERP6WkJD7e3V2/7+7uvsC/Pz/d3Fw+29raPp2cHL7S0VE/2tlZv7SzMz/Pzs4+ycjIPbi3Nz/GxUU//fx8PpiXF7+RkBA9rq0tvw==",
+      "vectorSha256": "3b057ce8b08d035b4d72c9454e87d3b60578e368720ae6907f97c1fd58e040c6",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5c0c6c5ebf4dde5ad098d6600dc8941144df9bb66ce813d9b38cdbe29f348429",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-45": {
+      "vector": "4uFhP+7tbT+6uTk/2djYvYGAgLvd3Fy+vLs7v7q5OT/+/X0///7+Pquqqj6cmxs/4eDgPPz7e7///v6+r66uvvv6+r7h4OA85ONjv66tLT/v7u6+p6amPtrZWT/b2tq+tbQ0PtzbW7/p6Oi9jIsLP6qpKb+trCy+rKsrv+blZT/i4WE/7u1tP7q5OT/Z2Ni9gYCAu93cXL68uzu/urk5P/79fT///v4+q6qqPpybGz/h4OA8/Pt7v//+/r6vrq6++/r6vuHg4Dzk42O/rq0tP+/u7r6npqY+2tlZP9va2r61tDQ+3Ntbv+no6L2Miws/qqkpv62sLL6sqyu/5uVlPw==",
+      "vectorSha256": "635182c779a1bf761174783becae2d2d7eb25df4b5ee46c5e2461490f3e549b9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f0f6dc727f6422dcfebfaacd8302405441830ed644a9ec49961271c52b6a2af2",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-46": {
+      "vector": "3NtbP+Pi4j7Ix0e/6ulpv52cHD7h4OC8yMdHv8zLSz+wry+/wsFBv8rJST+Miwu/xcREvvPy8r7d3Fy+r66uvpKRET+9vDw+9PNzv//+/r719HS+n56evoSDAz+pqKi9q6qqvpSTEz+joqI+trU1P7q5OT/NzEy+u7q6PrCvLz/c21s/4+LiPsjHR7/q6Wm/nZwcPuHg4LzIx0e/zMtLP7CvL7/CwUG/yslJP4yLC7/FxES+8/Lyvt3cXL6vrq6+kpERP728PD7083O///7+vvX0dL6fnp6+hIMDP6moqL2rqqq+lJMTP6Oioj62tTU/urk5P83MTL67uro+sK8vPw==",
+      "vectorSha256": "ed20ac606214a3af5b82d191c6584b30fa5ac1a9aec848728e68bc47d02320f5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "edb81c0b937c1ce5281fe43a67436454c89706406158c17555c9a8dadc66aed7",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-47": {
+      "vector": "y8rKvpCPD7/q6Wk/r66uPsPCwj7y8XG/lZQUvoaFBT/q6Wm/0tFRP+DfX7/39va+wsFBP8/Ozj7FxES+q6qqPvj3dz/r6uo+1tVVP52cHL7U01M/n56ePrq5OT+OjQ2/4eDgvNva2r6OjQ2/+fj4Pbq5OT+koyO/v76+vo6NDT/Lysq+kI8Pv+rpaT+vrq4+w8LCPvLxcb+VlBS+hoUFP+rpab/S0VE/4N9fv/f29r7CwUE/z87OPsXERL6rqqo++Pd3P+vq6j7W1VU/nZwcvtTTUz+fnp4+urk5P46NDb/h4OC829ravo6NDb/5+Pg9urk5P6SjI7+/vr6+jo0NPw==",
+      "vectorSha256": "d6900498c8367fd2192ff6edfb7a40b5e735d1c0a22e90f3b7c0adae47261959",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4d38f4abb0076dc20be81042e0b367aafbbaea6ce9a7dc397c49398fdc2e50c6",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-48": {
+      "vector": "sbAwvZOSkr6UkxO/3Ntbv6uqqj7Ix0e/rKsrP+fm5j6dnBw+z87OvsC/Pz+5uLg9mZiYvcLBQb/h4OA82NdXP6empr7R0FA96ejoPd7dXb/j4uK+19bWPq+urj6FhAQ+1dRUvt/e3j6wry+/6ejoPZSTEz+6uTm/jYwMvpSTEz+xsDC9k5KSvpSTE7/c21u/q6qqPsjHR7+sqys/5+bmPp2cHD7Pzs6+wL8/P7m4uD2ZmJi9wsFBv+Hg4DzY11c/p6amvtHQUD3p6Og93t1dv+Pi4r7X1tY+r66uPoWEBD7V1FS+397ePrCvL7/p6Og9lJMTP7q5Ob+NjAy+lJMTPw==",
+      "vectorSha256": "b721d2ee3cb2a0e7842e72693a97667c8d9c6d2e88ce43ce6f9776bc3253f73e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7a5b3612aa1cd5b9934cdf8b761f83eb56868e1147b5ab9065b7288ec9236ec9",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-49": {
+      "vector": "5eRkPuno6D3m5WU/nJsbP/Py8r6pqKi9y8rKvpWUFL69vDw+oqEhv7KxMb+6uTm/2NdXP8rJST+ZmJi9sbAwvd/e3r7083M/tbQ0vqSjI7/Avz+/3NtbP/r5eb/083O/np0dP+no6D3z8vK+lZQUvsfGxj7z8vK++fj4Pfb1dT/l5GQ+6ejoPeblZT+cmxs/8/LyvqmoqL3Lysq+lZQUvr28PD6ioSG/srExv7q5Ob/Y11c/yslJP5mYmL2xsDC9397evvTzcz+1tDS+pKMjv8C/P7/c21s/+vl5v/Tzc7+enR0/6ejoPfPy8r6VlBS+x8bGPvPy8r75+Pg99vV1Pw==",
+      "vectorSha256": "ca6db2ebca876b6a55c426579f74783e5fcac133520f6d2cc55ee4db1157aa0d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9c8ef2cd43754d6d972f2723ebe4767a48f9692e20ed0306ce8e436db1438ffa",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-50": {
+      "vector": "wsFBP7a1Nb/Lyso+uLc3v7e2tr7s62u/qaiova+urr6pqKi9rawsPtLRUT+Qjw8/uLc3v9nY2L3i4WE/5eRkvp6dHb/JyMi9x8bGPvf29r7b2to+o6Kivq+urr7i4WG/vr09P8zLSz/FxES+8/Lyvu7tbT+UkxO/oJ8fv8jHR7/CwUE/trU1v8vKyj64tze/t7a2vuzra7+pqKi9r66uvqmoqL2trCw+0tFRP5CPDz+4tze/2djYveLhYT/l5GS+np0dv8nIyL3HxsY+9/b2vtva2j6joqK+r66uvuLhYb++vT0/zMtLP8XERL7z8vK+7u1tP5STE7+gnx+/yMdHvw==",
+      "vectorSha256": "db6ecb641e288255a6d911b767694b49dcec0ac054b3aa237e1c0c59501032e2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e025b224520a75547595e8c72472f0633173b142b657540fdee56743f636301c",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-51": {
+      "vector": "xMNDv9TTU7+NjAy+ycjIPdHQUD2vrq4+ubi4vauqqr7o52c/urk5v9XUVL6bmpq+1NNTv8PCwr7q6Wk/+fj4PZuamr6Pjo4+zMtLv52cHD6Xlpa+p6amPvDvb7/Ix0e/tLMzv4uKij6zsrK+gYCAu5eWlr729XU/vr09v5qZGb/Ew0O/1NNTv42MDL7JyMg90dBQPa+urj65uLi9q6qqvujnZz+6uTm/1dRUvpuamr7U01O/w8LCvurpaT/5+Pg9m5qavo+Ojj7My0u/nZwcPpeWlr6npqY+8O9vv8jHR7+0szO/i4qKPrOysr6BgIC7l5aWvvb1dT++vT2/mpkZvw==",
+      "vectorSha256": "48c8517b560d785bc4e1d98303cd10d6a4ca6f0fb80ba9a0c7fc60aca4ca98bf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1e166e8c86ab7455f3236559164ff48f59a31a935aa9081c26a2537f5afa2133",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-52": {
+      "vector": "3dxcPoaFBT/Qz0+/oqEhv5eWlr66uTm//Pt7v4KBAT+enR0/2djYPYWEBD7x8HC9r66uPoOCgr7Y11c///7+voOCgr6Pjo4+lJMTP/r5eb/Y11e/19bWPpWUFD729XU/wL8/P5OSkr7d3Fy+6ulpv5WUFD7R0FC9s7Kyvuno6D3d3Fw+hoUFP9DPT7+ioSG/l5aWvrq5Ob/8+3u/goEBP56dHT/Z2Ng9hYQEPvHwcL2vrq4+g4KCvtjXVz///v6+g4KCvo+Ojj6UkxM/+vl5v9jXV7/X1tY+lZQUPvb1dT/Avz8/k5KSvt3cXL7q6Wm/lZQUPtHQUL2zsrK+6ejoPQ==",
+      "vectorSha256": "e2f86b1271d7af890c2c374b9c40927518167d8d29093fad82f181be5c7f5399",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9bc2182f5a2302c0ce8d9078ab5feb405fa3c90314b592fadf5b640b9279538e",
+      "updatedAt": "2025-09-20T22:28:15.459Z"
+    },
+    "love-53": {
+      "vector": "19bWPoOCgr75+Pg95ONjv4+Ojr6koyM///7+Pquqqj77+vq+5ONjv+TjY7+8uzs/9vV1v6empr6Ylxe/np0dv+blZb+Ihwe/5ONjv+vq6r6cmxs/+Pd3v8vKyr7b2tq+i4qKPublZb/U01O/3dxcPpCPD7+Qjw+/xMNDP5uamj7X1tY+g4KCvvn4+D3k42O/j46OvqSjIz///v4+q6qqPvv6+r7k42O/5ONjv7y7Oz/29XW/p6amvpiXF7+enR2/5uVlv4iHB7/k42O/6+rqvpybGz/493e/y8rKvtva2r6Lioo+5uVlv9TTU7/d3Fw+kI8Pv5CPD7/Ew0M/m5qaPg==",
+      "vectorSha256": "95029769fccd9da44e5a65fc40b1afec29cc4935c3eed8a47d9e428f4463ea5b",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b55f8f0e5cd1bfaa410e0edd055634310d3c0e45cd044d49a20d169b3838e1a6",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-01": {
+      "vector": "q6qqvp+enr719HS+vLs7v7++vr6+vT2/xsVFv6inJ7/Lysq+oaCgPOno6L23tra+u7q6vsXERL7w728/y8rKPu3sbL6UkxO///7+vrW0NL6Lioq+2NdXP+vq6r7W1VU/lZQUPr++vr7X1tY+6ejova+urr7o52c/qKcnv8TDQz+rqqq+n56evvX0dL68uzu/v76+vr69Pb/GxUW/qKcnv8vKyr6hoKA86ejovbe2tr67urq+xcREvvDvbz/Lyso+7exsvpSTE7///v6+tbQ0vouKir7Y11c/6+rqvtbVVT+VlBQ+v76+vtfW1j7p6Oi9r66uvujnZz+opye/xMNDPw==",
+      "vectorSha256": "a573b4077a322f24624a27f2523a68818f1499d79b9957d41ed032c52495ac29",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5558612250211d2c4d8271525167f7b2623640695deb45ea9250b57154f32ce1",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-02": {
+      "vector": "t7a2vtfW1r65uLg9iYiIPeDfX7/19HS+zs1Nv+XkZD7U01M/kI8PP5+enj7a2Vk/09LSvuDfX7+DgoI+397ePvPy8j6mpSU/z87OPsnIyL3T0tI+ycjIvcnIyL3s62s//v19P4WEBD6ysTG/np0dv8zLS7/T0tI+paQkvv38fL63tra+19bWvrm4uD2JiIg94N9fv/X0dL7OzU2/5eRkPtTTUz+Qjw8/n56ePtrZWT/T0tK+4N9fv4OCgj7f3t4+8/LyPqalJT/Pzs4+ycjIvdPS0j7JyMi9ycjIvezraz/+/X0/hYQEPrKxMb+enR2/zMtLv9PS0j6lpCS+/fx8vg==",
+      "vectorSha256": "ab25c8029293f4f4ff131480cda394754126b05d2087d60c73c0dfe9b4956d33",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "524a8b881061199ce9c7a7ec4b10a0b7bcd2b373b47373f5fe9027311ab46b60",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-04": {
+      "vector": "2djYvcbFRT+ysTG/ycjIPa6tLb+gnx+/goEBP6uqqj60szM/p6amPtva2j6lpCQ+qaioPfTzc7+amRk/2NdXP6qpKT/T0tI+z87OvtfW1r6pqKi9srExv8rJST/e3V0/srExv7W0ND6qqSk/yslJv4uKir6Qjw+/qaioveLhYT/Z2Ni9xsVFP7KxMb/JyMg9rq0tv6CfH7+CgQE/q6qqPrSzMz+npqY+29raPqWkJD6pqKg99PNzv5qZGT/Y11c/qqkpP9PS0j7Pzs6+19bWvqmoqL2ysTG/yslJP97dXT+ysTG/tbQ0PqqpKT/KyUm/i4qKvpCPD7+pqKi94uFhPw==",
+      "vectorSha256": "438d34f6f35892d4aba87cf0b1b2a89c47920df2d124f74449d4a2f2466531bf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "72e2278c2930c0aad9a9b6948a06ccebd4b44c4a7527e4ee2796d41b5d3875f0",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-05": {
+      "vector": "4N9fv8/Ozj67urq+8vFxv+blZT+TkpI+tLMzP/79fT/x8HA92tlZv7y7Oz/p6Og9v76+vp2cHD6GhQW/0dBQvby7Oz/x8HC9nZwcPuvq6j719HQ+4eDgvPf29r7u7W2/qaiovcrJST+Ihwc/3NtbP4WEBL7DwsI+yslJv7a1NT/g31+/z87OPru6ur7y8XG/5uVlP5OSkj60szM//v19P/HwcD3a2Vm/vLs7P+no6D2/vr6+nZwcPoaFBb/R0FC9vLs7P/HwcL2dnBw+6+rqPvX0dD7h4OC89/b2vu7tbb+pqKi9yslJP4iHBz/c21s/hYQEvsPCwj7KyUm/trU1Pw==",
+      "vectorSha256": "6e9611a21cf69cb19e49957b49ba19c4cbe0887bd572a6ad4d67657f5c8975b1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "10b35107f2a4d9fe8713dd8e50933d79dd7893ba9e7c420975e4c3ed6fb01bda",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-06": {
+      "vector": "2tlZP5aVFT/GxUW/lZQUPry7O7+vrq4+9/b2vtTTU7+Qjw+/1dRUvomIiD2FhAQ+3dxcPq2sLD6urS0/AACAv6GgoDz8+3s/qKcnv5OSkj60szM/3Ntbv4mIiD2dnBw+iYiIvZuamj7Ix0c/5ONjP5uamr6Lioq+nZwcPpCPD7/a2Vk/lpUVP8bFRb+VlBQ+vLs7v6+urj739va+1NNTv5CPD7/V1FS+iYiIPYWEBD7d3Fw+rawsPq6tLT8AAIC/oaCgPPz7ez+opye/k5KSPrSzMz/c21u/iYiIPZ2cHD6JiIi9m5qaPsjHRz/k42M/m5qavouKir6dnBw+kI8Pvw==",
+      "vectorSha256": "bb513e2e8f940b347d4dfc64a56e8d0ff95d1f4ae0a20a6c17d3b73cc6cbabdc",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "ecca1d9222ab4216386588909b95d60082fd2ca4d912889377a6e3f1595d9338",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-07": {
+      "vector": "0dBQvc3MTD7x8HC96OdnP5eWlj7493c/2tlZv/X0dL7Y11c/rKsrP7KxMb/j4uK+5ONjP9/e3j7OzU2/s7KyvvTzcz/e3V0/urk5v/n4+D20szM/5uVlP4qJCT/i4WG/ycjIvYuKir6EgwO/xcREPurpaT+/vr6+h4aGPomIiD3R0FC9zcxMPvHwcL3o52c/l5aWPvj3dz/a2Vm/9fR0vtjXVz+sqys/srExv+Pi4r7k42M/397ePs7NTb+zsrK+9PNzP97dXT+6uTm/+fj4PbSzMz/m5WU/iokJP+LhYb/JyMi9i4qKvoSDA7/FxEQ+6ulpP7++vr6HhoY+iYiIPQ==",
+      "vectorSha256": "4fc397a350b56005d5992ebe2e9a48694d08bc3ba381b849783d97678b99e071",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "799978f3a5fb1361ebd52747f1b71953f9ee238fd9f2c40f735d3e98f450a188",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-08": {
+      "vector": "4eDgPPTzc7/39vY+4uFhP5qZGT++vT2/l5aWPuDfX7+Miws/AACAv52cHD61tDS+nJsbv/b1dT+OjQ2/t7a2vrSzMz/V1FS+lZQUPpmYmL2mpSU/lpUVP/HwcD3u7W0/5+bmPoeGhj7R0FA9mZiYvZqZGT+Pjo4+vLs7v6Oior7h4OA89PNzv/f29j7i4WE/mpkZP769Pb+XlpY+4N9fv4yLCz8AAIC/nZwcPrW0NL6cmxu/9vV1P46NDb+3tra+tLMzP9XUVL6VlBQ+mZiYvaalJT+WlRU/8fBwPe7tbT/n5uY+h4aGPtHQUD2ZmJi9mpkZP4+Ojj68uzu/o6Kivg==",
+      "vectorSha256": "5bb901ccac6ee5fe7e8dd3ac9cd07feed2f521dee7c65eb23300f3e2f6052125",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8306bdf0cc21a510c500936932fa3952d9659276d2ca87f6b9a18676cca32257",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-09": {
+      "vector": "tLMzP6Oioj6BgIA75+bmPsvKyr7Ix0c/lJMTv5uamj7p6Og91tVVP+LhYb/S0VG/8/LyPr28PL7g318/1tVVv6uqqr7KyUk/1NNTv4+Ojr6FhAQ+hIMDP4OCgr79/Hy++Pd3v+DfX7+WlRW/kI8Pv7e2tj7l5GQ+kI8PvwAAgD+0szM/o6KiPoGAgDvn5uY+y8rKvsjHRz+UkxO/m5qaPuno6D3W1VU/4uFhv9LRUb/z8vI+vbw8vuDfXz/W1VW/q6qqvsrJST/U01O/j46OvoWEBD6EgwM/g4KCvv38fL7493e/4N9fv5aVFb+Qjw+/t7a2PuXkZD6Qjw+/AACAPw==",
+      "vectorSha256": "95b5ef4e932b536de265ced5afa9a41a712322922636ae552dca093ab7f11f96",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d9a880b94de336a68eea0f17bc68ef1555e4165c90c15f6004103538ad9c38ff",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-10": {
+      "vector": "wcBAPAAAgD+Ihwc/9PNzP52cHL7r6uq+uLc3P7CvL7+EgwO/mJcXv728PD7Hxsa+m5qavrGwML2NjAw+pqUlv7y7Oz+lpCS+0tFRv/Dvb7/U01M/8/LyPuXkZD6cmxu/mpkZP4OCgj6amRm/qqkpv8nIyL3n5ua+qqkpP8C/Pz/BwEA8AACAP4iHBz/083M/nZwcvuvq6r64tzc/sK8vv4SDA7+Ylxe/vbw8PsfGxr6bmpq+sbAwvY2MDD6mpSW/vLs7P6WkJL7S0VG/8O9vv9TTUz/z8vI+5eRkPpybG7+amRk/g4KCPpqZGb+qqSm/ycjIvefm5r6qqSk/wL8/Pw==",
+      "vectorSha256": "90bedcc64c7c2ffbd1e19e160bb6764cba41163cbb6c6fa3c0162c0285181617",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "81ffc3f96c45db283e34974e597a912ddd6b1708e9bc9c32cca0332b7346d4df",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-11": {
+      "vector": "xsVFv5mYmD3f3t4+w8LCPrKxMb+DgoI+i4qKPqWkJD7Ix0e/jo0Nv//+/r7e3V2/wcBAvIqJCT/c21s/nZwcvtfW1j7m5WU/j46OvpSTE7+TkpK+kpERP5CPD7/BwEC8i4qKvpqZGT+xsDC96ejovZSTE7+RkBC9397ePrKxMb/GxUW/mZiYPd/e3j7DwsI+srExv4OCgj6Lioo+paQkPsjHR7+OjQ2///7+vt7dXb/BwEC8iokJP9zbWz+dnBy+19bWPublZT+Pjo6+lJMTv5OSkr6SkRE/kI8Pv8HAQLyLioq+mpkZP7GwML3p6Oi9lJMTv5GQEL3f3t4+srExvw==",
+      "vectorSha256": "f46080e75c117968a8f4e080bb2b87b7848323dd1d9ef2097a288c5dd426457e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "1d89b7b027a0a2941c3940117ec4ed6cb5f25c365bc8387e5dcc7a71367bb727",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-12": {
+      "vector": "8O9vP5KREb/s62s/kpERv+LhYb+koyO/jIsLv6WkJL7X1tY++vl5v9va2r6pqKi9+fj4vcjHRz+9vDy+t7a2PgAAgD/BwEA89/b2vr69PT/e3V0/wcBAvLy7O7+trCw++Pd3v7q5Ob+dnBw+q6qqvs/Ozr6FhAQ+k5KSPp+enr7w728/kpERv+zraz+SkRG/4uFhv6SjI7+Miwu/paQkvtfW1j76+Xm/29ravqmoqL35+Pi9yMdHP728PL63trY+AACAP8HAQDz39va+vr09P97dXT/BwEC8vLs7v62sLD7493e/urk5v52cHD6rqqq+z87OvoWEBD6TkpI+n56evg==",
+      "vectorSha256": "d564644810fdeb3cf75dd2137381f14ae8d39fc95d90f7194271e01c00716ff0",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f737f5370f2e3a6bb503497570e368adff8142deee7e2295042393554c90a458",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-13": {
+      "vector": "7u1tv/f29j7w72+/l5aWPpiXFz/GxUW/5ONjP/n4+L2bmpq+wsFBP9TTUz+Lioo+sbAwPdbVVb+mpSU/wL8/v6uqqr7Lyso+kZAQPezraz/m5WU/rKsrP+XkZD63trY+5eRkPtfW1r7NzEy+w8LCPqalJb/s62s/6ulpP/HwcD3u7W2/9/b2PvDvb7+XlpY+mJcXP8bFRb/k42M/+fj4vZuamr7CwUE/1NNTP4uKij6xsDA91tVVv6alJT/Avz+/q6qqvsvKyj6RkBA97OtrP+blZT+sqys/5eRkPre2tj7l5GQ+19bWvs3MTL7DwsI+pqUlv+zraz/q6Wk/8fBwPQ==",
+      "vectorSha256": "88d76642a100ce0aa538b4bee83b90be6d26ce14ecf9d796e3b268e2f0715acf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "09bd08a5cb1df17059e0e9a28515d22055b284f5f2d59cad9c4a66b02df5f487",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-14": {
+      "vector": "+fj4PcTDQz+NjAw+vr09v8/Ozr7JyMi94+LiPru6uj6Pjo6+pqUlP8rJST/U01M/hYQEPublZT+5uLi9+vl5v7SzMz/KyUm/tLMzP+LhYT/JyMg96ulpv5GQED3X1tY+AACAP+TjY7/9/Hw+s7KyvqqpKb+BgIC7s7KyPtHQUL35+Pg9xMNDP42MDD6+vT2/z87OvsnIyL3j4uI+u7q6Po+Ojr6mpSU/yslJP9TTUz+FhAQ+5uVlP7m4uL36+Xm/tLMzP8rJSb+0szM/4uFhP8nIyD3q6Wm/kZAQPdfW1j4AAIA/5ONjv/38fD6zsrK+qqkpv4GAgLuzsrI+0dBQvQ==",
+      "vectorSha256": "14d26cec85ff1973d6b5a366c924b7772deb836a20b51a2b9abd3015ec4b6bf7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "8fe191214c73b8ae5cd2e4e990f27403d91bd9f08c0b84b5ff0e9f532b7fac79",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-15": {
+      "vector": "19bWvsrJST+trCy+qaioPa6tLb+ysTE/zcxMPsnIyL3d3Fy+uLc3v7GwML2ysTG/hoUFP/f29r7+/X0/o6KiPru6uj7493c/j46OPre2tj6DgoI+kI8PP/Py8r739vY+iYiIvfPy8r6DgoK+gYCAu/b1dT/V1FQ+r66uPvPy8j7X1ta+yslJP62sLL6pqKg9rq0tv7KxMT/NzEw+ycjIvd3cXL64tze/sbAwvbKxMb+GhQU/9/b2vv79fT+joqI+u7q6Pvj3dz+Pjo4+t7a2PoOCgj6Qjw8/8/Lyvvf29j6JiIi98/LyvoOCgr6BgIC79vV1P9XUVD6vrq4+8/LyPg==",
+      "vectorSha256": "8ca42a3b408f04093a2a70a9092397a50dd238e378e94e3ed5cb2d294778a53c",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "4ae46a8a29d8997364247a27c242fea8aefba3ada0c743bd77435f7ffa9aabbc",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-16": {
+      "vector": "8O9vP8HAQLzZ2Ni9//7+vvPy8r6pqKg9np0dv7SzMz+BgIA79/b2PpOSkj7o52e/lpUVv9DPT7/d3Fy+4N9fP7W0ND7X1ta+nZwcvtTTU7++vT2/8vFxv5iXFz/Avz8/mJcXP/Tzcz/h4OC8v76+voOCgj7x8HA9xsVFP46NDb/w728/wcBAvNnY2L3//v6+8/LyvqmoqD2enR2/tLMzP4GAgDv39vY+k5KSPujnZ7+WlRW/0M9Pv93cXL7g318/tbQ0PtfW1r6dnBy+1NNTv769Pb/y8XG/mJcXP8C/Pz+Ylxc/9PNzP+Hg4Ly/vr6+g4KCPvHwcD3GxUU/jo0Nvw==",
+      "vectorSha256": "bfde36c1f1ceecf7cbd5ba08047bc40be1ad484eac08a52a4a79cd145b0dcdc9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f77e7240438a31d980bda40c351864ef964a6c162107cbdfcbf97c50a087e239",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-17": {
+      "vector": "o6KivqCfH7+KiQk/397ePqinJ7+Qjw+/1dRUvsTDQz/FxES+zMtLv9rZWT/k42O//v19v+vq6r7V1FS+6ulpP5CPD7+6uTm/iokJv+Hg4DyRkBA99/b2vtDPTz+dnBw+yMdHP8nIyD2TkpI+s7KyPs3MTD61tDQ+wsFBv7CvLz+joqK+oJ8fv4qJCT/f3t4+qKcnv5CPD7/V1FS+xMNDP8XERL7My0u/2tlZP+TjY7/+/X2/6+rqvtXUVL7q6Wk/kI8Pv7q5Ob+KiQm/4eDgPJGQED339va+0M9PP52cHD7Ix0c/ycjIPZOSkj6zsrI+zcxMPrW0ND7CwUG/sK8vPw==",
+      "vectorSha256": "caffcef11e4af31c7744e66ba8c8f1a1c9d9ab5fa72511b9a0e20ec992f572a1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5730c4b72c3865e1671aec0e014565f438233b838442e793e38ca4ac99961fd7",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "positive-18": {
+      "vector": "5eRkPgAAgD+pqKg93dxcvpmYmL3w728/5ONjv5KRET+5uLi9v76+PtzbWz/Qz0+/+Pd3P7i3Nz/w72+/7Otrv+fm5r7s62u/i4qKvtnY2D2lpCS+z87OvoeGhj6Ihwe/v76+PpiXFz/y8XE/wcBAvPPy8r7GxUU/qaioPZGQED3l5GQ+AACAP6moqD3d3Fy+mZiYvfDvbz/k42O/kpERP7m4uL2/vr4+3NtbP9DPT7/493c/uLc3P/Dvb7/s62u/5+bmvuzra7+Lioq+2djYPaWkJL7Pzs6+h4aGPoiHB7+/vr4+mJcXP/LxcT/BwEC88/LyvsbFRT+pqKg9kZAQPQ==",
+      "vectorSha256": "da63a90f08a85cd4298f32a1bf510c19814302ef2de55aa7d1596c0dff866819",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9cff8a6476f70ec874afed18fbdb080a460a5d8d6b4ca13cafcbf87e43e28a84",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-19": {
+      "vector": "wL8/P8C/P7+vrq6+mJcXv+TjYz+joqI+6ulpP9LRUb+bmpq+8vFxv9fW1j7OzU2/+vl5P5uamj6Pjo6+h4aGvs3MTD6bmpq+i4qKvoSDAz+XlpY+AACAv6alJT+enR2//v19P4OCgj6pqKi95uVlP+jnZ7/GxUU/09LSPqCfH7/Avz8/wL8/v6+urr6Ylxe/5ONjP6Oioj7q6Wk/0tFRv5uamr7y8XG/19bWPs7NTb/6+Xk/m5qaPo+Ojr6Hhoa+zcxMPpuamr6Lioq+hIMDP5eWlj4AAIC/pqUlP56dHb/+/X0/g4KCPqmoqL3m5WU/6Odnv8bFRT/T0tI+oJ8fvw==",
+      "vectorSha256": "886fcd7a341a9ee8ed33c1365be88105d16cbb75704a61834fc403d5e0ea1b09",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "df205434f1a8f4175907b519fca65c5e99595dc1a500d231fea075f20ce2b430",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-20": {
+      "vector": "3NtbvwAAgD/U01M//fx8vuTjYz/n5uY+7Otrv//+/r7Pzs6+0dBQPcPCwr6ZmJg9oaCgPNXUVD7OzU2/0tFRP8C/P7/c21s/tbQ0vpOSkr6UkxM/vbw8Ptva2j6koyO/9/b2vvLxcT+fnp6+l5aWvv79fT/29XU/3t1dv7y7Oz/c21u/AACAP9TTUz/9/Hy+5ONjP+fm5j7s62u///7+vs/Ozr7R0FA9w8LCvpmYmD2hoKA81dRUPs7NTb/S0VE/wL8/v9zbWz+1tDS+k5KSvpSTEz+9vDw+29raPqSjI7/39va+8vFxP5+enr6Xlpa+/v19P/b1dT/e3V2/vLs7Pw==",
+      "vectorSha256": "2659a2f74fea7d59999363e617d5a0672fe19107f71e9e16484eff0307795c88",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "12ffe960f1b90a404c864f89829a19e820ed695bc997b62e42f8585afefa11dd",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-21": {
+      "vector": "sK8vv6KhIb/c21s/8/LyvrCvLz+1tDQ+8fBwPezra7/Ix0e/oJ8fv7u6ur6UkxO/6ejovf79fb/e3V0/6Odnv7Oysj6/vr4+0dBQvdPS0j7GxUW/+vl5P+Pi4j7z8vI+vLs7v4iHBz/m5WW/4+LiPqSjI7+ZmJg93dxcvoKBAT+wry+/oqEhv9zbWz/z8vK+sK8vP7W0ND7x8HA97Otrv8jHR7+gnx+/u7q6vpSTE7/p6Oi9/v19v97dXT/o52e/s7KyPr++vj7R0FC909LSPsbFRb/6+Xk/4+LiPvPy8j68uzu/iIcHP+blZb/j4uI+pKMjv5mYmD3d3Fy+goEBPw==",
+      "vectorSha256": "699f2a38698ad7dad169aeb2360101094ea5598120ef97cecd2c29f1167860ea",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "282fed43d796870a1c3051367101ee0cacaf79b41dfcb8bc22c30db82e8964c0",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-22": {
+      "vector": "nJsbP9/e3r7h4OA85+bmvuHg4DwAAIC/4+Livo2MDL719HS+iokJP5ybGz+2tTW/qaiovcC/P7/v7u4+8fBwvZ+enr6ysTE/8vFxv6+urr4AAIC/6ejovfPy8j6HhoY+1tVVP56dHT+7urq+lJMTv9/e3r7r6uq+8/LyvpCPD7+cmxs/397evuHg4Dzn5ua+4eDgPAAAgL/j4uK+jYwMvvX0dL6KiQk/nJsbP7a1Nb+pqKi9wL8/v+/u7j7x8HC9n56evrKxMT/y8XG/r66uvgAAgL/p6Oi98/LyPoeGhj7W1VU/np0dP7u6ur6UkxO/397evuvq6r7z8vK+kI8Pvw==",
+      "vectorSha256": "c78946e6fea1fd7dafffefcc3a49975e47d657df5f34ceaccfe19f0f47a20b28",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cd4883468300476e61c4cd257520bb7858d807540071bca1eace513648454338",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-23": {
+      "vector": "4+LiPtva2r7W1VU/x8bGvqOioj7b2tq++fj4vePi4j6TkpK+2djYPcPCwr6Ylxe/qaiovdPS0r7NzEy+4+Livv79fb+Pjo4+zs1NP7Oysr6ZmJg9jo0Nv5qZGb/19HS+iYiIvYKBAT+HhoY+7+7uvpCPD7/y8XE/rKsrv4aFBT/j4uI+29ravtbVVT/Hxsa+o6KiPtva2r75+Pi94+LiPpOSkr7Z2Ng9w8LCvpiXF7+pqKi909LSvs3MTL7j4uK+/v19v4+Ojj7OzU0/s7KyvpmYmD2OjQ2/mpkZv/X0dL6JiIi9goEBP4eGhj7v7u6+kI8Pv/LxcT+sqyu/hoUFPw==",
+      "vectorSha256": "ec81f44b4d84c21eb802471857782d5450a0c1e615bb9939a98eeb14abfe8b4f",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b849ea4ea84970b85b8d4f34754b664701a3e6538939336177c0a14438f82ac2",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-24": {
+      "vector": "oJ8fP46NDb/p6Og9l5aWPu3sbD7Avz+/gYCAO/v6+r6CgQG/jIsLv/79fb+zsrI+2tlZv97dXT/c21u/pKMjv5OSkj719HQ+8/LyPoqJCT+mpSU/zcxMPqinJz+bmpo+3t1dv+Pi4r6FhAQ+t7a2vvj3dz+zsrK+m5qavoGAgDugnx8/jo0Nv+no6D2XlpY+7exsPsC/P7+BgIA7+/r6voKBAb+Miwu//v19v7Oysj7a2Vm/3t1dP9zbW7+koyO/k5KSPvX0dD7z8vI+iokJP6alJT/NzEw+qKcnP5uamj7e3V2/4+LivoWEBD63tra++Pd3P7Oysr6bmpq+gYCAOw==",
+      "vectorSha256": "395735cd36e6fc70db25f7a23027f9f4d0debae20f977b81ba86b8b54c6513f9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cf398ea59d2080413f3a01ac13ee122ea49ebcc4d299d3a611479052fb535980",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-25": {
+      "vector": "np0dv+rpaT+TkpK+goEBv9XUVD7JyMg9+fj4PYSDA7/HxsY+7+7uvqmoqD24tze/4N9fv4uKir7e3V0/2djYvc3MTD6OjQ2/2djYvZiXF7+amRk//fx8vqmoqL2rqqq+mJcXv4yLCz/t7Gw+yMdHv+blZT/q6Wm/iYiIvYeGhj6enR2/6ulpP5OSkr6CgQG/1dRUPsnIyD35+Pg9hIMDv8fGxj7v7u6+qaioPbi3N7/g31+/i4qKvt7dXT/Z2Ni9zcxMPo6NDb/Z2Ni9mJcXv5qZGT/9/Hy+qaiovauqqr6Ylxe/jIsLP+3sbD7Ix0e/5uVlP+rpab+JiIi9h4aGPg==",
+      "vectorSha256": "2b64f9cb872abb33f8a73fed79ae270f7ea2e9e54130b659473d10e746d06b89",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "31f45b3f9a8c8f3eb1448a24105dee7299397234cc60755534c59d1cf20b77a1",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-26": {
+      "vector": "+fj4vZCPD7/u7W2/h4aGPtva2r7y8XE/kZAQPcHAQDyurS0/+/r6vqalJT+5uLi9r66uvu7tbb/FxES+j46OPpCPDz+trCw+6ejoPYSDAz+Miws/xsVFP6WkJL64tze/zcxMPvHwcD3Ix0e/qKcnP9zbWz+4tze/tbQ0vtjXV7/5+Pi9kI8Pv+7tbb+HhoY+29ravvLxcT+RkBA9wcBAPK6tLT/7+vq+pqUlP7m4uL2vrq6+7u1tv8XERL6Pjo4+kI8PP62sLD7p6Og9hIMDP4yLCz/GxUU/paQkvri3N7/NzEw+8fBwPcjHR7+opyc/3NtbP7i3N7+1tDS+2NdXvw==",
+      "vectorSha256": "df43de72066dd971268823231bae266dc2b13c1e68d9b8d6541aef021631b732",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "703809a149f88481d641d274540967a3c7958ec1c5e26b2499871cd3ed246914",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-27": {
+      "vector": "p6amPv/+/j729XU/jo0Nv5CPD7/o52c/qKcnv5uamj6CgQG/k5KSvuzraz/w728/urk5v4SDA7/8+3s//v19v/f29r7DwsK+xcREPtDPT7+fnp6+kZAQvbi3Nz+TkpI+6ejoveXkZL7s62u/0dBQPaempr7T0tI+y8rKPsjHRz+npqY+//7+Pvb1dT+OjQ2/kI8Pv+jnZz+opye/m5qaPoKBAb+TkpK+7OtrP/Dvbz+6uTm/hIMDv/z7ez/+/X2/9/b2vsPCwr7FxEQ+0M9Pv5+enr6RkBC9uLc3P5OSkj7p6Oi95eRkvuzra7/R0FA9p6amvtPS0j7Lyso+yMdHPw==",
+      "vectorSha256": "09c0ffcd204a2bdfe57105f928bea84ee68ebfc4c58fffaf3819b375fa2bd8f2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a9bffa3938f32ca63f5bf5f7233efd01424f9818587bdba471630a8656b4b2e3",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-28": {
+      "vector": "oJ8fv8rJSb+UkxM/2tlZv+/u7r6Ihwc/6Odnv83MTL7n5uY+pqUlP9va2j65uLg9sK8vv5ybGz/r6uo+mZiYPe/u7r67urq+0tFRv/r5eb/39va+3dxcvvHwcL3V1FQ+l5aWPpCPDz/GxUW/i4qKvvDvbz/CwUG/zs1Nv7SzM7+gnx+/yslJv5STEz/a2Vm/7+7uvoiHBz/o52e/zcxMvufm5j6mpSU/29raPrm4uD2wry+/nJsbP+vq6j6ZmJg97+7uvru6ur7S0VG/+vl5v/f29r7d3Fy+8fBwvdXUVD6XlpY+kI8PP8bFRb+Lioq+8O9vP8LBQb/OzU2/tLMzvw==",
+      "vectorSha256": "ed0a6a1ea2a0a65ae9e7b87c14f69cebddcea6280a7bd16e8cbd34495687c1dd",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "301bc91344c30c66b9d2b68b28cdba89445117034264789aa5c71d5df71f1926",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-29": {
+      "vector": "tbQ0Pvn4+L28uzu/6ejoPeDfXz/+/X2/2tlZv5STE7+6uTm/jYwMPs3MTL78+3s/srExP+LhYb+joqI+9fR0Pufm5j6urS2/srExP6empr729XW/goEBv46NDT/z8vI+srExv9fW1r6BgIA7tLMzP87NTb+ysTE/3t1dv7CvL7+1tDQ++fj4vby7O7/p6Og94N9fP/79fb/a2Vm/lJMTv7q5Ob+NjAw+zcxMvvz7ez+ysTE/4uFhv6Oioj719HQ+5+bmPq6tLb+ysTE/p6amvvb1db+CgQG/jo0NP/Py8j6ysTG/19bWvoGAgDu0szM/zs1Nv7KxMT/e3V2/sK8vvw==",
+      "vectorSha256": "f398d90995259cdb1af38983454019c84c919ef3301adec3f73d2693b34d38a7",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9670228eef011336239166fdd80fa89eb929d856053fc6bc274a80d919d81128",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-30": {
+      "vector": "AACAv+Pi4r6vrq4+zcxMvpmYmL2lpCS+qaioPcnIyD3Ix0e/m5qavsLBQb+amRk/qqkpv+DfXz/X1tY+vbw8vszLS7+pqKi9jIsLv9zbWz+TkpI+pKMjP4WEBD7m5WU/k5KSvrSzMz+pqKg9oJ8fv8nIyD2zsrK+k5KSvtva2j4AAIC/4+Livq+urj7NzEy+mZiYvaWkJL6pqKg9ycjIPcjHR7+bmpq+wsFBv5qZGT+qqSm/4N9fP9fW1j69vDy+zMtLv6moqL2Miwu/3NtbP5OSkj6koyM/hYQEPublZT+TkpK+tLMzP6moqD2gnx+/ycjIPbOysr6TkpK+29raPg==",
+      "vectorSha256": "6a8bf7198386493911dbbe6cf0c8c5062a2d5ad85c10258c5b01fbca31ad0d29",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "0047ab66766b8a8c1c591fcc2befb5681a753aeda4d190f25bd98a308c535bb6",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-31": {
+      "vector": "nJsbP9PS0j6/vr6+qaiovcTDQz/a2Vm/sbAwvaalJT/S0VE/kZAQPYuKir7KyUk/9fR0vszLSz/FxEQ++vl5v8HAQDyFhAS+kZAQvauqqr7NzEw+1dRUPoqJCb/7+vo+9/b2vtDPT7/q6Wm/+fj4Pe/u7r7V1FS+tbQ0PsTDQ7+cmxs/09LSPr++vr6pqKi9xMNDP9rZWb+xsDC9pqUlP9LRUT+RkBA9i4qKvsrJST/19HS+zMtLP8XERD76+Xm/wcBAPIWEBL6RkBC9q6qqvs3MTD7V1FQ+iokJv/v6+j739va+0M9Pv+rpab/5+Pg97+7uvtXUVL61tDQ+xMNDvw==",
+      "vectorSha256": "4659fd607330b31dbcf4cc3c47cbc8de8fd4b5d6902c457741789bfc6a9fadc4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "cdb45075e1137ad2e8845de461e59803816f7b55999a3bbe42180b8f4465961e",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-32": {
+      "vector": "j46Ovuzraz+Ihwc/+vl5P6moqL3v7u6+19bWPq6tLb/h4OA88fBwvf38fL6mpSW/q6qqPgAAgL+mpSU/h4aGvsLBQb+amRm/yMdHP6Oior68uzu/z87OvqqpKb/y8XE/sK8vP8rJSb/b2tq+2NdXP4OCgr7g318/2NdXv4WEBL6Pjo6+7OtrP4iHBz/6+Xk/qaiove/u7r7X1tY+rq0tv+Hg4Dzx8HC9/fx8vqalJb+rqqo+AACAv6alJT+Hhoa+wsFBv5qZGb/Ix0c/o6Kivry7O7/Pzs6+qqkpv/LxcT+wry8/yslJv9va2r7Y11c/g4KCvuDfXz/Y11e/hYQEvg==",
+      "vectorSha256": "6e57f66cb17f592c88773a00395092f0ea42a21b3e8f520823065afcba59dff1",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5cf5c3fc7544b5298378602daa00d25e1f33e357224c2bf8d71b49eb5fef146f",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-33": {
+      "vector": "n56evp+enj6RkBA919bWPpWUFD6gnx8/np0dv4uKij6ysTE/kpERv4+Ojj76+Xm/9/b2Pra1Nb+DgoK+xsVFv8XERL6hoKA8mZiYPcrJSb/8+3s/wsFBP5+enr60szM/8/Lyvu7tbb+BgIA76+rqvru6ur6FhAS+wcBAPNPS0r6fnp6+n56ePpGQED3X1tY+lZQUPqCfHz+enR2/i4qKPrKxMT+SkRG/j46OPvr5eb/39vY+trU1v4OCgr7GxUW/xcREvqGgoDyZmJg9yslJv/z7ez/CwUE/n56evrSzMz/z8vK+7u1tv4GAgDvr6uq+u7q6voWEBL7BwEA809LSvg==",
+      "vectorSha256": "6b25089f4f004bba4fe0b8db05a9cb569a31afb17b7e27c28c20cb4cad991da4",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "58a784b592cf31a2d837a303bd255f1d6782891bfde058d943098045516f814b",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-34": {
+      "vector": "hYQEPo2MDL6fnp6+o6KiPsnIyL39/Hy+5ONjP/j3dz+Pjo6+j46OPuLhYT+9vDw+jIsLP6CfHz+4tze/3NtbP+jnZz+bmpq+xMNDv46NDT+lpCQ+4uFhv5aVFT+Qjw8/4eDgvMPCwr7X1ta+vr09v8HAQDz7+vq+09LSPsHAQDyFhAQ+jYwMvp+enr6joqI+ycjIvf38fL7k42M/+Pd3P4+Ojr6Pjo4+4uFhP728PD6Miws/oJ8fP7i3N7/c21s/6OdnP5uamr7Ew0O/jo0NP6WkJD7i4WG/lpUVP5CPDz/h4OC8w8LCvtfW1r6+vT2/wcBAPPv6+r7T0tI+wcBAPA==",
+      "vectorSha256": "6fcd84847214c6cb7cf5c0b172f3e0f78c2026c408b9374608f795fc3af51dd9",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "906e58a87360f1fb5ca3f097c5cf24edf3591ec6940fcac77c4f4a218141b481",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-35": {
+      "vector": "AACAv7a1Nb+FhAQ+gYCAO9/e3j7h4OC8ubi4PdXUVL6NjAy+19bWvsbFRb+WlRW/nJsbv7Oysj6NjAw+w8LCvtjXVz+amRm/397ePs7NTb+zsrK+5eRkvsXERD7v7u4+5eRkvublZT/l5GS+oJ8fv8jHRz/OzU0/tbQ0PrGwMD0AAIC/trU1v4WEBD6BgIA7397ePuHg4Ly5uLg91dRUvo2MDL7X1ta+xsVFv5aVFb+cmxu/s7KyPo2MDD7DwsK+2NdXP5qZGb/f3t4+zs1Nv7Oysr7l5GS+xcREPu/u7j7l5GS+5uVlP+XkZL6gnx+/yMdHP87NTT+1tDQ+sbAwPQ==",
+      "vectorSha256": "538e54062f2a6446b8ea82947483fda302eb405e4f5a11881011569227ba2aed",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "00259080b77c8b656e4a1d3532ac914feb33b719536398bb63f26330e3e69685",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-36": {
+      "vector": "l5aWPouKij7j4uI+lJMTP+blZT+3tra+397ePry7O7/r6uo+hYQEvs3MTL7l5GQ+vr09v6WkJD7Ew0O/kI8Pv6CfH7/a2Vm/7exsPr69PT+wry+/29ravvHwcL3Avz+/3NtbP/Lxcb+OjQ2/9fR0vp2cHL6dnBw+6ulpP8C/Pz+XlpY+i4qKPuPi4j6UkxM/5uVlP7e2tr7f3t4+vLs7v+vq6j6FhAS+zcxMvuXkZD6+vT2/paQkPsTDQ7+Qjw+/oJ8fv9rZWb/t7Gw+vr09P7CvL7/b2tq+8fBwvcC/P7/c21s/8vFxv46NDb/19HS+nZwcvp2cHD7q6Wk/wL8/Pw==",
+      "vectorSha256": "3848de4bc7e6a0935db478478b6a9a179ca362e60ee826d0d984db2783ae816e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "a5a2b8c9f252b722ba6f669c21941e3830139dde28497820ed0739616c93f4df",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-37": {
+      "vector": "hoUFv6GgoLybmpo+7u1tv728PD7NzEy+wL8/P5mYmL2Miws/hIMDP9bVVb/5+Pi92tlZv+fm5r6FhAS+397ePu3sbL7r6uq+0dBQPcfGxr7493e/tLMzP5uamr729XW/np0dP7CvLz/Qz0+/rKsrv6empj6GhQW/z87Ovra1NT+GhQW/oaCgvJuamj7u7W2/vbw8Ps3MTL7Avz8/mZiYvYyLCz+EgwM/1tVVv/n4+L3a2Vm/5+bmvoWEBL7f3t4+7exsvuvq6r7R0FA9x8bGvvj3d7+0szM/m5qavvb1db+enR0/sK8vP9DPT7+sqyu/p6amPoaFBb/Pzs6+trU1Pw==",
+      "vectorSha256": "171a4d8c7c13ac1be18a74acd1e580454153935bcb59881dbd9df19bcc72950e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "3d7da6099766df76c5c1157013466fb76245864e04d95905ced7182aa93d4cda",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "positive-38": {
+      "vector": "5ONjP6WkJL69vDw+p6amvsXERD6vrq6+wcBAvMC/Pz/a2Vm/7u1tv+LhYb+4tzc/nJsbP5iXFz/m5WU/6ejoPZeWlr69vDy+qaioPf38fL6EgwM/xcREvqinJ7+koyO/oJ8fv/f29r7S0VG/8fBwPcPCwj7w728/yMdHP9fW1j7k42M/paQkvr28PD6npqa+xcREPq+urr7BwEC8wL8/P9rZWb/u7W2/4uFhv7i3Nz+cmxs/mJcXP+blZT/p6Og9l5aWvr28PL6pqKg9/fx8voSDAz/FxES+qKcnv6SjI7+gnx+/9/b2vtLRUb/x8HA9w8LCPvDvbz/Ix0c/19bWPg==",
+      "vectorSha256": "449c70d80a2a967d8ef6d6b11134ad34dd166d050fdccf7ba879e9cc7324394a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f16b975698547edf13090fdbcdcbf28e5a688a60c1672c2e30421787b0f7e3b5",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "happiness-01": {
+      "vector": "4uFhP728PL7s62s/lpUVP66tLT/FxEQ++fj4vZeWlj6VlBS+p6amvu/u7j6ioSE/5eRkPsPCwr6Lioo+5+bmPtnY2L22tTU/lJMTv+rpab/d3Fw+t7a2vsrJST+zsrI+9fR0PtzbW7+CgQE/wsFBv6inJ7+dnBy+urk5v/79fb/i4WE/vbw8vuzraz+WlRU/rq0tP8XERD75+Pi9l5aWPpWUFL6npqa+7+7uPqKhIT/l5GQ+w8LCvouKij7n5uY+2djYvba1NT+UkxO/6ulpv93cXD63tra+yslJP7Oysj719HQ+3Ntbv4KBAT/CwUG/qKcnv52cHL66uTm//v19vw==",
+      "vectorSha256": "7e84064cceebca70002d23070a868955f06c9b0adce3c7f691376a4970fbd6c3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "f068f5cad69870a56d56bbd09c4fa2b972da360b9b52e4ac9e12c01f2c6c2301",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "happiness-02": {
+      "vector": "oqEhP7W0ND66uTk/+vl5P5ybG7+0szM/lpUVP4uKir6hoKA8pqUlP7KxMb+OjQ2/x8bGPq6tLT+Lioq+i4qKvsLBQb/z8vI+nJsbP9DPT7+Ihwc/5+bmvpybGz/Lysq+5uVlv/z7e7+6uTm/zcxMPqGgoDzPzs6+gYCAu+TjY7+ioSE/tbQ0Prq5OT/6+Xk/nJsbv7SzMz+WlRU/i4qKvqGgoDympSU/srExv46NDb/HxsY+rq0tP4uKir6Lioq+wsFBv/Py8j6cmxs/0M9Pv4iHBz/n5ua+nJsbP8vKyr7m5WW//Pt7v7q5Ob/NzEw+oaCgPM/Ozr6BgIC75ONjvw==",
+      "vectorSha256": "fd2ab5d3a1a97ba7ff2bb371164d98b217203e043643189354314638f6ccaa07",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "d096dcfc32d9ca5d82d22739b1d65d5d1fbccd18c346cd4d0d022399824c7f0e",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "happiness-03": {
+      "vector": "nZwcvtfW1j65uLg97exsPtLRUb+/vr6+9fR0vra1Nb/My0u/srExP6yrK7/l5GS+iYiIPQAAgL/39vY+397evoyLC7++vT2/tLMzv+/u7j75+Pg9ycjIvZaVFT/r6uo+09LSvv/+/r7Lysq+np0dP56dHb/39vY+0dBQvYOCgj6dnBy+19bWPrm4uD3t7Gw+0tFRv7++vr719HS+trU1v8zLS7+ysTE/rKsrv+XkZL6JiIg9AACAv/f29j7f3t6+jIsLv769Pb+0szO/7+7uPvn4+D3JyMi9lpUVP+vq6j7T0tK+//7+vsvKyr6enR0/np0dv/f29j7R0FC9g4KCPg==",
+      "vectorSha256": "b958bf423dd9e7174d3793cb565454ba1fb1d3b11b91afee8c72f9c27e39c726",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "6cb58b9d175061251ad82a638800bd483a2126bb8f73caba4b404dce31bd79a0",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "happiness-04": {
+      "vector": "7exsvoyLCz/HxsY+o6KiPtDPTz/j4uK+t7a2vouKir6NjAw+1tVVP8PCwr719HQ+0M9PP+blZb/KyUk/29raPrm4uD2BgIA71dRUvrOysr61tDS+o6KivoiHBz+Miws/ubi4vdbVVb///v4+jYwMPvf29r6Miws/tLMzv+blZT/t7Gy+jIsLP8fGxj6joqI+0M9PP+Pi4r63tra+i4qKvo2MDD7W1VU/w8LCvvX0dD7Qz08/5uVlv8rJST/b2to+ubi4PYGAgDvV1FS+s7KyvrW0NL6joqK+iIcHP4yLCz+5uLi91tVVv//+/j6NjAw+9/b2voyLCz+0szO/5uVlPw==",
+      "vectorSha256": "9e990202aed53dd6c1b784ebb2f981bf42a0fd947313ae39f17eed991f7ed368",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "62c5b1a8e747525d91ea4f9ee70de4b68b8065536957c3c57415bf9142c526f2",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "happiness-05": {
+      "vector": "zMtLP7Oysr7R0FC9AACAvwAAgL/r6uq+9vV1P8bFRb/FxEQ+3dxcvqyrK7+DgoI+/v19v5CPDz+BgIC7/v19v+LhYb+Pjo4++/r6PqWkJL75+Pg9gYCAO/n4+L2Lioo+tLMzP7m4uL2mpSU/oJ8fP8bFRT/KyUm/iYiIPa+urj7My0s/s7KyvtHQUL0AAIC/AACAv+vq6r729XU/xsVFv8XERD7d3Fy+rKsrv4OCgj7+/X2/kI8PP4GAgLv+/X2/4uFhv4+Ojj77+vo+paQkvvn4+D2BgIA7+fj4vYuKij60szM/ubi4vaalJT+gnx8/xsVFP8rJSb+JiIg9r66uPg==",
+      "vectorSha256": "fb69336fbe9a8b8034c1e483fa78ba2e71e32d50bdecd2822fdf225f38aebfa5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "e55379000045fa1d98642aa001c77f010fa3be6b8f8070a2d974d2cfe21b88ab",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "happiness-06": {
+      "vector": "sK8vv52cHL7d3Fw+sbAwvcC/P7+Ihwe/29ravp+enr7o52c/kZAQPfHwcL3T0tI+goEBv/n4+L2pqKg90dBQPfTzc7+Lioq+lpUVv/X0dD61tDS+ycjIvZmYmD3KyUk/1dRUPvf29j6zsrI+8/LyPvLxcT///v6+jo0NP+DfX7+wry+/nZwcvt3cXD6xsDC9wL8/v4iHB7/b2tq+n56evujnZz+RkBA98fBwvdPS0j6CgQG/+fj4vamoqD3R0FA99PNzv4uKir6WlRW/9fR0PrW0NL7JyMi9mZiYPcrJST/V1FQ+9/b2PrOysj7z8vI+8vFxP//+/r6OjQ0/4N9fvw==",
+      "vectorSha256": "313b8e8dfa06ddd2fd441b24133a5db2a738e6d4639ae417499347ae20c556bf",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "286c9b7a203c4958f38478b43f708a86065d359e697389e49abdacbcf840c610",
+      "updatedAt": "2025-09-20T22:28:15.461Z"
+    },
+    "happiness-07": {
+      "vector": "tbQ0Pv38fD6Miws/sbAwve/u7r6rqqo+1dRUPoqJCT+zsrK+nZwcPqGgoDy1tDS+397ePoiHB78AAIA/5+bmPuDfX7+enR0/s7Kyvquqqj7+/X2/7OtrP5aVFb+ioSG/7Otrv8XERD6VlBS+goEBP8HAQDzU01M/2djYPd/e3r61tDQ+/fx8PoyLCz+xsDC97+7uvquqqj7V1FQ+iokJP7Oysr6dnBw+oaCgPLW0NL7f3t4+iIcHvwAAgD/n5uY+4N9fv56dHT+zsrK+q6qqPv79fb/s62s/lpUVv6KhIb/s62u/xcREPpWUFL6CgQE/wcBAPNTTUz/Z2Ng9397evg==",
+      "vectorSha256": "2aef37f20b7a0584359f54baccc863c8eeb9effab367428a3081333702e6309e",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "969fc57a44aa9ac453938269b73cffb910ce53aa01f5352f0a986dc081e98d48",
+      "updatedAt": "2025-09-20T22:28:15.462Z"
+    },
+    "happiness-08": {
+      "vector": "3dxcPpKREb/My0u//Pt7v66tLb/19HQ+/v19v6KhIT+BgIC7rawsvuPi4j6lpCQ+lJMTP+fm5r6CgQE/9vV1P+vq6j6Pjo4+o6KiPpybG7/6+Xk/xMNDv769Pb+RkBC97+7uPvX0dL7Lysq+9/b2vpeWlr7o52c/5uVlv6CfH7/d3Fw+kpERv8zLS7/8+3u/rq0tv/X0dD7+/X2/oqEhP4GAgLutrCy+4+LiPqWkJD6UkxM/5+bmvoKBAT/29XU/6+rqPo+Ojj6joqI+nJsbv/r5eT/Ew0O/vr09v5GQEL3v7u4+9fR0vsvKyr739va+l5aWvujnZz/m5WW/oJ8fvw==",
+      "vectorSha256": "469d72e49eba785612b69d72f9b0038ad72a966b0f7d607d8ff7ae6ddb61939d",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "9b371a02299e01d07f6ab894c946c0fabaa3a832fc1e217bbb614d425af30d30",
+      "updatedAt": "2025-09-20T22:28:15.462Z"
+    },
+    "happiness-09": {
+      "vector": "sbAwPby7Oz/CwUE/xcREvvz7e7/7+vo+19bWPsjHRz/l5GS+rKsrP5aVFb/Z2Ni9zs1NP8HAQLzDwsK+nZwcvuTjY7/KyUm/qaioPZ2cHD6Pjo4+/Pt7v4SDAz/Avz8/5eRkvqyrKz/CwUG/5+bmPo2MDL7NzEy+qKcnP5qZGT+xsDA9vLs7P8LBQT/FxES+/Pt7v/v6+j7X1tY+yMdHP+XkZL6sqys/lpUVv9nY2L3OzU0/wcBAvMPCwr6dnBy+5ONjv8rJSb+pqKg9nZwcPo+Ojj78+3u/hIMDP8C/Pz/l5GS+rKsrP8LBQb/n5uY+jYwMvs3MTL6opyc/mpkZPw==",
+      "vectorSha256": "286bffb831dfcba067b98232ce4ca77d7a91ab8c7b5e4331521e71330ff77bf2",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "85dde06702beb5e363d53572e67e4f6c0e1b8a93a302c1df63d51fb96e66d3cc",
+      "updatedAt": "2025-09-20T22:28:15.462Z"
+    },
+    "happiness-10": {
+      "vector": "j46OvpybG7/w728/trU1P5mYmD3a2Vk/p6amPtjXV7/u7W2/2NdXP+Pi4j6hoKC8i4qKvoKBAT/w72+/+/r6vri3Nz+rqqq+np0dv/v6+r7NzEy+oaCgPODfXz+ysTE/19bWvsjHR7/W1VW/09LSPrSzM7/r6uo+AACAP8PCwj6Pjo6+nJsbv/Dvbz+2tTU/mZiYPdrZWT+npqY+2NdXv+7tbb/Y11c/4+LiPqGgoLyLioq+goEBP/Dvb7/7+vq+uLc3P6uqqr6enR2/+/r6vs3MTL6hoKA84N9fP7KxMT/X1ta+yMdHv9bVVb/T0tI+tLMzv+vq6j4AAIA/w8LCPg==",
+      "vectorSha256": "f2d8b1b81122018f07f8b5b384f9e19a37df69ac75cff576520c3805ebf978f5",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "5c32f7da89eca91409ebb87d5dc00841db5531416682efd84a1c15b426baffb0",
+      "updatedAt": "2025-09-20T22:28:15.462Z"
+    },
+    "happiness-11": {
+      "vector": "y8rKPrKxMT+hoKA8oaCgvKmoqD3u7W0/lJMTv8bFRT+WlRW/rq0tP6empj6Hhoa+2djYPefm5r7T0tI+6OdnP4mIiD2vrq4+6ulpP6CfH7/+/X2/k5KSvrKxMb+amRm/wL8/v7GwMD2SkRE/4eDgPO3sbD7FxES+u7q6PpiXF7/Lyso+srExP6GgoDyhoKC8qaioPe7tbT+UkxO/xsVFP5aVFb+urS0/p6amPoeGhr7Z2Ng95+bmvtPS0j7o52c/iYiIPa+urj7q6Wk/oJ8fv/79fb+TkpK+srExv5qZGb/Avz+/sbAwPZKRET/h4OA87exsPsXERL67uro+mJcXvw==",
+      "vectorSha256": "a7505056d637ad18f0727dd75e816f982aacecb98df07707ecef891076a88e62",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "b2d8827d8af636e235d6a95e8d46b4f388abf430015b27332085c8839d67ae34",
+      "updatedAt": "2025-09-20T22:28:15.462Z"
+    },
+    "happiness-12": {
+      "vector": "oaCgvO3sbD7n5uY+vr09P5ybGz+9vDw+1NNTP9bVVb/w728/kZAQvZaVFb+RkBC9wsFBP42MDD6trCy+8fBwvZiXFz/8+3u/trU1v+vq6r6rqqq+7u1tP9va2j7s62s/ycjIPQAAgD/f3t6+z87OPsvKyj6koyO/19bWvsfGxr6hoKC87exsPufm5j6+vT0/nJsbP728PD7U01M/1tVVv/Dvbz+RkBC9lpUVv5GQEL3CwUE/jYwMPq2sLL7x8HC9mJcXP/z7e7+2tTW/6+rqvquqqr7u7W0/29raPuzraz/JyMg9AACAP9/e3r7Pzs4+y8rKPqSjI7/X1ta+x8bGvg==",
+      "vectorSha256": "8137cfa4636b7a75d04f70fd12685dff3637793f21b739f8f26cd4c856c3832a",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "7d9db9decd97e915f77b357be0916a78cb02254555f6b6f58cff48b3b22e4a4e",
+      "updatedAt": "2025-09-20T22:28:15.462Z"
+    },
+    "happiness-13": {
+      "vector": "m5qavpmYmD2KiQm/AACAP/Tzc7+fnp4+oJ8fP83MTD6ysTG/4uFhP9TTUz+XlpY+oJ8fP/f29r739va+trU1P9HQUD3i4WE/1dRUPoqJCT+UkxM/4+LiPsC/P7/f3t4+/Pt7P5eWlr7l5GS+gYCAu8TDQz/Lysq+mZiYPc3MTD6bmpq+mZiYPYqJCb8AAIA/9PNzv5+enj6gnx8/zcxMPrKxMb/i4WE/1NNTP5eWlj6gnx8/9/b2vvf29r62tTU/0dBQPeLhYT/V1FQ+iokJP5STEz/j4uI+wL8/v9/e3j78+3s/l5aWvuXkZL6BgIC7xMNDP8vKyr6ZmJg9zcxMPg==",
+      "vectorSha256": "ad385c890ed9e4ed9395080eca818c32364ab6de99d0681334dfc99150255ba3",
+      "model": "fake-64",
+      "provider": "fake",
+      "dimensions": 64,
+      "textHash": "59893bff06a7cf9927f0e9a5cf4242da86f09ac4c9b820b7fd5a637fe14d8999",
+      "updatedAt": "2025-09-20T22:28:15.462Z"
+    }
+  }
+}

--- a/data/quotes-manifest.json
+++ b/data/quotes-manifest.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "generatedAt": "2025-09-20T20:02:26.043Z",
-    "total": 536,
+    "generatedAt": "2025-09-20T22:24:08.719Z",
+    "total": 530,
     "categories": 12,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",
@@ -28,9 +28,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8933c4e1c39c62e00857c44f38086847fc0e19c4a8da8703ad467aecab5dc58f",
-        "updatedAt": "2025-09-20T19:50:31.541Z"
+        "model": "fake-64",
+        "vectorSha256": "b6fdb9efa0d7f00504824bc2da7048adb1ff66a94eca058260a47abe6ee59c5c",
+        "updatedAt": "2025-09-20T22:28:15.425Z"
       }
     },
     "adventure-02": {
@@ -50,9 +50,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5f948492032d20a2cfcb4c4a794f978bb03a42bed279ebad8a4d04c386cc2f24",
-        "updatedAt": "2025-09-20T19:50:31.541Z"
+        "model": "fake-64",
+        "vectorSha256": "23f9cd486465b952ec11f57e5fe39584f4f693a32dad07c29864921e3abc0714",
+        "updatedAt": "2025-09-20T22:28:15.426Z"
       }
     },
     "adventure-03": {
@@ -72,9 +72,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e3ea6f00fd66f603fb9795a6e2b95011650cb7ae00fbc4dcf901b3fca4ab7fc0",
-        "updatedAt": "2025-09-20T19:50:31.541Z"
+        "model": "fake-64",
+        "vectorSha256": "58d5b144bfb610bc3cde8368719fb62905d907853b38cb351e09dd4747c7c4cf",
+        "updatedAt": "2025-09-20T22:28:15.426Z"
       }
     },
     "adventure-04": {
@@ -94,9 +94,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0a914262e004bd4838664ff0f4240dbc2b316d46761b1de0d5fa3dc0a18d0055",
-        "updatedAt": "2025-09-20T19:50:31.542Z"
+        "model": "fake-64",
+        "vectorSha256": "711c7ab3b1d08421ae71911752cb76ef49c3cfd049bc41ea0f139ae565bb2e3c",
+        "updatedAt": "2025-09-20T22:28:15.427Z"
       }
     },
     "adventure-05": {
@@ -116,31 +116,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7f54377fc7e0b6ac4f928b3cef33702ddd8d93acec7c896a20760fb37cddaf33",
-        "updatedAt": "2025-09-20T19:50:31.542Z"
-      }
-    },
-    "adventure-06": {
-      "hashes": {
-        "text": "7230f88eff586d0b0809581e1b7abb87f6f41a38fba75101ab9a14798ff63e28",
-        "author": "f98a1539f718e5df90aa3cea8b3ebad8c528e3835d344563b2e88fcc9ad636c0",
-        "combined": "52db7a8e20e2ebde371798f1bd0349c99f672e49febc271ff0674a59ccd70515",
-        "tokenSignature": "a-flaubert-gustav-in-makes-modest-occupy-one-place-see-the-tiny-travel-what-world-you"
-      },
-      "lengths": {
-        "text": 75,
-        "author": 15
-      },
-      "source": {
-        "categoryId": "adventure",
-        "sequence": 6
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "02a2aa5010dbcd12475b897fc369e9a7f3b6d727c49a7350f75851f8dee344b4",
-        "updatedAt": "2025-09-20T19:50:31.542Z"
+        "model": "fake-64",
+        "vectorSha256": "9ab5523046d218c50fb1f22dbf17d9c027ef8888f1b509e30cb7989275e51e56",
+        "updatedAt": "2025-09-20T22:28:15.427Z"
       }
     },
     "adventure-07": {
@@ -156,13 +134,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 7
+        "sequence": 6
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a39b07d168972aeb3156231472c1ad6826a89a2f6cf72665b592aab893801111",
-        "updatedAt": "2025-09-20T19:50:31.542Z"
+        "model": "fake-64",
+        "vectorSha256": "f460deed234bb94e6ed1840da796ecbad6c2488c3907742018d17f28ff5473cf",
+        "updatedAt": "2025-09-20T22:28:15.427Z"
       }
     },
     "adventure-08": {
@@ -178,13 +156,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 8
+        "sequence": 7
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8a10b45e0572a5a9340a7c45cf3d41122c2d9ace1267cf7f5f49fcbfac474af5",
-        "updatedAt": "2025-09-20T19:50:31.542Z"
+        "model": "fake-64",
+        "vectorSha256": "f877e1aa96bff7f4de2ac4fc9077f16a431ff1896f8e31acb1b0b42f22bc8d8e",
+        "updatedAt": "2025-09-20T22:28:15.427Z"
       }
     },
     "adventure-09": {
@@ -200,13 +178,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 9
+        "sequence": 8
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5076466bef69505680125624cf53a1994c5150ccb969ce911aab749aa2ad3c34",
-        "updatedAt": "2025-09-20T19:50:31.801Z"
+        "model": "fake-64",
+        "vectorSha256": "c0aceab942529f721bef7212a44760fd4f0eabc8481ad4b60657b0e5b5cdb65f",
+        "updatedAt": "2025-09-20T22:28:15.427Z"
       }
     },
     "adventure-10": {
@@ -222,13 +200,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 10
+        "sequence": 9
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "95bafaa21edbd9a7331aa83c1eb96d0ea21c7089f538d21a4c7b6a910b7c0a51",
-        "updatedAt": "2025-09-20T19:50:31.801Z"
+        "model": "fake-64",
+        "vectorSha256": "90633daa1cb80de1f4d3b4676961c96f892a7721ffff6f765740e83306e18bd1",
+        "updatedAt": "2025-09-20T22:28:15.427Z"
       }
     },
     "adventure-11": {
@@ -244,13 +222,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 11
+        "sequence": 10
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5b942a6907da1e99640c86ab2f5357c1ac1e313e6a9f4c1c3ba68a0b3249d0b2",
-        "updatedAt": "2025-09-20T19:50:31.801Z"
+        "model": "fake-64",
+        "vectorSha256": "ef7657cf4ea2fcb6a01ebf8db2c8941a6afec89f18ece2ed17b5fd89fb84101f",
+        "updatedAt": "2025-09-20T22:28:15.429Z"
       }
     },
     "adventure-12": {
@@ -266,13 +244,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 12
+        "sequence": 11
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1b3c0ba0e3a0ab386717273d5a1e83ee55b04827edb99928aedbd9134d5584b0",
-        "updatedAt": "2025-09-20T19:50:31.801Z"
+        "model": "fake-64",
+        "vectorSha256": "fb26d4da9dea832f67a712686407f32e4b178c08511ca6b6f56173e3f62102cd",
+        "updatedAt": "2025-09-20T22:28:15.429Z"
       }
     },
     "adventure-13": {
@@ -288,13 +266,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 13
+        "sequence": 12
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "15a43a6216de7bc10121dc2677d878ebd8aeb62b6b242d0c1bf19231399bcbdb",
-        "updatedAt": "2025-09-20T19:50:31.802Z"
+        "model": "fake-64",
+        "vectorSha256": "9ec132d9d9f23d0fcd36e75899db81e3660cd53f86d27fef3f77bb920d1824e9",
+        "updatedAt": "2025-09-20T22:28:15.430Z"
       }
     },
     "adventure-14": {
@@ -310,13 +288,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 14
+        "sequence": 13
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "38696163f875eccb38a306695f86d357e8792f5b7d03fc75c2b76e8dc7047edf",
-        "updatedAt": "2025-09-20T19:50:31.802Z"
+        "model": "fake-64",
+        "vectorSha256": "7b1cdddba21aa731a18d85881c7a575043ff5803e7c99b7a81ee77ed6f768cd1",
+        "updatedAt": "2025-09-20T22:28:15.430Z"
       }
     },
     "adventure-15": {
@@ -332,13 +310,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 15
+        "sequence": 14
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ee7eae02aa0579fccd0d99d3eaec2cfcc29b62291b654c8fa8ebb8130949776e",
-        "updatedAt": "2025-09-20T19:50:31.802Z"
+        "model": "fake-64",
+        "vectorSha256": "91879eb76667573bc9cbfb7e8c8c5e5f5c3c1943b477b941c3f298e8fae114c0",
+        "updatedAt": "2025-09-20T22:28:15.430Z"
       }
     },
     "adventure-16": {
@@ -354,13 +332,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 16
+        "sequence": 15
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a264c09a6a7141e2e0bfb269fdac3495ab5c96dc45d7c183b5ecc0d748bcc2ad",
-        "updatedAt": "2025-09-20T19:50:31.802Z"
+        "model": "fake-64",
+        "vectorSha256": "691fceb025ac24a85b22b717fb6a5fff7ede4ccd4c54b60242c06a62c10ac48b",
+        "updatedAt": "2025-09-20T22:28:15.430Z"
       }
     },
     "adventure-17": {
@@ -376,13 +354,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 17
+        "sequence": 16
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b68c48d84e4bd249e272a46317d290f7fe34e58db535a06569195a1ee82cc640",
-        "updatedAt": "2025-09-20T19:50:32.013Z"
+        "model": "fake-64",
+        "vectorSha256": "c07bcce68e0b2bf1ff8aeee5bf87dcc423edcd0b5809a629807b3df4d6abca56",
+        "updatedAt": "2025-09-20T22:28:15.430Z"
       }
     },
     "adventure-18": {
@@ -398,13 +376,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 18
+        "sequence": 17
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "84733be67c9710913b065c3d48367bde830e8d2ea89a0cbf2e698b813fb7adfa",
-        "updatedAt": "2025-09-20T19:50:32.013Z"
+        "model": "fake-64",
+        "vectorSha256": "90f90d27b68c9437777d272011099df8937e14db679fb1a9047d1bcea033e3e9",
+        "updatedAt": "2025-09-20T22:28:15.431Z"
       }
     },
     "adventure-19": {
@@ -420,13 +398,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 19
+        "sequence": 18
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ed01835cf3abeaf6819f3ca3ee5af9b75ab2658f3bb08b9795c6429477a5eb07",
-        "updatedAt": "2025-09-20T19:50:32.013Z"
+        "model": "fake-64",
+        "vectorSha256": "b452280592860decb813fe582e37baa8f941337e32e3d3af9d100a013f8c4110",
+        "updatedAt": "2025-09-20T22:28:15.431Z"
       }
     },
     "adventure-20": {
@@ -442,13 +420,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 20
+        "sequence": 19
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2cef308ce27248c7a606317b3a6c6e9ddc4b18653d8eee2ae6da2d8ccc2d70fc",
-        "updatedAt": "2025-09-20T19:50:32.013Z"
+        "model": "fake-64",
+        "vectorSha256": "3815902a277a52189d18985a628c6ae879d71b58222bf8c116e7ed1fc404a194",
+        "updatedAt": "2025-09-20T22:28:15.431Z"
       }
     },
     "adventure-21": {
@@ -464,13 +442,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 21
+        "sequence": 20
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4a35c1ec6a690b2b4cb4d151ab94109d717edd89cebf3b98c8cc64b50991a82a",
-        "updatedAt": "2025-09-20T19:50:32.013Z"
+        "model": "fake-64",
+        "vectorSha256": "abdbb5896fed495cdbc573c70f38dac962f822c2607f8decca592ce33e2c82b4",
+        "updatedAt": "2025-09-20T22:28:15.431Z"
       }
     },
     "adventure-22": {
@@ -486,13 +464,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 22
+        "sequence": 21
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "698465aa4df8bfbff1f6d42c4c9e6ddf854d0c267b2113912b042fe3bcc854f4",
-        "updatedAt": "2025-09-20T19:50:32.014Z"
+        "model": "fake-64",
+        "vectorSha256": "e3fbf201f58c3922ab721a9a064400877af86469e5b42d083f8f7c171a4b58e6",
+        "updatedAt": "2025-09-20T22:28:15.431Z"
       }
     },
     "adventure-23": {
@@ -508,13 +486,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 23
+        "sequence": 22
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c465b544d5dc5b779331fcd4c963cb48769806325791dd8f9aee7429a8c461a8",
-        "updatedAt": "2025-09-20T19:50:32.014Z"
+        "model": "fake-64",
+        "vectorSha256": "43ae8145c2f80f2bb0d91bbd39ee34268b10c726e51f8bbeb4b203fd5e3e2d74",
+        "updatedAt": "2025-09-20T22:28:15.431Z"
       }
     },
     "adventure-24": {
@@ -530,13 +508,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 24
+        "sequence": 23
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c5afb279b7dc7a8392558eeb28464e79e583a78b9c55ceeb270975c98085cea0",
-        "updatedAt": "2025-09-20T19:50:32.014Z"
+        "model": "fake-64",
+        "vectorSha256": "18b2b2017fbc9eefa6d78242a30f6b2338688196727d565e76f312efa2dd2a3e",
+        "updatedAt": "2025-09-20T22:28:15.431Z"
       }
     },
     "adventure-25": {
@@ -552,13 +530,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 25
+        "sequence": 24
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "05d34bfe716ef424e0caa2c180959a845f3094c69ab847c371009001682ca836",
-        "updatedAt": "2025-09-20T19:50:32.252Z"
+        "model": "fake-64",
+        "vectorSha256": "f9ec2a745dceb0cab3e3418c9ee2f96e5b4acf98d8ce1e55c810bfc8dbd74092",
+        "updatedAt": "2025-09-20T22:28:15.431Z"
       }
     },
     "adventure-26": {
@@ -574,13 +552,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 26
+        "sequence": 25
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "931817dc4940998ae6ba40b9f08c04f1e6a1f8d01d558e9fbec4cf347cd9068b",
-        "updatedAt": "2025-09-20T19:50:32.252Z"
+        "model": "fake-64",
+        "vectorSha256": "d0bfbaf1878dba433617671fb49721a86c2b96cfffb46977a83e9e626ff37321",
+        "updatedAt": "2025-09-20T22:28:15.432Z"
       }
     },
     "adventure-27": {
@@ -596,13 +574,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 27
+        "sequence": 26
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "38d9b92b88a60fbede6f00b5e94543332763a28344b8d3698c5f296f7f0d1769",
-        "updatedAt": "2025-09-20T19:50:32.252Z"
+        "model": "fake-64",
+        "vectorSha256": "86a5d6b40bc39b560bb4c6dbaee708f0647772fa24559389538863f0146c8a03",
+        "updatedAt": "2025-09-20T22:28:15.432Z"
       }
     },
     "adventure-28": {
@@ -618,13 +596,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 28
+        "sequence": 27
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "faf1ec9aef2a0843c55024503937f15ff80e9fd8505bc4eb61929f5c3b0df334",
-        "updatedAt": "2025-09-20T19:50:32.252Z"
+        "model": "fake-64",
+        "vectorSha256": "1a0bbc7cd90252cf13ebf9ba0414f527832bd016a2b497639a52a7141d746a79",
+        "updatedAt": "2025-09-20T22:28:15.432Z"
       }
     },
     "adventure-29": {
@@ -640,13 +618,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 29
+        "sequence": 28
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0651e18a0bbc0ad85c4762654641361ec70e5fdf4b96cd7570b284d49fe4c1c9",
-        "updatedAt": "2025-09-20T19:50:32.253Z"
+        "model": "fake-64",
+        "vectorSha256": "36668fe4146904e07f8bee32184a7377c5b804da734de9a534b7e30e1a938136",
+        "updatedAt": "2025-09-20T22:28:15.433Z"
       }
     },
     "adventure-30": {
@@ -662,13 +640,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 30
+        "sequence": 29
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3c1d118d611865d30d6e383c7d7c8979367a66d5b78db97e8a7b08fb55413684",
-        "updatedAt": "2025-09-20T19:50:32.253Z"
+        "model": "fake-64",
+        "vectorSha256": "674b2be5a2d4f7d351b44b2d9414dade04cd5a4cf190eccaca098c433a67e9a0",
+        "updatedAt": "2025-09-20T22:28:15.433Z"
       }
     },
     "adventure-31": {
@@ -684,13 +662,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 31
+        "sequence": 30
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f4af442cbde52a97930233ea8787a0d36c2b568d299856e49ebc3e827121b7d4",
-        "updatedAt": "2025-09-20T19:50:32.253Z"
+        "model": "fake-64",
+        "vectorSha256": "8515e915ccc1109d297c66a3972a7db7bcbb78b7b010805043bb8af17a319590",
+        "updatedAt": "2025-09-20T22:28:15.433Z"
       }
     },
     "adventure-32": {
@@ -706,13 +684,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 32
+        "sequence": 31
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "78bd11a2d86748a423d2a7e9ddff2d3bb310d67443ae459bcc4bf8a3e6a94b40",
-        "updatedAt": "2025-09-20T19:50:32.253Z"
+        "model": "fake-64",
+        "vectorSha256": "aa26f4d52495656aa2718a0ccaea938a2609036b0b5c073259283e3da40b7889",
+        "updatedAt": "2025-09-20T22:28:15.433Z"
       }
     },
     "adventure-33": {
@@ -728,13 +706,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 33
+        "sequence": 32
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "342eb661081798bec275dd2d86fbc1c48526d279b03ffa07a00fd744a9c917c1",
-        "updatedAt": "2025-09-20T19:50:32.542Z"
+        "model": "fake-64",
+        "vectorSha256": "5057b44b3d18e08bfaec789f329581febc3378d95843d33c6447de43d98f9b9a",
+        "updatedAt": "2025-09-20T22:28:15.433Z"
       }
     },
     "adventure-34": {
@@ -750,13 +728,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 34
+        "sequence": 33
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "65c98e2dfa1a8731cc92498cbf14622e2093541ff48a3d1dba1f658be7d6c023",
-        "updatedAt": "2025-09-20T19:50:32.542Z"
+        "model": "fake-64",
+        "vectorSha256": "63aa39d9654057ee5fc1496d5be40bc75ba6acffd2e8ceb153f91d1af7918c25",
+        "updatedAt": "2025-09-20T22:28:15.434Z"
       }
     },
     "adventure-35": {
@@ -772,13 +750,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 35
+        "sequence": 34
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7b172b88a034075e947135746ab3a0f2df8b040b516606584a92df8b325ad46b",
-        "updatedAt": "2025-09-20T19:50:32.542Z"
+        "model": "fake-64",
+        "vectorSha256": "4dd383f59560bd794ff5bf5d967baff44cfc4f29812ea72cbd509e88ce38f108",
+        "updatedAt": "2025-09-20T22:28:15.434Z"
       }
     },
     "adventure-36": {
@@ -794,35 +772,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 36
+        "sequence": 35
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d3e71b84516961c7fd151125c4344594c0479364714c3f740f2f7594edd10981",
-        "updatedAt": "2025-09-20T19:50:32.542Z"
-      }
-    },
-    "adventure-37": {
-      "hashes": {
-        "text": "d1c3f03843e3b674de90a9152f7fdd06bec34492b94b5084ce1e98fa5cc9e9a1",
-        "author": "f4fb49f850fa81650c9105bd6d58426f661c1fbc1779d8e018a8c164d70979ac",
-        "combined": "85161b1cb69598b8af735fb6d24bf56176fbca8d1eea4b34a240cc2279afcdd7",
-        "tokenSignature": "a-flaubert-gustave-in-makes-modest-occupy-one-place-see-the-tiny-travel-what-world-you"
-      },
-      "lengths": {
-        "text": 75,
-        "author": 16
-      },
-      "source": {
-        "categoryId": "adventure",
-        "sequence": 37
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f5ecf8824cf9c2090fbf085f21982612418ef83631d2e01d52555fa84fc9596a",
-        "updatedAt": "2025-09-20T19:50:32.542Z"
+        "model": "fake-64",
+        "vectorSha256": "0e35c5d4d32f0e0088001891225a842ee028f2da0e17e95c294b1bd97680fe0b",
+        "updatedAt": "2025-09-20T22:28:15.434Z"
       }
     },
     "adventure-38": {
@@ -838,13 +794,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 38
+        "sequence": 36
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f8c9eb187a6270b79fd2a6b8f8ec2d01a9cf35de5ec445a87963f545c545beae",
-        "updatedAt": "2025-09-20T19:50:32.542Z"
+        "model": "fake-64",
+        "vectorSha256": "2626ea73d628da04a64b0474f3229564204f26a4d629559e98ac7e5659470f2a",
+        "updatedAt": "2025-09-20T22:28:15.434Z"
       }
     },
     "adventure-39": {
@@ -860,13 +816,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 39
+        "sequence": 37
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "902c8818d03359941260cec4ab0591d7cf141ecc7e0d0c7a1361db10d82b6a3d",
-        "updatedAt": "2025-09-20T19:50:32.543Z"
+        "model": "fake-64",
+        "vectorSha256": "c9d96a710f603b3d77cda5c0367550a731edf861e475b575d28321815370e5be",
+        "updatedAt": "2025-09-20T22:28:15.435Z"
       }
     },
     "adventure-40": {
@@ -882,13 +838,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 40
+        "sequence": 38
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c8b36cb4b97742bf5da3152e2ad950a1e657db4be1e93b8e6a968a60801198ca",
-        "updatedAt": "2025-09-20T19:50:32.543Z"
+        "model": "fake-64",
+        "vectorSha256": "6509d4912517cde85d40b0620fa06c183674b6b85f9c4788a871756d2de6ac8e",
+        "updatedAt": "2025-09-20T22:28:15.435Z"
       }
     },
     "adventure-41": {
@@ -904,13 +860,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 41
+        "sequence": 39
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "233f3c30e807249bd356cb46026995a7ed733d2e15094925cb349f9447ad7d3c",
-        "updatedAt": "2025-09-20T19:50:32.913Z"
+        "model": "fake-64",
+        "vectorSha256": "6ed0a6d304e644553bf790a4887bce45c53d01bb437ed7bb28c18534e05fe75c",
+        "updatedAt": "2025-09-20T22:28:15.435Z"
       }
     },
     "adventure-42": {
@@ -926,13 +882,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 42
+        "sequence": 40
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7f9b2b8dc11b6e3550f212b87e9ec5161ead51efe5e918cff708b1e2490656b5",
-        "updatedAt": "2025-09-20T19:50:32.913Z"
+        "model": "fake-64",
+        "vectorSha256": "b6633b40affbbc9f99d01794949a5378fcef492b53f16926845e722fbc821ea3",
+        "updatedAt": "2025-09-20T22:28:15.435Z"
       }
     },
     "adventure-43": {
@@ -948,13 +904,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 43
+        "sequence": 41
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "df3e13e1d0efa6550d3a02f3a18f6881b6fa709eaa12c6af6a52729bbf231ee2",
-        "updatedAt": "2025-09-20T19:50:32.913Z"
+        "model": "fake-64",
+        "vectorSha256": "4158c9bdc36ef0683bd062193710f5bf860649330a81ed6b4a91d737bdb78161",
+        "updatedAt": "2025-09-20T22:28:15.436Z"
       }
     },
     "adventure-44": {
@@ -970,13 +926,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 44
+        "sequence": 42
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bc3fbeb8055ca33aead6f181249aa1579c45f318b8d5f396edae40c056006e88",
-        "updatedAt": "2025-09-20T19:50:32.913Z"
+        "model": "fake-64",
+        "vectorSha256": "d564df8ff50b573df5d05b2034c71ce514a0a18843ac77b577d42c8bffe33029",
+        "updatedAt": "2025-09-20T22:28:15.436Z"
       }
     },
     "adventure-45": {
@@ -992,13 +948,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 45
+        "sequence": 43
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "026f97229a8164c6715efb313da2a3bc4154f3420c738dcf50545d8256659e78",
-        "updatedAt": "2025-09-20T19:50:32.914Z"
+        "model": "fake-64",
+        "vectorSha256": "e5fcf45297ba6e647296ee06232f0e84f3adfbb0d32ddb33f84ba73a306ca01d",
+        "updatedAt": "2025-09-20T22:28:15.436Z"
       }
     },
     "adventure-46": {
@@ -1014,13 +970,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 46
+        "sequence": 44
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8ed920228e928dad2af1e801061d012c75a440854ce0a79083ee00e6b5ee9118",
-        "updatedAt": "2025-09-20T19:50:32.914Z"
+        "model": "fake-64",
+        "vectorSha256": "92a09a7a2e60364dce6f628768bf987de63ea263b25f058189a3b7fa8b8f2311",
+        "updatedAt": "2025-09-20T22:28:15.436Z"
       }
     },
     "adventure-47": {
@@ -1036,13 +992,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 47
+        "sequence": 45
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a46bbbac0dbcb5a180e6eb4435097166a541ca2a4134e6709a99a2fd198b9192",
-        "updatedAt": "2025-09-20T19:50:32.914Z"
+        "model": "fake-64",
+        "vectorSha256": "5ebbeb5a3e9ea4a2cc591bd7e77aecd235240b8ee6f900f30ad3e3a3f06de8d4",
+        "updatedAt": "2025-09-20T22:28:15.436Z"
       }
     },
     "adventure-48": {
@@ -1058,13 +1014,13 @@
       },
       "source": {
         "categoryId": "adventure",
-        "sequence": 48
+        "sequence": 46
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ab1044043ea76db19812bb902044261eb40058bef76abf002ab5b2b7376f1530",
-        "updatedAt": "2025-09-20T19:50:32.914Z"
+        "model": "fake-64",
+        "vectorSha256": "b26449410cc5f3ea357dfd18456aa85c375aa3123b70052fcf6dd30e2d76a8fb",
+        "updatedAt": "2025-09-20T22:28:15.436Z"
       }
     },
     "time-01": {
@@ -1084,9 +1040,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "02cec4941f40818349811b784ad1d7bcdfc359342e718316afe46aad71978535",
-        "updatedAt": "2025-09-20T19:50:33.247Z"
+        "model": "fake-64",
+        "vectorSha256": "edaf0b82a9a0ad7f39b710e7fbc877a63d6ef47a6328b030b010eb63e544f1bb",
+        "updatedAt": "2025-09-20T22:28:15.436Z"
       }
     },
     "time-02": {
@@ -1106,9 +1062,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "28ae4375ca38232708cedf1bf9e167507d63fd1d79fcd215483527b8c3607974",
-        "updatedAt": "2025-09-20T19:50:33.247Z"
+        "model": "fake-64",
+        "vectorSha256": "929f1d670c35304ab094c626633a26a17074d6389a1fccb8ee5922c38920c823",
+        "updatedAt": "2025-09-20T22:28:15.436Z"
       }
     },
     "time-03": {
@@ -1128,9 +1084,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eee4e109ae22da00507790bf01806da29b19614d64293e5984cee4b3f04228ab",
-        "updatedAt": "2025-09-20T19:50:33.247Z"
+        "model": "fake-64",
+        "vectorSha256": "6fedd566d897744f4009939262a3e3de3ae3f9f8e69c1f0977e09ae017a8df3c",
+        "updatedAt": "2025-09-20T22:28:15.436Z"
       }
     },
     "time-04": {
@@ -1150,9 +1106,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "143e2ebac731d60815761b0b51949e3b61d7c4b89a8977d98c1c2c0f97cdfa15",
-        "updatedAt": "2025-09-20T19:50:33.247Z"
+        "model": "fake-64",
+        "vectorSha256": "dc385e6e8e08ec34faaa24c864a2ee66acd839d624aafbdc953cfb0680541bcc",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-05": {
@@ -1172,9 +1128,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fdbf4ace2dd6710a18d5a5f78f5f063d848bb575339acc88297bd8ad5abb9d20",
-        "updatedAt": "2025-09-20T19:50:33.247Z"
+        "model": "fake-64",
+        "vectorSha256": "c520786fd09e94c67901072db9b76d7ffb4a9fb4fcab3c3caf9cd89d3840a06c",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-06": {
@@ -1194,9 +1150,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4e832ea4b21cac9f1dcdbb2d7a50f9dd1d9627184f485c83725faa720eff60a0",
-        "updatedAt": "2025-09-20T19:50:33.247Z"
+        "model": "fake-64",
+        "vectorSha256": "4b84f00b0092703d22a191603e3064a9a4952b8e282a3950626e6f67ce7e0f7e",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-07": {
@@ -1216,9 +1172,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7088e71bd05d7562f637d89a631aec71168cc793c400bcc3eae4c98613a1e808",
-        "updatedAt": "2025-09-20T19:50:33.247Z"
+        "model": "fake-64",
+        "vectorSha256": "67b2d0954b20be3ecd2a0a1ece4bf309860146da605c5622594020a269c16e67",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-08": {
@@ -1238,9 +1194,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a41b855782aa90c6dd8ace1052e2be0b02078a9b3744365f5ef616c18d7296f5",
-        "updatedAt": "2025-09-20T19:50:33.247Z"
+        "model": "fake-64",
+        "vectorSha256": "f95efcda22cd638a91e76f00f208aeb429aac76cac4f6e7d1e8448b80e671eb3",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-09": {
@@ -1260,9 +1216,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "502d49ab9d77c9f15b5d307de5e9913cb004d7366958c3b246e6d46cdbb4fbf5",
-        "updatedAt": "2025-09-20T19:50:33.550Z"
+        "model": "fake-64",
+        "vectorSha256": "33942c7d3d6c2f9945cd68cb7422258e9292c67039b1341199a849800d2c6e7d",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-10": {
@@ -1282,9 +1238,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3207231739df7f9026007278232bf61a82994c6a0fdcf89802d6fd199656b741",
-        "updatedAt": "2025-09-20T19:50:33.550Z"
+        "model": "fake-64",
+        "vectorSha256": "0a13685cb4be454a7dedb69c5bdb16e0ef27f4402309178dcb0283c0cf76fcb3",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-11": {
@@ -1304,9 +1260,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7a49c751b470028bb540f70bfcdea167eb54f2e582d5e45dfe0c66e61b03d813",
-        "updatedAt": "2025-09-20T19:50:33.550Z"
+        "model": "fake-64",
+        "vectorSha256": "f1bba776ff6d33c44bd42855ccf6df5eea6c992064b36c254816ecd1aeacb72c",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-12": {
@@ -1326,9 +1282,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f229ccc2e1f952cf7df8c4fd3fcc3d7d550ca309000e6d3bf9542e41dc7096a5",
-        "updatedAt": "2025-09-20T19:50:33.550Z"
+        "model": "fake-64",
+        "vectorSha256": "e0eccc898abcc07c92988c8c34a59e25f92be3049e0071d7a3adb7730d6f4777",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-13": {
@@ -1348,9 +1304,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1045e45bd519b4ed5a38163f46a530e7982d2891d7ae6bf07168d2843fcb3ad6",
-        "updatedAt": "2025-09-20T19:50:33.550Z"
+        "model": "fake-64",
+        "vectorSha256": "d9ea96437fee0d7b2ce8c733222e330bf7a512db5a335c765a8f2769cdf78d42",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-14": {
@@ -1370,9 +1326,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8a84a8cd525084860c540f1258963a32a3c74996130e541c2e5286da7393abe0",
-        "updatedAt": "2025-09-20T19:50:33.550Z"
+        "model": "fake-64",
+        "vectorSha256": "f0d3a332899fe841b3f88c3c8d288b75c6d2dce76bdd2f2cb983876ed066f364",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-15": {
@@ -1392,9 +1348,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6aa914d7032caa3d1da01369243fbb98219602489a77b84bc00539b87b146799",
-        "updatedAt": "2025-09-20T19:50:33.550Z"
+        "model": "fake-64",
+        "vectorSha256": "aa402f42ef867f4c7d16e6e22e95d70b87f10217f5b769038336cc2f6d81219a",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-16": {
@@ -1414,9 +1370,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "188c623e48a4204dde1d946eca7e4aa0517a4261c41f7d0cda42a8be2c11a9eb",
-        "updatedAt": "2025-09-20T19:50:33.550Z"
+        "model": "fake-64",
+        "vectorSha256": "c8ac2af44cb6425c2d3013382bbf1ed40530823307b157cd8c52dc6e8df1aae8",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-17": {
@@ -1436,9 +1392,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eb35a0bf5b7e611244de5db5d39d6bb08cadd9753120e8554c193aa772430e40",
-        "updatedAt": "2025-09-20T19:50:33.736Z"
+        "model": "fake-64",
+        "vectorSha256": "bc59de1f6338f03bed346e9a6d2769150e2b666435a0393a3b04b3082f57b101",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-18": {
@@ -1458,9 +1414,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "40f4caa48e7ab96e6fbc2faf04288349ccc85047773a1720082b919ad27f44e9",
-        "updatedAt": "2025-09-20T19:50:33.736Z"
+        "model": "fake-64",
+        "vectorSha256": "f6d84b559f20f38a347baf22fb7206097e6e367e01138c8baa30b3ddc93b8dea",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-19": {
@@ -1480,9 +1436,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "abebf1278ed992a59e0ff6ffb18760f6af183c26ef59f147e802d39554ca0599",
-        "updatedAt": "2025-09-20T19:50:33.736Z"
+        "model": "fake-64",
+        "vectorSha256": "4c657f4f8f8b00b0102515621c50361c34cac202bdf8eebc6129682bf75f6544",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-20": {
@@ -1502,9 +1458,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ad203f694deeeeed26fd3cd4e0ac9202bdbdebadf2859b28163bfdd836fafd52",
-        "updatedAt": "2025-09-20T19:50:33.736Z"
+        "model": "fake-64",
+        "vectorSha256": "ab19b1bb7b5624ea1e7f1adaf392a177eb3b3d6f4e19fcea1ffa0ad964e5e9a4",
+        "updatedAt": "2025-09-20T22:28:15.437Z"
       }
     },
     "time-21": {
@@ -1524,9 +1480,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "99b47e56ac95b192db42b583e08e695dc6079f9cbf94611f0b5e3368e4f19401",
-        "updatedAt": "2025-09-20T19:50:33.736Z"
+        "model": "fake-64",
+        "vectorSha256": "221362caf266c42e0eac8a2e70eb251ab61ca76f04e73fe38d25ab643ffe8ce6",
+        "updatedAt": "2025-09-20T22:28:15.438Z"
       }
     },
     "time-22": {
@@ -1546,9 +1502,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "56a7475b98136ae81379d5f4f8c504f40d70f8d1ef916b436fe7838165ff408b",
-        "updatedAt": "2025-09-20T19:50:33.736Z"
+        "model": "fake-64",
+        "vectorSha256": "5faec91d1bffe27bc99473dd01b28047efb91a806b8d964922464e0608f722f3",
+        "updatedAt": "2025-09-20T22:28:15.438Z"
       }
     },
     "time-23": {
@@ -1568,9 +1524,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a40783b49927df079ac051e3f786bd68c33c6228afe2afaedd8b19266c6d7c5a",
-        "updatedAt": "2025-09-20T19:50:33.736Z"
+        "model": "fake-64",
+        "vectorSha256": "51149bd269c5c733c3be06f2c14d7c9254c7bc9ffa0c580180588d4a5c360eea",
+        "updatedAt": "2025-09-20T22:28:15.438Z"
       }
     },
     "time-24": {
@@ -1590,9 +1546,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "02ccd1dd169b230519a4df1be431174f9ce048b5bcbe2c1b67d87614ab2a20fe",
-        "updatedAt": "2025-09-20T19:50:33.736Z"
+        "model": "fake-64",
+        "vectorSha256": "d7453a9c03c07970db1eb4ee6e4db020e00903ad964670da7058dc85f87efc2b",
+        "updatedAt": "2025-09-20T22:28:15.438Z"
       }
     },
     "time-25": {
@@ -1612,9 +1568,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "97a03d6b758a1de91da1ff00eb73835b5437a6f6f4f468259173888942b8a3aa",
-        "updatedAt": "2025-09-20T19:50:34.020Z"
+        "model": "fake-64",
+        "vectorSha256": "f977f318bdfd0aabbf59dd2cc941eb89f48ff55167a83ea4546cb0746bdf5cf5",
+        "updatedAt": "2025-09-20T22:28:15.438Z"
       }
     },
     "time-26": {
@@ -1634,9 +1590,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2d279feb2ce72c1bf8b19e404c8cd0c9c2abf5663d284091f0f93ac4fd3ce2cc",
-        "updatedAt": "2025-09-20T19:50:34.020Z"
+        "model": "fake-64",
+        "vectorSha256": "6f8725a879f56f0bb8df0e7a56c7b57a8b8f3dbc305712f1a9971dc8bd85f05b",
+        "updatedAt": "2025-09-20T22:28:15.438Z"
       }
     },
     "time-27": {
@@ -1656,9 +1612,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "33001835efe2b37cc6dd0a66fbbd29ee7d0175720154b80ea082ba6a4cbc1213",
-        "updatedAt": "2025-09-20T19:50:34.020Z"
+        "model": "fake-64",
+        "vectorSha256": "436146128bec7d6cc30c4bb9345e9a2a06933bd01850a325158e94e1ca927f40",
+        "updatedAt": "2025-09-20T22:28:15.439Z"
       }
     },
     "time-28": {
@@ -1678,9 +1634,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e9e755cf299f48048868d584c48b9de3556f26ede590c55b6b43f836de6c479f",
-        "updatedAt": "2025-09-20T19:50:34.020Z"
+        "model": "fake-64",
+        "vectorSha256": "b70000fc8a1754ac019cc6a1df1c77132a4dd18502b0050819214a11b5219046",
+        "updatedAt": "2025-09-20T22:28:15.439Z"
       }
     },
     "time-29": {
@@ -1700,9 +1656,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "12fe0a125cd3881247c145045b3bbea03d6f0c24324484fecb503fcff0d61d39",
-        "updatedAt": "2025-09-20T19:50:34.021Z"
+        "model": "fake-64",
+        "vectorSha256": "afd8ec93241cf4f231932dbc1d42743780b65ba374d0e7a541d5c1b61cb673d0",
+        "updatedAt": "2025-09-20T22:28:15.439Z"
       }
     },
     "time-30": {
@@ -1722,9 +1678,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "59657163dd346bc560807d5b272b8f9ede72fb00e74e09cfd8686672956e3705",
-        "updatedAt": "2025-09-20T19:50:34.021Z"
+        "model": "fake-64",
+        "vectorSha256": "f8e01599778d0590f951617687440513a14675264fdded2368588e3d693dec51",
+        "updatedAt": "2025-09-20T22:28:15.439Z"
       }
     },
     "time-31": {
@@ -1744,9 +1700,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "42591851cd4e5b7f77333fe86e9820091bc2a250386c8979440412f3d9a66d0c",
-        "updatedAt": "2025-09-20T19:50:34.021Z"
+        "model": "fake-64",
+        "vectorSha256": "04e3787b23eebaa6f65d0bcae8a2214f6db89a4cd8949188dfa1342793cf7559",
+        "updatedAt": "2025-09-20T22:28:15.439Z"
       }
     },
     "time-32": {
@@ -1766,9 +1722,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "922f4bd4f6ea4ec45df6ada36348360c9e6ef79eaeccb5cdc17066869f780e8d",
-        "updatedAt": "2025-09-20T19:50:34.021Z"
+        "model": "fake-64",
+        "vectorSha256": "8813084bced7adc9d604b4a7ee6a42fe6ea94b9da8f9fa5ad7d41bacc96aeb65",
+        "updatedAt": "2025-09-20T22:28:15.439Z"
       }
     },
     "time-33": {
@@ -1788,9 +1744,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7d3346f49589f23428661ef7961da6f4306687d671409a5c8ec5573fe45e0b87",
-        "updatedAt": "2025-09-20T19:50:34.253Z"
+        "model": "fake-64",
+        "vectorSha256": "be9a153e15bb56fdf0d99b68c1364f0d0c3f5c2bfc7cadbf7ba91d960880c3b1",
+        "updatedAt": "2025-09-20T22:28:15.439Z"
       }
     },
     "time-34": {
@@ -1810,9 +1766,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7a3fcd837a72724681a793e2a3a000153cfca22f1ddfd88ae68da4070226dd9e",
-        "updatedAt": "2025-09-20T19:50:34.254Z"
+        "model": "fake-64",
+        "vectorSha256": "770b827c3aac609b8cf9b6d94110493ed4156576d2e65938aebfa65789f2ae7c",
+        "updatedAt": "2025-09-20T22:28:15.439Z"
       }
     },
     "time-35": {
@@ -1832,9 +1788,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5565ad1026c0d21314d5666d3a6022a09267fc53e7a382e47faa31103e51359d",
-        "updatedAt": "2025-09-20T19:50:34.254Z"
+        "model": "fake-64",
+        "vectorSha256": "de03990c3b171c944e57899b77a98a17a83311b32c6879c65cae739732bc390d",
+        "updatedAt": "2025-09-20T22:28:15.440Z"
       }
     },
     "time-36": {
@@ -1854,9 +1810,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "92bb6d98b3ce1aafbaf77a2815cdfc8b540d49b66c435ae45253838a417ab516",
-        "updatedAt": "2025-09-20T19:50:34.254Z"
+        "model": "fake-64",
+        "vectorSha256": "3f0f38f00c5c45fce9fe43a6289de60c3adb6a684ffe5203be0ccc5f01a689fd",
+        "updatedAt": "2025-09-20T22:28:15.440Z"
       }
     },
     "time-37": {
@@ -1876,9 +1832,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "afb48314c90ec59cb00967b351355ec2c06de0ba7007804130c59bc2f806bb27",
-        "updatedAt": "2025-09-20T19:50:34.254Z"
+        "model": "fake-64",
+        "vectorSha256": "6fbae47a2dc21f0776670e8bcffc6b20298a40528ebd25e61403deccb8620bea",
+        "updatedAt": "2025-09-20T22:28:15.440Z"
       }
     },
     "time-38": {
@@ -1898,9 +1854,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d728f3cf18239ac9412218b4b4d7c10fa8b80741045eb4bff4be34c58eea1245",
-        "updatedAt": "2025-09-20T19:50:34.254Z"
+        "model": "fake-64",
+        "vectorSha256": "f8f8947ae3cdd53ea6b49e4367277799403911f3b6c59577ca564b1a6525434c",
+        "updatedAt": "2025-09-20T22:28:15.440Z"
       }
     },
     "time-39": {
@@ -1920,9 +1876,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c5797c5a0aebc31c5629211b9f67f9206dc61e55c99a55598711e44ef42f25d4",
-        "updatedAt": "2025-09-20T19:50:34.254Z"
+        "model": "fake-64",
+        "vectorSha256": "03747e2395d97ca3cc11882c9362fbee584c2e272ba5d41b067fbe7b34ccc70f",
+        "updatedAt": "2025-09-20T22:28:15.440Z"
       }
     },
     "time-40": {
@@ -1942,9 +1898,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dfb64616eb2387473eceab2464201a9b0ecacd7c2c1f0a00fb226e2c1a9abe4f",
-        "updatedAt": "2025-09-20T19:50:34.254Z"
+        "model": "fake-64",
+        "vectorSha256": "4b2ee439f1696802c34198b3bfe45f310aadd9d18a12ed4278302eae15889b6c",
+        "updatedAt": "2025-09-20T22:28:15.440Z"
       }
     },
     "time-41": {
@@ -1964,9 +1920,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "17ce172ac91bc357cf74e29148008d0a12f3750b600246bb3e9d4f8b9e79ae4b",
-        "updatedAt": "2025-09-20T19:50:34.544Z"
+        "model": "fake-64",
+        "vectorSha256": "0a3e2f9fe3c6503c0cdcf386aab049bd47b5396a6789c4b44562f14ae35955e9",
+        "updatedAt": "2025-09-20T22:28:15.440Z"
       }
     },
     "time-42": {
@@ -1986,9 +1942,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4f759c0a0e3165a1f7080d03458b6a3c34aefd83104456605071f432a5acf798",
-        "updatedAt": "2025-09-20T19:50:34.544Z"
+        "model": "fake-64",
+        "vectorSha256": "f3faea0a09cc69c018491839d6aee4ca35df1a551b554a6b657791c3863c920c",
+        "updatedAt": "2025-09-20T22:28:15.440Z"
       }
     },
     "time-43": {
@@ -2008,9 +1964,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d1b1bee4693718ada7a4ccfc9c6fcc0a8b88e0f03afc6943cbf613723c081571",
-        "updatedAt": "2025-09-20T19:50:34.544Z"
+        "model": "fake-64",
+        "vectorSha256": "7c9050100058c77102290014380999f8e7c676d6d52b23d82bdeac4e742c5980",
+        "updatedAt": "2025-09-20T22:28:15.441Z"
       }
     },
     "time-44": {
@@ -2030,9 +1986,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "61e8930136d052358d555c2640e244e83629a7f6c189c8244dd264992a0e7fdf",
-        "updatedAt": "2025-09-20T19:50:34.544Z"
+        "model": "fake-64",
+        "vectorSha256": "b1bd5e6c0a2d8d2bc2083aba292871ccb70436850e7d904fb22a2540805d65b2",
+        "updatedAt": "2025-09-20T22:28:15.441Z"
       }
     },
     "time-45": {
@@ -2052,9 +2008,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3122b91ac67b3b83f4abee2592423c35cfdde83c47403777c009601456ac4282",
-        "updatedAt": "2025-09-20T19:50:34.544Z"
+        "model": "fake-64",
+        "vectorSha256": "2d70f06196ecb6b8f6aa32b7a4b34fd46ce169dcfb9f140feca6c7f661bbc127",
+        "updatedAt": "2025-09-20T22:28:15.441Z"
       }
     },
     "time-46": {
@@ -2074,9 +2030,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e96d05350a70de6cd13543d33d65b2429aa480cb43f2a1a9866f3d648d0b3e90",
-        "updatedAt": "2025-09-20T19:50:34.545Z"
+        "model": "fake-64",
+        "vectorSha256": "139f5d14e339838c9864364a951af9bb7363abc087b453d084ab8b42816d27f1",
+        "updatedAt": "2025-09-20T22:28:15.441Z"
       }
     },
     "time-47": {
@@ -2096,9 +2052,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7d69aa2be17885a854c50dec5272ecb41d54b4c0a911acd68496f8ed21bdce0f",
-        "updatedAt": "2025-09-20T19:50:34.545Z"
+        "model": "fake-64",
+        "vectorSha256": "e871e7b4436a2b18d875c0c53690556a3129c83f2dee60c0e5f56cc17491798c",
+        "updatedAt": "2025-09-20T22:28:15.441Z"
       }
     },
     "time-48": {
@@ -2118,9 +2074,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1ad79b81c0aae1f17c096148e92bdb08d471283b7bfb6cbe8b8a1c6234939350",
-        "updatedAt": "2025-09-20T19:50:34.545Z"
+        "model": "fake-64",
+        "vectorSha256": "9d6839037e7f3e16c9e774369dac3086cea4232ccc6644c5bc3e028593c64fef",
+        "updatedAt": "2025-09-20T22:28:15.441Z"
       }
     },
     "time-49": {
@@ -2140,9 +2096,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6c80d9e3f58d571369eec2551f1eacbcbf29f0bb31609c5787c6a3dc680a54a4",
-        "updatedAt": "2025-09-20T19:50:34.836Z"
+        "model": "fake-64",
+        "vectorSha256": "ad4e7e14dd15a1ab44a58ee4532ef0d814eb14afaa08cd6b7a6fd2bc8a959303",
+        "updatedAt": "2025-09-20T22:28:15.441Z"
       }
     },
     "time-50": {
@@ -2162,9 +2118,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "98fbcb0e4a9b9392b168aef224366999c238c1dbddec227f00813499bb648d24",
-        "updatedAt": "2025-09-20T19:50:34.836Z"
+        "model": "fake-64",
+        "vectorSha256": "1d8e13e0832fd195299f73e681cae0be9260d79557f31558ca445d02b7973ac8",
+        "updatedAt": "2025-09-20T22:28:15.441Z"
       }
     },
     "motivation-01": {
@@ -2184,9 +2140,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "edeb9c59f7db5e3c4113a3de4415c6f0102a2f79cb23d8c70cddbb3f2d99f1ee",
-        "updatedAt": "2025-09-20T19:50:34.836Z"
+        "model": "fake-64",
+        "vectorSha256": "14dcf42390cb5498c3a6d224f84dde1d3d9417b7e15ee78adccfb07d48ac595b",
+        "updatedAt": "2025-09-20T22:28:15.442Z"
       }
     },
     "motivation-02": {
@@ -2206,9 +2162,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "79c336568b44f71b1ec7a53462da8cf75322763fd97bde694dcefbd10fb4c31d",
-        "updatedAt": "2025-09-20T19:50:34.836Z"
+        "model": "fake-64",
+        "vectorSha256": "4de590227f42be74a1bd15586011b378049cc5f2ccd3e3e1ef9e8e5a44824e38",
+        "updatedAt": "2025-09-20T22:28:15.442Z"
       }
     },
     "motivation-03": {
@@ -2228,9 +2184,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b6cd8720316b5782403d1f6b2d20b6dc7386a417edf40bd5d38d690ea84c751f",
-        "updatedAt": "2025-09-20T19:50:34.836Z"
+        "model": "fake-64",
+        "vectorSha256": "5b99617cad3dbae8f579d9a3c0beaa734873e837251188fe0bf8afa6c9bd85d6",
+        "updatedAt": "2025-09-20T22:28:15.442Z"
       }
     },
     "motivation-04": {
@@ -2250,9 +2206,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "40e390b73cd8a082195d9f2253ca24873da83d472427ddfb0e620812b5f39127",
-        "updatedAt": "2025-09-20T19:50:34.836Z"
+        "model": "fake-64",
+        "vectorSha256": "1c2aa67b8c3f2432e8c21556738cd49514b82754c0fd45f1652f6e45d356856d",
+        "updatedAt": "2025-09-20T22:28:15.442Z"
       }
     },
     "motivation-05": {
@@ -2272,9 +2228,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9ef959b4e736745e98dc99b89d4d18a717e4e4d6e7535b1ddb5443ab7ad09b09",
-        "updatedAt": "2025-09-20T19:50:34.837Z"
+        "model": "fake-64",
+        "vectorSha256": "b33c59f1518afbe2ac42bf50a1ee2463d98aefee855b26e8051a74e0a3d11bc6",
+        "updatedAt": "2025-09-20T22:28:15.442Z"
       }
     },
     "motivation-06": {
@@ -2294,9 +2250,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "11b4fb2833eae01252615050bf1ef4db31fc4d84bddf8ab4b946805a7c7fef1d",
-        "updatedAt": "2025-09-20T19:50:34.837Z"
+        "model": "fake-64",
+        "vectorSha256": "d493135a4f18dadcdb65c2b6391c6a7b6ef2144101aca5af4ae9bba64a562fb8",
+        "updatedAt": "2025-09-20T22:28:15.442Z"
       }
     },
     "motivation-07": {
@@ -2316,9 +2272,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bcf2e15de99c9b57abde343c830728e3ecc4d402e91032bc062c7498cd8b84f9",
-        "updatedAt": "2025-09-20T19:50:35.124Z"
+        "model": "fake-64",
+        "vectorSha256": "da48a56501abda71524537750042af094181fefc918664351b4802acd058f1cb",
+        "updatedAt": "2025-09-20T22:28:15.442Z"
       }
     },
     "motivation-08": {
@@ -2338,9 +2294,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "336e6a5be718ab19a840b2cbda5afa8bc760b941f5fabda69e0903b08b81d15f",
-        "updatedAt": "2025-09-20T19:50:35.125Z"
+        "model": "fake-64",
+        "vectorSha256": "e6882283680d38994b01cffb08a2e7bb371dddb54f2d975cc8c828e04c3405c9",
+        "updatedAt": "2025-09-20T22:28:15.442Z"
       }
     },
     "motivation-09": {
@@ -2360,9 +2316,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0a02002181b9fc27d2668c18fe011488545827bd2080892340a14c9fdff3bc87",
-        "updatedAt": "2025-09-20T19:50:35.125Z"
+        "model": "fake-64",
+        "vectorSha256": "0296ebee156a554b33df097b9f291d676ebe91c7e111aa9ba0b2eb6c6df130b2",
+        "updatedAt": "2025-09-20T22:28:15.443Z"
       }
     },
     "motivation-10": {
@@ -2382,9 +2338,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "337ef4f5b7ad10fdb040a8742e8d57baf13ff1ba7f79adaa5ef58602d99b1395",
-        "updatedAt": "2025-09-20T19:50:35.125Z"
+        "model": "fake-64",
+        "vectorSha256": "0510e3a2882824c0b1993a3a9b4f0d0db286c8964e43202cd229091388f1f623",
+        "updatedAt": "2025-09-20T22:28:15.443Z"
       }
     },
     "motivation-11": {
@@ -2404,9 +2360,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f7fa4bea5251e8aa2d20029c7e4278cc2e146de720c8c25ff5a97c786b28dd28",
-        "updatedAt": "2025-09-20T19:50:35.125Z"
+        "model": "fake-64",
+        "vectorSha256": "8b270dff92ed722b67ab30a573547a9d5c131a40289b2cd89fc3272be35d2ad2",
+        "updatedAt": "2025-09-20T22:28:15.443Z"
       }
     },
     "motivation-12": {
@@ -2426,9 +2382,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "248d4576d6e20ab06a2a3a8ee9f159227fd6845775340a5ec0b7188a5f3b5327",
-        "updatedAt": "2025-09-20T19:50:35.125Z"
+        "model": "fake-64",
+        "vectorSha256": "fe0aacebc1fd2431276a116f5ce9ca3ffb0baf69fe3ef01cc399a044d2522747",
+        "updatedAt": "2025-09-20T22:28:15.443Z"
       }
     },
     "motivation-13": {
@@ -2448,9 +2404,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ec35a4379acc1148700740a15436fee7cb84f68cc354245dd189c91c12be95a0",
-        "updatedAt": "2025-09-20T19:50:35.125Z"
+        "model": "fake-64",
+        "vectorSha256": "bd5e55aca870997e50beddc7a315aa05617eed7ff85da95ecc31dae5488e1703",
+        "updatedAt": "2025-09-20T22:28:15.443Z"
       }
     },
     "motivation-14": {
@@ -2470,9 +2426,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1d767a2ba7b6970a6a749c8acf1c9d19d7027f7a39c620ffa580e238c2b4648a",
-        "updatedAt": "2025-09-20T19:50:35.125Z"
+        "model": "fake-64",
+        "vectorSha256": "bfcbbdcc6edb11e607420c553f3d9fd2c87194957337ab473ef0c25bab27cc09",
+        "updatedAt": "2025-09-20T22:28:15.443Z"
       }
     },
     "motivation-15": {
@@ -2492,9 +2448,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4e1628c118346181a9e767a13b86d5906b601aa46accb303105df4f76f501882",
-        "updatedAt": "2025-09-20T19:50:35.414Z"
+        "model": "fake-64",
+        "vectorSha256": "10a93c3ecc0b4febe1cfb1d191d20b5df7d831c24ff263d4cb08c6c172c0dce8",
+        "updatedAt": "2025-09-20T22:28:15.443Z"
       }
     },
     "motivation-16": {
@@ -2514,9 +2470,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9f695c60e8600ce3d6220451992187ef35ff51f3fc08315e030c211d5fed74eb",
-        "updatedAt": "2025-09-20T19:50:35.414Z"
+        "model": "fake-64",
+        "vectorSha256": "934f74517cd7d6e6015481f9114a55e2c82e7618a01e8b6f7adf4ec4bb21172e",
+        "updatedAt": "2025-09-20T22:28:15.443Z"
       }
     },
     "motivation-17": {
@@ -2536,9 +2492,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "23fd6c32e95286b6f6f945acce9450b57878aa3bd919ed54fe2fa3c8810af6e4",
-        "updatedAt": "2025-09-20T19:50:35.414Z"
+        "model": "fake-64",
+        "vectorSha256": "e1719be90b4d1c16a0501343bb2f1e34c2be1cdcedb70c45f90de4ef3e189830",
+        "updatedAt": "2025-09-20T22:28:15.444Z"
       }
     },
     "motivation-18": {
@@ -2558,9 +2514,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "08dfadbe8af4b5661121b5e9c164ed3acf73e368ec36ca4ea48e09e1f13523c3",
-        "updatedAt": "2025-09-20T19:50:35.414Z"
+        "model": "fake-64",
+        "vectorSha256": "c89c8a2487a0fdbc6d02def08cfef2ea828ae32849231b56ef073af31acf666a",
+        "updatedAt": "2025-09-20T22:28:15.444Z"
       }
     },
     "motivation-19": {
@@ -2580,9 +2536,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f3ecf406b9ec38b14897c6d4125ba5782f10824e4aeeb413fd99f5016a23dd8b",
-        "updatedAt": "2025-09-20T19:50:35.414Z"
+        "model": "fake-64",
+        "vectorSha256": "7af14376b1059c185ddbe898258a18f3b8384c35e403852ef8624e5f8f1a0337",
+        "updatedAt": "2025-09-20T22:28:15.444Z"
       }
     },
     "motivation-20": {
@@ -2602,9 +2558,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ef4d512407ef9be2904fe465cad2373970345e59c9d8aa82469dbebb5d8dce99",
-        "updatedAt": "2025-09-20T19:50:35.414Z"
+        "model": "fake-64",
+        "vectorSha256": "f88f63442e178406a748b7b502241670d12cc5431dc1724bcccc6bea69bb772e",
+        "updatedAt": "2025-09-20T22:28:15.444Z"
       }
     },
     "motivation-21": {
@@ -2624,9 +2580,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "560f2626eb899d25b44a3599d7f57d43efe0e72b887d565b62503eaca5af90e0",
-        "updatedAt": "2025-09-20T19:50:35.414Z"
+        "model": "fake-64",
+        "vectorSha256": "9f746639d7a681db72f27b5c3f94bf8dac17d22d9f6baf3b958141277faf8dae",
+        "updatedAt": "2025-09-20T22:28:15.444Z"
       }
     },
     "motivation-22": {
@@ -2646,9 +2602,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "da0ce4b4dc3f160c39dc6da10785f2d4826df4472efa071642bff68da7087631",
-        "updatedAt": "2025-09-20T19:50:35.414Z"
+        "model": "fake-64",
+        "vectorSha256": "6503ea0cce0fd91a3ea596843dc11c5de8648c7108bac7804fcf8f094682732f",
+        "updatedAt": "2025-09-20T22:28:15.444Z"
       }
     },
     "motivation-23": {
@@ -2668,9 +2624,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "49559589fb7505e4eaff1dcde0cfb5b1fbb2e28ba382279e5b54df06ea2c8acb",
-        "updatedAt": "2025-09-20T19:50:35.645Z"
+        "model": "fake-64",
+        "vectorSha256": "6d9611ab9e53ef1cd750766cc1e3e8655a7d1dd82008325f4ca23bef805c1750",
+        "updatedAt": "2025-09-20T22:28:15.444Z"
       }
     },
     "motivation-24": {
@@ -2690,9 +2646,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bd5754ad653dc3d67812550ea4b31aa4a0c881c9aa9dd55a955cfb861694b9a2",
-        "updatedAt": "2025-09-20T19:50:35.645Z"
+        "model": "fake-64",
+        "vectorSha256": "fdb4a8c7c476a6f5c81bdd36d5fd9f1ebfbf77af59f35786cda09f6c006e98b4",
+        "updatedAt": "2025-09-20T22:28:15.444Z"
       }
     },
     "motivation-25": {
@@ -2712,9 +2668,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0653f03eb46dc7ba7d11ce73cc684bc807d48ee16cadd96f6f02db35ba32703d",
-        "updatedAt": "2025-09-20T19:50:35.645Z"
+        "model": "fake-64",
+        "vectorSha256": "f1bdbed2c021424c14497051e987a3ecaae357c735bf10cdc736f4bcf451ef44",
+        "updatedAt": "2025-09-20T22:28:15.444Z"
       }
     },
     "motivation-26": {
@@ -2734,9 +2690,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7ca22c61e69a378d7860ccfdcceb73fedc1ea6a1381dd9619051ad88b2fd1f9b",
-        "updatedAt": "2025-09-20T19:50:35.645Z"
+        "model": "fake-64",
+        "vectorSha256": "6f16ff505254306a0337e92ab4398cade0728760f863005048371ff52953e8b8",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-27": {
@@ -2756,9 +2712,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "018ef6abf8f1ec2e9d34d0fad867cd0a32d2c5160f4d8839120894aa5e8f1779",
-        "updatedAt": "2025-09-20T19:50:35.645Z"
+        "model": "fake-64",
+        "vectorSha256": "4633e22a6e31ce0e2aeafaadaad6e197415ae41b36f6c8493e68ed6175f4f35e",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-29": {
@@ -2774,13 +2730,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 29
+        "sequence": 28
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "674796ac12de37d9cd2e2cf214f274e5ae2911fedcc88723b5a8617e4fdeff82",
-        "updatedAt": "2025-09-20T19:50:35.645Z"
+        "model": "fake-64",
+        "vectorSha256": "c3c4e38f50e67923148baba5a92d6b24776f2b2e73a27eacf48229373d9d657a",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-30": {
@@ -2796,13 +2752,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 30
+        "sequence": 29
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c62661eb2233ed0966e1222dfd6ae7fc8b711477df7bf3a61a233c98dfd5111c",
-        "updatedAt": "2025-09-20T19:50:35.645Z"
+        "model": "fake-64",
+        "vectorSha256": "096f3e559aa2ba1d453d3e2cdb756343dc43caa796748b4aef9a3c3798570923",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-31": {
@@ -2818,13 +2774,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 31
+        "sequence": 30
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d910cc5abe1dbd629c6fcd5c37cd206fe886995f879b4e0b47c345e47ff23df0",
-        "updatedAt": "2025-09-20T19:50:35.967Z"
+        "model": "fake-64",
+        "vectorSha256": "408922b28e8be32c0ff6e16be7eed20e0ec0d16a276520086e17a30a5163d5e6",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-32": {
@@ -2840,13 +2796,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 32
+        "sequence": 31
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ba34d1b049e4b7730056e7e1797ed8b64c916b85cb163e18b3052f39305ae68d",
-        "updatedAt": "2025-09-20T19:50:35.967Z"
+        "model": "fake-64",
+        "vectorSha256": "b1a1dfcc723fd0ecf8332546a408e10726b32e82a1f10ea10946bda4feb17c16",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-33": {
@@ -2862,13 +2818,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 33
+        "sequence": 32
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6e29df83ad7e7b33425ddc14a63a4eb63fbac4f74b7f7cb4ab63bbf04d30b657",
-        "updatedAt": "2025-09-20T19:50:35.967Z"
+        "model": "fake-64",
+        "vectorSha256": "8ddb0b98b9a7fb31d342ca9c8d9e366a233f1104d1fa5d0e89ad66e95e578059",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-34": {
@@ -2884,13 +2840,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 34
+        "sequence": 33
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "55d4543f933fb8769c134e7443d93d97679ff2e24171e5cb2965666d846d0cdc",
-        "updatedAt": "2025-09-20T19:50:35.967Z"
+        "model": "fake-64",
+        "vectorSha256": "3a84a5a46da6d5008523219ee5aa02622a3c815ac29fa65907dc9f9608e85202",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-35": {
@@ -2906,13 +2862,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 35
+        "sequence": 34
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0d0e948e121e720e5fa9bfaaaab5b74e1bc530b425b0806da2dbbd51bab40050",
-        "updatedAt": "2025-09-20T19:50:35.967Z"
+        "model": "fake-64",
+        "vectorSha256": "f80051520fe505af999233eb84bc6f0ff75925c6e8793df123368ec4e86704dd",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-36": {
@@ -2928,13 +2884,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 36
+        "sequence": 35
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3f1fa465831c6cbe4745c6b9219312f1a0619829f7d70b17ab733f772dc35f56",
-        "updatedAt": "2025-09-20T19:50:35.967Z"
+        "model": "fake-64",
+        "vectorSha256": "bf8d1d108521c0ed0edce58a0ed949ff763b79910ecd4c265a94b68f8f9b0418",
+        "updatedAt": "2025-09-20T22:28:15.445Z"
       }
     },
     "motivation-37": {
@@ -2950,13 +2906,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 37
+        "sequence": 36
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6df2d69b47b7a82bc99ef45e99493937a0d91b5d4472e0768653d0351cc3ca3b",
-        "updatedAt": "2025-09-20T19:50:35.967Z"
+        "model": "fake-64",
+        "vectorSha256": "ee318de524cc578185517326ee9007deb9e2dcaf12afb7ac53d7bc55a2f293f8",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-38": {
@@ -2972,13 +2928,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 38
+        "sequence": 37
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7b3a2ebb25909a8e5db6cd54cd8d924e624f0f46cb3a3a68f36e89f3205665a7",
-        "updatedAt": "2025-09-20T19:50:35.967Z"
+        "model": "fake-64",
+        "vectorSha256": "a5439c9d55f403f8043ff7aae350e892345b28a03cdd2eccd9909e5b053a677f",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-39": {
@@ -2994,13 +2950,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 39
+        "sequence": 38
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "280900f60d51104dc2a5caa50ebae40d38d7105c903cc509b2d149260ab0910d",
-        "updatedAt": "2025-09-20T19:50:36.250Z"
+        "model": "fake-64",
+        "vectorSha256": "55da8a695710dd20f5ac9ab435c8a25a1ec15b243dbc0256fa33829a44e2a3d9",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-40": {
@@ -3016,13 +2972,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 40
+        "sequence": 39
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e4c81d4dfc4f676dda8b743aaffed8ea4e3f282a0cc047cc6c12a748edf07a9f",
-        "updatedAt": "2025-09-20T19:50:36.250Z"
+        "model": "fake-64",
+        "vectorSha256": "8afae42d751a1b3c4863fd3b864ee31ce51b3843a4ea7e714f120d8d0cb37869",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-41": {
@@ -3038,13 +2994,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 41
+        "sequence": 40
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "79d61b6d49473bed668cd06f50c1d6444be96dad4ee238147a1b362708e6b80b",
-        "updatedAt": "2025-09-20T19:50:36.250Z"
+        "model": "fake-64",
+        "vectorSha256": "c6dabeb4c122e0d81de4e174a2beffebcdcf7bbc9b293cada0eefe166642b1ec",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-42": {
@@ -3060,13 +3016,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 42
+        "sequence": 41
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aa30c22b53ab51eeb67c536ede1bdc843556c76412e7525fce05f0fcfa40cc0b",
-        "updatedAt": "2025-09-20T19:50:36.250Z"
+        "model": "fake-64",
+        "vectorSha256": "cffddc88eaa2bc243662863b678fb03471443d4c7c3352106591d126b4319322",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-43": {
@@ -3082,13 +3038,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 43
+        "sequence": 42
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9c6186b31cb7e399881e929921d99578d9a84b777bb741b3f9b0332d90523d48",
-        "updatedAt": "2025-09-20T19:50:36.250Z"
+        "model": "fake-64",
+        "vectorSha256": "e6566f060fa49d23984745e70273bfec149a8eaa080dfcbfdd4dd46db33ed768",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-44": {
@@ -3104,13 +3060,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 44
+        "sequence": 43
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "12d2e9e314c51e8b135c96c54cb4be3612ff22ba5b45d82a49e549d7feb61ced",
-        "updatedAt": "2025-09-20T19:50:36.250Z"
+        "model": "fake-64",
+        "vectorSha256": "f9c8bfd8290ee546c211218a36d5c89acc0d26c8dcbbc8853680b016369022e5",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-45": {
@@ -3126,13 +3082,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 45
+        "sequence": 44
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "34c01e8af119bb7bae5bee28054615e4daf2184e1b502c10144d2144727b7de5",
-        "updatedAt": "2025-09-20T19:50:36.250Z"
+        "model": "fake-64",
+        "vectorSha256": "887fa12f436da3e04d5f07410a8742c4e318b6cdc5c8fdeeb97f431c43adcc55",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-46": {
@@ -3148,13 +3104,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 46
+        "sequence": 45
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c57832059df74657d0550da5e3fccc529b5aef1ea26d398dd8cc4b7e6ed7ad3f",
-        "updatedAt": "2025-09-20T19:50:36.250Z"
+        "model": "fake-64",
+        "vectorSha256": "318a5d85bb4f4266a1ad2df83be1368307b4ade92ea949b575e12a021b26023a",
+        "updatedAt": "2025-09-20T22:28:15.446Z"
       }
     },
     "motivation-47": {
@@ -3170,13 +3126,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 47
+        "sequence": 46
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d1691af35532eaa23805287e2ed1fbde84292f24b0e943125bf386b4c47c3018",
-        "updatedAt": "2025-09-20T19:50:36.499Z"
+        "model": "fake-64",
+        "vectorSha256": "d6fab055ca33145778576d5511d082be56461be882007651e8c0c1d669eda563",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "motivation-48": {
@@ -3192,13 +3148,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 48
+        "sequence": 47
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "742e83171c47b59628b69783597f2e903077f2ea1405c4e9bfcd4dfec912d120",
-        "updatedAt": "2025-09-20T19:50:36.499Z"
+        "model": "fake-64",
+        "vectorSha256": "e3a04c6e0a0612e2d5fa87e99c7095058b4705dbc7a0db0e0131f11fd54edc37",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "motivation-49": {
@@ -3214,13 +3170,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 49
+        "sequence": 48
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d844e6f097ef5460ddc0b5c93c5e6ec08d754012e924bd40e8a80295d3e3844b",
-        "updatedAt": "2025-09-20T19:50:36.499Z"
+        "model": "fake-64",
+        "vectorSha256": "aea76f2ec17bda31f48cfed7601b61de1b79668c9a54cc5e70fa030b280f21b3",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "motivation-50": {
@@ -3236,13 +3192,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 50
+        "sequence": 49
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1270c7d30edfc09d7ebc3bee0ad19fd471c3b05918439665a579f8c527af466f",
-        "updatedAt": "2025-09-20T19:50:36.499Z"
+        "model": "fake-64",
+        "vectorSha256": "4d3092fba8dba4fb073bd43132864116243de5041048a7a3d54386c3df8f6316",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "motivation-51": {
@@ -3258,13 +3214,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 51
+        "sequence": 50
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "168d1bcfe0019efea7e15a6b6f651d6e4e1641b02ab4b990048c57981bf0a669",
-        "updatedAt": "2025-09-20T19:50:36.499Z"
+        "model": "fake-64",
+        "vectorSha256": "eea58ea656f0f3332ef2c8821ac08d6c1eed08ad723993121000468853af12a1",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "motivation-52": {
@@ -3280,13 +3236,13 @@
       },
       "source": {
         "categoryId": "motivation",
-        "sequence": 52
+        "sequence": 51
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7e805784646c00a634371b5eb135273cb97370879e57fe0c92a7eb2733e711ac",
-        "updatedAt": "2025-09-20T19:50:36.499Z"
+        "model": "fake-64",
+        "vectorSha256": "d35a705136f5cb7a188578df794b5b12decf1bde78c5107d3ff170770823bdd5",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "friendship-01": {
@@ -3306,9 +3262,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6668929193c59b546887dd15e4225c4069da8ed4619f6d6d85027a3e2dfd75e8",
-        "updatedAt": "2025-09-20T19:50:36.499Z"
+        "model": "fake-64",
+        "vectorSha256": "e9d88a90583b427fefdb7ec7360b9019ee70177c2b431b202830629435906245",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "friendship-02": {
@@ -3328,9 +3284,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f23268e961b963ff84777c50325177e6f2d3cb82416b8a7961d5b9d27ef38bef",
-        "updatedAt": "2025-09-20T19:50:36.499Z"
+        "model": "fake-64",
+        "vectorSha256": "9910c6826022b99c08bdbd0b1abd24824d88d8abcb4689314cece82e5437d7b3",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "friendship-03": {
@@ -3350,9 +3306,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "70f53317ede45c44fcf5f584b3aece54c3f7b49fa7c49d425b9d9c469624a8d3",
-        "updatedAt": "2025-09-20T19:50:36.816Z"
+        "model": "fake-64",
+        "vectorSha256": "90c950ba106d9814fdb9129b9baf903a626b63eba762c145e168ce09cbe8f8e3",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "friendship-04": {
@@ -3372,9 +3328,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c8f9b0337d61acd9f8f2fc99f51d4724b0427d80e1769deb43ea593514a73461",
-        "updatedAt": "2025-09-20T19:50:36.816Z"
+        "model": "fake-64",
+        "vectorSha256": "ec66009ba0e1e456a8fa0dd52a3542dba8ec2cdc670bbd4e67a26f30d792fed4",
+        "updatedAt": "2025-09-20T22:28:15.447Z"
       }
     },
     "friendship-05": {
@@ -3394,9 +3350,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "114d476273a9705f9d5506c408e6a31f3418302d3b72ff4ac272205991bf966b",
-        "updatedAt": "2025-09-20T19:50:36.816Z"
+        "model": "fake-64",
+        "vectorSha256": "b252bc7d5c0478402ea3d5268b8ad309ad130dffc53e086be5fde50aabc0dfa4",
+        "updatedAt": "2025-09-20T22:28:15.448Z"
       }
     },
     "friendship-06": {
@@ -3416,9 +3372,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "946f0da07acb3a8314f096a43e155f26307ded2204bc2f71cbe4c0a4306e73a1",
-        "updatedAt": "2025-09-20T19:50:36.816Z"
+        "model": "fake-64",
+        "vectorSha256": "a76fc3c8ecf08df610fd14085ca66c43dd82b5316b82e3b754dd57463b365c54",
+        "updatedAt": "2025-09-20T22:28:15.451Z"
       }
     },
     "friendship-07": {
@@ -3438,9 +3394,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a2965d2b92669909f7d0c862e2a089974dd1fe0b843842c617f58e386d9ae982",
-        "updatedAt": "2025-09-20T19:50:36.816Z"
+        "model": "fake-64",
+        "vectorSha256": "3646990a524831c273929881e5b7ebbe9585009482168e50c7882e2cd27c4508",
+        "updatedAt": "2025-09-20T22:28:15.451Z"
       }
     },
     "friendship-08": {
@@ -3460,9 +3416,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e9af828604adc5841298e7eea16148d1ae1ca2357cb050d76dbe731ad19897fa",
-        "updatedAt": "2025-09-20T19:50:36.816Z"
+        "model": "fake-64",
+        "vectorSha256": "be55048ab03762d8900aac716f88f49b210610e605ba3aef57bc54db41f90c26",
+        "updatedAt": "2025-09-20T22:28:15.451Z"
       }
     },
     "friendship-09": {
@@ -3482,9 +3438,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f2e765c51e46ced87cb4a1392d27aa7d227ddc147809219b7b6e7d4b924a87ce",
-        "updatedAt": "2025-09-20T19:50:36.816Z"
+        "model": "fake-64",
+        "vectorSha256": "73e8a67aa0fa9012e85a422baaf4c098e5951c826f462111ed67d70ac40703bb",
+        "updatedAt": "2025-09-20T22:28:15.451Z"
       }
     },
     "friendship-10": {
@@ -3504,9 +3460,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "af7ddbcf9609e9af60074b8016c8f3f81539048b5f91a677854a22dae3be5f98",
-        "updatedAt": "2025-09-20T19:50:36.816Z"
+        "model": "fake-64",
+        "vectorSha256": "7772a3f9d345d3ceeb27e7202a8743b61aaafab151f3052533d0acebfbd392ce",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-11": {
@@ -3526,9 +3482,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "615b5263e26b6202509604eaefd2a132a56d29957b04f6d84c54393033d2dd0b",
-        "updatedAt": "2025-09-20T19:50:37.103Z"
+        "model": "fake-64",
+        "vectorSha256": "1dd6f624eeb9326415d5d05a9066ac1db124f39b638970ce1c9ff644683fe8c5",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-12": {
@@ -3548,9 +3504,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1938ddb070459c346a0526015df3f4fa3f63d0ff56335c160aeba22da02a5b5d",
-        "updatedAt": "2025-09-20T19:50:37.104Z"
+        "model": "fake-64",
+        "vectorSha256": "5220d8dbd58009cc284847239fb843fc710ea7050c23d2a11ca40c979bcdf4b3",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-13": {
@@ -3570,9 +3526,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b59ca9e2c26aa94e77233a472f866f87947e51d748e74cdefe9c2fad52bdb72f",
-        "updatedAt": "2025-09-20T19:50:37.104Z"
+        "model": "fake-64",
+        "vectorSha256": "60e49bcd223a4bf92bc1710aa6d95ea9de09a46a49b70c26e0af60e0c0bb1d85",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-14": {
@@ -3592,9 +3548,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6e81a34a3d8a3c727d13ea1ec2840d5ff5f1be4a72b8984e1fc788f6f190c0a1",
-        "updatedAt": "2025-09-20T19:50:37.104Z"
+        "model": "fake-64",
+        "vectorSha256": "4d2cf22b7838369576408e6f5ae62942d7d0e20df34a0728c490ef911229345f",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-15": {
@@ -3614,9 +3570,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fbda26c94fcd8e5e831f5d93064050d140830fcaed5388878596853946a1f152",
-        "updatedAt": "2025-09-20T19:50:37.104Z"
+        "model": "fake-64",
+        "vectorSha256": "5204ac63eb5954b30d31addc44df23b53b37b0bf57b22022aa426576b6259747",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-16": {
@@ -3636,9 +3592,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "834819d1eb652064d3ac21e1888bdef0d67f6e4547ca63ea2abb7de4c50ff6d6",
-        "updatedAt": "2025-09-20T19:50:37.104Z"
+        "model": "fake-64",
+        "vectorSha256": "c65135231ce72934675e8d433cb6e415915d27987043ed36d9c2d3af40673e93",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-17": {
@@ -3658,9 +3614,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "528d8dd4cee9575d0facb39e1d0db5692591a73e79112545f9912e5009488338",
-        "updatedAt": "2025-09-20T19:50:37.104Z"
+        "model": "fake-64",
+        "vectorSha256": "8b2b6792edb67628806c0127798f5d22a2ce23e9c474cba817c2862bcd2496fd",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-18": {
@@ -3680,9 +3636,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5b0dce9eda26482d7bde7de711a0ebc89849337fcd6f5df597fcdcfe2ff959bf",
-        "updatedAt": "2025-09-20T19:50:37.104Z"
+        "model": "fake-64",
+        "vectorSha256": "7a40edbe266bc3e57477a33f8279d7ddca313f8325f1dbf0b8e6feaa055e0a80",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-19": {
@@ -3702,9 +3658,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1a83823b236fcaa7d13f67033f5b294f7eac6b93926651c21e447867c81177e4",
-        "updatedAt": "2025-09-20T19:50:37.379Z"
+        "model": "fake-64",
+        "vectorSha256": "a873b9cd314d6e59676a5dffd5d98ac92946c79f973a42bbf0987e6bd9682c13",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-20": {
@@ -3724,9 +3680,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1240ed21876914933934751525ddd2801b0f38f4953c7ede1e5a9f5dcd5274c5",
-        "updatedAt": "2025-09-20T19:50:37.379Z"
+        "model": "fake-64",
+        "vectorSha256": "2e8722f08c882051b89695dfdab8e58d43b81c269d1a4378901bf69e73a0014a",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-21": {
@@ -3746,9 +3702,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7b8591557928bc5cbaca5d57bcc5ef91ebfc946a257201cc300deddaadcc885b",
-        "updatedAt": "2025-09-20T19:50:37.379Z"
+        "model": "fake-64",
+        "vectorSha256": "07ab7c66fe2ae64b33449a9d9622d41a6175eff34ae21c28ede19eaa232e3fb4",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-22": {
@@ -3768,9 +3724,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4ea7f335d1bae67c9cacb91fba6eda82dbb593eabe7e36073ca71b7bf2d071c3",
-        "updatedAt": "2025-09-20T19:50:37.379Z"
+        "model": "fake-64",
+        "vectorSha256": "bc4b95cbc60d017dee028e182f81c5cc2348dbd77613c560d799ec10fd6b25dd",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-23": {
@@ -3790,9 +3746,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "846e7a76f91aed99e689a078cdb108a38c125c04a57aac34c971a887d41ae629",
-        "updatedAt": "2025-09-20T19:50:37.379Z"
+        "model": "fake-64",
+        "vectorSha256": "eb7733ffe79918f5c61d9b4acbacdc95d97c179ec52556118f5f819d096f12a6",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-24": {
@@ -3812,9 +3768,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "394b0e0f592091120657d1dffc3cebb49edc38c4242001643c8096d5dddda65a",
-        "updatedAt": "2025-09-20T19:50:37.379Z"
+        "model": "fake-64",
+        "vectorSha256": "63f7d04b9695a55f19bf841301c7fd770968c8bc1696c2bffa151875af60fe37",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-25": {
@@ -3834,9 +3790,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "87553f0fe53640fef8ef4bfbbcb09e0a0511f93f8e9507f46eedd63fa09e6cd4",
-        "updatedAt": "2025-09-20T19:50:37.379Z"
+        "model": "fake-64",
+        "vectorSha256": "98f8b4e0cb1af6cab05ee8738dc877f15df4802b4e05d90f6ad85d79571bf8a5",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-26": {
@@ -3856,9 +3812,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a61c18e9436db63870380f394a015f976f0f5d4483c4b085feb4052968aee129",
-        "updatedAt": "2025-09-20T19:50:37.379Z"
+        "model": "fake-64",
+        "vectorSha256": "30d6d4974388b72d3b8140e141a43f4e0407fc661f7335a1a514220674ae84df",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-27": {
@@ -3878,9 +3834,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "881febc79367d44641781fba40e9bc2331032323d6ed985cf95c659ccf9cdcd8",
-        "updatedAt": "2025-09-20T19:50:37.740Z"
+        "model": "fake-64",
+        "vectorSha256": "b97d3308c7e36aa99532a9dc0a85899adb327bd1595ff309ddc41d1550b76329",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-28": {
@@ -3900,9 +3856,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0a2adf9d81953f7e9d984032e2e41006fb469605d630000cbfed2ac0ef5587d8",
-        "updatedAt": "2025-09-20T19:50:37.740Z"
+        "model": "fake-64",
+        "vectorSha256": "04dae8f3fe5f1f0d1c4cfaa18d37f4ff7a63b2917eec9218ea73da9377b3c7e9",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-29": {
@@ -3922,9 +3878,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "151f2103afdd47fa957f109d8ac415a17406af75aac529ccefc9caf5dc8c0a3c",
-        "updatedAt": "2025-09-20T19:50:37.740Z"
+        "model": "fake-64",
+        "vectorSha256": "6383eb6ddfb0028686c2603e710c0aff3f9380e62c68045e0e3ac4a06bab43e3",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-30": {
@@ -3944,9 +3900,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "03b4de7734e1bc77a43195da76fc6077b357a124cee85e76c3783898c9092561",
-        "updatedAt": "2025-09-20T19:50:37.740Z"
+        "model": "fake-64",
+        "vectorSha256": "89014116273dffc1b3195813b0cd6c2794b915f1aa22f12abd8898183b81a88b",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-31": {
@@ -3966,9 +3922,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1c89ae3f2dc8d14d146b3ca7d0fba70aaeff912dd2e50f3ce60f711b65d3e379",
-        "updatedAt": "2025-09-20T19:50:37.740Z"
+        "model": "fake-64",
+        "vectorSha256": "729aa0903f8b670180f58adb20e64fcb4472de236a3e67fbe3b49c7ce0530626",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-32": {
@@ -3988,9 +3944,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0a7dd0bc25f2fa23daa2588be733fdd21096277c7e75ac9f72490704c3df0edc",
-        "updatedAt": "2025-09-20T19:50:37.740Z"
+        "model": "fake-64",
+        "vectorSha256": "45697ad28aea7e37866593e8d68fe26b983e17568efaeb68bfa34fbd71b07dda",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-33": {
@@ -4010,9 +3966,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "34ebe732df7ae54db087f9471fdd8ee6f0342721ae83f450a93a671f4ce7ab70",
-        "updatedAt": "2025-09-20T19:50:37.740Z"
+        "model": "fake-64",
+        "vectorSha256": "3aab3b35249368918d9b410be024af48837c9d42d0851c5d2f798bac4b0b3dc6",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-34": {
@@ -4032,9 +3988,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "04a6b819381a1f1ab9de804c92659ff10ef4af6dcae4dfbfea3fc851704b927c",
-        "updatedAt": "2025-09-20T19:50:37.740Z"
+        "model": "fake-64",
+        "vectorSha256": "45481a8f3d64ad7dba9987622c21eeb4c2426352e213d18349ca7ff75c6253e0",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-35": {
@@ -4054,9 +4010,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aff8372a7bd599c326da8e6ffb0cebacbc4948623ff3a5d56ede3965b88455c8",
-        "updatedAt": "2025-09-20T19:50:38.010Z"
+        "model": "fake-64",
+        "vectorSha256": "8783cea2cbdd4d100efeca85ffbd81669997b85404be727d2ce2c9a7041c06d2",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-36": {
@@ -4076,9 +4032,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5f1f9c9c9fbda9e6bc3adbd7a4d293415e2579f685f1226253b47780d2610f5e",
-        "updatedAt": "2025-09-20T19:50:38.010Z"
+        "model": "fake-64",
+        "vectorSha256": "93ee0d8e390215c6b048c5605089a65eeacb5d75bd7a0fdfed46efe962f6fd51",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-37": {
@@ -4098,9 +4054,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b3025c9e99ede1909b97872aeb552607b6280d7afcdb9e4ca1e545c9b8a9f2c1",
-        "updatedAt": "2025-09-20T19:50:38.010Z"
+        "model": "fake-64",
+        "vectorSha256": "80ce8e7c79a7717720423b1ea60140ab61aa3b66cf1da2ae04357ba6b64e60b9",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-38": {
@@ -4120,9 +4076,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "27066ef167fe098b5406cc487212a9e7a31698b48665c9785f45f6e6c7a11e20",
-        "updatedAt": "2025-09-20T19:50:38.010Z"
+        "model": "fake-64",
+        "vectorSha256": "a86e1a37a4f447f39ccd5e6f423fa0520d5cb0e582867e04ae59ae82566d3797",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-39": {
@@ -4142,9 +4098,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "22b51900278e171cdb489ae17a78fa3682c34014e8dae137ade86e35e306dc14",
-        "updatedAt": "2025-09-20T19:50:38.010Z"
+        "model": "fake-64",
+        "vectorSha256": "2694424a4e36b56108b3ea33fd3f1bc44c7356c17add559f02f1b2d8804b307c",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-40": {
@@ -4164,9 +4120,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a36c9805eae5bddb73f6ee681f5d34dea7eec1518627be4426e110b8c3fcfad4",
-        "updatedAt": "2025-09-20T19:50:38.010Z"
+        "model": "fake-64",
+        "vectorSha256": "98b6c9a7c54236cdd480f7289ae366db9b502b3a8144b60340550432b49f877f",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-41": {
@@ -4186,9 +4142,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eec7dccfebf0769469b42a2853229f5c073b427e70d7a23a87d800db1a6431aa",
-        "updatedAt": "2025-09-20T19:50:38.010Z"
+        "model": "fake-64",
+        "vectorSha256": "cebd41406981469de74e43e9cb450271e713ef6ff1b84e3387e3b328cdbcdd92",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-42": {
@@ -4208,9 +4164,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5224a6b3099dd6e58811d0e0891b87679e6a0302e17606fc87bf5b97cbca26d6",
-        "updatedAt": "2025-09-20T19:50:38.011Z"
+        "model": "fake-64",
+        "vectorSha256": "4a754d731c248b8b41c179b1cd94382d9d737933930448f75cdb1842999161a0",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-43": {
@@ -4230,9 +4186,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0504bc6dda623780faf69f86c0d2e16d771203a098167a421860f27450dc9b7d",
-        "updatedAt": "2025-09-20T19:50:38.346Z"
+        "model": "fake-64",
+        "vectorSha256": "a2f138f4822f530fe9e391b4fd930349fda5735e847d8c826a3b64a0d9c1cf1b",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-44": {
@@ -4252,9 +4208,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fa09f003bb10f885aa4268627922aa18bc22352ff463d456d6ab51cb5e48ac07",
-        "updatedAt": "2025-09-20T19:50:38.346Z"
+        "model": "fake-64",
+        "vectorSha256": "1bd461b5b5d380ab9d2523cfe74e4f514520dd1ee2aefc8fa8e3b993239c14a8",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-45": {
@@ -4274,9 +4230,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "04047d7b977d3b7e1ccc9ae37ef9148532a19b6279a53c6586dd4cd20761abf6",
-        "updatedAt": "2025-09-20T19:50:38.346Z"
+        "model": "fake-64",
+        "vectorSha256": "9a923f9d83f819ba9f68ae3b25d93130220e312aa1b758105751db4b0d859213",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-46": {
@@ -4296,9 +4252,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e4406d5509246d360db26f4934f13f34888a24dc5af304416f5313ac9f27a1b2",
-        "updatedAt": "2025-09-20T19:50:38.346Z"
+        "model": "fake-64",
+        "vectorSha256": "2f64df55b6629ee3db1c8613ecd5545dfda83ca76a416206b5ae6edf13b05b23",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-47": {
@@ -4318,9 +4274,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "74550494adaef2339b347fbcd4bcdfbf280139532d357abedda8322912988a32",
-        "updatedAt": "2025-09-20T19:50:38.346Z"
+        "model": "fake-64",
+        "vectorSha256": "2378e765477dfa2ed7528245a21071fd5770a786d3c89350a744b57f7d4a6fd1",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-48": {
@@ -4340,9 +4296,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0222d851fb06d256a17bd034bded4148f3cf5140603ae561208166e5ae539cc2",
-        "updatedAt": "2025-09-20T19:50:38.346Z"
+        "model": "fake-64",
+        "vectorSha256": "229a446bff9fad66569b7800092c6028e58adf7fa340a5ba299ed7903aa62503",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-49": {
@@ -4362,9 +4318,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fb89f8f0499cb52f49c6ebfd02c931a9ede96e58f2ed1542bf73419aa16d3984",
-        "updatedAt": "2025-09-20T19:50:38.346Z"
+        "model": "fake-64",
+        "vectorSha256": "76705ae5ba6a40d588b07898f1df6f3d402d1a6c55b5dc0c0cb2a45970a095fa",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "friendship-50": {
@@ -4384,9 +4340,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5837905506c1c446d3b924493666bc51ac72dc25970aa28bff0a634c5581865e",
-        "updatedAt": "2025-09-20T19:50:38.346Z"
+        "model": "fake-64",
+        "vectorSha256": "51870e327b7cd6a52e7ac719b3db3bd13f667a1e1108d76322f894b801b5a829",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "music-01": {
@@ -4406,9 +4362,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b68dfdedf48610d58d540c67edacb66fa3cf75ff92e0fb4b6aa451bfc997b221",
-        "updatedAt": "2025-09-20T19:50:38.693Z"
+        "model": "fake-64",
+        "vectorSha256": "ff76746402400301ec3ce7529b12f7e52cfe988f6a959487f37f425c3ccaab2e",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "music-02": {
@@ -4428,9 +4384,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "498d629ebb1ecc1a3e4e03adce2f845c48d0b77d67020eeed2b98208da87c8f6",
-        "updatedAt": "2025-09-20T19:50:38.693Z"
+        "model": "fake-64",
+        "vectorSha256": "0d6570816c77995d0dbac3a83d3541d571530865d09bfcfe7aeace193e385a54",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "music-03": {
@@ -4450,9 +4406,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b96f517af83a29480264a3b70d42099a10e2ff0c638a66c9a642e3ea28d53de6",
-        "updatedAt": "2025-09-20T19:50:38.693Z"
+        "model": "fake-64",
+        "vectorSha256": "bf47f58fc0353cd7cdd5d7d368eaabca91dba6dd98a135c856250f1f99102a55",
+        "updatedAt": "2025-09-20T22:28:15.452Z"
       }
     },
     "music-04": {
@@ -4472,9 +4428,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7aae43c63a308a884f2e993c082d28e5f18c691322c1bfb90b40b4ca134f84fa",
-        "updatedAt": "2025-09-20T19:50:38.693Z"
+        "model": "fake-64",
+        "vectorSha256": "5afdc13ec80ba83b96cab16489994e63bc98c4f1e95bad6642d6cc7b18d17a1b",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-05": {
@@ -4494,9 +4450,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1b21d57c4f1adaa8bded6a7b78c7a1e75681bb1a7a54e9a5c055a2a942443712",
-        "updatedAt": "2025-09-20T19:50:38.694Z"
+        "model": "fake-64",
+        "vectorSha256": "376c2f01cdde8122df2f4755ce90ea324bc4de22df21f3e36daf757b2a483d51",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-06": {
@@ -4516,9 +4472,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3a214d1dc7c005a3c88185851bf31b8e5af2f336b9f1042648e297f9763d9b53",
-        "updatedAt": "2025-09-20T19:50:38.694Z"
+        "model": "fake-64",
+        "vectorSha256": "6feae5301f7b3a5a58e4652f97ea0c66b18acf464289dd09276b118c08846e8c",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-07": {
@@ -4538,9 +4494,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9dc30253d10ff890be5b1d07656a1f7480c66c369a99dd14c6b9f45f41a123d2",
-        "updatedAt": "2025-09-20T19:50:38.694Z"
+        "model": "fake-64",
+        "vectorSha256": "4f2e8e9a319fd9c20198f0cd3b556daf8678d2d4032140577c4f2de1f1d0a4ac",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-08": {
@@ -4560,9 +4516,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b5a912bfe1e748da5c763574956327d29aeacd0cacb7360bf81d5ea32af5ebcd",
-        "updatedAt": "2025-09-20T19:50:38.694Z"
+        "model": "fake-64",
+        "vectorSha256": "390c482fd08413c132fce74e089116de20f94d067061b73925a0c0533ec0c2db",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-09": {
@@ -4582,9 +4538,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1b4bbcebb6f37d72f6cc434e074506739e2aa9452961b89ab31f45ba76eb6e18",
-        "updatedAt": "2025-09-20T19:50:38.962Z"
+        "model": "fake-64",
+        "vectorSha256": "7757314da73cf0f25712a74890485c39e01fb0dbc36aef7987ad4499702b9cb7",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-10": {
@@ -4604,9 +4560,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "604f1b550c023e3de36cd22c32d8c8dc3465f3299e115dfcbcf627fafe652686",
-        "updatedAt": "2025-09-20T19:50:38.962Z"
+        "model": "fake-64",
+        "vectorSha256": "abd314fdc62cf5aaac607597c38dc6b6f6d663034a193d497facdbf752b8b300",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-11": {
@@ -4626,9 +4582,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b3db1fe2c42260966cb725dc052a8e9d6f3640e318e9a515658b0f5f1e9a14d1",
-        "updatedAt": "2025-09-20T19:50:38.962Z"
+        "model": "fake-64",
+        "vectorSha256": "bddef0e33a6d5813df811e1936e138158edfc773d85c358c5144abb087d1a697",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-12": {
@@ -4648,9 +4604,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8ce47736d7bf8d33cb1e9e9c10fe08287c7d725e44795c6794608ce0db5ce0a2",
-        "updatedAt": "2025-09-20T19:50:38.962Z"
+        "model": "fake-64",
+        "vectorSha256": "766269e7cba4041396ebbaf6debcdb99efd1bd7a4fd64306a6f9ebf148a86561",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-13": {
@@ -4670,9 +4626,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b6f4a91f4d2301b749ef33ab81acdf32b936a061014c4b3c9c7da895f1640556",
-        "updatedAt": "2025-09-20T19:50:38.962Z"
+        "model": "fake-64",
+        "vectorSha256": "7bf0545178f0938729d6b27eada81e83052919efbe14de47c34acaea67bd3e31",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-14": {
@@ -4692,9 +4648,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6509c6fdb569b82706db333554033d0102d0f289e9926862a2f145dcc5d9edcf",
-        "updatedAt": "2025-09-20T19:50:38.962Z"
+        "model": "fake-64",
+        "vectorSha256": "0a6ac745caa30d482d0adc60362cdd25e1d8ccf6c634f3723531b596d4ccde00",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-15": {
@@ -4714,9 +4670,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9ceadc974e7232a80b53480a354728099010f498fc6dacefab4875b5230c295a",
-        "updatedAt": "2025-09-20T19:50:38.963Z"
+        "model": "fake-64",
+        "vectorSha256": "0336855e7e50e1e0dc7cf26417272c57cc641422099d37221e0aa4e303e3d287",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-16": {
@@ -4736,9 +4692,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "99f7f9d1a432519f4af3538e9a28289ea03759c2f1b4d3cb28b66964b8fbf4d3",
-        "updatedAt": "2025-09-20T19:50:38.963Z"
+        "model": "fake-64",
+        "vectorSha256": "d59ef841d7c284abf976a75acde13609acbba78be25035b9a7592fbb9944bf1e",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-17": {
@@ -4758,9 +4714,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5a831bd73a6000610bc14385a7f5894314ec5f9cae650724d66ea6a79cf1df39",
-        "updatedAt": "2025-09-20T19:50:39.346Z"
+        "model": "fake-64",
+        "vectorSha256": "31a002ecbba28cc2d2af45712ab7b100fab836801dee5fe6691a92f043e52966",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-18": {
@@ -4780,9 +4736,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "49b4b107ef81e0cdef142ae1a0cb5eb350e505c6ec647ac372786f9c551ba22c",
-        "updatedAt": "2025-09-20T19:50:39.346Z"
+        "model": "fake-64",
+        "vectorSha256": "c8754e77222af9b651b8d30feed97bdd1de30f3242935d54e6c8c2887c18ff2c",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-19": {
@@ -4802,9 +4758,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1dcc9e766864e0580584dd71e418c18c8b4ded23fef8899ab6ce04ba8c0a603e",
-        "updatedAt": "2025-09-20T19:50:39.347Z"
+        "model": "fake-64",
+        "vectorSha256": "45ce9039f0a957643aa4c340754f7a794aa3f7ff7a73fa5e718adb1b33412c01",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-20": {
@@ -4824,9 +4780,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "18849edc0f00246a5c71645acdcdd155e867fa2c1010b652d0e6690d47e9c87b",
-        "updatedAt": "2025-09-20T19:50:39.347Z"
+        "model": "fake-64",
+        "vectorSha256": "4eab927b62dafbbc6f1827ce49a978288f7e1caa97d75f834ee8f4bba7549ccf",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-21": {
@@ -4846,9 +4802,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cbafd9ca742db80109a8cc26209fdbb4521a04be161bfa0e97d56458f8760e44",
-        "updatedAt": "2025-09-20T19:50:39.347Z"
+        "model": "fake-64",
+        "vectorSha256": "8e8cb2ff0d826a5216d14621e420f092efa1e42816fd69ab79d9611355ab90e2",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-22": {
@@ -4868,9 +4824,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3b25f3875178d6cb591ca2c268d2c3537cda741c6c48afc5b407e28aa8204917",
-        "updatedAt": "2025-09-20T19:50:39.347Z"
+        "model": "fake-64",
+        "vectorSha256": "c76d0e06a563dcb3ef225489371e5c26bb6a566f1cfea41813a39f23f15e0998",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-23": {
@@ -4890,9 +4846,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b9c0c273b47a4ecdd0a407313d8f0574b8e023d963be4306137ead38d50427c8",
-        "updatedAt": "2025-09-20T19:50:39.347Z"
+        "model": "fake-64",
+        "vectorSha256": "2f7bbf369ca088e6ad9b04c7904697d0450119c3fdde46eeaf64c456c3dfc459",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-24": {
@@ -4912,9 +4868,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fc9bc6ea368439fe6c8773ba881f58916dcea7543a8d670144c1349cabc16654",
-        "updatedAt": "2025-09-20T19:50:39.347Z"
+        "model": "fake-64",
+        "vectorSha256": "9990c10508721e7b9ba37c8e6271d4487711de3c3d9dcee1fe564395c4d36828",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-25": {
@@ -4934,9 +4890,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6f6ee9ec5eae7329f56cd0efc1d20c20f16c6aa7ab8d3d79a338a9eb7c5a2c09",
-        "updatedAt": "2025-09-20T19:50:39.692Z"
+        "model": "fake-64",
+        "vectorSha256": "981799ec93f0c3a7e19619121a6f64671476361b1999f27708d2682f04c5f802",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-26": {
@@ -4956,9 +4912,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "891eac8130f3cb836f0cd2058388ea1801aa79a3912ccf8edd2a9c972e2d8af0",
-        "updatedAt": "2025-09-20T19:50:39.692Z"
+        "model": "fake-64",
+        "vectorSha256": "0ace2aa2f9a39f28340ca5d4de11d9ec24f291e52df4e3d27018ab13cbb08adf",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-27": {
@@ -4978,9 +4934,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "39f0514913b0be999181a229d07b043d9994a019612e09616a736da81c7371c3",
-        "updatedAt": "2025-09-20T19:50:39.692Z"
+        "model": "fake-64",
+        "vectorSha256": "98d695e5da28ed56d214468360a6b2fcc581e9d176eb1123adfa87a6265f2d6d",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-28": {
@@ -5000,9 +4956,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5a272c79112532c6c8bd9e5e5eda4358a975f9ce6ef0be571995a48131837e09",
-        "updatedAt": "2025-09-20T19:50:39.692Z"
+        "model": "fake-64",
+        "vectorSha256": "e180cdc2d4cde3a8674e7977f43798312f1357bef696365b2c5fd6caa591d47d",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-29": {
@@ -5022,9 +4978,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "88f24ce6ad7a674d27bdcc76bf5ecdcffc0b58b8e96e8888aaf536e8a56965fb",
-        "updatedAt": "2025-09-20T19:50:39.692Z"
+        "model": "fake-64",
+        "vectorSha256": "5ae1bd42149dfff5701102ec2a3eb96e29b686ceb7337e2dd9be3aa23a42c654",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-30": {
@@ -5044,9 +5000,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1911d37393129be535aa0e2108d2cd4941a302d14385fb996ff39f42b2766c62",
-        "updatedAt": "2025-09-20T19:50:39.692Z"
+        "model": "fake-64",
+        "vectorSha256": "4d398693ba5e46cd3546ff5a6a7738d30a888fa78259a18757a369de304c0dac",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-31": {
@@ -5066,9 +5022,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "511144cd9c49e34dd3d450b37e06567933e013fff0935130c86c98ced966376f",
-        "updatedAt": "2025-09-20T19:50:39.692Z"
+        "model": "fake-64",
+        "vectorSha256": "2e0ca6c53ab1c1efae5bbce352bf62365d0a7171f6c903c0505a7f440740862b",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-32": {
@@ -5088,9 +5044,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e5f5e70b5078c816d60177b227b75977478281398b528bbd8c25947c7b55551a",
-        "updatedAt": "2025-09-20T19:50:39.692Z"
+        "model": "fake-64",
+        "vectorSha256": "462c3585ce516ce54c797ac17cd99ad8ad9e1864ede5876e2ea24a7157525424",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-33": {
@@ -5110,9 +5066,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "87f8c294b4bb665ebafc5ff095495b406f5574a65db9309ce84880c7f357002e",
-        "updatedAt": "2025-09-20T19:50:39.999Z"
+        "model": "fake-64",
+        "vectorSha256": "16434de92d36d954b74fd77860e5c9fe0a2b6fd1dcd7ab24c6cda8f759669196",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-34": {
@@ -5132,9 +5088,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fede9dd0e35b90547ccce7f4960ff89e06ad1913de241aaaa82519a78139bc33",
-        "updatedAt": "2025-09-20T19:50:39.999Z"
+        "model": "fake-64",
+        "vectorSha256": "358f450c6954da03bf659c79ae2aacbe9d29c901e24c1b4d517dc87f97dac31b",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-35": {
@@ -5154,9 +5110,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f71c8d5765f0705c739d2da6128a503c29694fd33af4fc5cc84392eeaf0049c0",
-        "updatedAt": "2025-09-20T19:50:39.999Z"
+        "model": "fake-64",
+        "vectorSha256": "1cba07895e529ca559dd308528c184bc84b0adbe20a3b5a720edca79bed028c7",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-36": {
@@ -5176,9 +5132,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "915f1b7f605862a49b46aa0b9389170959d144b519299d404c014f9479f929b0",
-        "updatedAt": "2025-09-20T19:50:39.999Z"
+        "model": "fake-64",
+        "vectorSha256": "33a831cadad9892cfd5c47f45748d6768bb595db077724c0665771fed845e62e",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-37": {
@@ -5198,9 +5154,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "68ff7d14917e8b8d533e66af1db1012bf52cb263eaeb9b0f3338bd2ef4d6297b",
-        "updatedAt": "2025-09-20T19:50:40.000Z"
+        "model": "fake-64",
+        "vectorSha256": "397398ad1310d6d985777e11e90ae8c5450df4bc26fe5d7c152317450b5c1c86",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-38": {
@@ -5220,9 +5176,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e68a393456c38ceb44936e4310f43dfe900374c8d1bb7028e2f723c86954368e",
-        "updatedAt": "2025-09-20T19:50:40.000Z"
+        "model": "fake-64",
+        "vectorSha256": "8098150b6be958156d8b406b53b0020e88056ad95f215e20399bb214a4346365",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-39": {
@@ -5242,9 +5198,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d625ce75264d8835afa03299e4fc65ca024e6cd84d89a287cc196856d26e60b5",
-        "updatedAt": "2025-09-20T19:50:40.000Z"
+        "model": "fake-64",
+        "vectorSha256": "c87543304ae694cf6fa20369973f5bd61737648b2b873fb1b9f1deb886db5587",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-40": {
@@ -5264,9 +5220,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b7213e43b2b7e98029d86080e96b756227afd6a78aeea602e2b6fa3f9f10ad16",
-        "updatedAt": "2025-09-20T19:50:40.000Z"
+        "model": "fake-64",
+        "vectorSha256": "1ea0717b5916a4440ecdff665b1fc331bc8509ce4b6edc0f428c0e6f88541d26",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-41": {
@@ -5286,9 +5242,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "290da35072a28f1508765641c6cb5f01d842e593cfe36564f634e2aec626f435",
-        "updatedAt": "2025-09-20T19:50:40.262Z"
+        "model": "fake-64",
+        "vectorSha256": "55028c3210780fedfabcbd33e8c7f36cc6a5ea02163b3b3ccc7693c4148d9140",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-42": {
@@ -5308,9 +5264,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f5a04b50934dc0d31318d4ac51ecda90a38b4db84ef002bea7d6b9744b92910d",
-        "updatedAt": "2025-09-20T19:50:40.262Z"
+        "model": "fake-64",
+        "vectorSha256": "0f8a6b112fc1809178302978bcfbd0e6e260b6b850969e971b717e824f80d081",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-43": {
@@ -5330,9 +5286,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c4e4f53040b6af07e110b4d58352ad96a7625fc46e314881efefbecfe39cdcc9",
-        "updatedAt": "2025-09-20T19:50:40.262Z"
+        "model": "fake-64",
+        "vectorSha256": "e928ffed44c149382425ce7bf96b315f02fe0ee06c102378976a834bd232f0ad",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-44": {
@@ -5352,9 +5308,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0514ab34c848ead00896c8b274097333a24c86e5d8278076c6c26a3918856444",
-        "updatedAt": "2025-09-20T19:50:40.262Z"
+        "model": "fake-64",
+        "vectorSha256": "16187a1ea111895ae3a3cbaef8b0dd74e6176af0679287e20edc2783bcc4e521",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-45": {
@@ -5374,9 +5330,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ceacd3f8c44c6c572a26c19c1c7a286614200c15ef5f3efca454805f90f7a343",
-        "updatedAt": "2025-09-20T19:50:40.262Z"
+        "model": "fake-64",
+        "vectorSha256": "01abda97071bd32a12bf02af090c562bba20815d341454e209cb5d8ec304465d",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-46": {
@@ -5396,9 +5352,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "49e5bd952d7f59e5010c00a5dc69d348c3ee3b2490f8a1b8b265af181f2d157d",
-        "updatedAt": "2025-09-20T19:50:40.262Z"
+        "model": "fake-64",
+        "vectorSha256": "c2476ea0fada27b1d6a5d9eb945694b901f7eca3a441fe8c2847bb50e4fc6c38",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-47": {
@@ -5418,9 +5374,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2e6ba17371a8df4a364692cfedbdfb9eee082ebbed85bbe9e68e35cd50209f29",
-        "updatedAt": "2025-09-20T19:50:40.262Z"
+        "model": "fake-64",
+        "vectorSha256": "1e3e1d7dcdef3f90b7437ce33f12cfa9b59f9bc32a94447d6a1d146c92deb772",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-48": {
@@ -5440,9 +5396,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9f9167ed698bb2fc189a8080e05461b2201fc5bac6461832a47fefd7cbaf3c11",
-        "updatedAt": "2025-09-20T19:50:40.262Z"
+        "model": "fake-64",
+        "vectorSha256": "125534852c2aaccc91e509cb595ee86b87f495697734f297f61e2362de72cfb4",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-49": {
@@ -5462,9 +5418,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2aec331b69de82be7854fff775325ca04dae71bc6c540e6ef10e5a1c00bf1aa2",
-        "updatedAt": "2025-09-20T19:50:40.507Z"
+        "model": "fake-64",
+        "vectorSha256": "f2ac56e04f02c55df5dfb6c209f5cb9edfc5ea21b246d816ed7342cd38125011",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "music-50": {
@@ -5484,31 +5440,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "32857c7181cbfaa6d4ec5f614c956e62d8b7f43af2510f8ec966e5a82a971185",
-        "updatedAt": "2025-09-20T19:50:40.507Z"
-      }
-    },
-    "travel-01": {
-      "hashes": {
-        "text": "a7af59db32da5c74dbc3e59c087873d4c51fd00e7eb2fd2b2d16f484643fa341",
-        "author": "b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
-        "combined": "f17bfacf3ff4126e5314f3310c7e009198cd29b976d2dc911174fe4d2e015394",
-        "tokenSignature": "a-and-book-do-is-not-only-page-read-the-those-travel-unknown-who-world"
-      },
-      "lengths": {
-        "text": 66,
-        "author": 7
-      },
-      "source": {
-        "categoryId": "travel",
-        "sequence": 1
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d083968e30fa55e314feb33c497e1236ab79f9c91e585ddf60deaefc5596c30d",
-        "updatedAt": "2025-09-20T19:50:40.507Z"
+        "model": "fake-64",
+        "vectorSha256": "c39777f5b48bd19ff9258446744e11ef80da6e6208dc0fad1c9cc4462b837247",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-02": {
@@ -5524,13 +5458,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 2
+        "sequence": 1
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2ff270578faf6b4cc32a723b8359fcfdc984272d63271acaf46608c2990cd909",
-        "updatedAt": "2025-09-20T19:50:40.507Z"
+        "model": "fake-64",
+        "vectorSha256": "fd2d52aa03ac006feb5680f2e2668bda9c76120cdb0b36e55833dca2124980d6",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-03": {
@@ -5546,13 +5480,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 3
+        "sequence": 2
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5ded6cc5f1cb707288094e95fc6f430a09bf878391e1049d3d98458dacdc5c60",
-        "updatedAt": "2025-09-20T19:50:40.507Z"
+        "model": "fake-64",
+        "vectorSha256": "09bcd82833e64c59220e1d42a18ff200b4b18cf985223e1ea859e0b408c503cd",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-05": {
@@ -5568,13 +5502,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 5
+        "sequence": 3
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e528902a45b7cdca057daf1ca6f917c9d53b7d9d7b851d3d9ce682e24eba9933",
-        "updatedAt": "2025-09-20T19:50:40.507Z"
+        "model": "fake-64",
+        "vectorSha256": "2fa19280ba06641e9575ec0f47f3e169a2f7c429633cbe20a609a51dc13d82ef",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-07": {
@@ -5590,13 +5524,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 7
+        "sequence": 4
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2a9cefc0ee30c615fa1d4ca9b022d7e4195676de05f2cfa185f82852c926a2fb",
-        "updatedAt": "2025-09-20T19:50:40.809Z"
+        "model": "fake-64",
+        "vectorSha256": "08aa62cc7b6a696d50788a6fde409effe20b6b0e1c7f9c9b9ea7b5b2f70766fd",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-08": {
@@ -5612,13 +5546,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 8
+        "sequence": 5
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "625f0412b0da3c12b5a2fe909eacb6bb70b703bc873bb1a50b7711324f249bf5",
-        "updatedAt": "2025-09-20T19:50:40.809Z"
+        "model": "fake-64",
+        "vectorSha256": "10ae945e8e957c0e29f645ae5067c4befa5aeb83ead86e28754a8b52d4ee54e5",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-09": {
@@ -5634,13 +5568,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 9
+        "sequence": 6
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e28200ff9052c8688edd1a06ef60fe12ed737968dc08b91fa7a3bb449219d015",
-        "updatedAt": "2025-09-20T19:50:40.809Z"
+        "model": "fake-64",
+        "vectorSha256": "9dcc655be2d1b35f6dfa81c1499ff9cbd12454c736251205c3aecfdf11334ef1",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-11": {
@@ -5656,13 +5590,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 11
+        "sequence": 7
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "31dfc1727224b2f16ed24cc7c806e4316621ad18215968217e631c864c533fe1",
-        "updatedAt": "2025-09-20T19:50:40.809Z"
+        "model": "fake-64",
+        "vectorSha256": "8083bc973d4c02aab16ebd4dbbb6dc870cad6598cc2452c838e1d03392779367",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-12": {
@@ -5678,13 +5612,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 12
+        "sequence": 8
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "abadaa73625f3a231197250cf6dd70c925d6c7a0f208e3f18c7b691def967652",
-        "updatedAt": "2025-09-20T19:50:40.809Z"
+        "model": "fake-64",
+        "vectorSha256": "93afcb4475fbc4a570988497f3dc98d5e1bebbe53af639e7c032e7aeabbed82f",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-13": {
@@ -5700,13 +5634,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 13
+        "sequence": 9
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "830495acada964497ec9d06e7fbcc9e21b5e6237bfc785f920147b7160af13ed",
-        "updatedAt": "2025-09-20T19:50:40.809Z"
+        "model": "fake-64",
+        "vectorSha256": "53b709a54b44f5f5cc49199cfa143c4d3a0a7427fd617059360204630aff141b",
+        "updatedAt": "2025-09-20T22:28:15.453Z"
       }
     },
     "travel-14": {
@@ -5722,13 +5656,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 14
+        "sequence": 10
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "404454d3aad5773d9d822f271602d05015ce5dc61d0fcfee23e0cda1253de1ed",
-        "updatedAt": "2025-09-20T19:50:40.809Z"
+        "model": "fake-64",
+        "vectorSha256": "cf5bb04cc0888130cfaa33e85c67fcd308d28c641a3e8f1797c0aa0efd027153",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-15": {
@@ -5744,13 +5678,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 15
+        "sequence": 11
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2ad8934cfab6bfd6becef31ea233477030a8ccebf8f2d31659362b731cd10d72",
-        "updatedAt": "2025-09-20T19:50:41.100Z"
+        "model": "fake-64",
+        "vectorSha256": "6073c1076b5798561489dc022ba29d2bfc0329892313a04958463784da9ff987",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-16": {
@@ -5766,13 +5700,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 16
+        "sequence": 12
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "73715addc9f43141200ea418e5ebbdaee7b22cbc2df2bfaffce1f980a38c7336",
-        "updatedAt": "2025-09-20T19:50:41.100Z"
+        "model": "fake-64",
+        "vectorSha256": "b5bb196bcb93891739f05ac99317eee020cbf51b5d1d12bc6780654aa572725f",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-17": {
@@ -5788,13 +5722,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 17
+        "sequence": 13
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0b14e94132b1f99259a7df188b0c02b14738ab0d7021426b53f1f092e7a38fd1",
-        "updatedAt": "2025-09-20T19:50:41.100Z"
+        "model": "fake-64",
+        "vectorSha256": "470dea3904dc7260039ac1a4cbe8e79a43ca7e12a57e4868fedd45c1a1d037d0",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-19": {
@@ -5810,13 +5744,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 19
+        "sequence": 14
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3d70473f22bfdde592030c5f3ae1763cd5c0612b59918ec437ff5ad1dd336c26",
-        "updatedAt": "2025-09-20T19:50:41.100Z"
+        "model": "fake-64",
+        "vectorSha256": "b9eddebd3095c739956c3b3f64aa62ec050cd4d1dfcb7a70dc5e93bfc6354568",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-20": {
@@ -5832,13 +5766,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 20
+        "sequence": 15
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7f53722804b2491e192eeb1db6f5da372b3e13cf055ee06abfa0ef21f894d3dc",
-        "updatedAt": "2025-09-20T19:50:41.100Z"
+        "model": "fake-64",
+        "vectorSha256": "377ecc5b90197d56b4c8c3582f790455958f8c98174b8c7a472504203a10c76a",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-21": {
@@ -5854,13 +5788,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 21
+        "sequence": 16
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2cf9f1b7f21043a57e715b6776186b82170750fee26f023bd96b9afcc956bb13",
-        "updatedAt": "2025-09-20T19:50:41.100Z"
+        "model": "fake-64",
+        "vectorSha256": "18fa1611850b3dba0d6c69ccaebf3b399270f984be17fc3ee4efdb29edb18374",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-22": {
@@ -5876,13 +5810,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 22
+        "sequence": 17
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3e58b2600fdff301951e9710f7a30c008289a28e133baeb44dd9b022c9e43854",
-        "updatedAt": "2025-09-20T19:50:41.100Z"
+        "model": "fake-64",
+        "vectorSha256": "99d1150d4a09361cfc3e864ba63f0a888fa3264daa109a039a3ce5c04017e1aa",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-23": {
@@ -5898,13 +5832,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 23
+        "sequence": 18
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f6ff17baeb84c2f5511d7b2e7104b87ae2c2e72e7ffdcde454a77b9907df4914",
-        "updatedAt": "2025-09-20T19:50:41.497Z"
+        "model": "fake-64",
+        "vectorSha256": "1017bcea535622c68188a49fdcef3ffcbb894cbb0f11346d7e29643211c45b89",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-24": {
@@ -5920,13 +5854,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 24
+        "sequence": 19
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f02332c15ec6ccea4d481ce00d23a54fcafa3adc18b1c5b4418d6388e7b774c9",
-        "updatedAt": "2025-09-20T19:50:41.497Z"
+        "model": "fake-64",
+        "vectorSha256": "44215a7f5fd88f0bb4533632f247e5e051fd6a53bc4b53899fd15a39053d4bc2",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-25": {
@@ -5942,13 +5876,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 25
+        "sequence": 20
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5838d60ce347232cfd24299f3b454076a73cb1f7b111f1efed9a42f2f27f879b",
-        "updatedAt": "2025-09-20T19:50:41.497Z"
+        "model": "fake-64",
+        "vectorSha256": "69dcbf69c19d96c80d82f769e961fa0878e9aadabb376d15f767dfd9aa05cb4d",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-26": {
@@ -5964,13 +5898,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 26
+        "sequence": 21
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3dbec91d457ab5bf7639166bdd9c674652c31c76b9fa1b9cfe70fdfc74be150e",
-        "updatedAt": "2025-09-20T19:50:41.497Z"
+        "model": "fake-64",
+        "vectorSha256": "75fb335f16c0c7ada62078f4c1af5046836dbfb53e9502b9c7948cf64ee3c2de",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-27": {
@@ -5986,13 +5920,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 27
+        "sequence": 22
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3982c9d5529ad27d7f06c5206545d3ffa77b1be52277c35ed8923a211893013a",
-        "updatedAt": "2025-09-20T19:50:41.497Z"
+        "model": "fake-64",
+        "vectorSha256": "9c899c5c90b12f39800fc6c8b752c18010232ca82429233050a935ae75b8b0bd",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-29": {
@@ -6008,13 +5942,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 29
+        "sequence": 23
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5a6706477fc40f40738b430a5bdf7111c8780abf881e495fe47a519908b8b98c",
-        "updatedAt": "2025-09-20T19:50:41.497Z"
+        "model": "fake-64",
+        "vectorSha256": "a562e170f5b997ee9b07e4f17bbec66ab3835c1759ffce5dbc97d9587e6bbb03",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-31": {
@@ -6030,13 +5964,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 31
+        "sequence": 24
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8a366a4a0b471ee073abde395ea72b352d55371cb2acc1e932dfba6185d75a07",
-        "updatedAt": "2025-09-20T19:50:41.690Z"
+        "model": "fake-64",
+        "vectorSha256": "3667e2ebcb097e2014eac616be8941d835b3cfccd474539a4524455b133cffcb",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-32": {
@@ -6052,13 +5986,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 32
+        "sequence": 25
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "edefa710e269cf82240d7414509ef976ff70cdc03a237184890d1bc82b68de78",
-        "updatedAt": "2025-09-20T19:50:41.690Z"
+        "model": "fake-64",
+        "vectorSha256": "7ae16da9a496a63481569d8f7e92bf3cb67cdab4f41baec51390c7cf78ab1bb3",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-33": {
@@ -6074,13 +6008,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 33
+        "sequence": 26
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b183a6b0f05a1056e9d33e9a14a802bffe89b1a75dc5c00c5abe96e890a806c8",
-        "updatedAt": "2025-09-20T19:50:41.690Z"
+        "model": "fake-64",
+        "vectorSha256": "147a2556dac43f4459fd49a4221411fdfca9f56ccc8ed4839473328c40b135ca",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-35": {
@@ -6096,13 +6030,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 35
+        "sequence": 27
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a52361509254ddb0e60178c541fb93f938cb888551e4012c97c38d0d19ebb08b",
-        "updatedAt": "2025-09-20T19:50:41.691Z"
+        "model": "fake-64",
+        "vectorSha256": "ff558c5c755236ca562da1905dcf1ea16b01e14e2974dc8c72240d150b661a5e",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-36": {
@@ -6118,13 +6052,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 36
+        "sequence": 28
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "95132e264f05f63ac0d37dbc45a0fbaf2320525aff1c41439b1049d210566d89",
-        "updatedAt": "2025-09-20T19:50:41.691Z"
+        "model": "fake-64",
+        "vectorSha256": "025001b5a5932dbf4441b1a49ffe62fe7e42102fd4e9015a5151e4e46e4c84b6",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-37": {
@@ -6140,35 +6074,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 37
+        "sequence": 29
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "03fbc3e3e10e76712abceab2fa527fd1da6558b41952ce21a8cd77cc841fa8b0",
-        "updatedAt": "2025-09-20T19:50:41.691Z"
-      }
-    },
-    "travel-39": {
-      "hashes": {
-        "text": "d4160dfb07bc90d08096972a9ab88c56225c8cd129be869e32464b8ae2a83299",
-        "author": "2f183a4e64493af3f377f745eda502363cd3e7ef6e4d266d444758de0a85fcc8",
-        "combined": "e4a0efcb88fca9e181388eef8b6f8818667ebce4f828061897b2492d7b2e613c",
-        "tokenSignature": "anonymous-collect-moment-not-things"
-      },
-      "lengths": {
-        "text": 27,
-        "author": 9
-      },
-      "source": {
-        "categoryId": "travel",
-        "sequence": 39
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dc5599fc8f6b2753c13a0d2dbf550bd3524fca79d5cde36cedb3bc92e82cbe89",
-        "updatedAt": "2025-09-20T19:50:41.984Z"
+        "model": "fake-64",
+        "vectorSha256": "05bee6938a0c590126c751733ffd99ae454928084db487b5f8a865dff8ed9c93",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-40": {
@@ -6184,13 +6096,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 40
+        "sequence": 30
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c0dec363a244d8adf3c33ddd94bf1b6e1cb22dee8636ca3059de2ee095424651",
-        "updatedAt": "2025-09-20T19:50:41.984Z"
+        "model": "fake-64",
+        "vectorSha256": "ae292b609724a090b2b28e22ab8ec1f37c38a0a4ef41c170f6e2d1206c80d6db",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-41": {
@@ -6206,13 +6118,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 41
+        "sequence": 31
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "749142b5a85cdb700b0b4413ac607f8180f127cb8ba17ee095492311331c58e0",
-        "updatedAt": "2025-09-20T19:50:41.984Z"
+        "model": "fake-64",
+        "vectorSha256": "870198cf94047c2a910c8533ad8ff1c5ae1132540d3afc6a258e31a311bb8799",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-43": {
@@ -6228,13 +6140,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 43
+        "sequence": 32
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ba60f0d0cfa11e601c2e6e7b7d20a28c860d4809b288050352567ff1af58a919",
-        "updatedAt": "2025-09-20T19:50:41.984Z"
+        "model": "fake-64",
+        "vectorSha256": "0c44c8500069c59b57d6b572c3cf80abad09dc3b769d81f1aed1cac0e192e273",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-44": {
@@ -6250,35 +6162,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 44
+        "sequence": 33
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "797ccbc57d0df1dab4402b3bb9c6de94e1a2b2f9461ac3474575e8d15e4910ef",
-        "updatedAt": "2025-09-20T19:50:41.984Z"
-      }
-    },
-    "travel-45": {
-      "hashes": {
-        "text": "75f9a1d93adcb36a99b02c38461284fdc1992c5898033c207534b8f8b1d38233",
-        "author": "ca7a7b4d4f3ae1eb0546d369c447b1dbddd980eb42fa452a8fbde9a9d44d0284",
-        "combined": "d7655c27953b0319a415df77018372ae77885bd7538b99d198ec77e7a059cb92",
-        "tokenSignature": "d-feet-have-if-in-instead-meant-of-one-place-rachel-roots-stay-to-we-were-wolchin"
-      },
-      "lengths": {
-        "text": 70,
-        "author": 14
-      },
-      "source": {
-        "categoryId": "travel",
-        "sequence": 45
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "554963d4d83b2a1a5182b90ae49f4c8d247ee74cf6f66dc2c557e8e7f2283e50",
-        "updatedAt": "2025-09-20T19:50:41.984Z"
+        "model": "fake-64",
+        "vectorSha256": "4c584f8bc0e8b4c4245c97ce1d1da0ebaf860c35c2d386320d7dcd3abcb82476",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-46": {
@@ -6294,13 +6184,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 46
+        "sequence": 34
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6738f20dc463dda168821fa53895e5cc92e43e821c9cc97d44c5be28b65d3764",
-        "updatedAt": "2025-09-20T19:50:41.984Z"
+        "model": "fake-64",
+        "vectorSha256": "9f0291484cf8f65e00760e4bca957df93a0a28645f04e7a6176c3f0d83249cbe",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-47": {
@@ -6316,13 +6206,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 47
+        "sequence": 35
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1611cfac76e9b3a05722fb44db75c1c1847f493e2910ddb2d7071b7356f3be55",
-        "updatedAt": "2025-09-20T19:50:42.217Z"
+        "model": "fake-64",
+        "vectorSha256": "5dfc1c320f5a58c183b93600030b6c55c38481b02a6ecc5b31bcf7e9fe46d00b",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-48": {
@@ -6338,13 +6228,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 48
+        "sequence": 36
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f2b8901fc5cb18ad82636a3e4c3d07cc439d2a0cef4d3349df5ccc48f2d5ca21",
-        "updatedAt": "2025-09-20T19:50:42.217Z"
+        "model": "fake-64",
+        "vectorSha256": "b146ef6bf88934f144f1304ba644e6af96558053a7032967cd0c0940b0af1952",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-49": {
@@ -6360,13 +6250,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 49
+        "sequence": 37
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "13fe54baba0efd79188798a4a9d404528bd5857d8adc1d6d2ed8627e172f07ef",
-        "updatedAt": "2025-09-20T19:50:42.217Z"
+        "model": "fake-64",
+        "vectorSha256": "560549c54600a3cca6a0eb1cb7356b4210d6a4a766ffc125af82703ce0637abe",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "travel-50": {
@@ -6382,13 +6272,13 @@
       },
       "source": {
         "categoryId": "travel",
-        "sequence": 50
+        "sequence": 38
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9c4dc79ffb829cd47a0ea197d89b7e849ef8606cd747bd12cb7b599e4d8d4da5",
-        "updatedAt": "2025-09-20T19:50:42.217Z"
+        "model": "fake-64",
+        "vectorSha256": "454f30406c2c41baa4c105256f99122a87bebe5df6f379440973d23c561a78a5",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-01": {
@@ -6408,9 +6298,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2baa50180a441f5bddfd7b5b3d4ed5fd4bac93b58d6a96f11db2391874856b58",
-        "updatedAt": "2025-09-20T19:50:42.217Z"
+        "model": "fake-64",
+        "vectorSha256": "9937d49dc519302429020e0b1f726535fbb044c924e77f707fe6ad9376df3407",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-02": {
@@ -6430,9 +6320,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "77eea29bb44b988c2a61ce603f4cd471c8fb71095fe1778b088d645369ecc17f",
-        "updatedAt": "2025-09-20T19:50:42.217Z"
+        "model": "fake-64",
+        "vectorSha256": "d60d008cca9f7a512ca59a7f7f1e465e0e081badc05dde98d1bd5804536eb53a",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-03": {
@@ -6452,9 +6342,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "653ad0d26d174f7c2b9456914a6ba868d465b7fd3c904302a3e004314b27393d",
-        "updatedAt": "2025-09-20T19:50:42.217Z"
+        "model": "fake-64",
+        "vectorSha256": "664ea1ea210945e239bc1f81bc848f0bb24af590108ccc09f3d28aa6e9810386",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-04": {
@@ -6474,9 +6364,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b76fb1ffcf69fd833e9c5cd2781eda2fa7038773bdb4627a6178503d07aaf4da",
-        "updatedAt": "2025-09-20T19:50:42.218Z"
+        "model": "fake-64",
+        "vectorSha256": "50275651635dc257b8054c4637dab7193f3ebd75a0c8bf49a36a89c7569b94bb",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-05": {
@@ -6496,9 +6386,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "eef0f475aeb3428399fce7942f2e934f958b1c55f635f349e1b95e7530d17340",
-        "updatedAt": "2025-09-20T19:50:42.455Z"
+        "model": "fake-64",
+        "vectorSha256": "cd25e8b4f982431d56c4927068b5daef33cb1d0d093148693711118d6335c992",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-06": {
@@ -6518,9 +6408,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7adc96b03bf3d7a3cad37ad2da8cc739cac7f009e30df9d2e1d62a07a4ded63a",
-        "updatedAt": "2025-09-20T19:50:42.455Z"
+        "model": "fake-64",
+        "vectorSha256": "31ccc7c2d9ce417b9da5df594df3ad7b4b366d6fb6f1e604f4720639af6f5d7c",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-07": {
@@ -6540,9 +6430,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b9c4f89812dee5855e43353054574558e9ce43d460e335053f735c2b29974126",
-        "updatedAt": "2025-09-20T19:50:42.456Z"
+        "model": "fake-64",
+        "vectorSha256": "438bdf5384386282801351bba91340846278a7b3a471657e0010cf8d9420e7c4",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-08": {
@@ -6562,9 +6452,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e1812ba92a778df0856e304a3f7b5635647a1cbbd565da6916d9a1aeebc523e9",
-        "updatedAt": "2025-09-20T19:50:42.456Z"
+        "model": "fake-64",
+        "vectorSha256": "db076f5cc70237e14b97a586314e0513d0030f45a4bf10574275f6134d4d6faa",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-09": {
@@ -6584,9 +6474,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e115be4edcb11663e3ea0526bd79b1b73743149031d9ddd1d8d26c83edbad611",
-        "updatedAt": "2025-09-20T19:50:42.456Z"
+        "model": "fake-64",
+        "vectorSha256": "70f6df3be06d3bcf90ae3e798c96815cf62b66a60de73df4dcdb42165d1443d9",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-10": {
@@ -6606,9 +6496,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "736972b0540ce3ec108935f2b37b230a0275d7de72be1893767e32db72a526c9",
-        "updatedAt": "2025-09-20T19:50:42.456Z"
+        "model": "fake-64",
+        "vectorSha256": "ac2c6d0995e21b57a8d21302c1954ff7e15d1cc387fb7e53e3e5a06624bf636d",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-11": {
@@ -6628,9 +6518,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ef2667f422d605654a5503ec2b64b654a2200d44bb62c9fb879f45e0fb2bd5da",
-        "updatedAt": "2025-09-20T19:50:42.456Z"
+        "model": "fake-64",
+        "vectorSha256": "4995416ade9c70633264c43bd2deeed17746208eec442c19561e17c1b9fe180f",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-12": {
@@ -6650,9 +6540,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9620e5c3760707dae22b297dbb68ba165c51395752681669a1136634f12bcdb4",
-        "updatedAt": "2025-09-20T19:50:42.456Z"
+        "model": "fake-64",
+        "vectorSha256": "9ce73b77eb1dc5aa09d307cc478fdae8478eee868261b75eb25c2c7f59c6e412",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-13": {
@@ -6672,9 +6562,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8a003263013e5dfee782969e9c99e3eb9621003023ec836a543695ad4876e5fe",
-        "updatedAt": "2025-09-20T19:50:42.741Z"
+        "model": "fake-64",
+        "vectorSha256": "a729b158ade84e0111a253858d7cd897793b9e4b368612f83ffed810e5c266b2",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-14": {
@@ -6694,9 +6584,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e74862d976d1e4a81b09b8ff6deaee9f936d7cadb5f8e9e365ba30e9d9c25515",
-        "updatedAt": "2025-09-20T19:50:42.741Z"
+        "model": "fake-64",
+        "vectorSha256": "c246452cbf3a76e71e3f2361c26857bd5d5bb1624b72173d10ec4d7e036b9edf",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-15": {
@@ -6716,9 +6606,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c3080ffd529ff7062224f15be671e78cf27dd03f1ae4d4e27ef01d0d7198a523",
-        "updatedAt": "2025-09-20T19:50:42.741Z"
+        "model": "fake-64",
+        "vectorSha256": "ee224c4acf170f57eada14ea24e44caaa1ec715dc08db784fcb8acd542ba15f8",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-16": {
@@ -6738,9 +6628,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c5c9f62c7c5d80676e2c1a46bf880e71b49d7260394426dae8e4e8704ea745fb",
-        "updatedAt": "2025-09-20T19:50:42.741Z"
+        "model": "fake-64",
+        "vectorSha256": "d996ebeddce2e30ac2716ffca107ba9d20d7f54b61b03a89bee7dcf2c085a1a0",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-17": {
@@ -6760,9 +6650,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4f7e57238330ede156a3647ec6c269af2aa8500714ae00cf0279768a5471025a",
-        "updatedAt": "2025-09-20T19:50:42.741Z"
+        "model": "fake-64",
+        "vectorSha256": "f4d8a4c19bd4d72abe4709e1b4fc683da47322e989831b210ccd7190bb379cc7",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-18": {
@@ -6782,9 +6672,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "78dc2d024207b1f419f3dde2200284f7bcb1d50774a75bdb9b2b4c2d708a6cda",
-        "updatedAt": "2025-09-20T19:50:42.741Z"
+        "model": "fake-64",
+        "vectorSha256": "b0e8afb61d901f2136cc9237b74928c4ecf29e51ccc45e56aa5ef9db9d72ad3a",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-20": {
@@ -6800,13 +6690,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 20
+        "sequence": 19
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "94b8642af1aecc562e718ce882093e41088760abbdb2c6286133271e5f823834",
-        "updatedAt": "2025-09-20T19:50:42.741Z"
+        "model": "fake-64",
+        "vectorSha256": "0945e3354f97f19b73314668e4d5afbe8f9c3a4b29fa05e8c721c047f65c03c0",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-21": {
@@ -6822,13 +6712,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 21
+        "sequence": 20
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "975be9fc02683517d63a3ad3a58c50e7fb98d50a0e3f4cfedac5911e41cc7420",
-        "updatedAt": "2025-09-20T19:50:43.049Z"
+        "model": "fake-64",
+        "vectorSha256": "92f994b3bb5a61dff426c073d90f5e61e3a6d7dfd1b40589557c5f1973bc0a12",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-22": {
@@ -6844,13 +6734,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 22
+        "sequence": 21
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "293c03bbf72e383b0bee78e9bb96d55e573cc8a0475083243e493ea3c53f8fed",
-        "updatedAt": "2025-09-20T19:50:43.049Z"
+        "model": "fake-64",
+        "vectorSha256": "eed61aa66c68ec35e04318b9e20d8f3440818b32dc38e8f9513f470449b9e5f3",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-23": {
@@ -6866,13 +6756,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 23
+        "sequence": 22
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bb5d675333e021dfc2673c3e4457fc8a95a90ca6086887f64dce4083a4046018",
-        "updatedAt": "2025-09-20T19:50:43.049Z"
+        "model": "fake-64",
+        "vectorSha256": "29fd970f059e5d69a2c0ff8bf523a20e3845b170e2a5a817c0b5fabe93259b39",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-24": {
@@ -6888,13 +6778,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 24
+        "sequence": 23
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a8fb02242d83166c615baa08bebbb9c335c803993681a12de4bcc651f9d46070",
-        "updatedAt": "2025-09-20T19:50:43.049Z"
+        "model": "fake-64",
+        "vectorSha256": "99c4b7e421cd545bf0713872981a49aaafcf4f4d1b46d42d138e89eb0472e025",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-25": {
@@ -6910,13 +6800,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 25
+        "sequence": 24
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4333b1fb18fb5756a1a268256eeff7e8dfaee2144d871bf66c5020903953ea2f",
-        "updatedAt": "2025-09-20T19:50:43.050Z"
+        "model": "fake-64",
+        "vectorSha256": "aad4aecc26cd7f5ca7bd3379a9bb3ec023a65fe2f9452a5ccb7308b34d20bed3",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-26": {
@@ -6932,13 +6822,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 26
+        "sequence": 25
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2537459e18ad6d9bfedf185aa62ff2156aac34d6bff8a54e10433655d08e8ced",
-        "updatedAt": "2025-09-20T19:50:43.050Z"
+        "model": "fake-64",
+        "vectorSha256": "dc3614f063df4c68900de9dc3131c8b0c2766638ea08fbb41b53b3f2993fb5b7",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-27": {
@@ -6954,13 +6844,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 27
+        "sequence": 26
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f25df06ed742f74d024917a15f4ede7ab4012aea25f7d45453c7c7c4c08c41f4",
-        "updatedAt": "2025-09-20T19:50:43.050Z"
+        "model": "fake-64",
+        "vectorSha256": "d5067c90211ced0bd431cc4f2d4a0465b18b75f521905f12d1ad702bcf1de295",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-28": {
@@ -6976,13 +6866,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 28
+        "sequence": 27
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f8dfd600b53dc89b228eb12e27e6366db841e3716f6fd78b93b6f4c9315ff94c",
-        "updatedAt": "2025-09-20T19:50:43.050Z"
+        "model": "fake-64",
+        "vectorSha256": "27976a189dec98c73b862aca3295222765bf4f5945675269e7d7d591fcedc2ad",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-29": {
@@ -6998,13 +6888,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 29
+        "sequence": 28
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "908ce98834ec898c2d8b35b84cda08cbab59a975800721900c00b37bb63a23dc",
-        "updatedAt": "2025-09-20T19:50:43.368Z"
+        "model": "fake-64",
+        "vectorSha256": "4187cb0f605dc9376d047e328bb031a9c70d5724ad869c400404bc1e260ba2c6",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-30": {
@@ -7020,13 +6910,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 30
+        "sequence": 29
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0e6b519a8043ad921b4d7c15357f14449220f9f9e065243adfe36347b2b1fe29",
-        "updatedAt": "2025-09-20T19:50:43.368Z"
+        "model": "fake-64",
+        "vectorSha256": "9faad8e2c8617cee2ca3d69b1e1a83644fedb10a62ef35922641ea8d9aa07445",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-31": {
@@ -7042,13 +6932,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 31
+        "sequence": 30
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6cf68d92143e68f3ad0a23da8340fad9ea77e9876ca66cafff7c082ba971347d",
-        "updatedAt": "2025-09-20T19:50:43.368Z"
+        "model": "fake-64",
+        "vectorSha256": "aa61407a2c0d2a1a85272758d0b4869ec48695e3805a85fde7753f8ea5408fbb",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-32": {
@@ -7064,13 +6954,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 32
+        "sequence": 31
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e3dab9839b99e32fb30afcbee776e6416f1c0343b81309e4a2a008cf25444b5d",
-        "updatedAt": "2025-09-20T19:50:43.368Z"
+        "model": "fake-64",
+        "vectorSha256": "cb8794a6e461293c745dfa540204c292aad85aad89086da9a934ee23e748bbc1",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-33": {
@@ -7086,13 +6976,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 33
+        "sequence": 32
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "91483775e8af9689b51b1e1047ccaee1a06c4d100956bb34cc63bd6b6048c1ca",
-        "updatedAt": "2025-09-20T19:50:43.369Z"
+        "model": "fake-64",
+        "vectorSha256": "f09e589628d9bb56c6ebc00a880d9b6c9d0939a821b23afbf56be742766f301b",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-34": {
@@ -7108,13 +6998,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 34
+        "sequence": 33
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b88b337007fb123ccd519dd0d1b66de0f1821104b60d52d0d46a0ac9facf3c41",
-        "updatedAt": "2025-09-20T19:50:43.369Z"
+        "model": "fake-64",
+        "vectorSha256": "ecd913c5645a9d2314de677e8e32c121d98944fd1599b466d43e289801a91696",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-35": {
@@ -7130,13 +7020,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 35
+        "sequence": 34
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "be7b52f9b0e1a1d63e32018a992216dc828c0af963f3e01431b834a82514fc26",
-        "updatedAt": "2025-09-20T19:50:43.369Z"
+        "model": "fake-64",
+        "vectorSha256": "ab893a3af1a19c64a10e2ea7975253b6ccfac1559b4978b691e40e2fc06a16b5",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-36": {
@@ -7152,13 +7042,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 36
+        "sequence": 35
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2698274fa4d1d7159b00b980e8c3f967207ba9ad9e0eb0afbb6d34cd931a74a3",
-        "updatedAt": "2025-09-20T19:50:43.369Z"
+        "model": "fake-64",
+        "vectorSha256": "1f99b61fec2dd741d7df8d065c0fc97d2913f6d55bc476906b30b08b2940e141",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-37": {
@@ -7174,13 +7064,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 37
+        "sequence": 36
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d5f4ff35d402af664ceefc8a940ed9ec20330b84fecb5cc15fce752901c20ca0",
-        "updatedAt": "2025-09-20T19:50:43.608Z"
+        "model": "fake-64",
+        "vectorSha256": "06762e0156de70d29d6e240760bc9067648d395c08560c67c9cbef4b4225daa9",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-38": {
@@ -7196,13 +7086,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 38
+        "sequence": 37
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "550cd2e47e3622ef8c7d02b3ebf959f54e89c61f3fecee49df8fe502b8419be2",
-        "updatedAt": "2025-09-20T19:50:43.608Z"
+        "model": "fake-64",
+        "vectorSha256": "f78476e253174c7a19da24db35aaaea9a651730897c683287f8bc8230c530514",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-39": {
@@ -7218,13 +7108,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 39
+        "sequence": 38
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2309a131233e3f68055e130926811911e0ab965a53ec4050ea3f0b0541031f62",
-        "updatedAt": "2025-09-20T19:50:43.608Z"
+        "model": "fake-64",
+        "vectorSha256": "3dd2cc2f3b5f08f2bc0fc72094b7a9ae2fb4e1c5e5975c34e5e4d189adea015d",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-40": {
@@ -7240,13 +7130,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 40
+        "sequence": 39
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9f5c7267eef4c7e0cbf99cee25e37ff8f113b27da0e007d1cfa75389415c37e4",
-        "updatedAt": "2025-09-20T19:50:43.608Z"
+        "model": "fake-64",
+        "vectorSha256": "890b4b6258f18ac15de32f2ca13306bb3888b94e8eb1bd26e4e26c433d2c7df0",
+        "updatedAt": "2025-09-20T22:28:15.454Z"
       }
     },
     "humor-41": {
@@ -7262,13 +7152,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 41
+        "sequence": 40
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a7874834e322eefcc67b1ad8944299a54d75c1364ec9a427ececa693dda0558d",
-        "updatedAt": "2025-09-20T19:50:43.609Z"
+        "model": "fake-64",
+        "vectorSha256": "fc1f6763f05ed3daa5129d5ca79e895d15ac8d4032c21e6cfb6215c28454caa7",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "humor-42": {
@@ -7284,13 +7174,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 42
+        "sequence": 41
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "32634f36d49fe0b2c4e5fa7b990b4a86cb2dbed8937967b6d72995222c9d5d08",
-        "updatedAt": "2025-09-20T19:50:43.609Z"
+        "model": "fake-64",
+        "vectorSha256": "d937b247a95d969bc797fa3deb9e150448e69ea060186a2dda90c871c21d1d70",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "humor-43": {
@@ -7306,13 +7196,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 43
+        "sequence": 42
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "09b14ca3dca1a27fd57a360c951da3fe4c0ebaf87b4e2a72479f0d43afdbf1c3",
-        "updatedAt": "2025-09-20T19:50:43.609Z"
+        "model": "fake-64",
+        "vectorSha256": "10378d3bf22bb05624462ec7ae07b485839d5a6b6813af8b2a05fb3a928b629c",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "humor-44": {
@@ -7328,13 +7218,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 44
+        "sequence": 43
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "02653fc7f571c2b6625636be1ca0e1a99dd704cc1f760d8ba107f49aa62a4340",
-        "updatedAt": "2025-09-20T19:50:43.609Z"
+        "model": "fake-64",
+        "vectorSha256": "53b269f52c415e1e3110974f5ec1643ed935363a42dfa66254bb1211d7f51e86",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "humor-45": {
@@ -7350,13 +7240,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 45
+        "sequence": 44
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "90ad07f6091b9259312e41439cfefea59a0c768836e9d34e94dccb18d43e9c0d",
-        "updatedAt": "2025-09-20T19:50:43.895Z"
+        "model": "fake-64",
+        "vectorSha256": "bd45eef0646ff70c891eba2b1ecf9da446c8c2328bd929ae8c354514e953c7d6",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "humor-46": {
@@ -7372,35 +7262,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 46
+        "sequence": 45
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d56598a631082ea75a9aea363659287d8e86c27754c52f7c5bd4625907fd2ca7",
-        "updatedAt": "2025-09-20T19:50:43.895Z"
-      }
-    },
-    "humor-48": {
-      "hashes": {
-        "text": "41a3d5e9b7ace0d1c401277528e51f73d08494764e440873b135cfa9629dd938",
-        "author": "4344defc3050196fa2d69dec191c167e3943fde8715eb4c91faec8fdb8f1702d",
-        "combined": "237b86871a042f17dece30d84fea839fa411e27028810c4672501a6ad9eb6f80",
-        "tokenSignature": "as-bernard-cannot-dance-family-george-get-if-immaturity-it-make-may-of-rid-shaw-skeleton-the-well-you"
-      },
-      "lengths": {
-        "text": 76,
-        "author": 32
-      },
-      "source": {
-        "categoryId": "humor",
-        "sequence": 48
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "444deee24bc3215cd1e95e36dce9a9f9b72760654bff8a59171d539e229d341f",
-        "updatedAt": "2025-09-20T19:50:43.895Z"
+        "model": "fake-64",
+        "vectorSha256": "0fa07e59481cffc10987feaed94811431a5227960506462ae408aa8b9879ebb9",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "humor-49": {
@@ -7416,13 +7284,13 @@
       },
       "source": {
         "categoryId": "humor",
-        "sequence": 49
+        "sequence": 46
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "00b1f5e6df214bfa50ddb306449e979c2079486454bf60c2b6e45c93c0e6de18",
-        "updatedAt": "2025-09-20T19:50:43.896Z"
+        "model": "fake-64",
+        "vectorSha256": "177f2039c629b88cbd8520a738ea869e5caad5a129a70525e3b0f11b8925c914",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-01": {
@@ -7442,9 +7310,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0fe8048abfbe707b83bd6fced7a117915831c08aa54ba832d764958ca1b0cd4d",
-        "updatedAt": "2025-09-20T19:50:43.896Z"
+        "model": "fake-64",
+        "vectorSha256": "2c5e4c6361d2a4bb2b9819b41ca57890d524d0e6061a6b45a2720d247e8d624c",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-02": {
@@ -7464,9 +7332,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "32ce8bfae1891ae51d6e56ea102d94acc3b99de646744977cc126b7d0a004561",
-        "updatedAt": "2025-09-20T19:50:43.896Z"
+        "model": "fake-64",
+        "vectorSha256": "146cd3d9e7504d119851dfef2539136b775f61e512052f9ef495c03f3b7e377b",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-03": {
@@ -7486,9 +7354,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d6fd59aed88a912d2f722340570976682e81804094f930d68bc741316093ad50",
-        "updatedAt": "2025-09-20T19:50:44.250Z"
+        "model": "fake-64",
+        "vectorSha256": "a4a696b6f01cae1b60c7f57247dfd03a2705c9984b5dbe244e5508898f0f64ab",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-04": {
@@ -7508,9 +7376,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5a18b5936c8a54f07d2092002858011ba53c965d8af3c9c70d8df29871ed9cca",
-        "updatedAt": "2025-09-20T19:50:44.250Z"
+        "model": "fake-64",
+        "vectorSha256": "70906032ec66d06a6f79cfe913a960eeb5e62e568b5cc3550a689a2f2cbb2deb",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-05": {
@@ -7530,9 +7398,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d10804acdf2e37be18b2e4acec9a548a0ddf4bb3b0c8ad35a7fb1a3448f742ef",
-        "updatedAt": "2025-09-20T19:50:44.251Z"
+        "model": "fake-64",
+        "vectorSha256": "d37c92edd8341a6a5f7e986d9903616bc9a3e19e93181ca72073d1cd65193ed6",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-06": {
@@ -7552,9 +7420,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3017dcf90e86b5f3daafc6bf842393b7b26e4c538e3d942b8c2385f0f7f1c7f4",
-        "updatedAt": "2025-09-20T19:50:44.251Z"
+        "model": "fake-64",
+        "vectorSha256": "f21218e2251d5c0b872dee5e1b469b1e64c4b9d22901bf8766f75b34aa61f3a9",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-07": {
@@ -7574,9 +7442,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e7772e1cb05cdbe9cde8b2117bef56e09ee5f9ed40a1d528054d35b1062f1015",
-        "updatedAt": "2025-09-20T19:50:44.251Z"
+        "model": "fake-64",
+        "vectorSha256": "cecd43c5b4437757f72e74669dcaed3258c52c3c001b5cbaff0933af3d982925",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-08": {
@@ -7596,9 +7464,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d8bc9f6cba96ec218ea4cad3d8f215f9ce21a8258b6e7bbc62f36fdd9c39468b",
-        "updatedAt": "2025-09-20T19:50:44.251Z"
+        "model": "fake-64",
+        "vectorSha256": "af23f3c2c3c233467eb1fdae79b7941bdfbcf45c833f150de1ce137ed1519be2",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-09": {
@@ -7618,9 +7486,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7fe4bbc06c278284ede9ca3f192a1397ab689e61916ff99c79c5def96e374bf9",
-        "updatedAt": "2025-09-20T19:50:44.251Z"
+        "model": "fake-64",
+        "vectorSha256": "d1d78b3876164fef113a6eeaa760cbcc455b9ad25d72861a2f766910676917d7",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-10": {
@@ -7640,9 +7508,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9c361a4233214a46c4fbde2921c9521b45de596ced17e6ffe9b3e2e2a0e438d0",
-        "updatedAt": "2025-09-20T19:50:44.251Z"
+        "model": "fake-64",
+        "vectorSha256": "aac9b1e5f51fcee6a601c3ba8b66ad396de01b48dc29037f3d547e84243d104c",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-11": {
@@ -7662,9 +7530,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ce595a71bf65c3f5c449ba27dc97b11e573c0bfc19f4ad3a9df25e96b067319f",
-        "updatedAt": "2025-09-20T19:50:44.537Z"
+        "model": "fake-64",
+        "vectorSha256": "68e21051eea38f763c15a32caea2e377cfcae537055a18791c691dd4d1dbfbfe",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-12": {
@@ -7684,9 +7552,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "223e6544916f3f490e3eae07177fa908cba4fb13b926bef1146f7435b0eb97b5",
-        "updatedAt": "2025-09-20T19:50:44.537Z"
+        "model": "fake-64",
+        "vectorSha256": "f675d91b57ee278319890f739d9f59ee3e433b142f5e016c702a60a4dbd63245",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-13": {
@@ -7706,9 +7574,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ff78cb499dca699d0b2f7020c26d96b8ebf53835fdfbca0b71035730670e1a37",
-        "updatedAt": "2025-09-20T19:50:44.537Z"
+        "model": "fake-64",
+        "vectorSha256": "affe8731c5ca7fb2ec497ceacb070b1c614cc4cc66073ef4741fb667317cdfcf",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-14": {
@@ -7728,9 +7596,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "976b985a65e7612b7373f6b8cc1dc8cb3809248b6387f0f810ad4e6274adffff",
-        "updatedAt": "2025-09-20T19:50:44.537Z"
+        "model": "fake-64",
+        "vectorSha256": "9548a4a08c6edcc636e48af2a735a0b705d790266e1c5ce2a3eccaa577e2b74e",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-15": {
@@ -7750,9 +7618,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6068c56e715860b362688f1cc0007856151d2ad409abb8ef275fd16902223d0a",
-        "updatedAt": "2025-09-20T19:50:44.537Z"
+        "model": "fake-64",
+        "vectorSha256": "350de91b4f2d4b0934eee268816bd932a5c0022307bf8fb36e50665047205a3a",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-16": {
@@ -7772,9 +7640,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "be1ce165bda634ef10ad470a968b5ad7cd0becce5d612086cf6ed4181fd8e0a8",
-        "updatedAt": "2025-09-20T19:50:44.537Z"
+        "model": "fake-64",
+        "vectorSha256": "614b8de47ea22c3e5e440dc6ea8b8435a6a049cc630a4d7d06ccbce7f7931c5c",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-17": {
@@ -7794,9 +7662,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "15ee37150f3c879d05340c84b938d61ea89d661dc80d087554385eabe2d89a81",
-        "updatedAt": "2025-09-20T19:50:44.537Z"
+        "model": "fake-64",
+        "vectorSha256": "00171ced120710b67eb21941de3f35de837f5433d5ccaed8114693aa8dd314e6",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-18": {
@@ -7816,9 +7684,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "86254af87bea56f783860c96c0baa22ebbe0447e512a94ff0779733ea25a001b",
-        "updatedAt": "2025-09-20T19:50:44.537Z"
+        "model": "fake-64",
+        "vectorSha256": "954adc013f59ec5c3196b4955e65b4f353bdaf9f98342c64e2c2c9b0f24098f8",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-19": {
@@ -7838,9 +7706,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8659073b07f5dae180897bd0596da05c619313edf6310368813f468240c3a587",
-        "updatedAt": "2025-09-20T19:50:44.884Z"
+        "model": "fake-64",
+        "vectorSha256": "bcec210a20398cbb55ae0ee5081639911eac0b473a6f6206e26ff1b844e3ec15",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-20": {
@@ -7860,9 +7728,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0ce1c6830dba383f0ad134ea28024a06f5f68d2d93ecb80b60cbfd8a1a3dab98",
-        "updatedAt": "2025-09-20T19:50:44.884Z"
+        "model": "fake-64",
+        "vectorSha256": "b37040d7b4f8cd98f351db53b054c43863bb9627a9fb97c827c571f1d238b03f",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-21": {
@@ -7882,9 +7750,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1e2f9a381093d469d81dc18afa163f02c1b11763dd1fc3b8356d69692d819634",
-        "updatedAt": "2025-09-20T19:50:44.885Z"
+        "model": "fake-64",
+        "vectorSha256": "eb01e3028cfce7d1591ffccf31767db027d083d0a00ab62ae828a24dc0fb8553",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-22": {
@@ -7904,9 +7772,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2ae34a9561553d7bd48717f48abc01edf842203b00f4424864d65ef88d484ba3",
-        "updatedAt": "2025-09-20T19:50:44.885Z"
+        "model": "fake-64",
+        "vectorSha256": "0ee1ccc4f5bfb35032951d91f78456173f68f34bb948b6d03dfdf60ebb32462c",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-23": {
@@ -7926,9 +7794,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d9f0c202a673a6a0653645a01b95b4a90e5204996ec6941acffc9494f1c61799",
-        "updatedAt": "2025-09-20T19:50:44.885Z"
+        "model": "fake-64",
+        "vectorSha256": "f0894a063b4afe8c8f59bdd52938190766ae8fc23b351de48aeb480fc47b03c1",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-24": {
@@ -7948,9 +7816,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "835a95ef7845ee56239fe6f5186771b34dde5b54b494be1df9437562196c8ddd",
-        "updatedAt": "2025-09-20T19:50:44.885Z"
+        "model": "fake-64",
+        "vectorSha256": "32b5608b1a7c35f1c68f03009bfa4ab81ede8e0559d39e88d90176f10c81525a",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-25": {
@@ -7970,9 +7838,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3b847d8e913a98175fc530a084594aaa3ef2151d7b6bb3bdfb5e08da090d489d",
-        "updatedAt": "2025-09-20T19:50:44.885Z"
+        "model": "fake-64",
+        "vectorSha256": "0a3fcea12a0cbf3c08f01487bc93b6fd43637be9f2544b43649d015ed13738d2",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-26": {
@@ -7992,9 +7860,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5bb9637f7ff1313b6c9e954fbca38f817bdc5e9304099734c9b3fd129fce1dec",
-        "updatedAt": "2025-09-20T19:50:44.885Z"
+        "model": "fake-64",
+        "vectorSha256": "306de5c6f2bdd8a9ba0fb26ac44bd9a0861fd29026add0776b4ab8f9e38e71ee",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-27": {
@@ -8014,9 +7882,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cdc7496009fe22bb6de7a0ba5e56a858cfc4fcbe657187434d85aab82758241f",
-        "updatedAt": "2025-09-20T19:50:45.181Z"
+        "model": "fake-64",
+        "vectorSha256": "d213cf5385767ffb087e095e65725360908716a1e0e334690bb1d13c2deac674",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-28": {
@@ -8036,9 +7904,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d9a1cbaaff7bab377ac0fee8ec5d66ac0a81fd8746bf1b11dd6686e2d3443e24",
-        "updatedAt": "2025-09-20T19:50:45.181Z"
+        "model": "fake-64",
+        "vectorSha256": "f899297dd3b2684b19b1411b5ae203c43347914fa744b17331b5941242eba4c8",
+        "updatedAt": "2025-09-20T22:28:15.455Z"
       }
     },
     "money-29": {
@@ -8058,9 +7926,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6960edca9f1d37b7fae53d69c3fbe0ba3e71b1657ace76e19f8a99cbc16d6b00",
-        "updatedAt": "2025-09-20T19:50:45.181Z"
+        "model": "fake-64",
+        "vectorSha256": "092bae296b44c84707235ea3fd126b66dd0ae6968e13be2a59a189b4fbefebf7",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-30": {
@@ -8080,9 +7948,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "463c3977bc95155570f6696a87eef5cac96a5d031bfc9adf8f3d3cf3538aff20",
-        "updatedAt": "2025-09-20T19:50:45.181Z"
+        "model": "fake-64",
+        "vectorSha256": "df5dbc28b92372af1ed963e6d70b508528fd1f00eabdec839939eede41593709",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-31": {
@@ -8102,9 +7970,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bcb18d6f2e3d4bd736333972fced36b4b1d275538f6b0cba0302ebf6d40fa705",
-        "updatedAt": "2025-09-20T19:50:45.182Z"
+        "model": "fake-64",
+        "vectorSha256": "4c2a0a555e819f3daefab1cad7bcc6506677729cd3243e3664e63fe8e634f30d",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-32": {
@@ -8124,9 +7992,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "efa1a672c4b5015a222f7920942290c1659f736c6265481318ab9b4144e90aeb",
-        "updatedAt": "2025-09-20T19:50:45.182Z"
+        "model": "fake-64",
+        "vectorSha256": "62f31e9788693fd8e698c1a81b12643d0d1494cefe7ea9c8c5fb938d1db9b551",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-33": {
@@ -8146,9 +8014,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9d5fdd30c38c37d47f6e1d764207133ecc45c548ad0227d968d78e26bffa9e91",
-        "updatedAt": "2025-09-20T19:50:45.182Z"
+        "model": "fake-64",
+        "vectorSha256": "44e3e4e8b2a4325e95e1b4319f443113e6671f8f52756b33601f9b90e09ac9a7",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-34": {
@@ -8168,9 +8036,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "afcd88d95ce5577cf0e89a1de4273895c98c3e5fc2c96d3239db21959ecaf310",
-        "updatedAt": "2025-09-20T19:50:45.182Z"
+        "model": "fake-64",
+        "vectorSha256": "7246c6e67d7f9c10fde5b62dc518f49b445e1085dd88da8efe5065449288db8d",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-35": {
@@ -8190,9 +8058,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d71defb0ee73162fea8b988519e64aad976e96586e9f74f2f976aad0bd494644",
-        "updatedAt": "2025-09-20T19:50:45.478Z"
+        "model": "fake-64",
+        "vectorSha256": "9a8b8e782c7197f4fc38eef0186e3605ea21808f7f3c6adb1481b7479e64ad70",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-37": {
@@ -8208,13 +8076,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 37
+        "sequence": 36
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "00a34db18b8cb0aef8a5430b134ab5f4fad882a3f95774a2ddfd18c01a3aa2a7",
-        "updatedAt": "2025-09-20T19:50:45.478Z"
+        "model": "fake-64",
+        "vectorSha256": "9e6e5db395ebca72485940e458c6698b1e8361da2d8d2fb8e2c6bc8d3e4d8164",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-38": {
@@ -8230,13 +8098,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 38
+        "sequence": 37
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b30da302160f42ed99d869562e7ae8dcf7aef1b061265c135474e07a17bc373d",
-        "updatedAt": "2025-09-20T19:50:45.478Z"
+        "model": "fake-64",
+        "vectorSha256": "6e8d9e1dfa40fdaa496548fd60a4bf23c01dd337e8b1595f83f3f68159ad415f",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-39": {
@@ -8252,13 +8120,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 39
+        "sequence": 38
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "145e4292af3d9017880a311cb105933555f76a987dc3710af2566f20fe5624fe",
-        "updatedAt": "2025-09-20T19:50:45.478Z"
+        "model": "fake-64",
+        "vectorSha256": "6cfc0545accb061c1253faf31f5edb47da9e2bcf1119ba916f6e91352b01f7bd",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-40": {
@@ -8274,13 +8142,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 40
+        "sequence": 39
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "529d30600b2c0d17a4bfa519c8b9388d8c03268acbbc1292c05901f6cf295e54",
-        "updatedAt": "2025-09-20T19:50:45.478Z"
+        "model": "fake-64",
+        "vectorSha256": "e0e97716b4a96b787e0f1dd198c84e5c19dd8f34c99a7705a3fe52afb8ed6987",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-41": {
@@ -8296,13 +8164,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 41
+        "sequence": 40
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "78c38a8bccc941201921409157a2f26067a9754b815e7fcb0f755f77f3e18849",
-        "updatedAt": "2025-09-20T19:50:45.478Z"
+        "model": "fake-64",
+        "vectorSha256": "da46dea38600ee04ee6557c2173b87bdd1675194322a5b9659be0ffe05ef9c02",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-42": {
@@ -8318,13 +8186,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 42
+        "sequence": 41
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1aafe56d5ca0b38e27ac6cf38fb097821b2bc5a868e95f033150f6f11127801c",
-        "updatedAt": "2025-09-20T19:50:45.478Z"
+        "model": "fake-64",
+        "vectorSha256": "0f01b804a9f5d9013bbb31f2b383c8243be582e6d715368d8c3321799e4ad23d",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-43": {
@@ -8340,13 +8208,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 43
+        "sequence": 42
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "135a76ffb309c7c99ee8c4f7e0910e3f63a9df7a8f9f97b79c4229c0b19ded99",
-        "updatedAt": "2025-09-20T19:50:45.748Z"
+        "model": "fake-64",
+        "vectorSha256": "0c9d55b33715cd3f064c5b45f245d7edb2cd8d1f3f197d13e24995f352baf032",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-44": {
@@ -8362,13 +8230,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 44
+        "sequence": 43
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8f0563488f7c907ed6fb086f807be2e4455d4855e96223a518f1140d0990a894",
-        "updatedAt": "2025-09-20T19:50:45.748Z"
+        "model": "fake-64",
+        "vectorSha256": "a3cf375f81d029c4e8ddb468e7305c21cc32639c129d8c8c9fbcd87d802dda8a",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-45": {
@@ -8384,13 +8252,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 45
+        "sequence": 44
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "937bdcec5646e19ae6636bfabd8882f77074ecf25675229bd4d3601ebe89c276",
-        "updatedAt": "2025-09-20T19:50:45.748Z"
+        "model": "fake-64",
+        "vectorSha256": "6573345723f46464803d14132de02304cf76cdc24cc6ee9c3edac539d87619a4",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-46": {
@@ -8406,13 +8274,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 46
+        "sequence": 45
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7449cf798e19e953ece2910de2058a77c3ac5271a3a52f7efaf1257f1b474e06",
-        "updatedAt": "2025-09-20T19:50:45.748Z"
+        "model": "fake-64",
+        "vectorSha256": "c361ce45d6fb655d27bc175bec4f8dbae2b2a86f7d27e7a658166986cae34c78",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-47": {
@@ -8428,13 +8296,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 47
+        "sequence": 46
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "645daff9cd95b46af76508181fd782e323470a8a8b32fcd157cd252a6742195b",
-        "updatedAt": "2025-09-20T19:50:45.748Z"
+        "model": "fake-64",
+        "vectorSha256": "84ba85c60f33bb1e61935eef564d5eec11e0415137bba487ae5ec936da4f22d9",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-48": {
@@ -8450,13 +8318,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 48
+        "sequence": 47
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "04d876727bbfe37c5bef081be0c54beb8c4eb4ac9e210867619913e397a4cac1",
-        "updatedAt": "2025-09-20T19:50:45.748Z"
+        "model": "fake-64",
+        "vectorSha256": "d0e08d338c22fc562f32f0131bc4e1aa02f364030e5b2ec9eff87901f791dc9d",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "money-49": {
@@ -8472,13 +8340,13 @@
       },
       "source": {
         "categoryId": "money",
-        "sequence": 49
+        "sequence": 48
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7024147c5cc4915f57b24946913d9ba4a26186e0cf453fb6a05b26551c0311a4",
-        "updatedAt": "2025-09-20T19:50:45.749Z"
+        "model": "fake-64",
+        "vectorSha256": "d0584b92753d47ab854718f417f6b36be7e2d5bf7761ed7c3c340cfb2e2d7f3b",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-01": {
@@ -8498,9 +8366,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "552caa9af14e8430c024f3390b2d7d728703606cd679d028b9638052ba21eb50",
-        "updatedAt": "2025-09-20T19:50:45.749Z"
+        "model": "fake-64",
+        "vectorSha256": "5c9947339b11879e0eeaf505baafcb6980c816a32c30d2fe457d7d8e29b0101f",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-02": {
@@ -8520,9 +8388,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8c5e6af98f5f883881e92c550e6f191d99c2388d0b84f322d109ecd14dba0480",
-        "updatedAt": "2025-09-20T19:50:46.023Z"
+        "model": "fake-64",
+        "vectorSha256": "50b573a45978e8cc6c915acfe917668c33f578f9a2253248a216932446e37506",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-03": {
@@ -8542,9 +8410,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b91eead272bd6602955b4f32774356f85dc73af0af96851d0ad9c076ccf526ca",
-        "updatedAt": "2025-09-20T19:50:46.023Z"
+        "model": "fake-64",
+        "vectorSha256": "4ed6bb7d81e2f6b5b19aadcb5b57309c13e0284c4fb6eb7e51ff08b16668fee7",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-04": {
@@ -8564,9 +8432,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b04617e3fb51810b0dd72bfa1146b3355cfef9cb92aa50347cfdb5d3460d80ee",
-        "updatedAt": "2025-09-20T19:50:46.023Z"
+        "model": "fake-64",
+        "vectorSha256": "10c77c0d3f6217b283ea6991cc69fcf125d246d947dcc4ff2765c27ca4212748",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-05": {
@@ -8586,9 +8454,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d02200a77238ffafab87bcb56695f76c51573afc1a92f8af9f2ebfb0e8adf99f",
-        "updatedAt": "2025-09-20T19:50:46.023Z"
+        "model": "fake-64",
+        "vectorSha256": "061b2e7aa7ab73b90288e4e11f512bef39f1ac758635146b2f231c503b12b976",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-06": {
@@ -8608,9 +8476,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "834c47cee75ad76982a6a119003472632f090fa03b57754a4ccddbbf22169bb4",
-        "updatedAt": "2025-09-20T19:50:46.023Z"
+        "model": "fake-64",
+        "vectorSha256": "69e42b2f6d572ecfc0a016af8e05ae62cf362cb79346e15e80b492c72ae935da",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-07": {
@@ -8630,9 +8498,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1128172a787a07e815afc900e28c05f93c3bb219540d9018b1704ccfb9551289",
-        "updatedAt": "2025-09-20T19:50:46.023Z"
+        "model": "fake-64",
+        "vectorSha256": "43d0ce84ecbc78437e156fa23e1b6fe3ec13711d97355ab122d9e01a28da1519",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-08": {
@@ -8652,9 +8520,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cce6950e10f8caca6ecfbbaeb0817001a075f331758deabbff24441263fde93a",
-        "updatedAt": "2025-09-20T19:50:46.023Z"
+        "model": "fake-64",
+        "vectorSha256": "bcf5c08abcccb1811c3b495a27898ae2ebc2d1db3481c7c9b66a9948013c4f3b",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-09": {
@@ -8674,9 +8542,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e0df956c16ef34bbf454b557dbaaaa24b8a913b3eda9a4dc55ffbca25dab9b8d",
-        "updatedAt": "2025-09-20T19:50:46.023Z"
+        "model": "fake-64",
+        "vectorSha256": "2d353f50c1081abf12503f65c560edf866d520b74c9ee560a4988d50498de485",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-10": {
@@ -8696,9 +8564,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "105583db52aa18bd4f86993963351ad02e0b1a4d70fe139e929dc0213e1954c2",
-        "updatedAt": "2025-09-20T19:50:46.287Z"
+        "model": "fake-64",
+        "vectorSha256": "29ff65ca3979d66e3fee8329ca1f2bad642ef099ea439662b3e87ed59ea69f2f",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-11": {
@@ -8718,9 +8586,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fcb70c32d352d469f1ea2fff0d6d999100b59498970d8ac0dff989793fa2f812",
-        "updatedAt": "2025-09-20T19:50:46.287Z"
+        "model": "fake-64",
+        "vectorSha256": "7d30736c40181620f053b84cdbe061568dccac5c62ef9ab2ddb9398199009b2c",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-12": {
@@ -8740,9 +8608,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a066acf75f70fc71b27eb32ffba1d56fe564e7a06401b84b31b9680fb1efe12a",
-        "updatedAt": "2025-09-20T19:50:46.287Z"
+        "model": "fake-64",
+        "vectorSha256": "8493e7765b00bdce36f5fea3eb422fd2326b166be20aac1ecba92a2b53c7741c",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-13": {
@@ -8762,9 +8630,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4280c622bdcfdee675f9f6f8dced666ab17ba7513f78a73a92cef7a73cfc2f4a",
-        "updatedAt": "2025-09-20T19:50:46.287Z"
+        "model": "fake-64",
+        "vectorSha256": "b01c7413670cfc8a3a360f38b093009f6cfc1c1a74bcaa571446cd7c7567aeef",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-14": {
@@ -8784,9 +8652,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6cd6ca9b13f86ef02217a8a25ffe4eabcbb515ec3ba1105429ada9209a6977bf",
-        "updatedAt": "2025-09-20T19:50:46.287Z"
+        "model": "fake-64",
+        "vectorSha256": "47841527a3f46cb4920ab18c965cfca05df51dc9da5667cd58c94cf1ce6b4b5d",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-15": {
@@ -8806,9 +8674,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0c603eaf3022b40344e7cb2408a07c9b8a043ceebfdaa55a11a59ce2ffac7373",
-        "updatedAt": "2025-09-20T19:50:46.287Z"
+        "model": "fake-64",
+        "vectorSha256": "8b5061e96ead629d29f022307395a0abdd6b22d429ccae7e38423feeef66f5f2",
+        "updatedAt": "2025-09-20T22:28:15.456Z"
       }
     },
     "family-16": {
@@ -8828,9 +8696,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9aabf5e06e30aa041815dd171483c03d89bd4d08141449ed9fb47e58a443147a",
-        "updatedAt": "2025-09-20T19:50:46.287Z"
+        "model": "fake-64",
+        "vectorSha256": "2ae4a9d9f9d9300c3a4064170e8e476677fa2b92267add0f3c05af6cc31546e8",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-17": {
@@ -8850,9 +8718,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "60cf9f3d3035a49bc96db701bb46479e5ce4853e993a273ff02573feb0f738bd",
-        "updatedAt": "2025-09-20T19:50:46.287Z"
+        "model": "fake-64",
+        "vectorSha256": "59d9e42274c4e98be7fdce9ded455600603fbf2617f659c080ecc97524e152cc",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-18": {
@@ -8872,9 +8740,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2037dc48595fd35dc91b04e316a9f3e7692eb15917dd6bb2941b2c48cf0be3e8",
-        "updatedAt": "2025-09-20T19:50:46.624Z"
+        "model": "fake-64",
+        "vectorSha256": "3561684ba0d24da8180d7115a870fa6c24ad3068eadb400feeb025c3751ebda4",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-19": {
@@ -8894,9 +8762,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "544e62b8dc08f72e1e1a00b3dbeac659dcac8dc46b6ebb86dcc60160903cecd4",
-        "updatedAt": "2025-09-20T19:50:46.624Z"
+        "model": "fake-64",
+        "vectorSha256": "c4cc0e610cf9aa2f5d5ab90d12f45bbbd7d6b9b449ad588f67e6e101ba26fdae",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-20": {
@@ -8916,9 +8784,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b018593c5171b93a311dd4953004ac73ba2eda09d5692be8c839d84862d698fb",
-        "updatedAt": "2025-09-20T19:50:46.624Z"
+        "model": "fake-64",
+        "vectorSha256": "cb6b90a6202a3c400c5362658dbbfd0afbc3b5cae9a3b04928fe3b43458cd983",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-21": {
@@ -8938,9 +8806,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b3f9405499a7874ee62495fc2d15996d747073f73fc43be34a54df07f0a63ee6",
-        "updatedAt": "2025-09-20T19:50:46.624Z"
+        "model": "fake-64",
+        "vectorSha256": "b165b23a64cedaa3cb1ad032867b3132375458ac1a5b1295dca22f88d3284bfa",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-22": {
@@ -8960,9 +8828,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a9203437bb9048cfba286ddc1eae9ac3c81e4f8ce5ec03cf14118a14a795e3b6",
-        "updatedAt": "2025-09-20T19:50:46.624Z"
+        "model": "fake-64",
+        "vectorSha256": "76ddefad4cc3f65d5ae1904ceea2f3ef31f5af384cf599000bbff8b74585d7f3",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-23": {
@@ -8982,9 +8850,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d9923b02917c1055a631c7b3752694cb5cea7322fbd3b2496f9cc6b87732c8d5",
-        "updatedAt": "2025-09-20T19:50:46.624Z"
+        "model": "fake-64",
+        "vectorSha256": "d0b7f788cf7c6431853ee5b1185dd3a1acb120c236e06cca607a66105c671103",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-24": {
@@ -9004,9 +8872,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7b1cbd70d90e735dfc00e3a3e0b6b1946d1149a9044566b3b1509479e0c69ad8",
-        "updatedAt": "2025-09-20T19:50:46.624Z"
+        "model": "fake-64",
+        "vectorSha256": "bcc70496454ffaf8d33c4f6224977161267cfeb99a5b0643d1be503e961c13d0",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-25": {
@@ -9026,9 +8894,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1c87fbec752be4462fc5eb0a567d20e4890d01c2cbb7db6b6e26f881ccda012f",
-        "updatedAt": "2025-09-20T19:50:46.624Z"
+        "model": "fake-64",
+        "vectorSha256": "32bea48fe166333ee2b80f08d5498f72147db8cb65145c765e56a6b803788170",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-26": {
@@ -9048,9 +8916,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b9bdf9de4606d0cd60050fa50a46fd940eca7c1ca6eba873d472897d475632e7",
-        "updatedAt": "2025-09-20T19:50:46.856Z"
+        "model": "fake-64",
+        "vectorSha256": "42a62dc7380f6c76b47ea25789328daf0e20ac3d96979f642b398c443e83d614",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-27": {
@@ -9070,9 +8938,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ffa191f9cbb4c1e025b655b0e365fc82e999901dcca937cb125d4e675dcf7ac6",
-        "updatedAt": "2025-09-20T19:50:46.856Z"
+        "model": "fake-64",
+        "vectorSha256": "ce5e231b2a3983afa986efa1e5a82eefef193dc039a9e6f0b6d4d81337998f7e",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-28": {
@@ -9092,9 +8960,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9ee2637b5cbbf473b03f688043b09acc9b3a4b2a8963466f0e6b70e5bffedac3",
-        "updatedAt": "2025-09-20T19:50:46.856Z"
+        "model": "fake-64",
+        "vectorSha256": "6e7406be43193cb515f4518d349a330873b1beecef8e843cc5dbcafd9900a9fd",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-29": {
@@ -9114,9 +8982,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d2a2717b1ff1ed740eb513fcb0e2e6336d0aed0fac3442c49f159974ef01eee8",
-        "updatedAt": "2025-09-20T19:50:46.857Z"
+        "model": "fake-64",
+        "vectorSha256": "f51c419b829cbf30d678d2d14ebc964f43c608a1af2a59614c1bf2efb5785f0b",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-30": {
@@ -9136,9 +9004,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1ca30a787ff09876f2b9dab2d75a78b23cf4469b906f7016b61acba5ef59e8c0",
-        "updatedAt": "2025-09-20T19:50:46.857Z"
+        "model": "fake-64",
+        "vectorSha256": "25db085cf3f49690d075123ddf0ae530084051e02fc31b327c3ff3961aa1b9ec",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-31": {
@@ -9158,9 +9026,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "56860790e0cb2fad1b50c78babe78c9a4d0aaba2de084166cf3f69c2274a1d5c",
-        "updatedAt": "2025-09-20T19:50:46.857Z"
+        "model": "fake-64",
+        "vectorSha256": "d0698a47072a69e30c9f7effdcff0133415665e7d193bf3cf20f07a013046c17",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-32": {
@@ -9180,9 +9048,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f7725e1a368fdf27c7976ad2b6ebe7e896e5fb7db044e67aac03786c837a0a2c",
-        "updatedAt": "2025-09-20T19:50:46.857Z"
+        "model": "fake-64",
+        "vectorSha256": "2dee54cbdba547405e99455e83eca7eae75e3f287e4a241ee58f11504d92d100",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-33": {
@@ -9202,9 +9070,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bc0b261c8402263b00bc8814e7b86a3b634e285899bc19155adbffbe033c0d63",
-        "updatedAt": "2025-09-20T19:50:46.857Z"
+        "model": "fake-64",
+        "vectorSha256": "29bc9a0287f03681bc115df6710867412ec5d7ce1e0c2e3ba2f1fbdaa6badcfc",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-34": {
@@ -9224,9 +9092,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "77a09a35360a0d49cc946ed3bd99cf57392b12f98a7833b2097a48cd6aaf2a08",
-        "updatedAt": "2025-09-20T19:50:47.195Z"
+        "model": "fake-64",
+        "vectorSha256": "bcd02cf042c7c2ba72e97738cb35b80e631ede3b8bbd230c5012994e5aa3cd64",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-35": {
@@ -9246,9 +9114,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6c5ecc72a9aae65fe6668b1ac75bca129d5b6440aad49fd3c913ffccc36a27ff",
-        "updatedAt": "2025-09-20T19:50:47.195Z"
+        "model": "fake-64",
+        "vectorSha256": "a7be7fc67c430c8262071580cf2e340a181c9211bb8a7d13eaaee77d614ec345",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-36": {
@@ -9268,9 +9136,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "669fd6bae9fab83a8a4b5b71a2ff18b55ce8a237fbc88fd4748120bf9801b03a",
-        "updatedAt": "2025-09-20T19:50:47.195Z"
+        "model": "fake-64",
+        "vectorSha256": "3e7db88bdea7887049cc7f2249063cf82ddcce51215213148cf6db6d812b76d4",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-37": {
@@ -9290,9 +9158,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f34806bf9108b66de1e4636f84585fdceb03a888c7012c5e492146f1b09923bf",
-        "updatedAt": "2025-09-20T19:50:47.195Z"
+        "model": "fake-64",
+        "vectorSha256": "ef5509a67752f098dfed28fad77703fb28aaba34be99377ed29226057014a9a5",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-38": {
@@ -9312,9 +9180,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "45cda9e8df70ad820efecbc49d09ddf3cd33e586d64e8ed1ae9479f05541bbe1",
-        "updatedAt": "2025-09-20T19:50:47.195Z"
+        "model": "fake-64",
+        "vectorSha256": "5cfdf05d18633cd33fb0fe09c2dc849f50c8c950b075c842afcf4522f288c13d",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-39": {
@@ -9334,9 +9202,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3396312d1baacc1303646539d3a36cf81d1376817ab351e47e315a8c2a0f9dad",
-        "updatedAt": "2025-09-20T19:50:47.195Z"
+        "model": "fake-64",
+        "vectorSha256": "33e962ce8859619834b8be56d3fdc3882736667086e4b109a0c1f8df40221e6b",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-40": {
@@ -9356,9 +9224,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ad1908a9f5863f5126748f31039707e3fabc263880ac1791330d5d9b78b07f1f",
-        "updatedAt": "2025-09-20T19:50:47.195Z"
+        "model": "fake-64",
+        "vectorSha256": "9664ea99df7bcd484807fa665919b9dbf9b73b1acd3e6d5420e536d0decdde4a",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-41": {
@@ -9378,9 +9246,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "aaeed2d13bdd0e0a1d11aaf4f5efadb3b9058cb237516a28ad1c669541d294cf",
-        "updatedAt": "2025-09-20T19:50:47.196Z"
+        "model": "fake-64",
+        "vectorSha256": "ea00446e1997edf56a86c64d5fcc992accaeefb24471cdfdc44954b4e48b65da",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-42": {
@@ -9400,9 +9268,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4c5093e9edeff60c5ff6d50bf1d3b01de3db2c8eaa0236315210c6e5b24fe873",
-        "updatedAt": "2025-09-20T19:50:47.401Z"
+        "model": "fake-64",
+        "vectorSha256": "709449fe43b5aecb8d7cce5a57513c34facf46b85c3e9734d4608f9b50a16b70",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-43": {
@@ -9422,9 +9290,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e972a3d42cf566abdebb18dd5fee1d154e7ceecb25ce649795a3af57527e18f2",
-        "updatedAt": "2025-09-20T19:50:47.401Z"
+        "model": "fake-64",
+        "vectorSha256": "c16f922ee3d028b954db20704f22294856c3e7f9d73b15c9d35c7e6c9c963b48",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-44": {
@@ -9444,9 +9312,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "67cc39b097c5cbf293333745a83e8fed8457b55ea3dc15de98fb168370823a42",
-        "updatedAt": "2025-09-20T19:50:47.401Z"
+        "model": "fake-64",
+        "vectorSha256": "5b1ad41e062a548a2cd103da979a5ecf5e7ceb6b52aabe45dbd814a564c20b1a",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-45": {
@@ -9466,9 +9334,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "617fec730cf22edb9da3cc6bd7e5c80daeb559a76ecb74cd7fbb0f523acff6a9",
-        "updatedAt": "2025-09-20T19:50:47.401Z"
+        "model": "fake-64",
+        "vectorSha256": "526c8738172c994e57daac6b24f9eecff5d0c53fb6ff40b14934b0acc13cf621",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-46": {
@@ -9488,9 +9356,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5e55d3ba020e47cbffb5de012d8f0233eee15806508c8b319d21ef28054ed1a8",
-        "updatedAt": "2025-09-20T19:50:47.401Z"
+        "model": "fake-64",
+        "vectorSha256": "09be582df19b4eb65d28a70618868f465fd958964eea177bbac225a6e8449f34",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-47": {
@@ -9510,9 +9378,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5b84c3350283eb9ef21e8c4ee74df282a2e589c86ac0fa9eac9002bde0491276",
-        "updatedAt": "2025-09-20T19:50:47.401Z"
+        "model": "fake-64",
+        "vectorSha256": "7c7473c4ceab8f2bde65504f2dda118eb713813a1f2dda195013a26a31edcf6e",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-48": {
@@ -9532,9 +9400,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bceaa2f35de8deaebf3b0cab3a2329726ebaf96f7c543b79530cd5e01a480908",
-        "updatedAt": "2025-09-20T19:50:47.402Z"
+        "model": "fake-64",
+        "vectorSha256": "44df791b291dd03fd5eb3420cb0494b5ae5c41ec99014647ce61d8f17b2f3a66",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-49": {
@@ -9554,9 +9422,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b55c8f02fca9da9aa8137b2e171da0e9033ed4ab21770cf5d40070a0d8f3c675",
-        "updatedAt": "2025-09-20T19:50:47.402Z"
+        "model": "fake-64",
+        "vectorSha256": "d164beda32b2575641c23b31b2aca40987fbbc005e7b3fd6ad9146a5d9fff825",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "family-50": {
@@ -9576,9 +9444,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4add67349a09e957a775fe213b17c78f1370890e2ed42457474a7c177ee9bb46",
-        "updatedAt": "2025-09-20T19:50:47.676Z"
+        "model": "fake-64",
+        "vectorSha256": "22867621bcb62cf69ef2917d1a1543da05d26f9befb2ee816622d97d41758a90",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "love-01": {
@@ -9598,9 +9466,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "908cb6754262d67eadd58c399999a38460d8132bc321d5ed1a49ff2a839fac7e",
-        "updatedAt": "2025-09-20T19:50:47.676Z"
+        "model": "fake-64",
+        "vectorSha256": "de2afca37abd49acac7e96f5b3eefb26b19ec27e1ad8764b7ac0d06f01b76cc1",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "love-02": {
@@ -9620,9 +9488,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4ac22a48614927d005bb18a2e21590d56154137b20eee34b9ad19327017b7ea4",
-        "updatedAt": "2025-09-20T19:50:47.676Z"
+        "model": "fake-64",
+        "vectorSha256": "82a5a9cb5c6d7abf607f4537c32be463864224e1aaf58c224313433d477e8b84",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "love-03": {
@@ -9642,9 +9510,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "105b4c0556ce87e14b4f767de4d2cd549529ca3504859218d8694abacf661ed5",
-        "updatedAt": "2025-09-20T19:50:47.676Z"
+        "model": "fake-64",
+        "vectorSha256": "394fe68ada293f9a6aa30e19e24179fb3dc5248c9c9480dabbc755af1df4fbba",
+        "updatedAt": "2025-09-20T22:28:15.457Z"
       }
     },
     "love-04": {
@@ -9664,9 +9532,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "71568da5c81f0d6ab9c37e19808811b3461cdb188fb09694b0842834aee73b0f",
-        "updatedAt": "2025-09-20T19:50:47.676Z"
+        "model": "fake-64",
+        "vectorSha256": "e8fea027968e4316060d091b38c1482fdf41b187440876881dbb39c083f6c619",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-05": {
@@ -9686,9 +9554,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e50a3c1941d1dc4d476ecb72e1e3df428fe0453c54aa54fb0a035491bd7185f3",
-        "updatedAt": "2025-09-20T19:50:47.677Z"
+        "model": "fake-64",
+        "vectorSha256": "3720431a7182267965ab267e6ec345b0793ba7e1993648f2cc814e79cd43f537",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-06": {
@@ -9708,9 +9576,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "63e93cc2741cea73df58c3c1b9ab32634ef5051ec229d8e6180c851594384cc7",
-        "updatedAt": "2025-09-20T19:50:47.677Z"
+        "model": "fake-64",
+        "vectorSha256": "619b716dd5c7fff964573675c582992a1b89ad8ba8414f6d264e59cad69ffee3",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-07": {
@@ -9730,9 +9598,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f35936ea77b807f84de3b39e415865bc8e87cf909b74907b3c6f8048e9180a53",
-        "updatedAt": "2025-09-20T19:50:47.677Z"
+        "model": "fake-64",
+        "vectorSha256": "b34781de337f0170391a4e8a188821697e2b185b42b89f970cf777a38aee39aa",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-08": {
@@ -9752,9 +9620,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "95d1daf27e8dc35a0a0ad874ebeb6faee3d2c07c9d05f6a06a796029caf7c709",
-        "updatedAt": "2025-09-20T19:50:48.024Z"
+        "model": "fake-64",
+        "vectorSha256": "6a7e1587b793802224ed352e9bf54e7542103bd8952da73fb696aadf4c19f6d6",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-09": {
@@ -9774,9 +9642,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8d13eceafadb8cff300e93c46b74360f7064d64aafd5902d48370ad169065f42",
-        "updatedAt": "2025-09-20T19:50:48.024Z"
+        "model": "fake-64",
+        "vectorSha256": "3fb3a0255cb9689dd78c0b6adc32a6172fb01bd5396b6e0f296a997f39a5cef3",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-10": {
@@ -9796,9 +9664,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4aabdf3be5f28ee00cc5b05a693378726ed4ea16b2400881ef32e744a04f14db",
-        "updatedAt": "2025-09-20T19:50:48.024Z"
+        "model": "fake-64",
+        "vectorSha256": "852087d5730db8f0ab2b1b7a37cb8e56ce4cf5a92c63dec6e27c7f2dd809eb14",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-11": {
@@ -9818,9 +9686,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "10cdd2c20d7e951427ecf8c362309a3ee8aa3ecca3495c730af926cbfe940a5d",
-        "updatedAt": "2025-09-20T19:50:48.024Z"
+        "model": "fake-64",
+        "vectorSha256": "9d7d32b76b9664be1cfd5db612faaf267317bd8965780ad75afc4dd38f405de8",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-12": {
@@ -9840,9 +9708,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9bb7decc49692a34e05a3210d806c2f0e6c4761549baacd12dce4f1243df54de",
-        "updatedAt": "2025-09-20T19:50:48.024Z"
+        "model": "fake-64",
+        "vectorSha256": "af694818508d8fa4793181367fe805f68134bfb1bf3d1b16e2b03066bfc7e732",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-13": {
@@ -9862,9 +9730,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "609b175747474f8179d3a2048f0a15e7dc9cbdeda1f0078b76712a2bcf5c0abd",
-        "updatedAt": "2025-09-20T19:50:48.024Z"
+        "model": "fake-64",
+        "vectorSha256": "c21676783522adfcf37bcd208de31f0a0909ace8d166969a453299c2ac2b2b7b",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-14": {
@@ -9884,9 +9752,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "75f30c8799bc58c33a1087910b6c2993436b946df53c332c302f9c98ebba9aef",
-        "updatedAt": "2025-09-20T19:50:48.025Z"
+        "model": "fake-64",
+        "vectorSha256": "1c74d2275fb31eb4edafe02ccf6432157b2a72e85f5d62667664d151c752cd56",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-15": {
@@ -9906,9 +9774,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "036816c5645d1312e0ce1b1fd97c9099f6852da28e76528c5c2f260d8485509a",
-        "updatedAt": "2025-09-20T19:50:48.025Z"
+        "model": "fake-64",
+        "vectorSha256": "faec8615817272363f92a43865c8d94e349deb68b85d4b44ffdbc07d6cce8664",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-16": {
@@ -9928,9 +9796,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "dc5183b9bc58d3158839cb5730005325ef63b183f6989185833edcecf6cff7ad",
-        "updatedAt": "2025-09-20T19:50:48.273Z"
+        "model": "fake-64",
+        "vectorSha256": "bc80fadd8fa76666fde42960c01622f4ce47e5a7711d84241924c982b136052d",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-17": {
@@ -9950,9 +9818,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6080bd668476e734f7595dde17e6220cab8e66d80d3bc8dbf9708c28ba0ebca2",
-        "updatedAt": "2025-09-20T19:50:48.273Z"
+        "model": "fake-64",
+        "vectorSha256": "8a82505516b832286e887e817dc44c934b74f5b5fce81045e22317bb5d1e78ba",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-18": {
@@ -9972,9 +9840,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5812aebf1e3b4046ceb0b0c8bf56247aa263e471cae0ae9e710c71654435e7d5",
-        "updatedAt": "2025-09-20T19:50:48.273Z"
+        "model": "fake-64",
+        "vectorSha256": "a5ce129e9b342dbb1894a9ce45050c70c49c8fe9aaf2d2d6c6b3b7708f416f7e",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-19": {
@@ -9994,9 +9862,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "56ee9b15be042037bb9307829e9374d1e88df4d1828a804ea0a3871061765501",
-        "updatedAt": "2025-09-20T19:50:48.273Z"
+        "model": "fake-64",
+        "vectorSha256": "245de3ee867e3896bbf425048313b52abfd0d163753cc19b25c04240e150c1da",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-20": {
@@ -10016,9 +9884,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "033aa70c31cf458df1dd2432931e2e95f368a7c7ea63e2564c754df8be965102",
-        "updatedAt": "2025-09-20T19:50:48.273Z"
+        "model": "fake-64",
+        "vectorSha256": "21db52171c7dedf506d0099386bdbca048e2ff7bf69f08bd81bb85735cb0f30e",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-21": {
@@ -10038,9 +9906,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "b4cee1714cb26ea6fd4b1762154bdd97c33db646e2f894bf676140ebb0369049",
-        "updatedAt": "2025-09-20T19:50:48.273Z"
+        "model": "fake-64",
+        "vectorSha256": "55f7867aa04ca7191eadbfdcdc2ca3702308159e23d40686b4513b90b41a38ba",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-22": {
@@ -10060,9 +9928,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6e81e9fbb095d919ae065bbc6d9a8e7ae9f3ee44da201e10b837c54f3f802f65",
-        "updatedAt": "2025-09-20T19:50:48.273Z"
+        "model": "fake-64",
+        "vectorSha256": "ed310c2074ca6d6b737a1336c2a3415beec56a049a32a11b7dae1f1d1f93735f",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-23": {
@@ -10082,9 +9950,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "26ccbd3abec28428fef49670df407ace14e404abedc10a80d6626212013611b1",
-        "updatedAt": "2025-09-20T19:50:48.273Z"
+        "model": "fake-64",
+        "vectorSha256": "11b0e1c7a5005e648490d823a19785ae487b91526bbf2da693243d6c9b385ebf",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-24": {
@@ -10104,9 +9972,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0ea77ec0778f64deb0a40e2241e4f380c203d2a32a1631e17f23419ebefb6665",
-        "updatedAt": "2025-09-20T19:50:48.565Z"
+        "model": "fake-64",
+        "vectorSha256": "881e449c27efbe96219d0e9340b807489ce96df928f819e71918cfc1a9d6a539",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-25": {
@@ -10126,9 +9994,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9f69b516bdc575f267bc066dea0822bd152f65a20d88075a3cd3bcbc4d447f64",
-        "updatedAt": "2025-09-20T19:50:48.566Z"
+        "model": "fake-64",
+        "vectorSha256": "4ef2f77583859f68502f52daf2c9f1baf561de503d28ea1abdcba46145ef3d04",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-26": {
@@ -10148,9 +10016,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7cf0d8ec69847f21cc4d4e7f0557d68a8c532a163a80190ff63a42cca41ebf9c",
-        "updatedAt": "2025-09-20T19:50:48.566Z"
+        "model": "fake-64",
+        "vectorSha256": "0fb0c758902024d1d9056fa219281c06913600de261741fa5a633ba26d70f251",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-27": {
@@ -10170,9 +10038,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c8c0a28a713d49d5613c754d5a1ebf30ecb798f0ae0f958c44e42bbfc2371c60",
-        "updatedAt": "2025-09-20T19:50:48.566Z"
+        "model": "fake-64",
+        "vectorSha256": "3ecd763259094da9ba75f9f913ef11e2bbca453a97ceb12f90ac8831430965ef",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-28": {
@@ -10192,9 +10060,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3f31268ea200875f6607074278f4076cfa6af681c200be31a2e3e40ff3dd0d48",
-        "updatedAt": "2025-09-20T19:50:48.566Z"
+        "model": "fake-64",
+        "vectorSha256": "49451048810e353b9991d49ceefa200c8ecf240d4b90772ef8861b460af2a8ed",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-29": {
@@ -10214,9 +10082,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8688f00ca733a24b52f12be4c0679763ffcf94e5e7dcfb254db13bcbec27bec7",
-        "updatedAt": "2025-09-20T19:50:48.566Z"
+        "model": "fake-64",
+        "vectorSha256": "4417b237c4b054f966f326f3d186a0beaffa215809e98b645544c9cc8d80f5f9",
+        "updatedAt": "2025-09-20T22:28:15.458Z"
       }
     },
     "love-30": {
@@ -10236,9 +10104,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "00e1b004081c3b5f978d59729e0a03b07312eb651ad1958db0b63cea1b48569c",
-        "updatedAt": "2025-09-20T19:50:48.566Z"
+        "model": "fake-64",
+        "vectorSha256": "742427226ac99ae71b374f28163c9e15e6f0e4f0e37cc350477badb1857ce3da",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-31": {
@@ -10258,9 +10126,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "af013822c81b1a15d051888cf94ddae158ef82f695974041a36f11f9d54792d0",
-        "updatedAt": "2025-09-20T19:50:48.566Z"
+        "model": "fake-64",
+        "vectorSha256": "a6923068c1a4985aec378df6f26e477236d00c9186339632905700e537437fa8",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-32": {
@@ -10280,9 +10148,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6e242316f051ab7ee4b307a460ea6c31349886d4ad4d7cb5d31a71c5191297b0",
-        "updatedAt": "2025-09-20T19:50:48.814Z"
+        "model": "fake-64",
+        "vectorSha256": "00ec981a4054c469a238a0e25c98ccc1180428407c2c44c7b6971507d9237a26",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-33": {
@@ -10302,9 +10170,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "090aa25cf2ed664094f188bb4dce58f0f88f96b6b5309a41d9e6c36ae3eabff2",
-        "updatedAt": "2025-09-20T19:50:48.814Z"
+        "model": "fake-64",
+        "vectorSha256": "d9d73df3ebcc49f4a8e03e3e97af01ab80f6d770e4c1c64b04b7662dd4018cb8",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-34": {
@@ -10324,9 +10192,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "386eeb9c951066b49deb5ae0b5c4b2e51c0c4fa858dc34ad53eed49123bdef03",
-        "updatedAt": "2025-09-20T19:50:48.814Z"
+        "model": "fake-64",
+        "vectorSha256": "c402eca41550d3e7b9d34df52a176c4976a914283e57a18db232176648dba5ba",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-35": {
@@ -10346,9 +10214,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8bfc2c8f22a1b7a865955c7a03078a9f052bc6695da981f485668925db6f70b7",
-        "updatedAt": "2025-09-20T19:50:48.814Z"
+        "model": "fake-64",
+        "vectorSha256": "7a5890ffdfa4894eb0abf359989c3727091ba84bf5301fc4649850e224745f95",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-36": {
@@ -10368,9 +10236,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "27ccfbd7e316ea0d425103031445b848e1bcd6fd8aeab395c9398efdf4f29c9e",
-        "updatedAt": "2025-09-20T19:50:48.814Z"
+        "model": "fake-64",
+        "vectorSha256": "d40676723c129a2c15d317531e7f9b410481b87259973e28827399540fe29b90",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-37": {
@@ -10390,9 +10258,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e34c2e5d0d9a6fb6918aaa15d4cd7eecce231187a6f66341f7c32b26af54b47b",
-        "updatedAt": "2025-09-20T19:50:48.814Z"
+        "model": "fake-64",
+        "vectorSha256": "df0f6a7e74bd19cfaa69c2f5424ee8874204700b71718036b78ea84f2017d950",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-39": {
@@ -10408,13 +10276,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 39
+        "sequence": 38
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6035df33ad193ec6c7e0838e49dcfc9b08f6965a74e858f58599296deb6c6cbd",
-        "updatedAt": "2025-09-20T19:50:48.815Z"
+        "model": "fake-64",
+        "vectorSha256": "402d3d8ea4a7773acde441b8fc033edda6fc9a88f98cc8fafea376545b034e7f",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-40": {
@@ -10430,13 +10298,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 40
+        "sequence": 39
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e244caa7851b0d48343a50150973cabfac1a58e277819c65fbc8f863627ca3b1",
-        "updatedAt": "2025-09-20T19:50:49.007Z"
+        "model": "fake-64",
+        "vectorSha256": "498884b021828c127c351112eac87a220fa6bb73b32c0449dc8685bcbeed950a",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-41": {
@@ -10452,13 +10320,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 41
+        "sequence": 40
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2a5553fd4c2264ecd473cd891d492f5992b7515becfb28f7c6373e9d1f19d36c",
-        "updatedAt": "2025-09-20T19:50:49.008Z"
+        "model": "fake-64",
+        "vectorSha256": "5bc6b6fff4024c18c853db33df1a99371f65858beeda0fd3f0628231c9d34776",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-42": {
@@ -10474,13 +10342,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 42
+        "sequence": 41
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e0fae6e9f9c778b1b997f389deb29bef9708b964a16c750fc74443e7784b68b7",
-        "updatedAt": "2025-09-20T19:50:49.008Z"
+        "model": "fake-64",
+        "vectorSha256": "fee37d5ccc55d0a02d417a8660687aea44eadf56ec71decdd8ef5468498cec9c",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-43": {
@@ -10496,13 +10364,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 43
+        "sequence": 42
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ebe8b0201cb4dab8190e443893ab45fd804a575c53274d009d358fde951e0d1a",
-        "updatedAt": "2025-09-20T19:50:49.008Z"
+        "model": "fake-64",
+        "vectorSha256": "3b057ce8b08d035b4d72c9454e87d3b60578e368720ae6907f97c1fd58e040c6",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-45": {
@@ -10518,13 +10386,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 45
+        "sequence": 43
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2b0be0b3fc9b4db21a9b578bb318efc8edc9eb79f00145b1f5b579208ce7eedd",
-        "updatedAt": "2025-09-20T19:50:49.008Z"
+        "model": "fake-64",
+        "vectorSha256": "635182c779a1bf761174783becae2d2d7eb25df4b5ee46c5e2461490f3e549b9",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-46": {
@@ -10540,13 +10408,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 46
+        "sequence": 44
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a00af21e936b937ece07987b67c1862868227aeb3a0003d7dbdf097960980b84",
-        "updatedAt": "2025-09-20T19:50:49.008Z"
+        "model": "fake-64",
+        "vectorSha256": "ed20ac606214a3af5b82d191c6584b30fa5ac1a9aec848728e68bc47d02320f5",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-47": {
@@ -10562,13 +10430,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 47
+        "sequence": 45
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d312f29c4c1904d567e5dc11b5bce13a2b241591b93a07d5504c69b5a782cbaa",
-        "updatedAt": "2025-09-20T19:50:49.008Z"
+        "model": "fake-64",
+        "vectorSha256": "d6900498c8367fd2192ff6edfb7a40b5e735d1c0a22e90f3b7c0adae47261959",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-48": {
@@ -10584,13 +10452,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 48
+        "sequence": 46
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9a0c38bbf83d0aee04d25e399dfdab6ea00e1bbd383fb4020d3fe13013900c6d",
-        "updatedAt": "2025-09-20T19:50:49.294Z"
+        "model": "fake-64",
+        "vectorSha256": "b721d2ee3cb2a0e7842e72693a97667c8d9c6d2e88ce43ce6f9776bc3253f73e",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-49": {
@@ -10606,13 +10474,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 49
+        "sequence": 47
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "96fa4c7c30b9f17f36dcbc6c81b22052396193c50f7d6c93b10e7e5760d3efd8",
-        "updatedAt": "2025-09-20T19:50:49.294Z"
+        "model": "fake-64",
+        "vectorSha256": "ca6db2ebca876b6a55c426579f74783e5fcac133520f6d2cc55ee4db1157aa0d",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-50": {
@@ -10628,13 +10496,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 50
+        "sequence": 48
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ad1cb7b83f7b009a26cb631b132dab7d812566f1314c217cace91a31135e83bf",
-        "updatedAt": "2025-09-20T19:50:49.294Z"
+        "model": "fake-64",
+        "vectorSha256": "db6ecb641e288255a6d911b767694b49dcec0ac054b3aa237e1c0c59501032e2",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-51": {
@@ -10650,13 +10518,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 51
+        "sequence": 49
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "9ea560a2667fb8af970fdae35a5a9f6da472750881393ea8a8ebd13086065caf",
-        "updatedAt": "2025-09-20T19:50:49.294Z"
+        "model": "fake-64",
+        "vectorSha256": "48c8517b560d785bc4e1d98303cd10d6a4ca6f0fb80ba9a0c7fc60aca4ca98bf",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-52": {
@@ -10672,13 +10540,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 52
+        "sequence": 50
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a97944ec83676f34f60414eab5a5bc46b01b386a9a07e33ba29b5a74ac5b69dc",
-        "updatedAt": "2025-09-20T19:50:49.295Z"
+        "model": "fake-64",
+        "vectorSha256": "e2f86b1271d7af890c2c374b9c40927518167d8d29093fad82f181be5c7f5399",
+        "updatedAt": "2025-09-20T22:28:15.459Z"
       }
     },
     "love-53": {
@@ -10694,13 +10562,13 @@
       },
       "source": {
         "categoryId": "love",
-        "sequence": 53
+        "sequence": 51
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e30e8dfc462ee1a61fea684c12facb14edda09e3a6b88994453ea2a585107fa1",
-        "updatedAt": "2025-09-20T19:50:49.295Z"
+        "model": "fake-64",
+        "vectorSha256": "95029769fccd9da44e5a65fc40b1afec29cc4935c3eed8a47d9e428f4463ea5b",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-01": {
@@ -10720,9 +10588,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ef2e3fef9c62602b66420e97c6327babf2ab29fd2bfbaa4db738d14776177c9f",
-        "updatedAt": "2025-09-20T19:50:49.295Z"
+        "model": "fake-64",
+        "vectorSha256": "a573b4077a322f24624a27f2523a68818f1499d79b9957d41ed032c52495ac29",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-02": {
@@ -10742,9 +10610,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ff922ae549ea2c6cce48e6616f17508210aaf1e909a1c0b674158eacc285d8d7",
-        "updatedAt": "2025-09-20T19:50:49.295Z"
+        "model": "fake-64",
+        "vectorSha256": "ab25c8029293f4f4ff131480cda394754126b05d2087d60c73c0dfe9b4956d33",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-04": {
@@ -10760,13 +10628,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 4
+        "sequence": 3
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8a78f2c220802868b44b6fcf77cf6f8570ca096fac90e7c909b1317cfb417837",
-        "updatedAt": "2025-09-20T19:50:49.563Z"
+        "model": "fake-64",
+        "vectorSha256": "438d34f6f35892d4aba87cf0b1b2a89c47920df2d124f74449d4a2f2466531bf",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-05": {
@@ -10782,13 +10650,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 5
+        "sequence": 4
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7d4e9d6a2215a643a9fb5053b391529c5109be5c9a9de86f9f8189cc012cad1a",
-        "updatedAt": "2025-09-20T19:50:49.563Z"
+        "model": "fake-64",
+        "vectorSha256": "6e9611a21cf69cb19e49957b49ba19c4cbe0887bd572a6ad4d67657f5c8975b1",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-06": {
@@ -10804,13 +10672,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 6
+        "sequence": 5
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c045cabd7cb586d06d159de65e623f5123524b5bee2fc87c6c46bfe8d415c9e5",
-        "updatedAt": "2025-09-20T19:50:49.563Z"
+        "model": "fake-64",
+        "vectorSha256": "bb513e2e8f940b347d4dfc64a56e8d0ff95d1f4ae0a20a6c17d3b73cc6cbabdc",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-07": {
@@ -10826,13 +10694,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 7
+        "sequence": 6
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1140bbbf1e2c4372f991fbb06ca5b799cec7c6f8adea7a193b457016cf4e75c5",
-        "updatedAt": "2025-09-20T19:50:49.563Z"
+        "model": "fake-64",
+        "vectorSha256": "4fc397a350b56005d5992ebe2e9a48694d08bc3ba381b849783d97678b99e071",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-08": {
@@ -10848,13 +10716,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 8
+        "sequence": 7
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "cf19e3bfe0887fbf942fa64a562f54cd06ec88a1db6ee6983b8c2731099b2a16",
-        "updatedAt": "2025-09-20T19:50:49.563Z"
+        "model": "fake-64",
+        "vectorSha256": "5bb901ccac6ee5fe7e8dd3ac9cd07feed2f521dee7c65eb23300f3e2f6052125",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-09": {
@@ -10870,13 +10738,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 9
+        "sequence": 8
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "e5aa936ee6ee6ede096a0d3056e649c55994367acf4ad12184fc7731c7fdd3c3",
-        "updatedAt": "2025-09-20T19:50:49.563Z"
+        "model": "fake-64",
+        "vectorSha256": "95b5ef4e932b536de265ced5afa9a41a712322922636ae552dca093ab7f11f96",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-10": {
@@ -10892,13 +10760,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 10
+        "sequence": 9
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "65d36b876719ca2faac1895c4dda751831806aaa2f97810093e456e6f498c637",
-        "updatedAt": "2025-09-20T19:50:49.563Z"
+        "model": "fake-64",
+        "vectorSha256": "90bedcc64c7c2ffbd1e19e160bb6764cba41163cbb6c6fa3c0162c0285181617",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-11": {
@@ -10914,13 +10782,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 11
+        "sequence": 10
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "710c91261e30791cf7be0db33f203ceb37ae78c37ecbf8db8fd3c4a6891ce05f",
-        "updatedAt": "2025-09-20T19:50:49.758Z"
+        "model": "fake-64",
+        "vectorSha256": "f46080e75c117968a8f4e080bb2b87b7848323dd1d9ef2097a288c5dd426457e",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-12": {
@@ -10936,13 +10804,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 12
+        "sequence": 11
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f06b9b2338f42896a65d2315797535aaa67a473e560b7a6d2a04b06c8f391c1d",
-        "updatedAt": "2025-09-20T19:50:49.758Z"
+        "model": "fake-64",
+        "vectorSha256": "d564644810fdeb3cf75dd2137381f14ae8d39fc95d90f7194271e01c00716ff0",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-13": {
@@ -10958,13 +10826,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 13
+        "sequence": 12
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "db0d3ef27d8c5c6a9fc0d448aacdd2bee95eef62feacf87408c0e6074d02597c",
-        "updatedAt": "2025-09-20T19:50:49.758Z"
+        "model": "fake-64",
+        "vectorSha256": "88d76642a100ce0aa538b4bee83b90be6d26ce14ecf9d796e3b268e2f0715acf",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-14": {
@@ -10980,13 +10848,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 14
+        "sequence": 13
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "30285136bf17d1b5c617ab20295f58332372b729e14708f964619ea176dc27b8",
-        "updatedAt": "2025-09-20T19:50:49.758Z"
+        "model": "fake-64",
+        "vectorSha256": "14d26cec85ff1973d6b5a366c924b7772deb836a20b51a2b9abd3015ec4b6bf7",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-15": {
@@ -11002,13 +10870,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 15
+        "sequence": 14
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "0e60f930385b17bcb571d57c11bfd54b7d3427b4819d683a652f34453ae0da9d",
-        "updatedAt": "2025-09-20T19:50:49.758Z"
+        "model": "fake-64",
+        "vectorSha256": "8ca42a3b408f04093a2a70a9092397a50dd238e378e94e3ed5cb2d294778a53c",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-16": {
@@ -11024,13 +10892,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 16
+        "sequence": 15
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3afc77d1347674d0b77fa0f6297c973d2bb9d27972e7fe01f8ec049a34667ff9",
-        "updatedAt": "2025-09-20T19:50:49.758Z"
+        "model": "fake-64",
+        "vectorSha256": "bfde36c1f1ceecf7cbd5ba08047bc40be1ad484eac08a52a4a79cd145b0dcdc9",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-17": {
@@ -11046,13 +10914,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 17
+        "sequence": 16
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "45bf63ad66b512a08f86d6df74d04f12d5f9c8e313997f77f367cd92729da254",
-        "updatedAt": "2025-09-20T19:50:49.758Z"
+        "model": "fake-64",
+        "vectorSha256": "caffcef11e4af31c7744e66ba8c8f1a1c9d9ab5fa72511b9a0e20ec992f572a1",
+        "updatedAt": "2025-09-20T22:28:15.460Z"
       }
     },
     "positive-18": {
@@ -11068,13 +10936,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 18
+        "sequence": 17
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a6da1463504bed51ebd7a09ab3966d101367ebcf98293ba092815a1e6f8f6716",
-        "updatedAt": "2025-09-20T19:50:49.758Z"
+        "model": "fake-64",
+        "vectorSha256": "da63a90f08a85cd4298f32a1bf510c19814302ef2de55aa7d1596c0dff866819",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-19": {
@@ -11090,13 +10958,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 19
+        "sequence": 18
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d8c995711e54d8fbd6b544723cb387520805b9cc9860ddf7b6c0051cd972160a",
-        "updatedAt": "2025-09-20T19:50:49.992Z"
+        "model": "fake-64",
+        "vectorSha256": "886fcd7a341a9ee8ed33c1365be88105d16cbb75704a61834fc403d5e0ea1b09",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-20": {
@@ -11112,13 +10980,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 20
+        "sequence": 19
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c81a3e1c81ee2445cfcdcba5b69760d1746f0d8cc150a20914831da382087086",
-        "updatedAt": "2025-09-20T19:50:49.992Z"
+        "model": "fake-64",
+        "vectorSha256": "2659a2f74fea7d59999363e617d5a0672fe19107f71e9e16484eff0307795c88",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-21": {
@@ -11134,13 +11002,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 21
+        "sequence": 20
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c9961b65cf68d0e462974ae335a134a7607c550cbdc58ddebd32477f405c934c",
-        "updatedAt": "2025-09-20T19:50:49.992Z"
+        "model": "fake-64",
+        "vectorSha256": "699f2a38698ad7dad169aeb2360101094ea5598120ef97cecd2c29f1167860ea",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-22": {
@@ -11156,13 +11024,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 22
+        "sequence": 21
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2cbc25e6283c6614373fff226466538409a3e23267dfe62500e1d992238ca51f",
-        "updatedAt": "2025-09-20T19:50:49.993Z"
+        "model": "fake-64",
+        "vectorSha256": "c78946e6fea1fd7dafffefcc3a49975e47d657df5f34ceaccfe19f0f47a20b28",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-23": {
@@ -11178,13 +11046,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 23
+        "sequence": 22
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "3855ea42ff4a0ffc44e2b86d6a523f24d56b003f9872c2aab6a644433454fa92",
-        "updatedAt": "2025-09-20T19:50:49.993Z"
+        "model": "fake-64",
+        "vectorSha256": "ec81f44b4d84c21eb802471857782d5450a0c1e615bb9939a98eeb14abfe8b4f",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-24": {
@@ -11200,13 +11068,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 24
+        "sequence": 23
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f8cb653979fb424377da85814a6b01d2d829b49ea35684afbf8ddbe41804c635",
-        "updatedAt": "2025-09-20T19:50:49.993Z"
+        "model": "fake-64",
+        "vectorSha256": "395735cd36e6fc70db25f7a23027f9f4d0debae20f977b81ba86b8b54c6513f9",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-25": {
@@ -11222,13 +11090,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 25
+        "sequence": 24
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2926ec767df98c60cf0a6f481292051027279b57c073b7e168d53bb40fe04c03",
-        "updatedAt": "2025-09-20T19:50:49.993Z"
+        "model": "fake-64",
+        "vectorSha256": "2b64f9cb872abb33f8a73fed79ae270f7ea2e9e54130b659473d10e746d06b89",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-26": {
@@ -11244,13 +11112,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 26
+        "sequence": 25
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "078d3bf8e54073900c7b309b94566d60aea1caf8e89346a2138bb381a9a41647",
-        "updatedAt": "2025-09-20T19:50:49.993Z"
+        "model": "fake-64",
+        "vectorSha256": "df43de72066dd971268823231bae266dc2b13c1e68d9b8d6541aef021631b732",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-27": {
@@ -11266,13 +11134,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 27
+        "sequence": 26
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "5a922f1b520b61260b986c847329420edfcc0972368ebde06dcfcd8d1112e2ce",
-        "updatedAt": "2025-09-20T19:50:50.286Z"
+        "model": "fake-64",
+        "vectorSha256": "09c0ffcd204a2bdfe57105f928bea84ee68ebfc4c58fffaf3819b375fa2bd8f2",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-28": {
@@ -11288,13 +11156,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 28
+        "sequence": 27
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "37e0569f6c26a01c4838a2f24f1d57922fd89181ea7d00811436245db2ec10b4",
-        "updatedAt": "2025-09-20T19:50:50.286Z"
+        "model": "fake-64",
+        "vectorSha256": "ed0a6a1ea2a0a65ae9e7b87c14f69cebddcea6280a7bd16e8cbd34495687c1dd",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-29": {
@@ -11310,13 +11178,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 29
+        "sequence": 28
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "29a21ed7e116bd58dd8d8df9833c5db2c4ef55bcee474240307e30654668c3ad",
-        "updatedAt": "2025-09-20T19:50:50.286Z"
+        "model": "fake-64",
+        "vectorSha256": "f398d90995259cdb1af38983454019c84c919ef3301adec3f73d2693b34d38a7",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-30": {
@@ -11332,13 +11200,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 30
+        "sequence": 29
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8e3e7c7dca80a67d71ac2c3035b35055979417d9ba637d44e0dfb32955bb2a71",
-        "updatedAt": "2025-09-20T19:50:50.286Z"
+        "model": "fake-64",
+        "vectorSha256": "6a8bf7198386493911dbbe6cf0c8c5062a2d5ad85c10258c5b01fbca31ad0d29",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-31": {
@@ -11354,13 +11222,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 31
+        "sequence": 30
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "fd593fdd5879454eebe32987d2d1dd634794671bc6a3a35a2d09a0301411e01c",
-        "updatedAt": "2025-09-20T19:50:50.287Z"
+        "model": "fake-64",
+        "vectorSha256": "4659fd607330b31dbcf4cc3c47cbc8de8fd4b5d6902c457741789bfc6a9fadc4",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-32": {
@@ -11376,13 +11244,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 32
+        "sequence": 31
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "45ded85cce310c46d4b526c561e952647cc80334fb6605861aa03498b1d1b2bc",
-        "updatedAt": "2025-09-20T19:50:50.287Z"
+        "model": "fake-64",
+        "vectorSha256": "6e57f66cb17f592c88773a00395092f0ea42a21b3e8f520823065afcba59dff1",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-33": {
@@ -11398,13 +11266,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 33
+        "sequence": 32
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1b150b657678e3203e7ccd8ab82a5f52e48696c263d1eaed3a1ecde3a0d1227e",
-        "updatedAt": "2025-09-20T19:50:50.287Z"
+        "model": "fake-64",
+        "vectorSha256": "6b25089f4f004bba4fe0b8db05a9cb569a31afb17b7e27c28c20cb4cad991da4",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-34": {
@@ -11420,13 +11288,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 34
+        "sequence": 33
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "02411af7b6cf83af336915261c719a1dc9655d700a250c286299913218fa6658",
-        "updatedAt": "2025-09-20T19:50:50.287Z"
+        "model": "fake-64",
+        "vectorSha256": "6fcd84847214c6cb7cf5c0b172f3e0f78c2026c408b9374608f795fc3af51dd9",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-35": {
@@ -11442,13 +11310,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 35
+        "sequence": 34
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "c9669a8542bf0a672d440bf6c03db5137036903fc84d01d0a67fa28fa418af79",
-        "updatedAt": "2025-09-20T19:50:50.645Z"
+        "model": "fake-64",
+        "vectorSha256": "538e54062f2a6446b8ea82947483fda302eb405e4f5a11881011569227ba2aed",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-36": {
@@ -11464,13 +11332,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 36
+        "sequence": 35
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "a93e26463435e65eefe9f0c230d2545b494fe3b60046c508f9cecc527489e9f5",
-        "updatedAt": "2025-09-20T19:50:50.645Z"
+        "model": "fake-64",
+        "vectorSha256": "3848de4bc7e6a0935db478478b6a9a179ca362e60ee826d0d984db2783ae816e",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-37": {
@@ -11486,13 +11354,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 37
+        "sequence": 36
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "1ca8c747222d89f6f70a791c5f1f6f87100e0cc342108490166fd684ce5ec13e",
-        "updatedAt": "2025-09-20T19:50:50.645Z"
+        "model": "fake-64",
+        "vectorSha256": "171a4d8c7c13ac1be18a74acd1e580454153935bcb59881dbd9df19bcc72950e",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "positive-38": {
@@ -11508,13 +11376,13 @@
       },
       "source": {
         "categoryId": "positive",
-        "sequence": 38
+        "sequence": 37
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "11820cbaeb62c0dbb7a43fbbd16201095ebc36748423954525e94d2d6059cbdd",
-        "updatedAt": "2025-09-20T19:50:50.645Z"
+        "model": "fake-64",
+        "vectorSha256": "449c70d80a2a967d8ef6d6b11134ad34dd166d050fdccf7ba879e9cc7324394a",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "happiness-01": {
@@ -11534,9 +11402,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8648d40ee7f65541b7aa7e79f802e6329eebb7ee2da4d23740db4b25d8a41f2c",
-        "updatedAt": "2025-09-20T19:50:50.645Z"
+        "model": "fake-64",
+        "vectorSha256": "7e84064cceebca70002d23070a868955f06c9b0adce3c7f691376a4970fbd6c3",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "happiness-02": {
@@ -11556,9 +11424,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "2e60a2d3ffbfb0fe17dba12e0ce45238de3e6b594a9314a537b55aa887b6cfe4",
-        "updatedAt": "2025-09-20T19:50:50.645Z"
+        "model": "fake-64",
+        "vectorSha256": "fd2ab5d3a1a97ba7ff2bb371164d98b217203e043643189354314638f6ccaa07",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "happiness-03": {
@@ -11578,9 +11446,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "4d54643ebbaa133f9587b1002820a5ac672ac5364355162534db15fe40984b34",
-        "updatedAt": "2025-09-20T19:50:50.646Z"
+        "model": "fake-64",
+        "vectorSha256": "b958bf423dd9e7174d3793cb565454ba1fb1d3b11b91afee8c72f9c27e39c726",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "happiness-04": {
@@ -11600,9 +11468,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "7ae34822f70a495ef6bf107e00b244f6fbe96dc251fb3a061658c5a505b299f2",
-        "updatedAt": "2025-09-20T19:50:50.646Z"
+        "model": "fake-64",
+        "vectorSha256": "9e990202aed53dd6c1b784ebb2f981bf42a0fd947313ae39f17eed991f7ed368",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "happiness-05": {
@@ -11622,9 +11490,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ca17f726c0d79af5c6edd3dc7aa13dd0da7d57d7ae064356c71a4331ccb8ca19",
-        "updatedAt": "2025-09-20T19:50:50.901Z"
+        "model": "fake-64",
+        "vectorSha256": "fb69336fbe9a8b8034c1e483fa78ba2e71e32d50bdecd2822fdf225f38aebfa5",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "happiness-06": {
@@ -11644,9 +11512,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "f61a01f6437e5eef9bc2be7477caf892d153fba966dd9de15d601eae929cf68f",
-        "updatedAt": "2025-09-20T19:50:50.901Z"
+        "model": "fake-64",
+        "vectorSha256": "313b8e8dfa06ddd2fd441b24133a5db2a738e6d4639ae417499347ae20c556bf",
+        "updatedAt": "2025-09-20T22:28:15.461Z"
       }
     },
     "happiness-07": {
@@ -11666,9 +11534,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "6b0165730846414340487206c429ea12d213dbfc643a20bd5f1b77c9823d6a42",
-        "updatedAt": "2025-09-20T19:50:50.902Z"
+        "model": "fake-64",
+        "vectorSha256": "2aef37f20b7a0584359f54baccc863c8eeb9effab367428a3081333702e6309e",
+        "updatedAt": "2025-09-20T22:28:15.462Z"
       }
     },
     "happiness-08": {
@@ -11688,9 +11556,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ed52d97541072ab454d833631631beb34f8b529af0d99aa76843385679e21e3f",
-        "updatedAt": "2025-09-20T19:50:50.902Z"
+        "model": "fake-64",
+        "vectorSha256": "469d72e49eba785612b69d72f9b0038ad72a966b0f7d607d8ff7ae6ddb61939d",
+        "updatedAt": "2025-09-20T22:28:15.462Z"
       }
     },
     "happiness-09": {
@@ -11710,9 +11578,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "8508aeda31eda33be8b9b309d31ff0240ca301f9f711989491cd7ce9310d949e",
-        "updatedAt": "2025-09-20T19:50:50.902Z"
+        "model": "fake-64",
+        "vectorSha256": "286bffb831dfcba067b98232ce4ca77d7a91ab8c7b5e4331521e71330ff77bf2",
+        "updatedAt": "2025-09-20T22:28:15.462Z"
       }
     },
     "happiness-10": {
@@ -11732,9 +11600,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "ab857c715592dea0214613a1bbb01e9c4dcc9aa4ba09f16a0830b30e755c0c76",
-        "updatedAt": "2025-09-20T19:50:50.902Z"
+        "model": "fake-64",
+        "vectorSha256": "f2d8b1b81122018f07f8b5b384f9e19a37df69ac75cff576520c3805ebf978f5",
+        "updatedAt": "2025-09-20T22:28:15.462Z"
       }
     },
     "happiness-11": {
@@ -11754,9 +11622,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "219a519d4636e752afe8362baa92bf59be40c6afe944d9eda368a417585feb8c",
-        "updatedAt": "2025-09-20T19:50:50.902Z"
+        "model": "fake-64",
+        "vectorSha256": "a7505056d637ad18f0727dd75e816f982aacecb98df07707ecef891076a88e62",
+        "updatedAt": "2025-09-20T22:28:15.462Z"
       }
     },
     "happiness-12": {
@@ -11776,9 +11644,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "d7a9f4960f5e8ee8e0777bb77fab082dd47f241d4f218632437d785c13ec002d",
-        "updatedAt": "2025-09-20T19:50:50.902Z"
+        "model": "fake-64",
+        "vectorSha256": "8137cfa4636b7a75d04f70fd12685dff3637793f21b739f8f26cd4c856c3832a",
+        "updatedAt": "2025-09-20T22:28:15.462Z"
       }
     },
     "happiness-13": {
@@ -11798,9 +11666,9 @@
       },
       "embedding": {
         "status": "ready",
-        "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
-        "vectorSha256": "bf05cbe83a64f27555ed4d8f522a6aeeeb241cd5866535bc95113bd480269686",
-        "updatedAt": "2025-09-20T19:50:51.096Z"
+        "model": "fake-64",
+        "vectorSha256": "ad385c890ed9e4ed9395080eca818c32364ab6de99d0681334dfc99150255ba3",
+        "updatedAt": "2025-09-20T22:28:15.462Z"
       }
     }
   }

--- a/tools/review-content-similarity.js
+++ b/tools/review-content-similarity.js
@@ -15,6 +15,7 @@ const rootDir = path.join(__dirname, '..');
 function parseArgs(argv) {
   const options = {
     datasets: new Set(),
+    candidateFiles: new Map(),
     provider: null,
     model: null,
     batchSize: 16,
@@ -45,6 +46,33 @@ function parseArgs(argv) {
     }
     if (arg.startsWith('--provider=')) {
       options.provider = arg.slice('--provider='.length).trim().toLowerCase();
+      return;
+    }
+    if (arg.startsWith('--candidates=')) {
+      const value = arg.slice('--candidates='.length).trim();
+      if (value) {
+        value.split(',').forEach((segment) => {
+          const trimmed = segment.trim();
+          if (!trimmed) {
+            return;
+          }
+          const separator = trimmed.indexOf(':');
+          if (separator === -1) {
+            console.warn(`Ignoring --candidates entry without dataset prefix: ${trimmed}`);
+            return;
+          }
+          const dataset = trimmed.slice(0, separator).trim().toLowerCase();
+          const filePath = trimmed.slice(separator + 1).trim();
+          if (!dataset || !filePath) {
+            return;
+          }
+          if (dataset !== 'jokes' && dataset !== 'quotes') {
+            console.warn(`Ignoring unsupported dataset for --candidates: ${dataset}`);
+            return;
+          }
+          options.candidateFiles.set(dataset, filePath);
+        });
+      }
       return;
     }
     if (arg.startsWith('--model=')) {
@@ -198,6 +226,98 @@ function loadDataset(name) {
   }
 
   throw new Error(`Unsupported dataset: ${name}`);
+}
+
+function toStringOrEmpty(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return String(value);
+}
+
+function prepareJokeCandidate(entry, index) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const idBase = typeof entry.id === 'string' ? entry.id.trim() : '';
+  const id = idBase || `candidate-${String(index + 1).padStart(3, '0')}`;
+  const labelBase = typeof entry.label === 'string' ? entry.label.trim() : '';
+  const label = labelBase || id;
+  const setup = toStringOrEmpty(entry.joke || entry.setup || '').trim();
+  const punchline = toStringOrEmpty(entry.punchline || entry.answer || '').trim();
+  if (!setup && !punchline) {
+    return null;
+  }
+  const embeddingInput = [setup, punchline].filter(Boolean).join(' \u2022 ');
+  return {
+    id,
+    label,
+    joke: setup,
+    punchline,
+    embeddingInput,
+    normalized: normalizeText(`${setup} ${punchline}`),
+    textHash: sha256(embeddingInput),
+    source: entry,
+  };
+}
+
+function prepareQuoteCandidate(entry, index) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const idBase = typeof entry.id === 'string' ? entry.id.trim() : '';
+  const id = idBase || `candidate-${String(index + 1).padStart(3, '0')}`;
+  const labelBase = typeof entry.label === 'string' ? entry.label.trim() : '';
+  const label = labelBase || id;
+  const text = toStringOrEmpty(entry.text).trim();
+  const author = toStringOrEmpty(entry.author).trim();
+  if (!text) {
+    return null;
+  }
+  const embeddingInput = author ? `${text} — ${author}` : text;
+  return {
+    id,
+    label,
+    text,
+    author,
+    embeddingInput,
+    normalized: normalizeText(`${text} ${author}`),
+    textHash: sha256(embeddingInput),
+    source: entry,
+  };
+}
+
+function loadCandidateFile(datasetName, filePath) {
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(rootDir, filePath);
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`[${datasetName}] Candidate file not found: ${filePath}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+  } catch (error) {
+    throw new Error(`[${datasetName}] Failed to parse candidate file ${filePath}: ${error.message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`[${datasetName}] Candidate file ${filePath} must contain an array of entries.`);
+  }
+  const prepared = [];
+  parsed.forEach((entry, index) => {
+    let candidate = null;
+    if (datasetName === 'jokes') {
+      candidate = prepareJokeCandidate(entry, index);
+    } else if (datasetName === 'quotes') {
+      candidate = prepareQuoteCandidate(entry, index);
+    }
+    if (candidate) {
+      prepared.push(candidate);
+    }
+  });
+  return {
+    absolutePath,
+    originalLength: parsed.length,
+    entries: prepared,
+  };
 }
 
 function loadManifest(name) {
@@ -709,6 +829,110 @@ function findSimilarPairs(datasetName, entries, manifest, store, threshold, opti
   return matches;
 }
 
+async function embedCandidateEntries(datasetName, candidates, options) {
+  if (!candidates.length) {
+    return null;
+  }
+  if (!options.provider) {
+    throw new Error(`[${datasetName}] --provider is required when using --candidates.`);
+  }
+  if (options.dryRun) {
+    console.log(`[${datasetName}] Dry run: would fetch embeddings for ${candidates.length} candidate entr${candidates.length === 1 ? 'y' : 'ies'} from ${options.provider}.`);
+    return null;
+  }
+  const batches = chunkArray(candidates, options.batchSize);
+  console.log(`[${datasetName}] Fetching embeddings for ${candidates.length} candidate entr${candidates.length === 1 ? 'y' : 'ies'} in ${batches.length} batch${batches.length === 1 ? '' : 'es'}.`);
+  const vectors = [];
+  let usedModel = null;
+  let dimensions = null;
+  for (let i = 0; i < batches.length; i += 1) {
+    const batch = batches[i];
+    const texts = batch.map((candidate) => candidate.embeddingInput);
+    const { vectors: batchVectors, model, dimensions: batchDimensions } = await fetchEmbeddings(options.provider, options.model, texts, options);
+    if (!usedModel) {
+      usedModel = model;
+    }
+    if (!dimensions) {
+      dimensions = batchDimensions;
+    }
+    batchVectors.forEach((vector) => {
+      vectors.push(vector);
+    });
+  }
+  return { vectors, model: usedModel, dimensions };
+}
+
+function compareCandidateVectors(entries, store, candidates, candidateVectors, threshold) {
+  const datasetVectors = new Map();
+  Object.entries(store.records || {}).forEach(([id, record]) => {
+    if (!record || !record.vector) {
+      return;
+    }
+    datasetVectors.set(id, base64ToVector(record.vector));
+  });
+
+  const entryMap = new Map();
+  entries.forEach((entry) => {
+    entryMap.set(entry.id, entry);
+  });
+
+  const datasetMatches = [];
+  candidates.forEach((candidate, index) => {
+    const vectorA = candidateVectors[index];
+    if (!vectorA || !vectorA.length) {
+      return;
+    }
+    datasetVectors.forEach((vectorB, id) => {
+      if (!vectorB || vectorB.length !== vectorA.length) {
+        return;
+      }
+      const similarity = cosineSimilarity(vectorA, vectorB);
+      if (similarity >= threshold) {
+        const entry = entryMap.get(id);
+        datasetMatches.push({
+          candidateId: candidate.id,
+          candidateLabel: candidate.label,
+          datasetId: id,
+          similarity,
+          candidatePreview: candidate.embeddingInput.slice(0, 120),
+          datasetPreview: entry ? entry.embeddingInput.slice(0, 120) : '',
+        });
+      }
+    });
+  });
+
+  const candidateMatches = [];
+  for (let i = 0; i < candidates.length; i += 1) {
+    const vectorA = candidateVectors[i];
+    if (!vectorA || !vectorA.length) {
+      continue;
+    }
+    for (let j = i + 1; j < candidates.length; j += 1) {
+      const vectorB = candidateVectors[j];
+      if (!vectorB || vectorB.length !== vectorA.length) {
+        continue;
+      }
+      const similarity = cosineSimilarity(vectorA, vectorB);
+      if (similarity >= threshold) {
+        candidateMatches.push({
+          aId: candidates[i].id,
+          aLabel: candidates[i].label,
+          bId: candidates[j].id,
+          bLabel: candidates[j].label,
+          similarity,
+          aPreview: candidates[i].embeddingInput.slice(0, 120),
+          bPreview: candidates[j].embeddingInput.slice(0, 120),
+        });
+      }
+    }
+  }
+
+  datasetMatches.sort((left, right) => right.similarity - left.similarity);
+  candidateMatches.sort((left, right) => right.similarity - left.similarity);
+
+  return { datasetMatches, candidateMatches };
+}
+
 function updateManifestEmbedding(manifest, id, update) {
   if (!manifest.records || !manifest.records[id]) {
     return;
@@ -814,7 +1038,7 @@ async function ensureEmbeddingsForDataset(datasetName, entries, manifest, store,
   return { store, updated: updates.length > 0, updates };
 }
 
-function writeReport(reportPath, datasetName, matches, threshold, storeMeta) {
+function writeReport(reportPath, datasetName, matches, threshold, storeMeta, candidateSummary) {
   const report = {
     dataset: datasetName,
     threshold,
@@ -829,6 +1053,32 @@ function writeReport(reportPath, datasetName, matches, threshold, storeMeta) {
       previewB: match.previewB,
     })),
   };
+  if (candidateSummary) {
+    report.candidates = {
+      sourcePath: candidateSummary.sourcePath,
+      totalProvided: candidateSummary.totalProvided,
+      totalPrepared: candidateSummary.totalPrepared,
+      provider: candidateSummary.provider || null,
+      model: candidateSummary.model || null,
+      datasetMatches: candidateSummary.datasetMatches.map((match) => ({
+        candidateId: match.candidateId,
+        candidateLabel: match.candidateLabel,
+        datasetId: match.datasetId,
+        similarity: match.similarity,
+        candidatePreview: match.candidatePreview,
+        datasetPreview: match.datasetPreview,
+      })),
+      candidateMatches: candidateSummary.candidateMatches.map((match) => ({
+        candidateA: match.aId,
+        candidateALabel: match.aLabel,
+        candidateB: match.bId,
+        candidateBLabel: match.bLabel,
+        similarity: match.similarity,
+        previewA: match.aPreview,
+        previewB: match.bPreview,
+      })),
+    };
+  }
   fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
   console.log(`Wrote report to ${path.relative(rootDir, reportPath)}`);
 }
@@ -882,11 +1132,78 @@ async function main() {
       }
     }
 
+    let candidateSummary = null;
+    const candidatePath = options.candidateFiles.get(datasetName);
+    if (candidatePath) {
+      const candidateData = loadCandidateFile(datasetName, candidatePath);
+      const relativeCandidatePath = path.relative(rootDir, candidateData.absolutePath);
+      console.log(`[${datasetName}] Loaded ${candidateData.entries.length} candidate entr${candidateData.entries.length === 1 ? 'y' : 'ies'} from ${relativeCandidatePath} (provided ${candidateData.originalLength}).`);
+      if (!candidateData.entries.length) {
+        console.log(`[${datasetName}] Candidate file did not contain any usable entries.`);
+      } else {
+        const candidateEmbeddings = await embedCandidateEntries(datasetName, candidateData.entries, options);
+        if (!candidateEmbeddings) {
+          console.log(`[${datasetName}] Candidate embeddings were not generated; rerun without --dry-run to evaluate overlaps.`);
+        } else if (!Array.isArray(candidateEmbeddings.vectors)
+          || candidateEmbeddings.vectors.length !== candidateData.entries.length) {
+          const received = Array.isArray(candidateEmbeddings.vectors) ? candidateEmbeddings.vectors.length : 0;
+          console.warn(`[${datasetName}] Candidate embedding count mismatch (${received} vs ${candidateData.entries.length}); skipping candidate comparison.`);
+        } else {
+          const comparison = compareCandidateVectors(entries, store, candidateData.entries, candidateEmbeddings.vectors, threshold);
+          candidateSummary = {
+            sourcePath: relativeCandidatePath,
+            totalProvided: candidateData.originalLength,
+            totalPrepared: candidateData.entries.length,
+            provider: options.provider,
+            model: candidateEmbeddings.model,
+            datasetMatches: comparison.datasetMatches,
+            candidateMatches: comparison.candidateMatches,
+          };
+
+          if (!comparison.datasetMatches.length) {
+            console.log(`[${datasetName}] No candidate overlaps with existing records above ${threshold}.`);
+          } else {
+            console.log(`[${datasetName}] ${comparison.datasetMatches.length} candidate entr${comparison.datasetMatches.length === 1 ? 'y' : 'ies'} overlap existing records ≥ ${threshold}.`);
+            comparison.datasetMatches.slice(0, 10).forEach((match, index) => {
+              console.log(`  ${index + 1}. ${match.candidateLabel} ↔ ${match.datasetId} (similarity: ${match.similarity.toFixed(4)})`);
+              if (match.candidatePreview) {
+                console.log(`     • candidate: ${match.candidatePreview}`);
+              }
+              if (match.datasetPreview) {
+                console.log(`     • existing: ${match.datasetPreview}`);
+              }
+            });
+            if (comparison.datasetMatches.length > 10) {
+              console.log(`  … ${comparison.datasetMatches.length - 10} more matches`);
+            }
+          }
+
+          if (!comparison.candidateMatches.length) {
+            console.log(`[${datasetName}] No duplicates detected among candidate entries above ${threshold}.`);
+          } else {
+            console.log(`[${datasetName}] ${comparison.candidateMatches.length} candidate pair${comparison.candidateMatches.length === 1 ? '' : 's'} exceed the ${threshold} similarity threshold.`);
+            comparison.candidateMatches.slice(0, 10).forEach((match, index) => {
+              console.log(`  ${index + 1}. ${match.aLabel} ↔ ${match.bLabel} (similarity: ${match.similarity.toFixed(4)})`);
+              if (match.aPreview) {
+                console.log(`     • A: ${match.aPreview}`);
+              }
+              if (match.bPreview) {
+                console.log(`     • B: ${match.bPreview}`);
+              }
+            });
+            if (comparison.candidateMatches.length > 10) {
+              console.log(`  … ${comparison.candidateMatches.length - 10} more candidate overlaps`);
+            }
+          }
+        }
+      }
+    }
+
     if (options.reportPath) {
       const absoluteReportPath = path.isAbsolute(options.reportPath)
         ? options.reportPath
         : path.join(rootDir, options.reportPath.replace(/\{dataset\}/g, datasetName));
-      writeReport(absoluteReportPath, datasetName, matches, threshold, store.meta);
+      writeReport(absoluteReportPath, datasetName, matches, threshold, store.meta, candidateSummary);
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove jokes and quotes flagged with cosine similarity ≥ 0.80 and regenerate the datasets and manifests
- write fresh fake-embedding stores so similarity scans run against the trimmed decks
- extend review-content-similarity with a --candidates option for onboarding checks and document the workflow

## Testing
- node --check apps/jokes/jokes.js
- node -e "global.window = {}; require('./apps/jokes/jokes.js'); console.log(Array.isArray(window.jokes), window.jokes.length);"
- node -e "global.window={}; require('./apps/quotes/quotes-data.js'); const data=window.quotesData; console.log(Array.isArray(data), data.reduce((t,cat)=>t+(Array.isArray(cat.quotes)?cat.quotes.length:0),0));"
- node tools/review-content-similarity.js --dataset=jokes --provider=fake --batch-size=8 --threshold-jokes=0.8 --candidates=jokes:/tmp/joke-candidates.json --write --update-manifest
- node tools/review-content-similarity.js --dataset=quotes --provider=fake --batch-size=8 --threshold-quotes=0.8 --write --update-manifest

------
https://chatgpt.com/codex/tasks/task_e_68cf253af204832886c14034fe7cd3ae