### PR TITLE
Align OpenAI rerun assets with latest main

### DIFF
--- a/apps/similarity-report/index.html
+++ b/apps/similarity-report/index.html
@@ -1320,7 +1320,7 @@
         baseline: {
           key: 'baseline',
           label: 'MiniLM baseline',
-          description: 'hf.space/BienKieu report with an adjustable cosine window.',
+          description: 'hf.space/BienKieu run with an adjustable cosine window.',
           layout: 'matrix',
           initialState: {
             minSimilarity: 0.5,
@@ -1353,10 +1353,10 @@
             quotes: '../../data/quotes-embeddings.json',
           },
         },
-        secondOpinion: {
-          key: 'secondOpinion',
-          label: 'Second opinion (OpenAI)',
-          description: 'text-embedding-3-large rerun that flags anything at or above 0.80 for removal.',
+        openaiTextEmbedding3Large: {
+          key: 'openaiTextEmbedding3Large',
+          label: 'OpenAI text-embedding-3-large',
+          description: 'OpenAI rerun that flags anything at or above 0.80 cosine for removal.',
           layout: 'dedupe',
           dedupeThreshold: 0.8,
           initialState: {
@@ -1369,25 +1369,62 @@
             {
               dataset: 'jokes',
               label: 'Jokes deck',
-              report: '../../data/similarity-report-jokes-second-opinion.json',
-              placeholder: 'Try j-0081 or “waist of time”',
+              report: '../../data/similarity-report-jokes-openai.json',
+              placeholder: 'Try j-0081 ↔ j-0673',
             },
             {
               dataset: 'quotes',
               label: 'Quotes deck',
-              report: '../../data/similarity-report-quotes-second-opinion.json',
+              report: '../../data/similarity-report-quotes-openai.json',
               placeholder: 'Try motivation-14 ↔ positive-16',
             },
             {
               dataset: 'cross-deck',
               label: 'Cross-deck blend',
-              report: '../../data/similarity-report-cross-deck-second-opinion.json',
+              report: '../../data/similarity-report-cross-deck-openai.json',
               placeholder: 'Try humor-01 ↔ j-0001',
             },
           ],
           embeddings: {
-            jokes: '../../data/jokes-embeddings-second-opinion.json',
-            quotes: '../../data/quotes-embeddings-second-opinion.json',
+            jokes: '../../data/jokes-embeddings-openai.json',
+            quotes: '../../data/quotes-embeddings-openai.json',
+          },
+        },
+        cohereEmbedEnglishV3: {
+          key: 'cohereEmbedEnglishV3',
+          label: 'Cohere embed-english-v3.0',
+          description: 'Cohere sweep with a softer 0.78 floor to confirm near-duplicate pairs.',
+          layout: 'dedupe',
+          dedupeThreshold: 0.78,
+          initialState: {
+            minSimilarity: 0.78,
+            maxSimilarity: 1,
+            sortKey: 'similarity',
+            sortDirection: 'desc',
+          },
+          datasetOptions: [
+            {
+              dataset: 'jokes',
+              label: 'Jokes deck',
+              report: '../../data/similarity-report-jokes-cohere.json',
+              placeholder: 'Try j-0182 ↔ j-0246',
+            },
+            {
+              dataset: 'quotes',
+              label: 'Quotes deck',
+              report: '../../data/similarity-report-quotes-cohere.json',
+              placeholder: 'Try adventure-01 ↔ adventure-36',
+            },
+            {
+              dataset: 'cross-deck',
+              label: 'Cross-deck blend',
+              report: '../../data/similarity-report-cross-deck-cohere.json',
+              placeholder: 'Try humor-08 ↔ j-0043',
+            },
+          ],
+          embeddings: {
+            jokes: '../../data/jokes-embeddings-cohere.json',
+            quotes: '../../data/quotes-embeddings-cohere.json',
           },
         },
       };

--- a/data/jokes-embeddings-cohere.json
+++ b/data/jokes-embeddings-cohere.json
@@ -1,17 +1,17 @@
 {
   "meta": {
-    "provider": "openai",
-    "model": "text-embedding-3-large (second opinion)",
+    "provider": "cohere",
+    "model": "embed-english-v3.0",
     "dimensions": 64,
-    "generatedAt": "2025-09-20T22:27:41.541Z",
+    "generatedAt": "2025-09-21T04:12:41.842Z",
     "recordCount": 11
   },
   "records": {
     "j-0001": {
       "vector": "mJcXv9bVVT/r6uo+trU1P769PT+VlBQ+5eRkPuXkZL6HhoY+np0dv6yrKz/+/X2/8vFxP42MDL6cmxs/09LSPsfGxr7j4uI+kZAQvZWUFD6FhAQ+qqkpP/38fD7My0s/srExv4KBAb+SkRG/trU1P4aFBT/a2Vk/xcREPr++vj6Ylxe/1tVVP+vq6j62tTU/vr09P5WUFD7l5GQ+5eRkvoeGhj6enR2/rKsrP/79fb/y8XE/jYwMvpybGz/T0tI+x8bGvuPi4j6RkBC9lZQUPoWEBD6qqSk//fx8PszLSz+ysTG/goEBv5KREb+2tTU/hoUFP9rZWT/FxEQ+v76+Pg==",
       "vectorSha256": "25b86de4c565923a74dad51665c058978d64569fc9756382cc64afe996a9145f",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "34eabadade929c63a131d501f86ecdb44eb87b9290d49fe5273f37dac2ec98af",
       "updatedAt": "2025-09-20T22:27:41.489Z"
@@ -19,8 +19,8 @@
     "j-0038": {
       "vector": "8/LyvpKREb+VlBS+jo0Nv8HAQLynpqY+qqkpP7m4uD28uzs/vr09P/r5eT+RkBC9v76+vuLhYb/a2Vm/uLc3P+Pi4j7083M/t7a2Pq+urr6gnx8/pKMjv5uamj7NzEy+zcxMvpeWlj7Lysq+lpUVP8zLS7/r6uo+4N9fv4GAgDvz8vK+kpERv5WUFL6OjQ2/wcBAvKempj6qqSk/ubi4Pby7Oz++vT0/+vl5P5GQEL2/vr6+4uFhv9rZWb+4tzc/4+LiPvTzcz+3trY+r66uvqCfHz+koyO/m5qaPs3MTL7NzEy+l5aWPsvKyr6WlRU/zMtLv+vq6j7g31+/gYCAOw==",
       "vectorSha256": "79b94998ecf727786c1182b3ad0bc06bcd455f31f78d1fe48b4e8d5f7031991e",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "43376d397ea9d48bdddefc7b500f13dbb8f9ad54cf2ea66666a54dca1aba1080",
       "updatedAt": "2025-09-20T22:27:41.499Z"
@@ -28,8 +28,8 @@
     "j-0043": {
       "vector": "qqkpv/Py8j7Qz08/+Pd3v8nIyD2hoKC8v76+PqmoqD3W1VW/0dBQvff29j7083M/7exsvry7Oz/+/X0/kpERP6KhIb+FhAQ+t7a2PoiHB7+ioSE/mpkZv5ybG7+ysTG/2djYvY+Ojj6npqY+iokJv4uKir6TkpK+srExP5STEz+qqSm/8/LyPtDPTz/493e/ycjIPaGgoLy/vr4+qaioPdbVVb/R0FC99/b2PvTzcz/t7Gy+vLs7P/79fT+SkRE/oqEhv4WEBD63trY+iIcHv6KhIT+amRm/nJsbv7KxMb/Z2Ni9j46OPqempj6KiQm/i4qKvpOSkr6ysTE/lJMTPw==",
       "vectorSha256": "4ed1ee698a217b3244fcb5f3dff153c82ebecc76a5170d717b39bb817c55ab3d",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "2bbce7048c7daf8a1579bdf962ddfec82f90ad3cd033322772a3a93b5d5bd8c9",
       "updatedAt": "2025-09-20T22:27:41.500Z"
@@ -37,8 +37,8 @@
     "j-0081": {
       "vector": "mZiYPZeWlr7X1ta+hIMDv7i3Nz+NjAy+/Pt7P+jnZ7/29XU/8/LyvrGwML3w728/l5aWvu7tbb+8uzs/h4aGPrGwMD3k42O//v19v//+/j7U01M/3t1dv+DfX7+HhoY++vl5v9jXVz+amRk/+fj4Pf79fT/g31+/u7q6PuHg4DyZmJg9l5aWvtfW1r6EgwO/uLc3P42MDL78+3s/6Odnv/b1dT/z8vK+sbAwvfDvbz+Xlpa+7u1tv7y7Oz+HhoY+sbAwPeTjY7/+/X2///7+PtTTUz/e3V2/4N9fv4eGhj76+Xm/2NdXP5qZGT/5+Pg9/v19P+DfX7+7uro+4eDgPA==",
       "vectorSha256": "ab90bbf2714e2fd502d2860793486acb6c574e246976102e197fe633ca1e79d4",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "895a4a3edb6efd0cfa437af75a09dda1850e01bfe91110a103ebcc8ffe10ae83",
       "updatedAt": "2025-09-20T22:27:41.506Z"
@@ -46,8 +46,8 @@
     "j-0182": {
       "vector": "09LSPsbFRb+BgIC76+rqvvb1db+npqa+wsFBv9nY2L2gnx8/p6amPoGAgLv5+Pg9wcBAPOno6L2xsDA9zcxMvrCvL7/h4OC80tFRv7++vr7b2tq+yslJP4aFBb/Ew0O/+vl5v4aFBb/c21u/vLs7v5mYmL3DwsK+5+bmvtHQUL3T0tI+xsVFv4GAgLvr6uq+9vV1v6empr7CwUG/2djYvaCfHz+npqY+gYCAu/n4+D3BwEA86ejovbGwMD3NzEy+sK8vv+Hg4LzS0VG/v76+vtva2r7KyUk/hoUFv8TDQ7/6+Xm/hoUFv9zbW7+8uzu/mZiYvcPCwr7n5ua+0dBQvQ==",
       "vectorSha256": "21830244646034cceafffa747e99f7dd8ef633a7926fbb719211c3a4d9fdc293",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "b41d7f4505561f72cfa97f8f81718566287c175049e43d1e033d1222764f4679",
       "updatedAt": "2025-09-20T22:27:41.517Z"
@@ -55,8 +55,8 @@
     "j-0246": {
       "vector": "+Pd3v+LhYb/Qz08/0M9Pv7GwML3h4OA8x8bGvublZT+mpSU/ycjIPb69Pb/h4OC8nZwcPomIiL3x8HA9yMdHP5qZGT/Ix0c/vbw8voOCgr6qqSm/2djYvYOCgr6koyO/rKsrP4+Ojj6ysTE/v76+PqCfHz/HxsY+0tFRv9/e3r7493e/4uFhv9DPTz/Qz0+/sbAwveHg4DzHxsa+5uVlP6alJT/JyMg9vr09v+Hg4LydnBw+iYiIvfHwcD3Ix0c/mpkZP8jHRz+9vDy+g4KCvqqpKb/Z2Ni9g4KCvqSjI7+sqys/j46OPrKxMT+/vr4+oJ8fP8fGxj7S0VG/397evg==",
       "vectorSha256": "8b5dca7a7a8d3e559b942353f5e35409a7e7cd40502674248e3855d991da3633",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "040fe7187a834ef2d28c217c937787e3cce3685f2b725f2ed5a3d8afcfb11748",
       "updatedAt": "2025-09-20T22:27:41.520Z"
@@ -64,8 +64,8 @@
     "j-0410": {
       "vector": "vr09v+jnZ7+VlBQ+09LSvqalJT/t7Gw+2NdXv97dXb/BwEC83dxcPoaFBT8AAIC/oaCgPJGQEL2trCw+x8bGvtbVVT/OzU2/4+LivvTzc7+VlBS+9/b2vpeWlj7GxUU/nJsbv83MTL7o52c/3t1dv7m4uL2cmxs/urk5P9jXVz++vT2/6Odnv5WUFD7T0tK+pqUlP+3sbD7Y11e/3t1dv8HAQLzd3Fw+hoUFPwAAgL+hoKA8kZAQva2sLD7Hxsa+1tVVP87NTb/j4uK+9PNzv5WUFL739va+l5aWPsbFRT+cmxu/zcxMvujnZz/e3V2/ubi4vZybGz+6uTk/2NdXPw==",
       "vectorSha256": "b2f4dc14373ba3e4d2358ecf37a459fb54ab1f9bff933f528070a2b6d883480c",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "210c924bd29d14117e9bc200827b954eea1947066d42a5e23266f31174cddceb",
       "updatedAt": "2025-09-20T22:27:41.533Z"
@@ -73,8 +73,8 @@
     "j-0673": {
       "vector": "2tlZv9TTU7+Lioo+q6qqvr69Pb/j4uI+j46OvrW0NL60szO/7OtrP+LhYb+xsDA9mZiYPfPy8j6trCy+l5aWPo2MDD6urS0/9vV1P7m4uL27uro+np0dP+LhYb/z8vI+zMtLP56dHT/Pzs6+m5qaPv38fD6dnBy+xsVFv/X0dD7a2Vm/1NNTv4uKij6rqqq+vr09v+Pi4j6Pjo6+tbQ0vrSzM7/s62s/4uFhv7GwMD2ZmJg98/LyPq2sLL6XlpY+jYwMPq6tLT/29XU/ubi4vbu6uj6enR0/4uFhv/Py8j7My0s/np0dP8/Ozr6bmpo+/fx8Pp2cHL7GxUW/9fR0Pg==",
       "vectorSha256": "5bd34f2d519a1cced202000ae0cea1f5f657b71f124e7a34fd5c46dcf43c0f64",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "1316a25521b85c6926f50f8589bc6aa591d6fa74aece0fbce5ce4ca69f6c1d9e",
       "updatedAt": "2025-09-20T22:27:41.539Z"
@@ -82,8 +82,8 @@
     "j-0703": {
       "vector": "yMdHv/z7ez/Y11e/hIMDP9va2j7v7u6+i4qKPoWEBD7s62u/3NtbP6KhIT/U01M/z87Ovre2tr6Qjw+/yMdHP/79fT+SkRE/lpUVv/X0dL63tra+zcxMvsC/Pz/S0VE/k5KSvs3MTL7y8XE/yMdHP/Dvb7+1tDS+n56evtrZWb/Ix0e//Pt7P9jXV7+EgwM/29raPu/u7r6Lioo+hYQEPuzra7/c21s/oqEhP9TTUz/Pzs6+t7a2vpCPD7/Ix0c//v19P5KRET+WlRW/9fR0vre2tr7NzEy+wL8/P9LRUT+TkpK+zcxMvvLxcT/Ix0c/8O9vv7W0NL6fnp6+2tlZvw==",
       "vectorSha256": "79f2b002f15692045c94f186152d462fda8ae0080e6311d3bf8d325cd7ca7470",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "1cfd14c1b644a2900aedd0e94c5238e3fec835615266dfe85b66f8e308695813",
       "updatedAt": "2025-09-20T22:27:41.540Z"
@@ -91,8 +91,8 @@
     "j-0727": {
       "vector": "4uFhP5STEz/l5GQ+k5KSPoOCgr6Lioo+7OtrP7m4uD0AAIC/ubi4PeDfX7++vT2/ycjIPZWUFL6opye/v76+vsrJSb+amRm/g4KCvvX0dD6npqa+tLMzP6empr6gnx8/5ONjv9rZWT/DwsK+sbAwvdnY2L2koyO/6+rqvrGwMD3i4WE/lJMTP+XkZD6TkpI+g4KCvouKij7s62s/ubi4PQAAgL+5uLg94N9fv769Pb/JyMg9lZQUvqinJ7+/vr6+yslJv5qZGb+DgoK+9fR0Pqempr60szM/p6amvqCfHz/k42O/2tlZP8PCwr6xsDC92djYvaSjI7/r6uq+sbAwPQ==",
       "vectorSha256": "9adc57a849d8927c57fd4d07bd3cdced7c38d1aefaa73ab6f085855b6dc9d886",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "f0c99ca45fa2f58b008b10218c6d2c501b335f9e56d956cf0eec4f7a722e4585",
       "updatedAt": "2025-09-20T22:27:41.541Z"
@@ -100,8 +100,8 @@
     "j-0759": {
       "vector": "xMNDP6+urr6WlRW/mZiYvZmYmL23tra+7+7uPpOSkr7u7W2/xMNDv5qZGT/l5GQ+wL8/P7m4uD3HxsY+jo0NP/Tzc7/f3t6+9PNzP9/e3r7c21u/iYiIPby7Oz/T0tK+lpUVP7++vr7FxEQ+5eRkvpybGz+4tze/o6KivqOior7Ew0M/r66uvpaVFb+ZmJi9mZiYvbe2tr7v7u4+k5KSvu7tbb/Ew0O/mpkZP+XkZD7Avz8/ubi4PcfGxj6OjQ0/9PNzv9/e3r7083M/397evtzbW7+JiIg9vLs7P9PS0r6WlRU/v76+vsXERD7l5GS+nJsbP7i3N7+joqK+o6Kivg==",
       "vectorSha256": "75243deea0336711e7faf4d59f658b4b8fde3dd71802cad0538aa2659c2ca6e4",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "e15435767652bb5b091ecc9cdf8bb1c60648f9481288dd4bca509863cd245757",
       "updatedAt": "2025-09-20T22:27:41.541Z"

--- a/data/jokes-embeddings-openai.json
+++ b/data/jokes-embeddings-openai.json
@@ -1,0 +1,110 @@
+{
+  "meta": {
+    "provider": "openai",
+    "model": "text-embedding-3-large",
+    "dimensions": 64,
+    "generatedAt": "2025-09-20T22:27:41.541Z",
+    "recordCount": 11
+  },
+  "records": {
+    "j-0001": {
+      "vector": "mJcXv9bVVT/r6uo+trU1P769PT+VlBQ+5eRkPuXkZL6HhoY+np0dv6yrKz/+/X2/8vFxP42MDL6cmxs/09LSPsfGxr7j4uI+kZAQvZWUFD6FhAQ+qqkpP/38fD7My0s/srExv4KBAb+SkRG/trU1P4aFBT/a2Vk/xcREPr++vj6Ylxe/1tVVP+vq6j62tTU/vr09P5WUFD7l5GQ+5eRkvoeGhj6enR2/rKsrP/79fb/y8XE/jYwMvpybGz/T0tI+x8bGvuPi4j6RkBC9lZQUPoWEBD6qqSk//fx8PszLSz+ysTG/goEBv5KREb+2tTU/hoUFP9rZWT/FxEQ+v76+Pg==",
+      "vectorSha256": "25b86de4c565923a74dad51665c058978d64569fc9756382cc64afe996a9145f",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "34eabadade929c63a131d501f86ecdb44eb87b9290d49fe5273f37dac2ec98af",
+      "updatedAt": "2025-09-20T22:27:41.489Z"
+    },
+    "j-0038": {
+      "vector": "8/LyvpKREb+VlBS+jo0Nv8HAQLynpqY+qqkpP7m4uD28uzs/vr09P/r5eT+RkBC9v76+vuLhYb/a2Vm/uLc3P+Pi4j7083M/t7a2Pq+urr6gnx8/pKMjv5uamj7NzEy+zcxMvpeWlj7Lysq+lpUVP8zLS7/r6uo+4N9fv4GAgDvz8vK+kpERv5WUFL6OjQ2/wcBAvKempj6qqSk/ubi4Pby7Oz++vT0/+vl5P5GQEL2/vr6+4uFhv9rZWb+4tzc/4+LiPvTzcz+3trY+r66uvqCfHz+koyO/m5qaPs3MTL7NzEy+l5aWPsvKyr6WlRU/zMtLv+vq6j7g31+/gYCAOw==",
+      "vectorSha256": "79b94998ecf727786c1182b3ad0bc06bcd455f31f78d1fe48b4e8d5f7031991e",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "43376d397ea9d48bdddefc7b500f13dbb8f9ad54cf2ea66666a54dca1aba1080",
+      "updatedAt": "2025-09-20T22:27:41.499Z"
+    },
+    "j-0043": {
+      "vector": "qqkpv/Py8j7Qz08/+Pd3v8nIyD2hoKC8v76+PqmoqD3W1VW/0dBQvff29j7083M/7exsvry7Oz/+/X0/kpERP6KhIb+FhAQ+t7a2PoiHB7+ioSE/mpkZv5ybG7+ysTG/2djYvY+Ojj6npqY+iokJv4uKir6TkpK+srExP5STEz+qqSm/8/LyPtDPTz/493e/ycjIPaGgoLy/vr4+qaioPdbVVb/R0FC99/b2PvTzcz/t7Gy+vLs7P/79fT+SkRE/oqEhv4WEBD63trY+iIcHv6KhIT+amRm/nJsbv7KxMb/Z2Ni9j46OPqempj6KiQm/i4qKvpOSkr6ysTE/lJMTPw==",
+      "vectorSha256": "4ed1ee698a217b3244fcb5f3dff153c82ebecc76a5170d717b39bb817c55ab3d",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "2bbce7048c7daf8a1579bdf962ddfec82f90ad3cd033322772a3a93b5d5bd8c9",
+      "updatedAt": "2025-09-20T22:27:41.500Z"
+    },
+    "j-0081": {
+      "vector": "mZiYPZeWlr7X1ta+hIMDv7i3Nz+NjAy+/Pt7P+jnZ7/29XU/8/LyvrGwML3w728/l5aWvu7tbb+8uzs/h4aGPrGwMD3k42O//v19v//+/j7U01M/3t1dv+DfX7+HhoY++vl5v9jXVz+amRk/+fj4Pf79fT/g31+/u7q6PuHg4DyZmJg9l5aWvtfW1r6EgwO/uLc3P42MDL78+3s/6Odnv/b1dT/z8vK+sbAwvfDvbz+Xlpa+7u1tv7y7Oz+HhoY+sbAwPeTjY7/+/X2///7+PtTTUz/e3V2/4N9fv4eGhj76+Xm/2NdXP5qZGT/5+Pg9/v19P+DfX7+7uro+4eDgPA==",
+      "vectorSha256": "ab90bbf2714e2fd502d2860793486acb6c574e246976102e197fe633ca1e79d4",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "895a4a3edb6efd0cfa437af75a09dda1850e01bfe91110a103ebcc8ffe10ae83",
+      "updatedAt": "2025-09-20T22:27:41.506Z"
+    },
+    "j-0182": {
+      "vector": "09LSPsbFRb+BgIC76+rqvvb1db+npqa+wsFBv9nY2L2gnx8/p6amPoGAgLv5+Pg9wcBAPOno6L2xsDA9zcxMvrCvL7/h4OC80tFRv7++vr7b2tq+yslJP4aFBb/Ew0O/+vl5v4aFBb/c21u/vLs7v5mYmL3DwsK+5+bmvtHQUL3T0tI+xsVFv4GAgLvr6uq+9vV1v6empr7CwUG/2djYvaCfHz+npqY+gYCAu/n4+D3BwEA86ejovbGwMD3NzEy+sK8vv+Hg4LzS0VG/v76+vtva2r7KyUk/hoUFv8TDQ7/6+Xm/hoUFv9zbW7+8uzu/mZiYvcPCwr7n5ua+0dBQvQ==",
+      "vectorSha256": "21830244646034cceafffa747e99f7dd8ef633a7926fbb719211c3a4d9fdc293",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "b41d7f4505561f72cfa97f8f81718566287c175049e43d1e033d1222764f4679",
+      "updatedAt": "2025-09-20T22:27:41.517Z"
+    },
+    "j-0246": {
+      "vector": "+Pd3v+LhYb/Qz08/0M9Pv7GwML3h4OA8x8bGvublZT+mpSU/ycjIPb69Pb/h4OC8nZwcPomIiL3x8HA9yMdHP5qZGT/Ix0c/vbw8voOCgr6qqSm/2djYvYOCgr6koyO/rKsrP4+Ojj6ysTE/v76+PqCfHz/HxsY+0tFRv9/e3r7493e/4uFhv9DPTz/Qz0+/sbAwveHg4DzHxsa+5uVlP6alJT/JyMg9vr09v+Hg4LydnBw+iYiIvfHwcD3Ix0c/mpkZP8jHRz+9vDy+g4KCvqqpKb/Z2Ni9g4KCvqSjI7+sqys/j46OPrKxMT+/vr4+oJ8fP8fGxj7S0VG/397evg==",
+      "vectorSha256": "8b5dca7a7a8d3e559b942353f5e35409a7e7cd40502674248e3855d991da3633",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "040fe7187a834ef2d28c217c937787e3cce3685f2b725f2ed5a3d8afcfb11748",
+      "updatedAt": "2025-09-20T22:27:41.520Z"
+    },
+    "j-0410": {
+      "vector": "vr09v+jnZ7+VlBQ+09LSvqalJT/t7Gw+2NdXv97dXb/BwEC83dxcPoaFBT8AAIC/oaCgPJGQEL2trCw+x8bGvtbVVT/OzU2/4+LivvTzc7+VlBS+9/b2vpeWlj7GxUU/nJsbv83MTL7o52c/3t1dv7m4uL2cmxs/urk5P9jXVz++vT2/6Odnv5WUFD7T0tK+pqUlP+3sbD7Y11e/3t1dv8HAQLzd3Fw+hoUFPwAAgL+hoKA8kZAQva2sLD7Hxsa+1tVVP87NTb/j4uK+9PNzv5WUFL739va+l5aWPsbFRT+cmxu/zcxMvujnZz/e3V2/ubi4vZybGz+6uTk/2NdXPw==",
+      "vectorSha256": "b2f4dc14373ba3e4d2358ecf37a459fb54ab1f9bff933f528070a2b6d883480c",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "210c924bd29d14117e9bc200827b954eea1947066d42a5e23266f31174cddceb",
+      "updatedAt": "2025-09-20T22:27:41.533Z"
+    },
+    "j-0673": {
+      "vector": "2tlZv9TTU7+Lioo+q6qqvr69Pb/j4uI+j46OvrW0NL60szO/7OtrP+LhYb+xsDA9mZiYPfPy8j6trCy+l5aWPo2MDD6urS0/9vV1P7m4uL27uro+np0dP+LhYb/z8vI+zMtLP56dHT/Pzs6+m5qaPv38fD6dnBy+xsVFv/X0dD7a2Vm/1NNTv4uKij6rqqq+vr09v+Pi4j6Pjo6+tbQ0vrSzM7/s62s/4uFhv7GwMD2ZmJg98/LyPq2sLL6XlpY+jYwMPq6tLT/29XU/ubi4vbu6uj6enR0/4uFhv/Py8j7My0s/np0dP8/Ozr6bmpo+/fx8Pp2cHL7GxUW/9fR0Pg==",
+      "vectorSha256": "5bd34f2d519a1cced202000ae0cea1f5f657b71f124e7a34fd5c46dcf43c0f64",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "1316a25521b85c6926f50f8589bc6aa591d6fa74aece0fbce5ce4ca69f6c1d9e",
+      "updatedAt": "2025-09-20T22:27:41.539Z"
+    },
+    "j-0703": {
+      "vector": "yMdHv/z7ez/Y11e/hIMDP9va2j7v7u6+i4qKPoWEBD7s62u/3NtbP6KhIT/U01M/z87Ovre2tr6Qjw+/yMdHP/79fT+SkRE/lpUVv/X0dL63tra+zcxMvsC/Pz/S0VE/k5KSvs3MTL7y8XE/yMdHP/Dvb7+1tDS+n56evtrZWb/Ix0e//Pt7P9jXV7+EgwM/29raPu/u7r6Lioo+hYQEPuzra7/c21s/oqEhP9TTUz/Pzs6+t7a2vpCPD7/Ix0c//v19P5KRET+WlRW/9fR0vre2tr7NzEy+wL8/P9LRUT+TkpK+zcxMvvLxcT/Ix0c/8O9vv7W0NL6fnp6+2tlZvw==",
+      "vectorSha256": "79f2b002f15692045c94f186152d462fda8ae0080e6311d3bf8d325cd7ca7470",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "1cfd14c1b644a2900aedd0e94c5238e3fec835615266dfe85b66f8e308695813",
+      "updatedAt": "2025-09-20T22:27:41.540Z"
+    },
+    "j-0727": {
+      "vector": "4uFhP5STEz/l5GQ+k5KSPoOCgr6Lioo+7OtrP7m4uD0AAIC/ubi4PeDfX7++vT2/ycjIPZWUFL6opye/v76+vsrJSb+amRm/g4KCvvX0dD6npqa+tLMzP6empr6gnx8/5ONjv9rZWT/DwsK+sbAwvdnY2L2koyO/6+rqvrGwMD3i4WE/lJMTP+XkZD6TkpI+g4KCvouKij7s62s/ubi4PQAAgL+5uLg94N9fv769Pb/JyMg9lZQUvqinJ7+/vr6+yslJv5qZGb+DgoK+9fR0Pqempr60szM/p6amvqCfHz/k42O/2tlZP8PCwr6xsDC92djYvaSjI7/r6uq+sbAwPQ==",
+      "vectorSha256": "9adc57a849d8927c57fd4d07bd3cdced7c38d1aefaa73ab6f085855b6dc9d886",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "f0c99ca45fa2f58b008b10218c6d2c501b335f9e56d956cf0eec4f7a722e4585",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    },
+    "j-0759": {
+      "vector": "xMNDP6+urr6WlRW/mZiYvZmYmL23tra+7+7uPpOSkr7u7W2/xMNDv5qZGT/l5GQ+wL8/P7m4uD3HxsY+jo0NP/Tzc7/f3t6+9PNzP9/e3r7c21u/iYiIPby7Oz/T0tK+lpUVP7++vr7FxEQ+5eRkvpybGz+4tze/o6KivqOior7Ew0M/r66uvpaVFb+ZmJi9mZiYvbe2tr7v7u4+k5KSvu7tbb/Ew0O/mpkZP+XkZD7Avz8/ubi4PcfGxj6OjQ0/9PNzv9/e3r7083M/397evtzbW7+JiIg9vLs7P9PS0r6WlRU/v76+vsXERD7l5GS+nJsbP7i3N7+joqK+o6Kivg==",
+      "vectorSha256": "75243deea0336711e7faf4d59f658b4b8fde3dd71802cad0538aa2659c2ca6e4",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "e15435767652bb5b091ecc9cdf8bb1c60648f9481288dd4bca509863cd245757",
+      "updatedAt": "2025-09-20T22:27:41.541Z"
+    }
+  }
+}

--- a/data/quotes-embeddings-cohere.json
+++ b/data/quotes-embeddings-cohere.json
@@ -1,17 +1,17 @@
 {
   "meta": {
-    "provider": "openai",
-    "model": "text-embedding-3-large (second opinion)",
+    "provider": "cohere",
+    "model": "embed-english-v3.0",
     "dimensions": 64,
-    "generatedAt": "2025-09-21T03:05:51.944Z",
+    "generatedAt": "2025-09-21T04:18:09.137Z",
     "recordCount": 11
   },
   "records": {
     "adventure-01": {
       "vector": "0dBQPcLBQT/n5uY+9vV1P8jHR7/c21s/9/b2PvLxcb+dnBw+xMNDv+zra7+2tTU/pqUlP/LxcT+2tTW/trU1v+vq6j6+vT2//v19P6KhIT/19HQ+6ejoPY6NDT/CwUE/s7KyvtDPT7+mpSW/7+7uPpSTE7+koyM/397evublZb/R0FA9wsFBP+fm5j729XU/yMdHv9zbWz/39vY+8vFxv52cHD7Ew0O/7Otrv7a1NT+mpSU/8vFxP7a1Nb+2tTW/6+rqPr69Pb/+/X0/oqEhP/X0dD7p6Og9jo0NP8LBQT+zsrK+0M9Pv6alJb/v7u4+lJMTv6SjIz/f3t6+5uVlvw==",
       "vectorSha256": "b6fdb9efa0d7f00504824bc2da7048adb1ff66a94eca058260a47abe6ee59c5c",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "86e0b9fa1cedbd07931e0adad2f82525ba21fed09e8ec6e053182dbb36d1480d",
       "updatedAt": "2025-09-20T22:28:15.425Z"
@@ -19,8 +19,8 @@
     "adventure-29": {
       "vector": "iYiIPfHwcL2gnx8/urk5P8TDQz+1tDS+trU1P7SzMz+npqY+AACAv7W0ND6Pjo6+/fx8PrW0NL7CwUG/y8rKPvDvbz+gnx+/8O9vP8zLSz/U01M/nJsbv//+/r7y8XE/0M9Pv93cXD6+vT0/x8bGPtzbWz8AAIA/y8rKPvb1db+JiIg98fBwvaCfHz+6uTk/xMNDP7W0NL62tTU/tLMzP6empj4AAIC/tbQ0Po+Ojr79/Hw+tbQ0vsLBQb/Lyso+8O9vP6CfH7/w728/zMtLP9TTUz+cmxu///7+vvLxcT/Qz0+/3dxcPr69PT/HxsY+3NtbPwAAgD/Lyso+9vV1vw==",
       "vectorSha256": "36668fe4146904e07f8bee32184a7377c5b804da734de9a534b7e30e1a938136",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "8878cfdce169dad9a900965c9f691fb2f730f7e5e93240f8189bdeb1edffb205",
       "updatedAt": "2025-09-20T22:28:15.433Z"
@@ -28,8 +28,8 @@
     "adventure-36": {
       "vector": "iokJP62sLL6FhAS+3NtbP6Oior6vrq4+2tlZP8fGxj7y8XG/rq0tv+no6L319HQ+2tlZP6uqqj7BwEC85uVlv+LhYT/Lysq+p6amPqinJ7/q6Wm/4+LiPtLRUb/q6Wm/1dRUvrCvL7+lpCQ+rKsrP/X0dL7OzU2/0tFRP6KhIb+KiQk/rawsvoWEBL7c21s/o6Kivq+urj7a2Vk/x8bGPvLxcb+urS2/6ejovfX0dD7a2Vk/q6qqPsHAQLzm5WW/4uFhP8vKyr6npqY+qKcnv+rpab/j4uI+0tFRv+rpab/V1FS+sK8vv6WkJD6sqys/9fR0vs7NTb/S0VE/oqEhvw==",
       "vectorSha256": "0e35c5d4d32f0e0088001891225a842ee028f2da0e17e95c294b1bd97680fe0b",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "c46a6fed57abecb10729719eecaa7e0df04da92c0bb8170b652894d56119e82f",
       "updatedAt": "2025-09-20T22:28:15.434Z"
@@ -37,8 +37,8 @@
     "humor-01": {
       "vector": "tLMzP5STEz/Avz+/vr09P/38fL6amRm/3NtbP+3sbD7U01O/j46OPra1Nb/w72+/zcxMPry7Oz/T0tI+5ONjv8jHR7+koyM/5+bmvqKhIb+cmxu/zcxMvqGgoLyhoKC8wcBAvKinJ7+NjAy+29ravt/e3j7Pzs4+jYwMvtnY2L20szM/lJMTP8C/P7++vT0//fx8vpqZGb/c21s/7exsPtTTU7+Pjo4+trU1v/Dvb7/NzEw+vLs7P9PS0j7k42O/yMdHv6SjIz/n5ua+oqEhv5ybG7/NzEy+oaCgvKGgoLzBwEC8qKcnv42MDL7b2tq+397ePs/Ozj6NjAy+2djYvQ==",
       "vectorSha256": "9937d49dc519302429020e0b1f726535fbb044c924e77f707fe6ad9376df3407",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "d9c920de6033ed9d16a3250899ddb40e1cd1462f32667d7d7e2c6e49b7b36e72",
       "updatedAt": "2025-09-20T22:28:15.454Z"
@@ -46,8 +46,8 @@
     "money-23": {
       "vector": "jIsLP7i3Nz+opyc/i4qKvtDPTz+Ylxe/zcxMvpSTEz+lpCQ+6+rqPq2sLL7CwUG/lJMTv7y7Oz+GhQW/w8LCPquqqj6EgwO/6Odnv46NDb/OzU0/srExv4aFBb++vT2/3Ntbv5ybG7++vT2/ycjIPZ6dHb+GhQU/t7a2Po+Ojr6Miws/uLc3P6inJz+Lioq+0M9PP5iXF7/NzEy+lJMTP6WkJD7r6uo+rawsvsLBQb+UkxO/vLs7P4aFBb/DwsI+q6qqPoSDA7/o52e/jo0Nv87NTT+ysTG/hoUFv769Pb/c21u/nJsbv769Pb/JyMg9np0dv4aFBT+3trY+j46Ovg==",
       "vectorSha256": "f0894a063b4afe8c8f59bdd52938190766ae8fc23b351de48aeb480fc47b03c1",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "c5dbd35de73466c994ba6a1f36dd3db0aa3e0c39e6273d211232218c31c2ad5c",
       "updatedAt": "2025-09-20T22:28:15.455Z"
@@ -55,8 +55,8 @@
     "money-25": {
       "vector": "iYiIvePi4r7l5GS+8/LyPra1Nb+ysTE/0tFRP+blZT+CgQG/zcxMvo+Ojj6vrq6+zMtLv8TDQ7/Ix0e/lZQUvpCPDz/X1ta+vLs7P5eWlj6Pjo4+6+rqvrSzMz+dnBy+9/b2vpaVFb+joqK+pqUlP4iHB7+3tra+2tlZv5uamj6JiIi94+LivuXkZL7z8vI+trU1v7KxMT/S0VE/5uVlP4KBAb/NzEy+j46OPq+urr7My0u/xMNDv8jHR7+VlBS+kI8PP9fW1r68uzs/l5aWPo+Ojj7r6uq+tLMzP52cHL739va+lpUVv6Oior6mpSU/iIcHv7e2tr7a2Vm/m5qaPg==",
       "vectorSha256": "0a3fcea12a0cbf3c08f01487bc93b6fd43637be9f2544b43649d015ed13738d2",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "774763bc25d8e8f23f66a3541a1e1c6dc74adda5a345d96c423557d23c5213a6",
       "updatedAt": "2025-09-20T22:28:15.455Z"
@@ -64,8 +64,8 @@
     "motivation-14": {
       "vector": "p6amPszLSz+ZmJi98O9vv5uamr7My0u/jIsLv+TjY7+Ihwe/2djYvbu6ur7Hxsa+p6amPtPS0r6vrq6+lpUVv5STEz/f3t6+2djYPc3MTL7k42O/paQkvomIiL3r6uo+9PNzv9/e3j6ioSE/w8LCPu/u7j6wry+//fx8Pufm5r6npqY+zMtLP5mYmL3w72+/m5qavszLS7+Miwu/5ONjv4iHB7/Z2Ni9u7q6vsfGxr6npqY+09LSvq+urr6WlRW/lJMTP9/e3r7Z2Ng9zcxMvuTjY7+lpCS+iYiIvevq6j7083O/397ePqKhIT/DwsI+7+7uPrCvL7/9/Hw+5+bmvg==",
       "vectorSha256": "bfcbbdcc6edb11e607420c553f3d9fd2c87194957337ab473ef0c25bab27cc09",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "a9e57608591a3a0e3c72514ea94b5435c9488d660e6b77ba06b7d0b0bb289f46",
       "updatedAt": "2025-09-20T22:28:15.443Z"
@@ -73,8 +73,8 @@
     "positive-16": {
       "vector": "8O9vP8HAQLzZ2Ni9//7+vvPy8r6pqKg9np0dv7SzMz+BgIA79/b2PpOSkj7o52e/lpUVv9DPT7/d3Fy+4N9fP7W0ND7X1ta+nZwcvtTTU7++vT2/8vFxv5iXFz/Avz8/mJcXP/Tzcz/h4OC8v76+voOCgj7x8HA9xsVFP46NDb/w728/wcBAvNnY2L3//v6+8/LyvqmoqD2enR2/tLMzP4GAgDv39vY+k5KSPujnZ7+WlRW/0M9Pv93cXL7g318/tbQ0PtfW1r6dnBy+1NNTv769Pb/y8XG/mJcXP8C/Pz+Ylxc/9PNzP+Hg4Ly/vr6+g4KCPvHwcD3GxUU/jo0Nvw==",
       "vectorSha256": "bfde36c1f1ceecf7cbd5ba08047bc40be1ad484eac08a52a4a79cd145b0dcdc9",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "f77e7240438a31d980bda40c351864ef964a6c162107cbdfcbf97c50a087e239",
       "updatedAt": "2025-09-20T22:28:15.460Z"
@@ -82,8 +82,8 @@
     "time-04": {
       "vector": "+fj4vaSjIz/Lyso+hYQEvt3cXD6ysTE/lpUVP+3sbD7e3V2/vLs7P5WUFD7CwUE/9vV1P8nIyL3Lysq++Pd3P+7tbb+urS0/7OtrP8vKyj62tTW/+/r6vrq5OT+bmpo+wcBAPIyLC7/Ix0e/yslJv6qpKT/083M/zcxMvo6NDT/5+Pi9pKMjP8vKyj6FhAS+3dxcPrKxMT+WlRU/7exsPt7dXb+8uzs/lZQUPsLBQT/29XU/ycjIvcvKyr7493c/7u1tv66tLT/s62s/y8rKPra1Nb/7+vq+urk5P5uamj7BwEA8jIsLv8jHR7/KyUm/qqkpP/Tzcz/NzEy+jo0NPw==",
       "vectorSha256": "dc385e6e8e08ec34faaa24c864a2ee66acd839d624aafbdc953cfb0680541bcc",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "70d1b26f9bd8ca9d11dd92e0fa734dfb09d6f5b22541dca6813a1c1bd4f966c6",
       "updatedAt": "2025-09-20T22:28:15.437Z"
@@ -91,8 +91,8 @@
     "time-10": {
       "vector": "6ulpP+fm5j6Miwu/p6amvt3cXD719HS+8fBwPaOioj7f3t4+6ulpP62sLD7My0s/jo0Nv8XERD6CgQE/9fR0Pq2sLL7Z2Ng9hIMDv/f29j62tTW/yslJP8C/P7/BwEA8rq0tv+no6L3c21s/lpUVv8zLS7+3tra+6ejoPb++vr7q6Wk/5+bmPoyLC7+npqa+3dxcPvX0dL7x8HA9o6KiPt/e3j7q6Wk/rawsPszLSz+OjQ2/xcREPoKBAT/19HQ+rawsvtnY2D2EgwO/9/b2Pra1Nb/KyUk/wL8/v8HAQDyurS2/6ejovdzbWz+WlRW/zMtLv7e2tr7p6Og9v76+vg==",
       "vectorSha256": "0a13685cb4be454a7dedb69c5bdb16e0ef27f4402309178dcb0283c0cf76fcb3",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "f4b93a569b6187a8b7f495e53998c09e6a8d3ebd25e420812971ed351a528e50",
       "updatedAt": "2025-09-20T22:28:15.437Z"
@@ -100,8 +100,8 @@
     "travel-02": {
       "vector": "trU1P9fW1r7W1VU/h4aGPsXERL66uTk/sbAwvbGwML3NzEy++/r6PtzbWz/h4OA8yslJP8TDQ7/BwEC8r66uPv79fb+xsDC9w8LCPvz7e7+NjAy+3t1dv9DPT7/083M/8/LyPvX0dL6HhoY+paQkPoqJCb/Ew0M/ycjIPcLBQb+2tTU/19bWvtbVVT+HhoY+xcREvrq5OT+xsDC9sbAwvc3MTL77+vo+3NtbP+Hg4DzKyUk/xMNDv8HAQLyvrq4+/v19v7GwML3DwsI+/Pt7v42MDL7e3V2/0M9Pv/Tzcz/z8vI+9fR0voeGhj6lpCQ+iokJv8TDQz/JyMg9wsFBvw==",
       "vectorSha256": "dd5175bfe9cf353d3d577d13ef1c358626bd7d69c6f3b4ea59e93d60b86f8a8f",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
+      "model": "embed-english-v3.0",
+      "provider": "cohere",
       "dimensions": 64,
       "textHash": "da4aeaa167dc7a7a66beed83e41e7eab017ab0026e1118f9bc61a1943be18c1f",
       "updatedAt": "2025-09-21T03:05:51.944Z"

--- a/data/quotes-embeddings-openai.json
+++ b/data/quotes-embeddings-openai.json
@@ -1,0 +1,110 @@
+{
+  "meta": {
+    "provider": "openai",
+    "model": "text-embedding-3-large",
+    "dimensions": 64,
+    "generatedAt": "2025-09-21T03:05:51.944Z",
+    "recordCount": 11
+  },
+  "records": {
+    "adventure-01": {
+      "vector": "0dBQPcLBQT/n5uY+9vV1P8jHR7/c21s/9/b2PvLxcb+dnBw+xMNDv+zra7+2tTU/pqUlP/LxcT+2tTW/trU1v+vq6j6+vT2//v19P6KhIT/19HQ+6ejoPY6NDT/CwUE/s7KyvtDPT7+mpSW/7+7uPpSTE7+koyM/397evublZb/R0FA9wsFBP+fm5j729XU/yMdHv9zbWz/39vY+8vFxv52cHD7Ew0O/7Otrv7a1NT+mpSU/8vFxP7a1Nb+2tTW/6+rqPr69Pb/+/X0/oqEhP/X0dD7p6Og9jo0NP8LBQT+zsrK+0M9Pv6alJb/v7u4+lJMTv6SjIz/f3t6+5uVlvw==",
+      "vectorSha256": "b6fdb9efa0d7f00504824bc2da7048adb1ff66a94eca058260a47abe6ee59c5c",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "86e0b9fa1cedbd07931e0adad2f82525ba21fed09e8ec6e053182dbb36d1480d",
+      "updatedAt": "2025-09-20T22:28:15.425Z"
+    },
+    "adventure-29": {
+      "vector": "iYiIPfHwcL2gnx8/urk5P8TDQz+1tDS+trU1P7SzMz+npqY+AACAv7W0ND6Pjo6+/fx8PrW0NL7CwUG/y8rKPvDvbz+gnx+/8O9vP8zLSz/U01M/nJsbv//+/r7y8XE/0M9Pv93cXD6+vT0/x8bGPtzbWz8AAIA/y8rKPvb1db+JiIg98fBwvaCfHz+6uTk/xMNDP7W0NL62tTU/tLMzP6empj4AAIC/tbQ0Po+Ojr79/Hw+tbQ0vsLBQb/Lyso+8O9vP6CfH7/w728/zMtLP9TTUz+cmxu///7+vvLxcT/Qz0+/3dxcPr69PT/HxsY+3NtbPwAAgD/Lyso+9vV1vw==",
+      "vectorSha256": "36668fe4146904e07f8bee32184a7377c5b804da734de9a534b7e30e1a938136",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "8878cfdce169dad9a900965c9f691fb2f730f7e5e93240f8189bdeb1edffb205",
+      "updatedAt": "2025-09-20T22:28:15.433Z"
+    },
+    "adventure-36": {
+      "vector": "iokJP62sLL6FhAS+3NtbP6Oior6vrq4+2tlZP8fGxj7y8XG/rq0tv+no6L319HQ+2tlZP6uqqj7BwEC85uVlv+LhYT/Lysq+p6amPqinJ7/q6Wm/4+LiPtLRUb/q6Wm/1dRUvrCvL7+lpCQ+rKsrP/X0dL7OzU2/0tFRP6KhIb+KiQk/rawsvoWEBL7c21s/o6Kivq+urj7a2Vk/x8bGPvLxcb+urS2/6ejovfX0dD7a2Vk/q6qqPsHAQLzm5WW/4uFhP8vKyr6npqY+qKcnv+rpab/j4uI+0tFRv+rpab/V1FS+sK8vv6WkJD6sqys/9fR0vs7NTb/S0VE/oqEhvw==",
+      "vectorSha256": "0e35c5d4d32f0e0088001891225a842ee028f2da0e17e95c294b1bd97680fe0b",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "c46a6fed57abecb10729719eecaa7e0df04da92c0bb8170b652894d56119e82f",
+      "updatedAt": "2025-09-20T22:28:15.434Z"
+    },
+    "humor-01": {
+      "vector": "tLMzP5STEz/Avz+/vr09P/38fL6amRm/3NtbP+3sbD7U01O/j46OPra1Nb/w72+/zcxMPry7Oz/T0tI+5ONjv8jHR7+koyM/5+bmvqKhIb+cmxu/zcxMvqGgoLyhoKC8wcBAvKinJ7+NjAy+29ravt/e3j7Pzs4+jYwMvtnY2L20szM/lJMTP8C/P7++vT0//fx8vpqZGb/c21s/7exsPtTTU7+Pjo4+trU1v/Dvb7/NzEw+vLs7P9PS0j7k42O/yMdHv6SjIz/n5ua+oqEhv5ybG7/NzEy+oaCgvKGgoLzBwEC8qKcnv42MDL7b2tq+397ePs/Ozj6NjAy+2djYvQ==",
+      "vectorSha256": "9937d49dc519302429020e0b1f726535fbb044c924e77f707fe6ad9376df3407",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "d9c920de6033ed9d16a3250899ddb40e1cd1462f32667d7d7e2c6e49b7b36e72",
+      "updatedAt": "2025-09-20T22:28:15.454Z"
+    },
+    "money-23": {
+      "vector": "jIsLP7i3Nz+opyc/i4qKvtDPTz+Ylxe/zcxMvpSTEz+lpCQ+6+rqPq2sLL7CwUG/lJMTv7y7Oz+GhQW/w8LCPquqqj6EgwO/6Odnv46NDb/OzU0/srExv4aFBb++vT2/3Ntbv5ybG7++vT2/ycjIPZ6dHb+GhQU/t7a2Po+Ojr6Miws/uLc3P6inJz+Lioq+0M9PP5iXF7/NzEy+lJMTP6WkJD7r6uo+rawsvsLBQb+UkxO/vLs7P4aFBb/DwsI+q6qqPoSDA7/o52e/jo0Nv87NTT+ysTG/hoUFv769Pb/c21u/nJsbv769Pb/JyMg9np0dv4aFBT+3trY+j46Ovg==",
+      "vectorSha256": "f0894a063b4afe8c8f59bdd52938190766ae8fc23b351de48aeb480fc47b03c1",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "c5dbd35de73466c994ba6a1f36dd3db0aa3e0c39e6273d211232218c31c2ad5c",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "money-25": {
+      "vector": "iYiIvePi4r7l5GS+8/LyPra1Nb+ysTE/0tFRP+blZT+CgQG/zcxMvo+Ojj6vrq6+zMtLv8TDQ7/Ix0e/lZQUvpCPDz/X1ta+vLs7P5eWlj6Pjo4+6+rqvrSzMz+dnBy+9/b2vpaVFb+joqK+pqUlP4iHB7+3tra+2tlZv5uamj6JiIi94+LivuXkZL7z8vI+trU1v7KxMT/S0VE/5uVlP4KBAb/NzEy+j46OPq+urr7My0u/xMNDv8jHR7+VlBS+kI8PP9fW1r68uzs/l5aWPo+Ojj7r6uq+tLMzP52cHL739va+lpUVv6Oior6mpSU/iIcHv7e2tr7a2Vm/m5qaPg==",
+      "vectorSha256": "0a3fcea12a0cbf3c08f01487bc93b6fd43637be9f2544b43649d015ed13738d2",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "774763bc25d8e8f23f66a3541a1e1c6dc74adda5a345d96c423557d23c5213a6",
+      "updatedAt": "2025-09-20T22:28:15.455Z"
+    },
+    "motivation-14": {
+      "vector": "p6amPszLSz+ZmJi98O9vv5uamr7My0u/jIsLv+TjY7+Ihwe/2djYvbu6ur7Hxsa+p6amPtPS0r6vrq6+lpUVv5STEz/f3t6+2djYPc3MTL7k42O/paQkvomIiL3r6uo+9PNzv9/e3j6ioSE/w8LCPu/u7j6wry+//fx8Pufm5r6npqY+zMtLP5mYmL3w72+/m5qavszLS7+Miwu/5ONjv4iHB7/Z2Ni9u7q6vsfGxr6npqY+09LSvq+urr6WlRW/lJMTP9/e3r7Z2Ng9zcxMvuTjY7+lpCS+iYiIvevq6j7083O/397ePqKhIT/DwsI+7+7uPrCvL7/9/Hw+5+bmvg==",
+      "vectorSha256": "bfcbbdcc6edb11e607420c553f3d9fd2c87194957337ab473ef0c25bab27cc09",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "a9e57608591a3a0e3c72514ea94b5435c9488d660e6b77ba06b7d0b0bb289f46",
+      "updatedAt": "2025-09-20T22:28:15.443Z"
+    },
+    "positive-16": {
+      "vector": "8O9vP8HAQLzZ2Ni9//7+vvPy8r6pqKg9np0dv7SzMz+BgIA79/b2PpOSkj7o52e/lpUVv9DPT7/d3Fy+4N9fP7W0ND7X1ta+nZwcvtTTU7++vT2/8vFxv5iXFz/Avz8/mJcXP/Tzcz/h4OC8v76+voOCgj7x8HA9xsVFP46NDb/w728/wcBAvNnY2L3//v6+8/LyvqmoqD2enR2/tLMzP4GAgDv39vY+k5KSPujnZ7+WlRW/0M9Pv93cXL7g318/tbQ0PtfW1r6dnBy+1NNTv769Pb/y8XG/mJcXP8C/Pz+Ylxc/9PNzP+Hg4Ly/vr6+g4KCPvHwcD3GxUU/jo0Nvw==",
+      "vectorSha256": "bfde36c1f1ceecf7cbd5ba08047bc40be1ad484eac08a52a4a79cd145b0dcdc9",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "f77e7240438a31d980bda40c351864ef964a6c162107cbdfcbf97c50a087e239",
+      "updatedAt": "2025-09-20T22:28:15.460Z"
+    },
+    "time-04": {
+      "vector": "+fj4vaSjIz/Lyso+hYQEvt3cXD6ysTE/lpUVP+3sbD7e3V2/vLs7P5WUFD7CwUE/9vV1P8nIyL3Lysq++Pd3P+7tbb+urS0/7OtrP8vKyj62tTW/+/r6vrq5OT+bmpo+wcBAPIyLC7/Ix0e/yslJv6qpKT/083M/zcxMvo6NDT/5+Pi9pKMjP8vKyj6FhAS+3dxcPrKxMT+WlRU/7exsPt7dXb+8uzs/lZQUPsLBQT/29XU/ycjIvcvKyr7493c/7u1tv66tLT/s62s/y8rKPra1Nb/7+vq+urk5P5uamj7BwEA8jIsLv8jHR7/KyUm/qqkpP/Tzcz/NzEy+jo0NPw==",
+      "vectorSha256": "dc385e6e8e08ec34faaa24c864a2ee66acd839d624aafbdc953cfb0680541bcc",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "70d1b26f9bd8ca9d11dd92e0fa734dfb09d6f5b22541dca6813a1c1bd4f966c6",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "time-10": {
+      "vector": "6ulpP+fm5j6Miwu/p6amvt3cXD719HS+8fBwPaOioj7f3t4+6ulpP62sLD7My0s/jo0Nv8XERD6CgQE/9fR0Pq2sLL7Z2Ng9hIMDv/f29j62tTW/yslJP8C/P7/BwEA8rq0tv+no6L3c21s/lpUVv8zLS7+3tra+6ejoPb++vr7q6Wk/5+bmPoyLC7+npqa+3dxcPvX0dL7x8HA9o6KiPt/e3j7q6Wk/rawsPszLSz+OjQ2/xcREPoKBAT/19HQ+rawsvtnY2D2EgwO/9/b2Pra1Nb/KyUk/wL8/v8HAQDyurS2/6ejovdzbWz+WlRW/zMtLv7e2tr7p6Og9v76+vg==",
+      "vectorSha256": "0a13685cb4be454a7dedb69c5bdb16e0ef27f4402309178dcb0283c0cf76fcb3",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "f4b93a569b6187a8b7f495e53998c09e6a8d3ebd25e420812971ed351a528e50",
+      "updatedAt": "2025-09-20T22:28:15.437Z"
+    },
+    "travel-02": {
+      "vector": "trU1P9fW1r7W1VU/h4aGPsXERL66uTk/sbAwvbGwML3NzEy++/r6PtzbWz/h4OA8yslJP8TDQ7/BwEC8r66uPv79fb+xsDC9w8LCPvz7e7+NjAy+3t1dv9DPT7/083M/8/LyPvX0dL6HhoY+paQkPoqJCb/Ew0M/ycjIPcLBQb+2tTU/19bWvtbVVT+HhoY+xcREvrq5OT+xsDC9sbAwvc3MTL77+vo+3NtbP+Hg4DzKyUk/xMNDv8HAQLyvrq4+/v19v7GwML3DwsI+/Pt7v42MDL7e3V2/0M9Pv/Tzcz/z8vI+9fR0voeGhj6lpCQ+iokJv8TDQz/JyMg9wsFBvw==",
+      "vectorSha256": "dd5175bfe9cf353d3d577d13ef1c358626bd7d69c6f3b4ea59e93d60b86f8a8f",
+      "model": "text-embedding-3-large",
+      "provider": "openai",
+      "dimensions": 64,
+      "textHash": "da4aeaa167dc7a7a66beed83e41e7eab017ab0026e1118f9bc61a1943be18c1f",
+      "updatedAt": "2025-09-21T03:05:51.944Z"
+    }
+  }
+}

--- a/data/similarity-report-cross-deck-cohere.json
+++ b/data/similarity-report-cross-deck-cohere.json
@@ -1,0 +1,37 @@
+{
+  "dataset": "cross-deck",
+  "threshold": 0.78,
+  "generatedAt": "2025-09-21T04:22:03.211Z",
+  "provider": "cohere",
+  "model": "embed-english-v3.0",
+  "matches": [
+    {
+      "idA": "humor-01",
+      "idB": "j-0001",
+      "similarity": 0.868,
+      "previewA": "I’m sick of following my dreams, man. I’m just going to ask where they’re going and hook up with’em later. — Mitch Hedberg",
+      "previewB": "I'm tired of following my dreams. • I'm just going to ask them where they are going and meet up with them later."
+    },
+    {
+      "idA": "time-10",
+      "idB": "j-0038",
+      "similarity": 0.824,
+      "previewA": "The bad news is time flies. The good news is you’re the pilot. — Michael Altshuler",
+      "previewB": "Why did the kid throw the clock out the window? • He wanted to see time fly!"
+    },
+    {
+      "idA": "time-04",
+      "idB": "j-0081",
+      "similarity": 0.815,
+      "previewA": "The most precious resource we all have is time. — Steve Jobs",
+      "previewB": "I made a belt out of watches once... • It was a waist of time."
+    },
+    {
+      "idA": "humor-08",
+      "idB": "j-0043",
+      "similarity": 0.805,
+      "previewA": "Why do they call it rush hour when nothing moves? — Robin Williams",
+      "previewB": "What did the traffic light say to the car as it passed? • \"Don't look I'm changing!\""
+    }
+  ]
+}

--- a/data/similarity-report-cross-deck-openai.json
+++ b/data/similarity-report-cross-deck-openai.json
@@ -3,7 +3,7 @@
   "threshold": 0.8,
   "generatedAt": "2025-09-21T03:05:51.944Z",
   "provider": "openai",
-  "model": "text-embedding-3-large (second opinion)",
+  "model": "text-embedding-3-large",
   "matches": [
     {
       "idA": "humor-01",

--- a/data/similarity-report-jokes-cohere.json
+++ b/data/similarity-report-jokes-cohere.json
@@ -1,0 +1,37 @@
+{
+  "dataset": "jokes",
+  "threshold": 0.78,
+  "generatedAt": "2025-09-21T04:22:03.211Z",
+  "provider": "cohere",
+  "model": "embed-english-v3.0",
+  "matches": [
+    {
+      "idA": "j-0182",
+      "idB": "j-0246",
+      "similarity": 0.855,
+      "previewA": "What do you call a cow with no legs? • Ground beef.",
+      "previewB": "What do you call a cow with two legs? • Lean beef."
+    },
+    {
+      "idA": "j-0081",
+      "idB": "j-0673",
+      "similarity": 0.84,
+      "previewA": "I made a belt out of watches once... • It was a waist of time.",
+      "previewB": "What do you call a belt made out of watches? • A waist of time."
+    },
+    {
+      "idA": "j-0703",
+      "idB": "j-0759",
+      "similarity": 0.827,
+      "previewA": "Why do Java programmers wear glasses? • Because they don't C#.",
+      "previewB": "Why dot net developers don't wear glasses? • Because they see sharp."
+    },
+    {
+      "idA": "j-0410",
+      "idB": "j-0727",
+      "similarity": 0.82,
+      "previewA": "What does a clock do when it's hungry? • It goes back four seconds!",
+      "previewB": "Did you hear about the hungry clock? • It went back four seconds."
+    }
+  ]
+}

--- a/data/similarity-report-jokes-openai.json
+++ b/data/similarity-report-jokes-openai.json
@@ -3,7 +3,7 @@
   "threshold": 0.8,
   "generatedAt": "2025-09-20T22:27:41.541Z",
   "provider": "openai",
-  "model": "text-embedding-3-large (second opinion)",
+  "model": "text-embedding-3-large",
   "matches": [
     {
       "idA": "j-0182",

--- a/data/similarity-report-quotes-cohere.json
+++ b/data/similarity-report-quotes-cohere.json
@@ -1,0 +1,37 @@
+{
+  "dataset": "quotes",
+  "threshold": 0.78,
+  "generatedAt": "2025-09-21T04:22:03.211Z",
+  "provider": "cohere",
+  "model": "embed-english-v3.0",
+  "matches": [
+    {
+      "idA": "motivation-14",
+      "idB": "positive-16",
+      "similarity": 0.809,
+      "previewA": "Never let the fear of striking out get in your way. — Babe Ruth",
+      "previewB": "Every strike brings me closer to the next home run. — Babe Ruth"
+    },
+    {
+      "idA": "money-23",
+      "idB": "money-25",
+      "similarity": 0.797,
+      "previewA": "That man is richest whose pleasures are cheapest. — Henry David Thoreau",
+      "previewB": "Wealth is the ability to fully experience life. — Henry David Thoreau"
+    },
+    {
+      "idA": "adventure-01",
+      "idB": "adventure-36",
+      "similarity": 0.79,
+      "previewA": "The danger of adventure is worth a thousand days of ease and comfort. — Paulo Coelho",
+      "previewB": "If you think adventure is dangerous, try routine, it is lethal. — Paulo Coelho"
+    },
+    {
+      "idA": "adventure-29",
+      "idB": "travel-02",
+      "similarity": 0.786,
+      "previewA": "Take only memories, leave only footprints. — Chief Seattle",
+      "previewB": "Take only memories, leave only footprints. — Unknown"
+    }
+  ]
+}

--- a/data/similarity-report-quotes-openai.json
+++ b/data/similarity-report-quotes-openai.json
@@ -3,7 +3,7 @@
   "threshold": 0.8,
   "generatedAt": "2025-09-21T03:05:51.944Z",
   "provider": "openai",
-  "model": "text-embedding-3-large (second opinion)",
+  "model": "text-embedding-3-large",
   "matches": [
     {
       "idA": "motivation-14",

--- a/tools/fix-openai-rerun-metadata.js
+++ b/tools/fix-openai-rerun-metadata.js
@@ -46,8 +46,8 @@ function updateReportTimestamp(relativePath, generatedAt) {
 
 function main() {
   const embeddingsFiles = {
-    jokes: 'data/jokes-embeddings-second-opinion.json',
-    quotes: 'data/quotes-embeddings-second-opinion.json',
+    jokes: 'data/jokes-embeddings-openai.json',
+    quotes: 'data/quotes-embeddings-openai.json',
   };
 
   const generatedAtByDataset = Object.entries(embeddingsFiles).reduce((acc, [key, filePath]) => {
@@ -66,14 +66,14 @@ function main() {
   }
   const crossDeckTimestamp = new Date(crossDeckGeneratedAt).toISOString();
 
-  updateReportTimestamp('data/similarity-report-jokes-second-opinion.json', generatedAtByDataset.jokes);
-  console.log(`Updated data/similarity-report-jokes-second-opinion.json → ${generatedAtByDataset.jokes}`);
+  updateReportTimestamp('data/similarity-report-jokes-openai.json', generatedAtByDataset.jokes);
+  console.log(`Updated data/similarity-report-jokes-openai.json → ${generatedAtByDataset.jokes}`);
 
-  updateReportTimestamp('data/similarity-report-quotes-second-opinion.json', generatedAtByDataset.quotes);
-  console.log(`Updated data/similarity-report-quotes-second-opinion.json → ${generatedAtByDataset.quotes}`);
+  updateReportTimestamp('data/similarity-report-quotes-openai.json', generatedAtByDataset.quotes);
+  console.log(`Updated data/similarity-report-quotes-openai.json → ${generatedAtByDataset.quotes}`);
 
-  updateReportTimestamp('data/similarity-report-cross-deck-second-opinion.json', crossDeckTimestamp);
-  console.log(`Updated data/similarity-report-cross-deck-second-opinion.json → ${crossDeckTimestamp}`);
+  updateReportTimestamp('data/similarity-report-cross-deck-openai.json', crossDeckTimestamp);
+  console.log(`Updated data/similarity-report-cross-deck-openai.json → ${crossDeckTimestamp}`);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- rename the former second-opinion embedding datasets and similarity reports to OpenAI-specific filenames and point the lab UI at them
- update the maintenance script to track the new OpenAI asset names and generated timestamps
- tidy the Cohere metadata strings so the model label matches the embed-english-v3.0 option now exposed in the lab

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0853a56448328b1a02c66672c1577