### PR TITLE
Lower Cohere dedupe floor and extend lab coverage

### DIFF
--- a/apps/similarity-report/index.html
+++ b/apps/similarity-report/index.html
@@ -1393,11 +1393,11 @@
         cohereEmbedEnglishV3: {
           key: 'cohereEmbedEnglishV3',
           label: 'Cohere embed-english-v3.0',
-          description: 'Cohere sweep with a softer 0.78 floor to confirm near-duplicate pairs.',
+          description: 'Cohere sweep with a softer 0.50 floor to confirm near-duplicate pairs.',
           layout: 'dedupe',
-          dedupeThreshold: 0.78,
+          dedupeThreshold: 0.5,
           initialState: {
-            minSimilarity: 0.78,
+            minSimilarity: 0.5,
             maxSimilarity: 1,
             sortKey: 'similarity',
             sortDirection: 'desc',

--- a/tests/similarity-report.spec.js
+++ b/tests/similarity-report.spec.js
@@ -112,5 +112,53 @@ test.describe('Cosine Similarity Lab', () => {
     const previewCount = await coherePreviewImages.count();
     expect(previewCount).toBeGreaterThan(0);
     await expect(coherePreviewImages.first()).toHaveAttribute('src', /^data:image\//);
+
+    const cohereCardCount = await dedupeList.locator('.dedupe-card').count();
+    expect(cohereCardCount).toBeGreaterThanOrEqual(300);
+
+    const cohereBaselineValue = parseLocaleNumber(await baselineEl.textContent());
+    expect(cohereBaselineValue).toBeCloseTo(0.5, 2);
+
+    const cohereMinSliderValue = Number.parseFloat(await minSlider.evaluate((node) => node.value));
+    expect(cohereMinSliderValue).toBeLessThanOrEqual(0.51);
+    expect(cohereMinSliderValue).toBeGreaterThanOrEqual(0.5);
+
+    const cohereDatasetMin = await page.evaluate(async () => {
+      const response = await fetch('/data/similarity-report-jokes-cohere.json');
+      const data = await response.json();
+      return data.matches.reduce((minimum, match) => {
+        const value = typeof match.similarity === 'number' ? match.similarity : 1;
+        return value < minimum ? value : minimum;
+      }, 1);
+    });
+    expect(cohereDatasetMin).toBeGreaterThanOrEqual(0.5);
+    expect(cohereDatasetMin).toBeLessThanOrEqual(0.51);
+
+    const quotesButton = page.locator('[data-dataset="quotes"]');
+    await quotesButton.click();
+    await expect(page.locator('body')).toHaveAttribute('data-active-dataset', 'quotes');
+    await expect(page.locator('[data-search]')).toHaveAttribute('placeholder', /adventure-01/);
+    await expect(dedupeList.locator('.dedupe-card .id-badge').first()).not.toHaveText(/^j-/);
+
+    const quotesCardCount = await dedupeList.locator('.dedupe-card').count();
+    expect(quotesCardCount).toBeGreaterThanOrEqual(300);
+
+    const quotesBaselineValue = parseLocaleNumber(await baselineEl.textContent());
+    expect(quotesBaselineValue).toBeCloseTo(0.5, 2);
+
+    const quotesMinSliderValue = Number.parseFloat(await minSlider.evaluate((node) => node.value));
+    expect(quotesMinSliderValue).toBeLessThanOrEqual(0.51);
+    expect(quotesMinSliderValue).toBeGreaterThanOrEqual(0.5);
+
+    const quotesDatasetMin = await page.evaluate(async () => {
+      const response = await fetch('/data/similarity-report-quotes-cohere.json');
+      const data = await response.json();
+      return data.matches.reduce((minimum, match) => {
+        const value = typeof match.similarity === 'number' ? match.similarity : 1;
+        return value < minimum ? value : minimum;
+      }, 1);
+    });
+    expect(quotesDatasetMin).toBeGreaterThanOrEqual(0.5);
+    expect(quotesDatasetMin).toBeLessThanOrEqual(0.51);
   });
 });


### PR DESCRIPTION
## Summary
- drop the Cohere embed-english-v3.0 dedupe floor and initial slider minimum from 0.78 to 0.5 so low-similarity pairs stay visible in the lab report
- expand the Cosine Similarity Lab Playwright flow to assert the Cohere view keeps a 0.5 floor across jokes and quotes, including dataset minima checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d142dad5b8832895446840b30f59c6