### PR TITLE
Restore full matrix view for dedupe models

### DIFF
--- a/apps/similarity-report/index.html
+++ b/apps/similarity-report/index.html
@@ -802,11 +802,6 @@
       grid-template-columns: 1fr;
     }
 
-    .results[data-layout="dedupe"] .detail-panel,
-    .results[data-layout="dedupe"] .table-wrapper {
-      display: none;
-    }
-
     .dedupe-view {
       background: var(--surface-strong);
       border: 1px solid var(--card-border);
@@ -2809,12 +2804,10 @@
         const matches = getMatchesForDataset();
         state.visibleMatches = matches;
         updateCount(matches.length);
+        renderTable(matches);
         if (config.layout === 'dedupe') {
           renderDedupe(matches, config);
-          updateStats();
-          return;
         }
-        renderTable(matches);
         updateStats();
         applySortIndicators();
         let activeMatch = matches.find((item) => buildPairKey(state.dataset, item.idA, item.idB) === state.activePairKey);
@@ -2920,6 +2913,10 @@
         if (detailEmpty) {
           detailEmpty.hidden = false;
           detailEmpty.textContent = message;
+        }
+        if (copyButton) {
+          copyButton.disabled = true;
+          copyButton.textContent = 'Copy pair IDs';
         }
       }
 
@@ -3085,21 +3082,16 @@
         }
         const isDedupe = layout === 'dedupe';
         if (tableWrapper) {
-          tableWrapper.hidden = isDedupe;
+          tableWrapper.hidden = false;
         }
         if (dedupeView) {
           dedupeView.hidden = !isDedupe;
         }
         if (detailPanel) {
-          detailPanel.hidden = isDedupe;
+          detailPanel.hidden = false;
         }
         if (copyButton) {
-          copyButton.hidden = isDedupe;
-          if (isDedupe) {
-            copyButton.disabled = true;
-          } else {
-            copyButton.disabled = false;
-          }
+          copyButton.hidden = false;
         }
         if (minSlider) {
           minSlider.disabled = false;
@@ -3415,7 +3407,7 @@
 
       document.addEventListener('keydown', (event) => {
         const config = getActiveModelConfig();
-        if (!config || config.layout === 'dedupe') {
+        if (!config) {
           return;
         }
         if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {

--- a/tests/similarity-report.spec.js
+++ b/tests/similarity-report.spec.js
@@ -26,6 +26,11 @@ test.describe('Cosine Similarity Lab', () => {
     const dedupeView = page.locator('[data-dedupe-view]');
     const dedupeList = page.locator('[data-dedupe-list]');
     const resultsSection = page.locator('[data-results]');
+    const tableWrapper = page.locator('[data-matrix-view]');
+    const detailPanel = page.locator('[data-detail]');
+    const detailBody = page.locator('[data-detail-body]');
+    const detailTitle = page.locator('[data-detail-title]');
+    const copyButton = page.locator('[data-copy-pair]');
 
     const minAttr = await minSlider.getAttribute('min');
     const minBound = Number.parseFloat(minAttr || '0');
@@ -79,6 +84,12 @@ test.describe('Cosine Similarity Lab', () => {
     await expect(page.locator('body')).toHaveAttribute('data-active-dataset', 'jokes');
     await expect(resultsSection).toHaveAttribute('data-layout', 'dedupe');
     await expect(dedupeView).toBeVisible();
+    await page.waitForSelector('[data-results-body] tr:not(.empty-row)');
+    await expect(tableWrapper).toBeVisible();
+    await expect(detailPanel).toBeVisible();
+    await expect(detailBody).toBeVisible();
+    await expect(detailTitle).toContainText('↔');
+    await expect(copyButton).toBeEnabled();
 
     await page.waitForSelector('[data-dedupe-list] .dedupe-card');
     const dedupeCardCount = await dedupeList.locator('.dedupe-card').count();
@@ -103,6 +114,12 @@ test.describe('Cosine Similarity Lab', () => {
     await expect(cohereButton).toHaveClass(/is-active/);
     await expect(providerEl).toContainText('Cohere embeddings');
     await expect(modelEl).toContainText('embed-english-v3.0');
+    await page.waitForSelector('[data-results-body] tr:not(.empty-row)');
+    await expect(tableWrapper).toBeVisible();
+    await expect(detailPanel).toBeVisible();
+    await expect(detailBody).toBeVisible();
+    await expect(detailTitle).toContainText('↔');
+    await expect(copyButton).toBeEnabled();
 
     const searchPlaceholder = await page.locator('[data-search]').getAttribute('placeholder');
     expect((searchPlaceholder || '').toLowerCase()).toContain('j-0182');


### PR DESCRIPTION
## Summary
- keep the similarity table and detail inspector visible when dedupe models are selected
- render both the matrix and dedupe recommendations so copy/keyboard interactions stay available
- extend the Playwright smoke test to assert the dedupe models still expose the matrix view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1b448b5208328a38736cf6f48890f