### PR TITLE
Add live filters to jokes and quotes listings

### DIFF
--- a/apps/jokes/all-jokes-compact.html
+++ b/apps/jokes/all-jokes-compact.html
@@ -37,6 +37,12 @@
         --table-border: rgba(148, 163, 209, 0.12);
         --badge-bg: rgba(105, 128, 255, 0.16);
       }
+
+      .filter input[type="search"] {
+        background: rgba(14, 20, 36, 0.9);
+        border-color: rgba(148, 163, 209, 0.4);
+        color: inherit;
+      }
     }
 
     body {
@@ -90,6 +96,37 @@
       font-size: 0.9rem;
       font-weight: 600;
       color: inherit;
+    }
+
+    .filter {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-top: 4px;
+    }
+
+    .filter label {
+      font-weight: 600;
+      font-size: 0.95rem;
+      color: var(--text-secondary);
+    }
+
+    .filter input[type="search"] {
+      width: 100%;
+      box-sizing: border-box;
+      border-radius: 14px;
+      border: 1px solid var(--table-border);
+      background: rgba(255, 255, 255, 0.92);
+      color: inherit;
+      padding: 12px 16px;
+      font: inherit;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .filter input[type="search"]:focus-visible {
+      outline: 2px solid rgba(112, 132, 255, 0.5);
+      outline-offset: 2px;
+      box-shadow: 0 0 0 3px rgba(112, 132, 255, 0.18);
     }
 
     .table-wrapper {
@@ -182,8 +219,12 @@
   <main>
     <header class="page-header">
       <h1>All Jokes (Compact)</h1>
-      <p>Condensed view with tighter spacing for quicker scanning. <span class="badge"><span data-count>0</span> jokes</span></p>
+      <p>Condensed view with tighter spacing for quicker scanning. <span class="badge">Showing <span data-count>0</span> of <span data-total>0</span> jokes</span></p>
     </header>
+    <form class="filter" data-filter-form>
+      <label for="compact-joke-filter">Filter jokes</label>
+      <input id="compact-joke-filter" type="search" name="compact-joke-filter" placeholder="Type to filter…" autocomplete="off" data-filter-input>
+    </form>
     <div class="table-wrapper" role="region" aria-live="polite">
       <table>
         <caption class="sr-only">Compact list of jokes with punchlines</caption>

--- a/apps/jokes/all-jokes.html
+++ b/apps/jokes/all-jokes.html
@@ -36,6 +36,12 @@
       .punchline-row td {
         background: rgba(255, 255, 255, 0.08);
       }
+
+      .filter input[type="search"] {
+        background: rgba(18, 18, 18, 0.9);
+        border-color: rgba(241, 245, 255, 0.35);
+        color: inherit;
+      }
     }
 
     main {
@@ -55,6 +61,36 @@
 
     .count {
       font-weight: 600;
+    }
+
+    .filter {
+      margin-top: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .filter label {
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .filter input[type="search"] {
+      width: 100%;
+      box-sizing: border-box;
+      border-radius: 12px;
+      border: 1px solid rgba(0, 0, 0, 0.2);
+      background: rgba(255, 255, 255, 0.95);
+      color: inherit;
+      padding: 10px 14px;
+      font: inherit;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .filter input[type="search"]:focus-visible {
+      outline: 2px solid rgba(48, 86, 211, 0.55);
+      outline-offset: 2px;
+      box-shadow: 0 0 0 3px rgba(48, 86, 211, 0.18);
     }
 
     table {
@@ -92,8 +128,12 @@
 <body>
   <main>
     <h1>All Jokes</h1>
-    <p>Every joke from the dataset in one place. Use your browser search to find a favourite.</p>
-    <p class="count"><span data-count>0</span> jokes</p>
+    <p>Every joke from the dataset in one place. Use the filter to zero in on a favourite.</p>
+    <p class="count">Showing <span data-count>0</span> of <span data-total>0</span> jokes</p>
+    <form class="filter" data-filter-form>
+      <label for="joke-filter">Filter jokes</label>
+      <input id="joke-filter" type="search" name="joke-filter" placeholder="Type to filter…" autocomplete="off" data-filter-input>
+    </form>
     <table>
       <caption>Setup followed by punchline</caption>
       <tbody>

--- a/apps/jokes/render-all.js
+++ b/apps/jokes/render-all.js
@@ -1,13 +1,19 @@
 (function () {
   const tbody = document.querySelector('tbody');
   const countTarget = document.querySelector('[data-count]');
-
-  const jokes = Array.isArray(window.jokes)
-    ? window.jokes.filter((entry) => entry && entry.joke)
-    : [];
+  const totalTarget = document.querySelector('[data-total]');
+  const filterForm = document.querySelector('[data-filter-form]');
+  const filterInput = document.querySelector('[data-filter-input]');
+  const isCompact = document.body && document.body.dataset.compact === 'true';
 
   if (!tbody) {
     return;
+  }
+
+  if (filterForm) {
+    filterForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+    });
   }
 
   const formatPunchline = (value) => {
@@ -26,46 +32,121 @@
     return copy;
   }
 
-  const deck = shuffle(jokes);
+  const rawJokes = Array.isArray(window.jokes)
+    ? window.jokes
+        .map((entry) => {
+          const setup = entry && typeof entry.joke === 'string' ? entry.joke.trim() : '';
+          const rawPunchline = entry && typeof entry.punchline === 'string' ? entry.punchline.trim() : '';
+          if (!setup) {
+            return null;
+          }
+          return { setup, rawPunchline };
+        })
+        .filter(Boolean)
+    : [];
 
-  if (countTarget) {
-    countTarget.textContent = deck.length.toLocaleString();
+  const deck = shuffle(
+    rawJokes.map((entry) => {
+      const punchline = formatPunchline(entry.rawPunchline);
+      const searchText = `${entry.setup} ${entry.rawPunchline}`.toLowerCase();
+      return {
+        setup: entry.setup,
+        punchline,
+        searchText,
+      };
+    })
+  );
+
+  const totalCount = deck.length;
+  if (totalTarget) {
+    totalTarget.textContent = totalCount.toLocaleString();
   }
 
-  tbody.textContent = '';
-
-  if (!deck.length) {
-    const emptyRow = document.createElement('tr');
-    const emptyCell = document.createElement('td');
-    emptyCell.textContent = 'No jokes available.';
-    emptyRow.appendChild(emptyCell);
-    tbody.appendChild(emptyRow);
-    return;
+  function updateCount(value) {
+    if (countTarget) {
+      countTarget.textContent = value.toLocaleString();
+    }
   }
 
-  const fragment = document.createDocumentFragment();
+  function renderRows(list, term) {
+    tbody.textContent = '';
 
-  deck.forEach((entry) => {
-    const setupRow = document.createElement('tr');
+    if (!list.length) {
+      const emptyRow = document.createElement('tr');
+      const emptyCell = document.createElement('td');
+      if (isCompact) {
+        emptyCell.colSpan = 3;
+      }
+      emptyCell.textContent = term ? `No jokes match “${term}”.` : 'No jokes available.';
+      emptyRow.appendChild(emptyCell);
+      tbody.appendChild(emptyRow);
+      return;
+    }
 
-    const setupCell = document.createElement('td');
-    setupCell.className = 'setup-cell';
-    setupCell.textContent = entry.joke;
+    const fragment = document.createDocumentFragment();
 
-    setupRow.appendChild(setupCell);
+    list.forEach((entry, index) => {
+      if (isCompact) {
+        const row = document.createElement('tr');
 
-    const punchlineRow = document.createElement('tr');
-    punchlineRow.className = 'punchline-row';
+        const indexCell = document.createElement('th');
+        indexCell.scope = 'row';
+        indexCell.textContent = (index + 1).toLocaleString();
+        row.appendChild(indexCell);
 
-    const punchlineCell = document.createElement('td');
-    punchlineCell.className = 'punchline-cell';
-    punchlineCell.textContent = formatPunchline(entry.punchline);
+        const compactSetupCell = document.createElement('td');
+        compactSetupCell.className = 'setup-cell';
+        compactSetupCell.textContent = entry.setup;
+        row.appendChild(compactSetupCell);
 
-    punchlineRow.appendChild(punchlineCell);
+        const compactPunchlineCell = document.createElement('td');
+        compactPunchlineCell.className = 'punchline-cell';
+        compactPunchlineCell.textContent = entry.punchline;
+        row.appendChild(compactPunchlineCell);
 
-    fragment.appendChild(setupRow);
-    fragment.appendChild(punchlineRow);
-  });
+        fragment.appendChild(row);
+        return;
+      }
 
-  tbody.appendChild(fragment);
+      const setupRow = document.createElement('tr');
+
+      const setupCell = document.createElement('td');
+      setupCell.className = 'setup-cell';
+      setupCell.textContent = entry.setup;
+
+      setupRow.appendChild(setupCell);
+
+      const punchlineRow = document.createElement('tr');
+      punchlineRow.className = 'punchline-row';
+
+      const punchlineCell = document.createElement('td');
+      punchlineCell.className = 'punchline-cell';
+      punchlineCell.textContent = entry.punchline;
+
+      punchlineRow.appendChild(punchlineCell);
+
+      fragment.appendChild(setupRow);
+      fragment.appendChild(punchlineRow);
+    });
+
+    tbody.appendChild(fragment);
+  }
+
+  function applyFilter(term) {
+    const normalized = typeof term === 'string' ? term.trim().toLowerCase() : '';
+    const filtered = normalized
+      ? deck.filter((entry) => entry.searchText.includes(normalized))
+      : deck;
+
+    updateCount(filtered.length);
+    renderRows(filtered, normalized);
+  }
+
+  applyFilter(filterInput ? filterInput.value : '');
+
+  if (filterInput) {
+    filterInput.addEventListener('input', () => {
+      applyFilter(filterInput.value);
+    });
+  }
 })();

--- a/apps/quotes/all-quotes.html
+++ b/apps/quotes/all-quotes.html
@@ -39,6 +39,12 @@
       table {
         border-color: rgba(255, 255, 255, 0.2);
       }
+
+      .filter input[type="search"] {
+        background: rgba(18, 18, 18, 0.9);
+        border-color: rgba(241, 245, 255, 0.35);
+        color: inherit;
+      }
     }
 
     main {
@@ -58,6 +64,36 @@
 
     .count {
       font-weight: 600;
+    }
+
+    .filter {
+      margin-top: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .filter label {
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .filter input[type="search"] {
+      width: 100%;
+      box-sizing: border-box;
+      border-radius: 12px;
+      border: 1px solid rgba(0, 0, 0, 0.2);
+      background: rgba(255, 255, 255, 0.95);
+      color: inherit;
+      padding: 10px 14px;
+      font: inherit;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .filter input[type="search"]:focus-visible {
+      outline: 2px solid rgba(48, 86, 211, 0.55);
+      outline-offset: 2px;
+      box-shadow: 0 0 0 3px rgba(48, 86, 211, 0.18);
     }
 
     table {
@@ -113,7 +149,11 @@
   <main>
     <h1>All Quotes</h1>
     <p>Flip through every quote across the themed decks in one place.</p>
-    <p class="count"><span data-count>0</span> quotes</p>
+    <p class="count">Showing <span data-count>0</span> of <span data-total>0</span> quotes</p>
+    <form class="filter" data-filter-form>
+      <label for="quote-filter">Filter quotes</label>
+      <input id="quote-filter" type="search" name="quote-filter" placeholder="Type to filter…" autocomplete="off" data-filter-input>
+    </form>
     <table>
       <caption>Quote followed by author and category</caption>
       <tbody>

--- a/apps/quotes/render-all.js
+++ b/apps/quotes/render-all.js
@@ -1,9 +1,18 @@
 (function () {
   const tbody = document.querySelector('tbody');
   const countTarget = document.querySelector('[data-count]');
+  const totalTarget = document.querySelector('[data-total]');
+  const filterForm = document.querySelector('[data-filter-form]');
+  const filterInput = document.querySelector('[data-filter-input]');
 
   if (!tbody) {
     return;
+  }
+
+  if (filterForm) {
+    filterForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+    });
   }
 
   const categories = Array.isArray(window.quotesData)
@@ -41,60 +50,97 @@
     return copy;
   }
 
-  const deck = shuffle(rows);
+  const deck = shuffle(
+    rows.map((entry) => {
+      const searchText = [entry.text, entry.author, entry.category].filter(Boolean).join(' ').toLowerCase();
+      return {
+        category: entry.category,
+        text: entry.text,
+        author: entry.author,
+        searchText,
+      };
+    })
+  );
 
-  if (countTarget) {
-    countTarget.textContent = deck.length.toLocaleString();
+  const totalCount = deck.length;
+  if (totalTarget) {
+    totalTarget.textContent = totalCount.toLocaleString();
   }
 
-  tbody.textContent = '';
-
-  if (!deck.length) {
-    const emptyRow = document.createElement('tr');
-    const emptyCell = document.createElement('td');
-    emptyCell.textContent = 'No quotes available.';
-    emptyRow.appendChild(emptyCell);
-    tbody.appendChild(emptyRow);
-    return;
+  function updateCount(value) {
+    if (countTarget) {
+      countTarget.textContent = value.toLocaleString();
+    }
   }
 
-  const fragment = document.createDocumentFragment();
+  function renderRows(list, term) {
+    tbody.textContent = '';
 
-  deck.forEach((entry) => {
-    const quoteRow = document.createElement('tr');
-    quoteRow.className = 'quote-row';
-
-    const quoteCell = document.createElement('td');
-    quoteCell.className = 'quote-cell';
-    quoteCell.textContent = entry.text;
-    quoteRow.appendChild(quoteCell);
-
-    const metaRow = document.createElement('tr');
-    metaRow.className = 'meta-row';
-
-    const metaCell = document.createElement('td');
-    metaCell.className = 'meta-cell';
-
-    metaCell.appendChild(document.createTextNode('— '));
-
-    const authorSpan = document.createElement('span');
-    authorSpan.className = 'meta-author';
-    authorSpan.textContent = entry.author;
-    metaCell.appendChild(authorSpan);
-
-    if (entry.category) {
-      metaCell.appendChild(document.createTextNode(' · '));
-      const categorySpan = document.createElement('span');
-      categorySpan.className = 'meta-category';
-      categorySpan.textContent = entry.category;
-      metaCell.appendChild(categorySpan);
+    if (!list.length) {
+      const emptyRow = document.createElement('tr');
+      const emptyCell = document.createElement('td');
+      emptyCell.textContent = term ? `No quotes match “${term}”.` : 'No quotes available.';
+      emptyRow.appendChild(emptyCell);
+      tbody.appendChild(emptyRow);
+      return;
     }
 
-    metaRow.appendChild(metaCell);
+    const fragment = document.createDocumentFragment();
 
-    fragment.appendChild(quoteRow);
-    fragment.appendChild(metaRow);
-  });
+    list.forEach((entry) => {
+      const quoteRow = document.createElement('tr');
+      quoteRow.className = 'quote-row';
 
-  tbody.appendChild(fragment);
+      const quoteCell = document.createElement('td');
+      quoteCell.className = 'quote-cell';
+      quoteCell.textContent = entry.text;
+      quoteRow.appendChild(quoteCell);
+
+      const metaRow = document.createElement('tr');
+      metaRow.className = 'meta-row';
+
+      const metaCell = document.createElement('td');
+      metaCell.className = 'meta-cell';
+
+      metaCell.appendChild(document.createTextNode('— '));
+
+      const authorSpan = document.createElement('span');
+      authorSpan.className = 'meta-author';
+      authorSpan.textContent = entry.author;
+      metaCell.appendChild(authorSpan);
+
+      if (entry.category) {
+        metaCell.appendChild(document.createTextNode(' · '));
+        const categorySpan = document.createElement('span');
+        categorySpan.className = 'meta-category';
+        categorySpan.textContent = entry.category;
+        metaCell.appendChild(categorySpan);
+      }
+
+      metaRow.appendChild(metaCell);
+
+      fragment.appendChild(quoteRow);
+      fragment.appendChild(metaRow);
+    });
+
+    tbody.appendChild(fragment);
+  }
+
+  function applyFilter(term) {
+    const normalized = typeof term === 'string' ? term.trim().toLowerCase() : '';
+    const filtered = normalized
+      ? deck.filter((entry) => entry.searchText.includes(normalized))
+      : deck;
+
+    updateCount(filtered.length);
+    renderRows(filtered, normalized);
+  }
+
+  applyFilter(filterInput ? filterInput.value : '');
+
+  if (filterInput) {
+    filterInput.addEventListener('input', () => {
+      applyFilter(filterInput.value);
+    });
+  }
 })();


### PR DESCRIPTION
## Summary
- add searchable filter controls to the jokes "all" pages with updated counts
- enhance the jokes renderer to support compact tables and live filtering
- add the same filtering workflow to the all quotes page and renderer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d152c532ec8328af762942883fd335