### PR TITLE
Fix second opinion metadata dates

### DIFF
--- a/data/jokes-embeddings-second-opinion.json
+++ b/data/jokes-embeddings-second-opinion.json
@@ -3,7 +3,7 @@
     "provider": "openai",
     "model": "text-embedding-3-large (second opinion)",
     "dimensions": 64,
-    "generatedAt": "2025-10-12T09:12:48.000Z",
+    "generatedAt": "2025-09-21T09:12:48.000Z",
     "recordCount": 11
   },
   "records": {

--- a/data/quotes-embeddings-second-opinion.json
+++ b/data/quotes-embeddings-second-opinion.json
@@ -3,7 +3,7 @@
     "provider": "openai",
     "model": "text-embedding-3-large (second opinion)",
     "dimensions": 64,
-    "generatedAt": "2025-10-12T09:12:48.000Z",
+    "generatedAt": "2025-09-21T09:12:48.000Z",
     "recordCount": 11
   },
   "records": {

--- a/data/similarity-report-cross-deck-second-opinion.json
+++ b/data/similarity-report-cross-deck-second-opinion.json
@@ -1,7 +1,7 @@
 {
   "dataset": "cross-deck",
   "threshold": 0.8,
-  "generatedAt": "2025-10-12T09:12:48.000Z",
+  "generatedAt": "2025-09-21T09:12:48.000Z",
   "provider": "openai",
   "model": "text-embedding-3-large (second opinion)",
   "matches": [

--- a/data/similarity-report-jokes-second-opinion.json
+++ b/data/similarity-report-jokes-second-opinion.json
@@ -1,7 +1,7 @@
 {
   "dataset": "jokes",
   "threshold": 0.8,
-  "generatedAt": "2025-10-12T09:12:48.000Z",
+  "generatedAt": "2025-09-21T09:12:48.000Z",
   "provider": "openai",
   "model": "text-embedding-3-large (second opinion)",
   "matches": [

--- a/data/similarity-report-quotes-second-opinion.json
+++ b/data/similarity-report-quotes-second-opinion.json
@@ -1,7 +1,7 @@
 {
   "dataset": "quotes",
   "threshold": 0.8,
-  "generatedAt": "2025-10-12T09:12:48.000Z",
+  "generatedAt": "2025-09-21T09:12:48.000Z",
   "provider": "openai",
   "model": "text-embedding-3-large (second opinion)",
   "matches": [


### PR DESCRIPTION
## Summary
- correct the generatedAt timestamp for all second-opinion embedding and similarity report datasets so they reflect September 21, 2025

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0570fb8308328a3ca92cfb65fcdde