### PR TITLE
Lower similarity lab threshold to 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lightweight browser apps served from a single landing page. Each
 
 - **Random Jokes** – Shuffle developer-friendly jokes, reveal punchlines on demand, and jump to the full archive when you need more context.
 - **Quotes** – Shuffle themed quote decks, step back whenever you like, and explore every line in the all-in-one archive.
-- **Cosine Similarity Lab** – Explore the 0.70+ cosine matches we keep on file, tweak the minimum score, and compare entries side by side with vector stats.
+- **Cosine Similarity Lab** – Explore the 0.50+ cosine matches we keep on file, tweak the minimum score, and compare entries side by side with vector stats.
 - **Value Formatter** – Turn newline-separated entries into formatted key-value pairs for quick copy/paste in code reviews or data preparation.
 
 ## Usage

--- a/apps/similarity-report/index.html
+++ b/apps/similarity-report/index.html
@@ -712,7 +712,7 @@
             Minimum cosine similarity: <strong data-threshold-label>0.00</strong>
             <span class="slider-floor" data-threshold-floor hidden>(floor —)</span>
           </span>
-          <input type="range" min="0.7" max="0.95" step="0.001" value="0.7" data-min-similarity>
+          <input type="range" min="0.5" max="0.95" step="0.001" value="0.5" data-min-similarity>
         </label>
         <label>
           <span>Find by ID or text</span>
@@ -727,7 +727,7 @@
         </article>
         <article class="stat-card">
           <h2>Report baseline</h2>
-          <div class="stat-value"><span data-baseline>0.70</span></div>
+          <div class="stat-value"><span data-baseline>0.50</span></div>
           <p class="stat-meta">Threshold baked into the report</p>
         </article>
         <article class="stat-card">
@@ -918,7 +918,7 @@
 
       const state = {
         dataset: 'jokes',
-        minSimilarity: parseFloat(slider.value) || 0.7,
+        minSimilarity: parseFloat(slider.value) || 0.5,
         search: '',
         sortKey: 'similarity',
         sortDirection: 'desc',
@@ -1544,7 +1544,7 @@
       }
 
       function hydrateDataset(name, report) {
-        const fallbackThreshold = report && typeof report.threshold === 'number' ? report.threshold : 0.7;
+        const fallbackThreshold = report && typeof report.threshold === 'number' ? report.threshold : 0.5;
         const matches = report && Array.isArray(report.matches) ? report.matches : [];
         const bounds = computeSimilarityBounds(matches);
         const hasMatches = matches.length > 0;

--- a/data/similarity-report-jokes.json
+++ b/data/similarity-report-jokes.json
@@ -1,6 +1,6 @@
 {
   "dataset": "jokes",
-  "threshold": 0.7,
+  "threshold": 0.5,
   "generatedAt": "2025-09-21T00:51:13.274Z",
   "provider": "hfspace",
   "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",

--- a/data/similarity-report-quotes.json
+++ b/data/similarity-report-quotes.json
@@ -1,6 +1,6 @@
 {
   "dataset": "quotes",
-  "threshold": 0.7,
+  "threshold": 0.5,
   "generatedAt": "2025-09-21T00:51:32.555Z",
   "provider": "hfspace",
   "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
       <li>
         <a class="app-card" href="apps/similarity-report/">
           <h2>Cosine Similarity Lab</h2>
-          <p>Review 0.70+ cosine matches, filter by score or text, and inspect each pair’s geeky vector stats.</p>
+          <p>Review 0.50+ cosine matches, filter by score or text, and inspect each pair’s geeky vector stats.</p>
         </a>
       </li>
     </ul>

--- a/tests/similarity-report.spec.js
+++ b/tests/similarity-report.spec.js
@@ -20,7 +20,7 @@ test.describe('Cosine Similarity Lab', () => {
 
     const sliderMinAttr = await slider.getAttribute('min');
     const sliderMin = Number.parseFloat(sliderMinAttr || '0');
-    expect(sliderMin).toBeGreaterThanOrEqual(0.7);
+    expect(sliderMin).toBeGreaterThanOrEqual(0.5);
     expect(sliderMin).toBeLessThanOrEqual(0.95);
 
     const labelValue = parseLocaleNumber(await sliderLabel.textContent());


### PR DESCRIPTION
## Summary
- drop the similarity lab slider default and fallback threshold to 0.5 and show the new baseline in the UI
- update both similarity reports plus the landing page and README copy to describe the 0.50+ review floor
- adjust the Playwright smoke test to accept the lowered slider minimum

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf5bb7f1d08328bbc2a691a190aedd