### PR TITLE
Normalize second opinion metadata timestamps

### DIFF
--- a/data/jokes-embeddings-second-opinion.json
+++ b/data/jokes-embeddings-second-opinion.json
@@ -3,7 +3,7 @@
     "provider": "openai",
     "model": "text-embedding-3-large (second opinion)",
     "dimensions": 64,
-    "generatedAt": "2025-10-12T09:12:48.000Z",
+    "generatedAt": "2025-09-20T22:27:41.541Z",
     "recordCount": 11
   },
   "records": {

--- a/data/quotes-embeddings-second-opinion.json
+++ b/data/quotes-embeddings-second-opinion.json
@@ -3,7 +3,7 @@
     "provider": "openai",
     "model": "text-embedding-3-large (second opinion)",
     "dimensions": 64,
-    "generatedAt": "2025-10-12T09:12:48.000Z",
+    "generatedAt": "2025-09-21T03:05:51.944Z",
     "recordCount": 11
   },
   "records": {

--- a/data/similarity-report-cross-deck-second-opinion.json
+++ b/data/similarity-report-cross-deck-second-opinion.json
@@ -1,7 +1,7 @@
 {
   "dataset": "cross-deck",
   "threshold": 0.8,
-  "generatedAt": "2025-10-12T09:12:48.000Z",
+  "generatedAt": "2025-09-21T03:05:51.944Z",
   "provider": "openai",
   "model": "text-embedding-3-large (second opinion)",
   "matches": [

--- a/data/similarity-report-jokes-second-opinion.json
+++ b/data/similarity-report-jokes-second-opinion.json
@@ -1,7 +1,7 @@
 {
   "dataset": "jokes",
   "threshold": 0.8,
-  "generatedAt": "2025-10-12T09:12:48.000Z",
+  "generatedAt": "2025-09-20T22:27:41.541Z",
   "provider": "openai",
   "model": "text-embedding-3-large (second opinion)",
   "matches": [

--- a/data/similarity-report-quotes-second-opinion.json
+++ b/data/similarity-report-quotes-second-opinion.json
@@ -1,7 +1,7 @@
 {
   "dataset": "quotes",
   "threshold": 0.8,
-  "generatedAt": "2025-10-12T09:12:48.000Z",
+  "generatedAt": "2025-09-21T03:05:51.944Z",
   "provider": "openai",
   "model": "text-embedding-3-large (second opinion)",
   "matches": [

--- a/tools/fix-second-opinion-metadata.js
+++ b/tools/fix-second-opinion-metadata.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+
+function loadJson(relativePath) {
+  const absolutePath = path.join(rootDir, relativePath);
+  const contents = fs.readFileSync(absolutePath, 'utf8');
+  return { absolutePath, data: JSON.parse(contents) };
+}
+
+function writeJson(absolutePath, value) {
+  fs.writeFileSync(absolutePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function normalizeEmbeddingsMeta(relativePath) {
+  const { absolutePath, data } = loadJson(relativePath);
+  const records = data && data.records ? Object.values(data.records) : [];
+  if (!records.length) {
+    throw new Error(`Embeddings store at ${relativePath} does not contain any records.`);
+  }
+  const latest = records.reduce((max, record) => {
+    if (!record || !record.updatedAt) {
+      return max;
+    }
+    const timestamp = Date.parse(record.updatedAt);
+    return Number.isNaN(timestamp) ? max : Math.max(max, timestamp);
+  }, Number.NEGATIVE_INFINITY);
+  if (!Number.isFinite(latest)) {
+    throw new Error(`Embeddings store at ${relativePath} has no valid updatedAt timestamps.`);
+  }
+  const generatedAt = new Date(latest).toISOString();
+  data.meta = data.meta || {};
+  data.meta.generatedAt = generatedAt;
+  data.meta.recordCount = records.length;
+  writeJson(absolutePath, data);
+  return generatedAt;
+}
+
+function updateReportTimestamp(relativePath, generatedAt) {
+  const { absolutePath, data } = loadJson(relativePath);
+  data.generatedAt = generatedAt;
+  writeJson(absolutePath, data);
+}
+
+function main() {
+  const embeddingsFiles = {
+    jokes: 'data/jokes-embeddings-second-opinion.json',
+    quotes: 'data/quotes-embeddings-second-opinion.json',
+  };
+
+  const generatedAtByDataset = Object.entries(embeddingsFiles).reduce((acc, [key, filePath]) => {
+    const timestamp = normalizeEmbeddingsMeta(filePath);
+    acc[key] = timestamp;
+    console.log(`Updated ${filePath} → ${timestamp}`);
+    return acc;
+  }, {});
+
+  const crossDeckGeneratedAt = ['jokes', 'quotes']
+    .map((key) => Date.parse(generatedAtByDataset[key] || ''))
+    .filter((value) => Number.isFinite(value))
+    .reduce((max, value) => Math.max(max, value), Number.NEGATIVE_INFINITY);
+  if (!Number.isFinite(crossDeckGeneratedAt)) {
+    throw new Error('Failed to resolve generatedAt timestamp for cross-deck report.');
+  }
+  const crossDeckTimestamp = new Date(crossDeckGeneratedAt).toISOString();
+
+  updateReportTimestamp('data/similarity-report-jokes-second-opinion.json', generatedAtByDataset.jokes);
+  console.log(`Updated data/similarity-report-jokes-second-opinion.json → ${generatedAtByDataset.jokes}`);
+
+  updateReportTimestamp('data/similarity-report-quotes-second-opinion.json', generatedAtByDataset.quotes);
+  console.log(`Updated data/similarity-report-quotes-second-opinion.json → ${generatedAtByDataset.quotes}`);
+
+  updateReportTimestamp('data/similarity-report-cross-deck-second-opinion.json', crossDeckTimestamp);
+  console.log(`Updated data/similarity-report-cross-deck-second-opinion.json → ${crossDeckTimestamp}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a small maintenance script that recalculates `generatedAt` from the latest `updatedAt` in the second-opinion embedding stores and applies the same timestamps to the related reports
- regenerate the second-opinion metadata using the script so the embeds and reports reflect their actual September 20–21, 2025 processing times

## Testing
- node --check tools/fix-second-opinion-metadata.js

------
https://chatgpt.com/codex/tasks/task_e_68d0570fb8308328a3ca92cfb65fcdde