### PR TITLE
Fix min/max controls for second opinion view

### DIFF
--- a/apps/similarity-report/index.html
+++ b/apps/similarity-report/index.html
@@ -2784,10 +2784,10 @@
           }
         }
         if (minSlider) {
-          minSlider.disabled = isDedupe;
+          minSlider.disabled = false;
         }
         if (maxSlider) {
-          maxSlider.disabled = isDedupe;
+          maxSlider.disabled = false;
         }
       }
 


### PR DESCRIPTION
## Summary
- keep the min/max similarity sliders enabled when switching to the second opinion dedupe view so the range selector works again

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d04e8d7c2483288f07996f6774aeb3