### PR TITLE
Prune duplicate deck entries and surface manual overrides in Cosine Lab

### DIFF
--- a/apps/jokes/jokes.js
+++ b/apps/jokes/jokes.js
@@ -1266,10 +1266,6 @@ window.jokes = [
             "joke": "Why did the miner get fired from his job?",
             "punchline": "He took it for granite..."
         }, {
-            "id": "j-0317",
-            "joke": "What did the hat say to the scarf? You can hang around.",
-            "punchline": "I'll just go on ahead."
-        }, {
             "id": "j-0318",
             "joke": "Where do cats write notes?",
             "punchline": "Scratch Paper!"
@@ -1710,10 +1706,6 @@ window.jokes = [
             "joke": "I ordered a chicken and an egg from Amazon.",
             "punchline": "I'll let you know."
         }, {
-            "id": "j-0428",
-            "joke": "Ever wondered why bees hum?",
-            "punchline": "It's because they don't know the words."
-        }, {
             "id": "j-0429",
             "joke": "How many optometrists does it take to change a light bulb? 1 or 2?",
             "punchline": "1... or 2?"
@@ -2077,10 +2069,6 @@ window.jokes = [
             "id": "j-0520",
             "joke": "I had a dream that I was a muffler last night.",
             "punchline": "I woke up exhausted!"
-        }, {
-            "id": "j-0521",
-            "joke": "A dad washes his car with his son.",
-            "punchline": "But after a while, the son says, \"why can't you just use a sponge?\""
         }, {
             "id": "j-0522",
             "joke": "Doctor you've got you help me, I'm addicted to twitter.",
@@ -2738,10 +2726,6 @@ window.jokes = [
             "joke": "Why did the programmer quit his job?",
             "punchline": "Because he didn't get arrays."
         }, {
-            "id": "j-0688",
-            "joke": "Did you hear about the two silk worms in a race?",
-            "punchline": "It ended in a tie."
-        }, {
             "id": "j-0689",
             "joke": "What do you call a laughing motorcycle?",
             "punchline": "A Yamahahahaha."
@@ -2782,10 +2766,6 @@ window.jokes = [
             "joke": "What did the duck say when he bought lipstick?",
             "punchline": "Put it on my bill"
         }, {
-            "id": "j-0700",
-            "joke": "did you know the first French fries weren't cooked in France?",
-            "punchline": "they were cooked in Greece"
-        }, {
             "id": "j-0701",
             "joke": "Which song would an exception sing?",
             "punchline": "Can't catch me - Avicii"
@@ -2805,10 +2785,6 @@ window.jokes = [
             "id": "j-0705",
             "joke": "Do you know what the word 'was' was initially?",
             "punchline": "Before was was was was was is."
-        }, {
-            "id": "j-0706",
-            "joke": "I'm reading a book about anti-gravity...",
-            "punchline": "It's impossible to put down"
         }, {
             "id": "j-0707",
             "joke": "If you're American when you go into the bathroom, and American when you come out, what are you when you're in there?",
@@ -2845,10 +2821,6 @@ window.jokes = [
             "id": "j-0717",
             "joke": "What do you call a factory that sells passable products?",
             "punchline": "A satisfactory"
-        }, {
-            "id": "j-0718",
-            "joke": "When a dad drives past a graveyard: Did you know that's a popular cemetery?",
-            "punchline": "Yep, people are just dying to get in there"
         }, {
             "id": "j-0719",
             "joke": "Why did the invisible man turn down the job offer?",
@@ -2890,10 +2862,6 @@ window.jokes = [
             "joke": "Well...",
             "punchline": "That’s a deep subject."
         }, {
-            "id": "j-0729",
-            "joke": "Did you hear the story about the cheese that saved the world?",
-            "punchline": "It was legend dairy."
-        }, {
             "id": "j-0730",
             "joke": "Did you watch the new comic book movie?",
             "punchline": "It was very graphic!"
@@ -2910,10 +2878,6 @@ window.jokes = [
             "joke": "I can't tell if i like this blender...",
             "punchline": "It keeps giving me mixed results."
         }, {
-            "id": "j-0734",
-            "joke": "I couldn't get a reservation at the library...",
-            "punchline": "They were fully booked."
-        }, {
             "id": "j-0735",
             "joke": "I was gonna tell you a joke about UDP...",
             "punchline": "...but you might not get it."
@@ -2925,10 +2889,6 @@ window.jokes = [
             "id": "j-0737",
             "joke": "Why do C# and Java developers keep breaking their keyboards?",
             "punchline": "Because they use a strongly typed language."
-        }, {
-            "id": "j-0740",
-            "joke": "Can I watch the TV?",
-            "punchline": "Yes, but don’t turn it on."
         }, {
             "id": "j-0741",
             "joke": "What do ghosts call their true love?",
@@ -3026,14 +2986,6 @@ window.jokes = [
             "joke": "What goes after USA?",
             "punchline": "USB."
         }, {
-            "id": "j-0767",
-            "joke": "Why don't eggs tell jokes?",
-            "punchline": "Because they would crack each other up."
-        }, {
-            "id": "j-0768",
-            "joke": "How do you make the number one disappear?",
-            "punchline": "Add the letter G and it’s “gone”!"
-        }, {
             "id": "j-0769",
             "joke": "My older brother always tore the last pages of my comic books, and never told me why.",
             "punchline": "I had to draw my own conclusions."
@@ -3041,10 +2993,6 @@ window.jokes = [
             "id": "j-0770",
             "joke": "The Sergeant-Major growled at the young soldier: I didn’t see you at camouflage training this morning.",
             "punchline": "Thank you very much, sir."
-        }, {
-            "id": "j-0771",
-            "joke": "Why did the kid throw the watch out the window?",
-            "punchline": "So time would fly."
         }, {
             "id": "j-0772",
             "joke": "Where did the API go to eat?",
@@ -3074,21 +3022,9 @@ window.jokes = [
             "joke": "Why didn't the skeleton go for prom?",
             "punchline": "Because it had nobody."
         }, {
-            "id": "j-0779",
-            "joke": "A grocery store cashier asked if I would like my milk in a bag.",
-            "punchline": "I told her 'No, thanks. The carton works fine.'"
-        }, {
             "id": "j-0780",
             "joke": "99.9% of the people are dumb!",
             "punchline": "Fortunately I belong to the remaining 1%"
-        }, {
-            "id": "j-0781",
-            "joke": "I just got fired from my job at the keyboard factory.",
-            "punchline": "They told me I wasn't putting in enough shifts."
-        }, {
-            "id": "j-0782",
-            "joke": "You see, mountains aren't just funny.",
-            "punchline": "They are hill areas."
         }, {
             "id": "j-0783",
             "joke": "What do elves post on Social Media?",
@@ -3158,10 +3094,6 @@ window.jokes = [
             "joke": "Why was the JavaScript developer sad?",
             "punchline": "He didn't know how to null his feelings."
         }, {
-            "id": "j-0802",
-            "joke": "Why couldn't the bicycle stand up by itself?",
-            "punchline": "It was two-tired."
-        }, {
             "id": "j-0803",
             "joke": "Why did the math book look sad?",
             "punchline": "Because it had too many problems."
@@ -3174,21 +3106,9 @@ window.jokes = [
             "joke": "What did the janitor say when he jumped out of the closet?",
             "punchline": "Supplies!"
         }, {
-            "id": "j-0807",
-            "joke": "What's the best thing about Switzerland?",
-            "punchline": "I don't know, but their flag is a big plus."
-        }, {
             "id": "j-0808",
             "joke": "Why did the golfer bring two pairs of pants?",
             "punchline": "In case he got a hole in one."
-        }, {
-            "id": "j-0810",
-            "joke": "Why don't scientists trust atoms?",
-            "punchline": "Because they make up everything."
-        }, {
-            "id": "j-0812",
-            "joke": "Why did the cookie go to the doctor?",
-            "punchline": "Because it was feeling crumbly."
         }, {
             "id": "j-0813",
             "joke": "What do you call a computer mouse that swears a lot?",
@@ -3197,10 +3117,6 @@ window.jokes = [
             "id": "j-0814",
             "joke": "Why did the designer break up with their font?",
             "punchline": "Because it wasn't their type."
-        }, {
-            "id": "j-0816",
-            "joke": "Why did the developer go broke?",
-            "punchline": "They kept spending all their cache."
         }, {
             "id": "j-0817",
             "joke": "How do you comfort a designer?",
@@ -3277,10 +3193,6 @@ window.jokes = [
             "id": "j-0836",
             "joke": "Why did the database administrator leave his wife?",
             "punchline": "She had one-to-many relationships."
-        }, {
-            "id": "j-0837",
-            "joke": "Why do programmers wear glasses?",
-            "punchline": "Because they need to C#."
         }, {
             "id": "j-0838",
             "joke": "Why do front end developers eat lunch alone?",
@@ -3365,10 +3277,6 @@ window.jokes = [
             "id": "j-0859",
             "joke": "What's grey and comes in pints?",
             "punchline": "An elephant."
-        }, {
-            "id": "j-0860",
-            "joke": "What do you call a pile of kittens?",
-            "punchline": "A meowntain."
         }, {
             "id": "j-0861",
             "joke": "What did the cell say when his sister cell stepped on his foot?",

--- a/apps/quotes/quotes-data.js
+++ b/apps/quotes/quotes-data.js
@@ -1279,11 +1279,6 @@ window.quotesData = [
         "author": "Gustave Flaubert"
       },
       {
-        "id": "travel-05",
-        "text": "Every man dies, but not every man really lives.",
-        "author": "William Wallace"
-      },
-      {
         "id": "travel-07",
         "text": "Life is a journey. Make the most of it.",
         "author": "Unknown"
@@ -2802,11 +2797,6 @@ window.quotesData = [
         "author": "Albert Schweitzer"
       },
       {
-        "id": "resilience-02",
-        "text": "Life shrinks or expands in proportion to one's courage.",
-        "author": "Anais Nin"
-      },
-      {
         "id": "resilience-03",
         "text": "Fall seven times, stand up eight.",
         "author": "Japanese Proverb"
@@ -3045,11 +3035,6 @@ window.quotesData = [
         "author": "Anatole France"
       },
       {
-        "id": "growth-09",
-        "text": "They say that time changes things, but you actually have to change them yourself.",
-        "author": "Andy Warhol"
-      },
-      {
         "id": "growth-10",
         "text": "No one has ever become poor by giving.",
         "author": "Anne Frank"
@@ -3084,11 +3069,6 @@ window.quotesData = [
         "id": "joy-03",
         "text": "Find a place inside where there's joy, and the joy will burn out the pain.",
         "author": "Joseph Campbell"
-      },
-      {
-        "id": "joy-04",
-        "text": "Time you enjoy wasting, was not wasted.",
-        "author": "John Lennon"
       },
       {
         "id": "joy-05",

--- a/apps/similarity-report/index.html
+++ b/apps/similarity-report/index.html
@@ -32,6 +32,9 @@
       --detail-glow: rgba(56, 189, 248, 0.18);
       --input-background: rgba(15, 23, 42, 0.68);
       --input-border: rgba(148, 163, 209, 0.3);
+      --flag-protect-bg: rgba(34, 197, 94, 0.18);
+      --flag-protect-text: rgba(34, 197, 94, 0.92);
+      --flag-protect-border: rgba(34, 197, 94, 0.32);
       background-color: var(--background-color);
       color: var(--text-primary);
     }
@@ -57,6 +60,9 @@
         --detail-glow: rgba(99, 102, 241, 0.12);
         --input-background: rgba(248, 250, 255, 0.92);
         --input-border: rgba(148, 163, 209, 0.32);
+        --flag-protect-bg: rgba(34, 197, 94, 0.14);
+        --flag-protect-text: rgba(21, 128, 61, 0.9);
+        --flag-protect-border: rgba(21, 128, 61, 0.28);
       }
     }
 
@@ -353,6 +359,29 @@
       font-size: 1.1rem;
     }
 
+    .score-flags {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 6px;
+      flex-wrap: wrap;
+    }
+
+    .score-flag {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 10px;
+      border-radius: 999px;
+      background: var(--flag-protect-bg);
+      color: var(--flag-protect-text);
+      border: 1px solid var(--flag-protect-border);
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
     .score-meter {
       position: relative;
       margin-top: 8px;
@@ -378,6 +407,27 @@
       margin-top: 12px;
       font-size: 0.78rem;
       color: var(--text-secondary);
+    }
+
+    tbody tr.is-protected .score-value {
+      color: var(--flag-protect-text);
+    }
+
+    tbody tr.is-protected .score-deltas {
+      color: color-mix(in srgb, var(--flag-protect-text) 55%, var(--text-secondary) 45%);
+    }
+
+    tbody tr.is-protected {
+      position: relative;
+    }
+
+    tbody tr.is-protected::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: 18px;
+      border: 1px dashed var(--flag-protect-border);
+      pointer-events: none;
     }
 
     .score-delta {
@@ -612,6 +662,42 @@
       font-size: 1.2rem;
       font-weight: 700;
       letter-spacing: 0.04em;
+    }
+
+    .detail-title-group {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .detail-flag {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 2px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--flag-protect-border);
+      background: var(--flag-protect-bg);
+      color: var(--flag-protect-text);
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .detail-flag[hidden] {
+      display: none;
+    }
+
+    .detail-flag-reason {
+      margin: 6px 0 0;
+      font-size: 0.9rem;
+      color: var(--text-secondary);
+    }
+
+    .detail-flag-reason[hidden] {
+      display: none;
     }
 
     .detail-score {
@@ -876,9 +962,13 @@
         <p class="detail-empty" data-detail-empty>Select a row to inspect the vector neighbours.</p>
         <div class="detail-body" data-detail-body hidden>
           <div class="detail-header">
-            <h2 class="detail-title" data-detail-title>—</h2>
+            <div class="detail-title-group">
+              <h2 class="detail-title" data-detail-title>—</h2>
+              <span class="detail-flag" data-detail-flag hidden>Protected pair</span>
+            </div>
             <button type="button" class="copy-button" data-copy-pair disabled>Copy pair IDs</button>
           </div>
+          <p class="detail-flag-reason" data-detail-flag-reason hidden></p>
           <div class="detail-score">
             <span class="detail-score__value" data-detail-score>0.000</span>
             <span class="detail-score__label">cosine similarity</span>
@@ -1060,6 +1150,8 @@
       const detailEmpty = document.querySelector('[data-detail-empty]');
       const detailBody = document.querySelector('[data-detail-body]');
       const detailTitle = document.querySelector('[data-detail-title]');
+      const detailFlag = document.querySelector('[data-detail-flag]');
+      const detailFlagReason = document.querySelector('[data-detail-flag-reason]');
       const detailScore = document.querySelector('[data-detail-score]');
       const detailDistance = document.querySelector('[data-detail-distance]');
       const detailLength = document.querySelector('[data-detail-length]');
@@ -1271,6 +1363,9 @@
         minimumFractionDigits: 2,
         maximumFractionDigits: 4,
       });
+
+      let overrideIndex = new Map();
+      let overridesPromise = null;
 
       const state = {
         model: DEFAULT_MODEL_KEY,
@@ -2231,6 +2326,7 @@
           levenshteinSourceA,
           levenshteinSourceB,
         );
+        const override = getOverrideForPair(datasetName, match.idA, match.idB);
         return {
           idA: match.idA,
           idB: match.idB,
@@ -2248,11 +2344,114 @@
           wordDelta: Math.abs(wordsA - wordsB),
           levenshteinDistance,
           levenshteinSimilarity,
+          override,
+          isProtected: Boolean(override),
         };
       }
 
       function buildPairKey(dataset, idA, idB) {
         return `${dataset}:${idA}|${idB}`;
+      }
+
+      function sortIdsForOverride(idA, idB) {
+        const left = typeof idA === 'string' ? idA.trim() : '';
+        const right = typeof idB === 'string' ? idB.trim() : '';
+        if (!left || !right) {
+          return [left, right];
+        }
+        return left <= right ? [left, right] : [right, left];
+      }
+
+      function createOverrideKey(dataset, idA, idB) {
+        const datasetName = typeof dataset === 'string' ? dataset.trim() : '';
+        if (!datasetName) {
+          return null;
+        }
+        const [left, right] = sortIdsForOverride(idA, idB);
+        if (!left || !right) {
+          return null;
+        }
+        return `${datasetName}:${left}|${right}`;
+      }
+
+      function getOverrideForPair(dataset, idA, idB) {
+        const key = createOverrideKey(dataset, idA, idB);
+        if (!key) {
+          return null;
+        }
+        if (!(overrideIndex instanceof Map) || !overrideIndex.has(dataset)) {
+          return null;
+        }
+        const datasetOverrides = overrideIndex.get(dataset);
+        return datasetOverrides instanceof Map && datasetOverrides.has(key)
+          ? datasetOverrides.get(key)
+          : null;
+      }
+
+      function parseOverrides(payload) {
+        const index = new Map();
+        if (!payload || typeof payload !== 'object') {
+          return index;
+        }
+        const datasets = payload.datasets && typeof payload.datasets === 'object' ? payload.datasets : {};
+        Object.entries(datasets).forEach(([datasetName, datasetPayload]) => {
+          if (!datasetName || !datasetPayload || typeof datasetPayload !== 'object') {
+            return;
+          }
+          const pairs = Array.isArray(datasetPayload.protectedPairs) ? datasetPayload.protectedPairs : [];
+          if (!pairs.length) {
+            return;
+          }
+          const datasetMap = new Map();
+          pairs.forEach((entry) => {
+            if (!entry || typeof entry !== 'object' || !Array.isArray(entry.ids) || entry.ids.length < 2) {
+              return;
+            }
+            const [idA, idB] = entry.ids;
+            const key = createOverrideKey(datasetName, idA, idB);
+            if (!key) {
+              return;
+            }
+            const label = typeof entry.label === 'string' && entry.label.trim()
+              ? entry.label.trim()
+              : 'Protected pair';
+            const reason = typeof entry.reason === 'string' ? entry.reason.trim() : '';
+            const action = entry.action === 'hide' ? 'hide' : 'protect';
+            datasetMap.set(key, {
+              ids: [idA, idB],
+              label,
+              reason,
+              action,
+            });
+          });
+          if (datasetMap.size) {
+            index.set(datasetName, datasetMap);
+          }
+        });
+        return index;
+      }
+
+      function loadOverrides() {
+        if (overridesPromise) {
+          return overridesPromise;
+        }
+        overridesPromise = fetch('../../data/similarity-overrides.json')
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`Failed to load overrides (${response.status})`);
+            }
+            return response.json();
+          })
+          .then((json) => {
+            overrideIndex = parseOverrides(json);
+            return overrideIndex;
+          })
+          .catch((error) => {
+            console.warn(error);
+            overrideIndex = new Map();
+            return overrideIndex;
+          });
+        return overridesPromise;
       }
 
       function updateCount(count) {
@@ -2282,12 +2481,26 @@
           if (state.activePairKey === pairKey) {
             row.classList.add('is-active');
           }
+          if (match.override) {
+            row.classList.add('is-protected');
+          }
 
           const scoreCell = document.createElement('td');
           scoreCell.className = 'cell-score';
           const scoreValue = document.createElement('span');
           scoreValue.className = 'score-value';
           scoreValue.textContent = formatSimilarity(match.similarity);
+          const scoreFlags = document.createElement('div');
+          scoreFlags.className = 'score-flags';
+          if (match.override) {
+            const flag = document.createElement('span');
+            flag.className = 'score-flag';
+            flag.textContent = match.override.label || 'Protected pair';
+            if (match.override.reason) {
+              flag.title = match.override.reason;
+            }
+            scoreFlags.appendChild(flag);
+          }
           const scoreMeter = document.createElement('div');
           scoreMeter.className = 'score-meter';
           const scoreFill = document.createElement('div');
@@ -2311,6 +2524,9 @@
           scoreDeltas.appendChild(wordDelta);
           scoreDeltas.appendChild(levenshteinDelta);
           scoreCell.appendChild(scoreValue);
+          if (scoreFlags.childElementCount) {
+            scoreCell.appendChild(scoreFlags);
+          }
           scoreCell.appendChild(scoreMeter);
           scoreCell.appendChild(scoreDeltas);
           row.appendChild(scoreCell);
@@ -2427,6 +2643,15 @@
           return;
         }
 
+        if (detailFlag) {
+          detailFlag.hidden = true;
+          detailFlag.textContent = 'Protected pair';
+        }
+        if (detailFlagReason) {
+          detailFlagReason.hidden = true;
+          detailFlagReason.textContent = '';
+        }
+
         if (!match) {
           detailBody.hidden = true;
           detailEmpty.hidden = false;
@@ -2448,6 +2673,19 @@
         if (detailLevenshtein) {
           const levenshteinPercent = formatPercent(match.levenshteinSimilarity);
           detailLevenshtein.textContent = `Levenshtein Δ ${match.levenshteinDistance.toLocaleString()} • ${levenshteinPercent}% overlap`;
+        }
+        if (detailFlag && match.override) {
+          detailFlag.hidden = false;
+          detailFlag.textContent = match.override.label || 'Protected pair';
+        }
+        if (detailFlagReason) {
+          if (match.override && match.override.reason) {
+            detailFlagReason.hidden = false;
+            detailFlagReason.textContent = match.override.reason;
+          } else {
+            detailFlagReason.hidden = true;
+            detailFlagReason.textContent = '';
+          }
         }
 
         if (match.recordA) {
@@ -2541,6 +2779,15 @@
         const searchTerm = normalizeString(state.search);
         const minValue = state.minSimilarity;
         return entry.matches
+          .filter((match) => {
+            if (!match) {
+              return false;
+            }
+            if (match.override && match.override.action === 'hide') {
+              return false;
+            }
+            return true;
+          })
           .filter((match) => match.similarity >= minValue && match.similarity <= state.maxSimilarity)
           .filter((match) => {
             if (!searchTerm) {
@@ -3116,9 +3363,13 @@
 
       document.addEventListener('DOMContentLoaded', () => {
         recordMaps = buildRecordMaps();
-        buildModelButtons();
-        document.body.setAttribute('data-active-dataset', state.dataset || 'jokes');
-        setActiveModel(DEFAULT_MODEL_KEY, { initial: true });
+        loadOverrides()
+          .catch(() => new Map())
+          .finally(() => {
+            buildModelButtons();
+            document.body.setAttribute('data-active-dataset', state.dataset || 'jokes');
+            setActiveModel(DEFAULT_MODEL_KEY, { initial: true });
+          });
       });
     })();
   </script>

--- a/data/jokes-embeddings-cohere.json
+++ b/data/jokes-embeddings-cohere.json
@@ -3,8 +3,8 @@
     "provider": "cohere",
     "model": "embed-english-v3.0",
     "dimensions": 64,
-    "generatedAt": "2025-09-22T01:50:07.859Z",
-    "recordCount": 888
+    "generatedAt": "2025-09-22T23:16:21.862Z",
+    "recordCount": 865
   },
   "records": {
     "j-0001": {
@@ -2851,15 +2851,6 @@
       "textHash": "2e7cbaa621c65b1b0a89d0bfe4d1814f0f0d5194fbb75009fede86c77110c20a",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0317": {
-      "vector": "mJcXv8PCwr6Miwu/w8LCvv38fD7CwUE/vr09P62sLL6vrq6+lJMTv66tLT/U01M/4N9fv/Dvb7/X1tY+x8bGPu3sbL6UkxO/ubi4vfn4+D2zsrK+/fx8voKBAT+ZmJi909LSvquqqr6trCw+lZQUvuPi4j7z8vK+xsVFP+zra7+Ylxe/w8LCvoyLC7/DwsK+/fx8PsLBQT++vT0/rawsvq+urr6UkxO/rq0tP9TTUz/g31+/8O9vv9fW1j7HxsY+7exsvpSTE7+5uLi9+fj4PbOysr79/Hy+goEBP5mYmL3T0tK+q6qqvq2sLD6VlBS+4+LiPvPy8r7GxUU/7Otrvw==",
-      "vectorSha256": "80aa9b1c4a3cad5ca1d94fe5859e81c6db24726ce7ad9c1f1dcb00129068f65d",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "3d322d3250dbcf92a4edd45cced926832c328e88981bfef4b1d53034016ad772",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0318": {
       "vector": "ycjIPb28PL6EgwM/kpERP6qpKb/W1VW/jYwMvt/e3j76+Xm/1tVVP9HQUL2JiIi9jo0Nv/v6+r7Z2Ng9rKsrP8nIyD3l5GQ+q6qqPoqJCb/x8HA9mpkZP56dHb/R0FA9+Pd3v/f29r64tze/mJcXv4OCgr6koyM/o6KiPv38fD7JyMg9vbw8voSDAz+SkRE/qqkpv9bVVb+NjAy+397ePvr5eb/W1VU/0dBQvYmIiL2OjQ2/+/r6vtnY2D2sqys/ycjIPeXkZD6rqqo+iokJv/HwcD2amRk/np0dv9HQUD3493e/9/b2vri3N7+Ylxe/g4KCvqSjIz+joqI+/fx8Pg==",
       "vectorSha256": "9460f17eb1ece2d0a14aead94af50956820dc444a85e1100f94added44be9c2e",
@@ -3850,15 +3841,6 @@
       "textHash": "2a1dfe1645d5e6edcf4afe8d23a0f516fea52ec9ace243501dca35b9df465036",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0428": {
-      "vector": "sK8vv9LRUT/5+Pi9/Pt7v+blZT+qqSm/8vFxv5aVFb+6uTm/wL8/P7W0ND6wry8/2tlZv7m4uD2DgoI+5uVlP/79fT/d3Fy+sK8vP9XUVD6vrq6+0dBQPaempr7Y11c/j46OPqGgoLzLysq+3NtbP6GgoDyJiIg98O9vP56dHT+wry+/0tFRP/n4+L38+3u/5uVlP6qpKb/y8XG/lpUVv7q5Ob/Avz8/tbQ0PrCvLz/a2Vm/ubi4PYOCgj7m5WU//v19P93cXL6wry8/1dRUPq+urr7R0FA9p6amvtjXVz+Pjo4+oaCgvMvKyr7c21s/oaCgPImIiD3w728/np0dPw==",
-      "vectorSha256": "6f1072b6025f0a0c9bf77afc2d6b372410d1f245391f55b08ece1bc97aee34be",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "10993f06cbc0b3e8f14153315fc713e6c50e3c1b8d258fde45020572d45392c5",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0429": {
       "vector": "qKcnv9bVVT+GhQU/oqEhP/Py8r6ioSG/vr09vwAAgL+trCy+tbQ0PoOCgj6OjQ0/nZwcvgAAgD/e3V2/1tVVv4yLC7+TkpI+j46Ovo2MDD6Pjo4+yslJv7CvL7+joqI+wcBAPPv6+r7493e/rq0tP728PL6opyc/q6qqvsnIyD2opye/1tVVP4aFBT+ioSE/8/LyvqKhIb++vT2/AACAv62sLL61tDQ+g4KCPo6NDT+dnBy+AACAP97dXb/W1VW/jIsLv5OSkj6Pjo6+jYwMPo+Ojj7KyUm/sK8vv6Oioj7BwEA8+/r6vvj3d7+urS0/vbw8vqinJz+rqqq+ycjIPQ==",
       "vectorSha256": "5dd24b3fd538b82e9341fba24a288672d07cd5baebcc1d13c7d8939ce688fca9",
@@ -4676,15 +4658,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "5d5bb2db70d28d42f07b1ce702540e1142952896f67c30e1ee9358b5501a749c",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0521": {
-      "vector": "xcREvp+enr6DgoI+3dxcvt7dXT/z8vI+rawsvrW0NL6hoKA809LSvqCfH7+enR2/8O9vv/b1db+koyM/w8LCPrSzM78AAIA/iokJv/z7e7+RkBC9rKsrP4qJCb+koyO/mZiYPby7O7/6+Xm/jIsLv9fW1j6zsrK+srExv97dXT/FxES+n56evoOCgj7d3Fy+3t1dP/Py8j6trCy+tbQ0vqGgoDzT0tK+oJ8fv56dHb/w72+/9vV1v6SjIz/DwsI+tLMzvwAAgD+KiQm//Pt7v5GQEL2sqys/iokJv6SjI7+ZmJg9vLs7v/r5eb+Miwu/19bWPrOysr6ysTG/3t1dPw==",
-      "vectorSha256": "e84d7de730f4a77e38bcbff8cf586c15396e187a224da3caf36dc5eb0051287c",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "69d23236d2409920cdf496f3c410c326d64d447694a53c0267440f10c1edc68e",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0522": {
@@ -6163,15 +6136,6 @@
       "textHash": "dc9a7fea085ae7e6d6666f61aa2ee6599a5aa7edbaddfe809860252b7d48cb25",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0688": {
-      "vector": "/Pt7P+XkZL7o52c/oaCgvOno6D3g318/srExP9/e3j7Lyso+1dRUPoGAgDvT0tK+iYiIPaCfH7+koyM/zMtLv9XUVD6FhAS+hIMDv5+enr6EgwO/s7KyPvPy8r6opyc/yslJv6WkJL6Ihwe/lpUVP4mIiL339vY+7u1tv8XERL78+3s/5eRkvujnZz+hoKC86ejoPeDfXz+ysTE/397ePsvKyj7V1FQ+gYCAO9PS0r6JiIg9oJ8fv6SjIz/My0u/1dRUPoWEBL6EgwO/n56evoSDA7+zsrI+8/LyvqinJz/KyUm/paQkvoiHB7+WlRU/iYiIvff29j7u7W2/xcREvg==",
-      "vectorSha256": "404470d04f73092e9a07cd0016dab2c1d0fb9ae973859a7e74c0bfc4b871bec7",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "0bd36d37f14e18b7dfc57a28517744dab95565897cd58c7780e117d0c62bb965",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0689": {
       "vector": "jIsLP7a1NT+Lioo+w8LCPuvq6j67urq+np0dv/Py8r62tTW/xMNDv6GgoDzg31+/ycjIvfn4+L36+Xm//v19P5iXF7/19HS+y8rKvoiHBz+JiIg9p6amPr++vj7Lysq+lJMTv56dHT+qqSk/5eRkvuHg4LykoyM/wcBAPOTjYz+Miws/trU1P4uKij7DwsI+6+rqPru6ur6enR2/8/Lyvra1Nb/Ew0O/oaCgPODfX7/JyMi9+fj4vfr5eb/+/X0/mJcXv/X0dL7Lysq+iIcHP4mIiD2npqY+v76+PsvKyr6UkxO/np0dP6qpKT/l5GS+4eDgvKSjIz/BwEA85ONjPw==",
       "vectorSha256": "42c7f9bac8d37bf2b9fb6c97c8d8bb3253f623ccd2cb4bea8df4f30a1ed5a855",
@@ -6262,15 +6226,6 @@
       "textHash": "6eb935d001203eff2fe076cca7a7c171f1771b3f4d1a44b9a975b9a6d07fb354",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0700": {
-      "vector": "mpkZv6alJb+VlBQ+r66uvtDPT7/X1ta+8O9vv4WEBD69vDy+8O9vv9va2j61tDS+397evpKRET+WlRU/zs1NP5aVFT+DgoI+jIsLv7W0NL6ysTG/kZAQvcPCwr65uLg9mJcXv4GAgLuYlxc/iokJP4OCgj6+vT0/wcBAvPb1db+amRm/pqUlv5WUFD6vrq6+0M9Pv9fW1r7w72+/hYQEPr28PL7w72+/29raPrW0NL7f3t6+kpERP5aVFT/OzU0/lpUVP4OCgj6Miwu/tbQ0vrKxMb+RkBC9w8LCvrm4uD2Ylxe/gYCAu5iXFz+KiQk/g4KCPr69PT/BwEC89vV1vw==",
-      "vectorSha256": "4ae2773bde4b28f1ded078515510b32bddca8d7b12136427975e4faac98b7630",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "2d9fd38cf95d80941777ffb2f1b62e1cb897d128c7335de78e033c040e6fa07a",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0701": {
       "vector": "3t1dP7Oysj7Hxsa+x8bGPujnZz/R0FA9np0dP4GAgDuamRk/hYQEPp6dHb/CwUE/hIMDv9LRUb+5uLg9zs1Nv6inJ7+UkxO/1tVVv6moqD2ysTG/1NNTP8PCwj7o52c/rq0tv4OCgr7GxUW/urk5P6qpKb+OjQ0/tLMzP9LRUT/e3V0/s7KyPsfGxr7HxsY+6OdnP9HQUD2enR0/gYCAO5qZGT+FhAQ+np0dv8LBQT+EgwO/0tFRv7m4uD3OzU2/qKcnv5STE7/W1VW/qaioPbKxMb/U01M/w8LCPujnZz+urS2/g4KCvsbFRb+6uTk/qqkpv46NDT+0szM/0tFRPw==",
       "vectorSha256": "5f1af468d718ed36b3853f15624c11e8c1031b31e90a3f556dcfbe0f810ada42",
@@ -6314,15 +6269,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "e963c62c16fd2ab183cd2ff0018220269112b18d77fa6a74fe7c27826934cdb5",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0706": {
-      "vector": "4+LivublZT/V1FQ+2NdXP/HwcL2BgIA7np0dv8nIyL2trCy++fj4Pfb1db/o52e/oJ8fv5OSkr7X1ta+qKcnv5CPDz+0szO/lJMTv728PD7CwUE/pKMjP7e2tr6JiIi9+fj4PamoqD2BgIA7j46OPpaVFb+RkBA9oqEhP52cHD7j4uK+5uVlP9XUVD7Y11c/8fBwvYGAgDuenR2/ycjIva2sLL75+Pg99vV1v+jnZ7+gnx+/k5KSvtfW1r6opye/kI8PP7SzM7+UkxO/vbw8PsLBQT+koyM/t7a2vomIiL35+Pg9qaioPYGAgDuPjo4+lpUVv5GQED2ioSE/nZwcPg==",
-      "vectorSha256": "ad512b332976d075b887f7f482c311d18ad7686756a1627f92bda4ef00af0e56",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "c71d8a07d29e3121a8ae9746b8964f41c941f04baacd71b2dab3bd417d45f459",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0707": {
@@ -6404,15 +6350,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "de73ac7910cff31987295f895986ac85392d1a9a7bf95c538e4f7bed124739e6",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0718": {
-      "vector": "x8bGvp2cHL6Ihwe/8vFxP7i3N7+Miwu/1NNTv97dXT+0szM/+Pd3P+3sbL6UkxM/l5aWvujnZz/S0VG/iokJv8zLS7/My0s/q6qqPp6dHb/6+Xm/sK8vv4+Ojj62tTU/6ejoPY+Ojr6qqSk/mJcXP+7tbb+enR0/n56evgAAgL/Hxsa+nZwcvoiHB7/y8XE/uLc3v4yLC7/U01O/3t1dP7SzMz/493c/7exsvpSTEz+Xlpa+6OdnP9LRUb+KiQm/zMtLv8zLSz+rqqo+np0dv/r5eb+wry+/j46OPra1NT/p6Og9j46OvqqpKT+Ylxc/7u1tv56dHT+fnp6+AACAvw==",
-      "vectorSha256": "3790b47b1aca0c469bd5a8d6e54e87a370cc30f0694e0c0d6457eba9a694e7ed",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "456645fb565637e84fe9cdd4fda2360f6e1938d22092a8b4bba8c77fd152e09d",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0719": {
@@ -6505,15 +6442,6 @@
       "textHash": "7e0c789a0442f27ca15d54980a72dd1445a37237327cb5d568f48e77a6f041fd",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0729": {
-      "vector": "sbAwvdHQUL3X1tY+3dxcPoGAgDv//v4+iYiIvdXUVD7q6Wk/8fBwvZCPDz/19HQ+/Pt7v6KhIb/g31+/+/r6PrGwMD3d3Fy+rawsvpSTEz+CgQG/4+LivublZT+ioSE/8fBwvQAAgL/493c/rq0tv5aVFT/Lyso+m5qavqalJT+xsDC90dBQvdfW1j7d3Fw+gYCAO//+/j6JiIi91dRUPurpaT/x8HC9kI8PP/X0dD78+3u/oqEhv+DfX7/7+vo+sbAwPd3cXL6trCy+lJMTP4KBAb/j4uK+5uVlP6KhIT/x8HC9AACAv/j3dz+urS2/lpUVP8vKyj6bmpq+pqUlPw==",
-      "vectorSha256": "529102e13277c805c58c5d35511d4cb88eaa53acfa274144cc84eb4df511d34c",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "83f89a927a4300df12702a50833ab3fb04e974dfe1ee55030e01643715c97f5f",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0730": {
       "vector": "s7KyPtnY2L3W1VU/1tVVP+zra7/r6uq+6Odnv+blZb+8uzs/mpkZP8PCwr6qqSm/pKMjv8vKyj739va+iYiIPeblZT/o52e/kpERv8TDQ7/HxsY+4+LiPqqpKT+koyO/tLMzP4uKir6Qjw8/trU1v/Tzcz+pqKg9zMtLv97dXb+zsrI+2djYvdbVVT/W1VU/7Otrv+vq6r7o52e/5uVlv7y7Oz+amRk/w8LCvqqpKb+koyO/y8rKPvf29r6JiIg95uVlP+jnZ7+SkRG/xMNDv8fGxj7j4uI+qqkpP6SjI7+0szM/i4qKvpCPDz+2tTW/9PNzP6moqD3My0u/3t1dvw==",
       "vectorSha256": "51deea93b17c9655d26128a34826903b099f6a771695fb8cefeca8af1f2bbb19",
@@ -6550,15 +6478,6 @@
       "textHash": "abc390e916cdc4b698783c3214110de61b984b418552bb9162833b490ae97beb",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0734": {
-      "vector": "kpERv7i3N7++vT0/29raPqalJb/f3t6+x8bGvtDPTz/x8HA9srExP/HwcD2mpSU/vLs7P4yLCz/n5ua+2NdXv9nY2D3b2to+t7a2PqqpKT+0szO/3NtbP+no6D3f3t4+9vV1v+vq6r7X1tY+6+rqvp+enr6qqSk/r66uvpOSkr6SkRG/uLc3v769PT/b2to+pqUlv9/e3r7Hxsa+0M9PP/HwcD2ysTE/8fBwPaalJT+8uzs/jIsLP+fm5r7Y11e/2djYPdva2j63trY+qqkpP7SzM7/c21s/6ejoPd/e3j729XW/6+rqvtfW1j7r6uq+n56evqqpKT+vrq6+k5KSvg==",
-      "vectorSha256": "6617c0761bb04d325506590ad6506b0fa6cc5a114f2e0b82c3864a0a945b8533",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "c63a610e84def940b8db734f1e5c79fef7f66fa31719497842b368e1947c2295",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0735": {
       "vector": "q6qqPqKhIT+VlBQ+397ePoKBAT/X1tY+lpUVv5ybG7/Lysq+8fBwPc7NTb/s62u/q6qqvpiXFz/l5GS+h4aGvqSjI7+KiQm/rKsrv4qJCb+opye//Pt7v+XkZD6RkBC9pqUlP4GAgDvr6uo+4uFhv8XERD6DgoI+t7a2Pq2sLL6rqqo+oqEhP5WUFD7f3t4+goEBP9fW1j6WlRW/nJsbv8vKyr7x8HA9zs1Nv+zra7+rqqq+mJcXP+XkZL6Hhoa+pKMjv4qJCb+sqyu/iokJv6inJ7/8+3u/5eRkPpGQEL2mpSU/gYCAO+vq6j7i4WG/xcREPoOCgj63trY+rawsvg==",
       "vectorSha256": "b66bf76a0c61f12f8c1782f7640315d4c34b403a6d51e3cc0ff4392949eac498",
@@ -6584,15 +6503,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "2ab56142ea720b794504a5f2590fa7fe45a754d4ff3712732add82a8a8ef855b",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0740": {
-      "vector": "5eRkPoKBAT/Z2Ni99vV1v+Pi4r6FhAS+1NNTP6GgoLzMy0s/6ulpv/Py8r6gnx+/oqEhP/LxcT+FhAQ+g4KCPgAAgD+fnp4+uLc3v7a1Nb/g318/kI8PP+rpab+amRk/2NdXv4yLCz/Y11c/k5KSvpSTEz/V1FQ+vbw8PoqJCb/l5GQ+goEBP9nY2L329XW/4+LivoWEBL7U01M/oaCgvMzLSz/q6Wm/8/LyvqCfH7+ioSE/8vFxP4WEBD6DgoI+AACAP5+enj64tze/trU1v+DfXz+Qjw8/6ulpv5qZGT/Y11e/jIsLP9jXVz+TkpK+lJMTP9XUVD69vDw+iokJvw==",
-      "vectorSha256": "a0902e6bf3b9b23c18c1e4dcd029a67113a70c027ddc845cae60c6e1397a5c11",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "11db585c7670fdd7e46bcf8802103443f3921fbbbbabfcabbbafef5b15d7291b",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0741": {
@@ -6811,24 +6721,6 @@
       "textHash": "0a8d011f4bd0f57f9c4d5b0e91bb8659e1ea839efb5415532df2016c355d0c4b",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0767": {
-      "vector": "vr09P7i3Nz+TkpK+sbAwPZmYmL2ZmJi9xMNDP9bVVT/083M/k5KSPpSTEz/d3Fw+5uVlP9rZWb/Ix0c/paQkPvDvbz/z8vK+jo0NP5uamr6pqKg9zs1NP/LxcT/k42M/nZwcPsvKyr7BwEA8w8LCPs7NTb+vrq4+/Pt7P+XkZL6+vT0/uLc3P5OSkr6xsDA9mZiYvZmYmL3Ew0M/1tVVP/Tzcz+TkpI+lJMTP93cXD7m5WU/2tlZv8jHRz+lpCQ+8O9vP/Py8r6OjQ0/m5qavqmoqD3OzU0/8vFxP+TjYz+dnBw+y8rKvsHAQDzDwsI+zs1Nv6+urj78+3s/5eRkvg==",
-      "vectorSha256": "ef65168aa495574da58e5f8b492d44157b19c74ebafa997d4bdfd076160a739a",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "a34368ed4fe7995bf9569fbf783c350199d58c8a412c48b7210b8ff5855cb7ab",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0768": {
-      "vector": "ubi4Pe3sbL6WlRU/paQkPr69PT/Y11c/v76+PtbVVT/Z2Ni9trU1P/HwcD3m5WW/w8LCPvn4+D2JiIg91dRUvrOysr7Y11c/oJ8fv9rZWT+ysTG/oJ8fP8bFRT/c21u/t7a2Pv79fT+fnp4+iokJv7u6ur76+Xm/+fj4vdHQUL25uLg97exsvpaVFT+lpCQ+vr09P9jXVz+/vr4+1tVVP9nY2L22tTU/8fBwPeblZb/DwsI++fj4PYmIiD3V1FS+s7KyvtjXVz+gnx+/2tlZP7KxMb+gnx8/xsVFP9zbW7+3trY+/v19P5+enj6KiQm/u7q6vvr5eb/5+Pi90dBQvQ==",
-      "vectorSha256": "a680913aba4c7529040503aa006b37b42877744976779ac9c8f2e71ba6e19651",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "004b86d985130fde39c850a47e38bc65542531b21b72ccbf8fedacb48a290ad5",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0769": {
       "vector": "AACAv7y7Oz/v7u4+1tVVv7++vj7a2Vm/p6amvuzra7/NzEy+2djYvcLBQT/493e/4N9fP/Tzcz+CgQG/nJsbv+Hg4LylpCQ+iokJv7y7O7+UkxM/6Odnv6GgoLyLioq+yMdHP/HwcD20szM/+/r6vrCvL7+SkRE/iokJv9/e3j4AAIC/vLs7P+/u7j7W1VW/v76+PtrZWb+npqa+7Otrv83MTL7Z2Ni9wsFBP/j3d7/g318/9PNzP4KBAb+cmxu/4eDgvKWkJD6KiQm/vLs7v5STEz/o52e/oaCgvIuKir7Ix0c/8fBwPbSzMz/7+vq+sK8vv5KRET+KiQm/397ePg==",
       "vectorSha256": "3a53233fd3455fc1f2540823bd51736168523abaad12640bdc3004e27cda1cd1",
@@ -6845,15 +6737,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "0a868ec1f17fac1812c10ea026c46641d39f6903fe61a632ddc393f0057ad1dc",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0771": {
-      "vector": "5eRkPtLRUb+/vr4+np0dv/38fL68uzu/q6qqPo+Ojr7u7W0/6ulpv+rpaT+joqI+q6qqPoiHBz+FhAS+pqUlvwAAgD/s62u/9PNzP9/e3j6Ylxe/sK8vv5iXF7+lpCQ+pKMjv5ybG7/j4uK+2NdXv83MTL7l5GS+w8LCvtfW1r7l5GQ+0tFRv7++vj6enR2//fx8vry7O7+rqqo+j46Ovu7tbT/q6Wm/6ulpP6Oioj6rqqo+iIcHP4WEBL6mpSW/AACAP+zra7/083M/397ePpiXF7+wry+/mJcXv6WkJD6koyO/nJsbv+Pi4r7Y11e/zcxMvuXkZL7DwsK+19bWvg==",
-      "vectorSha256": "1788b201afb42adb6e6733ead3bb8266b40fccfa91cd2030fdc79aab46aa9fab",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "51388aa2b83016102b19f27cd861d9e8b1775e93a3f072e79bf2cec508ef6fc3",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0772": {
@@ -6919,15 +6802,6 @@
       "textHash": "c4cccb6375dae89054f76cdf7195e25195002010c3d034eccb1e53aba54fac0f",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0779": {
-      "vector": "hYQEPrCvLz+8uzs/k5KSvsrJST+KiQm/w8LCPu7tbb+Pjo6++Pd3v/Dvbz/6+Xk/3t1dv/LxcT+mpSW/goEBv7e2tr6qqSm/xMNDP/j3d7/JyMi9+Pd3PwAAgD+ysTE/vr09v/v6+r7p6Oi9+vl5v4mIiD3JyMg99PNzP5uamj6FhAQ+sK8vP7y7Oz+TkpK+yslJP4qJCb/DwsI+7u1tv4+Ojr7493e/8O9vP/r5eT/e3V2/8vFxP6alJb+CgQG/t7a2vqqpKb/Ew0M/+Pd3v8nIyL3493c/AACAP7KxMT++vT2/+/r6vuno6L36+Xm/iYiIPcnIyD3083M/m5qaPg==",
-      "vectorSha256": "a5e4cb4887192f3ec43dedb4b5347d858a9e4ebaa647b29691161cdc8b13907d",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "3d283d7cda842784ac5aaf9734556ef24aa7532180b2ef61acef1d52b156e8b3",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0780": {
       "vector": "xMNDv6empr6BgIA709LSvrq5Ob/c21u/h4aGvvTzc7/n5ua+yMdHv+/u7j6vrq4+j46OPo6NDT/083M/wL8/P8PCwr65uLg9i4qKvqWkJL7OzU0/u7q6vvX0dD7GxUW/jYwMPtTTUz+wry8/m5qavurpab/19HQ+jo0Nv/f29r7Ew0O/p6amvoGAgDvT0tK+urk5v9zbW7+Hhoa+9PNzv+fm5r7Ix0e/7+7uPq+urj6Pjo4+jo0NP/Tzcz/Avz8/w8LCvrm4uD2Lioq+paQkvs7NTT+7urq+9fR0PsbFRb+NjAw+1NNTP7CvLz+bmpq+6ulpv/X0dD6OjQ2/9/b2vg==",
       "vectorSha256": "c8e4c63cd1056d0b433eda5045542415a4c075d5c79fd8541b94fd1d08170d0e",
@@ -6935,24 +6809,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "2bc565d2049c1ec2a89e2e4bc8c3f65f7be7355dcb9c5f31de711b5506aa9d50",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0781": {
-      "vector": "srExv+jnZ7/KyUm/9PNzv7GwML3i4WG/zs1NP4iHBz+EgwM/oJ8fPwAAgD/Hxsa+wcBAPMHAQDzOzU0/vLs7P6KhIb+rqqo++vl5v5aVFT+WlRU/jIsLv/b1dT/f3t4+29raPquqqj7Lyso+k5KSPpqZGT/19HQ+1NNTP5WUFL6ysTG/6Odnv8rJSb/083O/sbAwveLhYb/OzU0/iIcHP4SDAz+gnx8/AACAP8fGxr7BwEA8wcBAPM7NTT+8uzs/oqEhv6uqqj76+Xm/lpUVP5aVFT+Miwu/9vV1P9/e3j7b2to+q6qqPsvKyj6TkpI+mpkZP/X0dD7U01M/lZQUvg==",
-      "vectorSha256": "e229331d3a4e069ff9b8cc7e21847a3ecfd445b27d06cda65287d82496364960",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "b88cd1e621b502064e4c945273c49dd6a8105af96b8f91108724f8fef682ae26",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0782": {
-      "vector": "ubi4veno6D27uro+wsFBP9HQUD3BwEA83dxcvrOysr7e3V0/5uVlP7GwML3n5uY+t7a2Pri3Nz+SkRE/tbQ0vtLRUb+ioSE/9fR0vo6NDT/a2Vm/j46OvuPi4r6opyc/qKcnv7SzMz/h4OC89PNzP4qJCT+opyc/6+rqvr69PT+5uLi96ejoPbu6uj7CwUE/0dBQPcHAQDzd3Fy+s7Kyvt7dXT/m5WU/sbAwvefm5j63trY+uLc3P5KRET+1tDS+0tFRv6KhIT/19HS+jo0NP9rZWb+Pjo6+4+LivqinJz+opye/tLMzP+Hg4Lz083M/iokJP6inJz/r6uq+vr09Pw==",
-      "vectorSha256": "fa0c64aa5b662c8c9f38be0c3f2bd394052f2b393731172788d26846a4c83770",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "8533e1cb18619f5f5877d638197224b07b1461aa27ade73d6f26a97fda29b846",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0783": {
@@ -7108,15 +6964,6 @@
       "textHash": "a4444d95fb1ae8419e343ad8a5ef31c34e47a512b4a84cf11b6e8679268639b8",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0802": {
-      "vector": "lpUVP8fGxj6qqSk/hoUFv8zLS7+UkxO/p6amPtzbW7/p6Oi9xMNDv6CfHz+JiIi9h4aGPvTzc7/w72+/p6amvouKir7z8vK+3t1dv5mYmL2fnp4+7exsPpqZGb+xsDA90tFRP9XUVL6Ihwc/pKMjv7i3Nz+enR2/trU1P6inJ7+WlRU/x8bGPqqpKT+GhQW/zMtLv5STE7+npqY+3Ntbv+no6L3Ew0O/oJ8fP4mIiL2HhoY+9PNzv/Dvb7+npqa+i4qKvvPy8r7e3V2/mZiYvZ+enj7t7Gw+mpkZv7GwMD3S0VE/1dRUvoiHBz+koyO/uLc3P56dHb+2tTU/qKcnvw==",
-      "vectorSha256": "e5f01176c08ba932fa8b346216451709729ff2dea39a130eab2bbb3e2eecb6ed",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "a100424b941a5fdcd2d71806d027da8cd942e7ccaf082a5996c513ab563dfabe",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0803": {
       "vector": "jYwMvpSTE7/5+Pg9nJsbv97dXb+6uTk/sK8vP6uqqr6UkxO/uLc3P4SDA7/l5GS+8fBwPaGgoLyHhoa+9fR0PomIiD0AAIA/ycjIPaKhIT+3tra+7exsvublZT+koyM/t7a2voWEBL7m5WW/goEBvwAAgD+fnp6+gYCAO62sLL6NjAy+lJMTv/n4+D2cmxu/3t1dv7q5OT+wry8/q6qqvpSTE7+4tzc/hIMDv+XkZL7x8HA9oaCgvIeGhr719HQ+iYiIPQAAgD/JyMg9oqEhP7e2tr7t7Gy+5uVlP6SjIz+3tra+hYQEvublZb+CgQG/AACAP5+enr6BgIA7rawsvg==",
       "vectorSha256": "f9974b8579d4835c04b4edd4186c7737adc58f5a06fa1c1fb2cefc376e05111c",
@@ -7144,15 +6991,6 @@
       "textHash": "add96b451187078e3879032409672fcff138f9fd8ae4905d0b0d7057f9f91843",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0807": {
-      "vector": "hIMDP+7tbb/GxUU/v76+Pvb1dT+0szO/urk5v6qpKb/V1FQ+wsFBP/b1db+JiIi9urk5v7y7O7/b2to+nZwcPpKRET+hoKC8urk5v5uamj6Pjo6+lpUVP5ybG7+hoKA8iokJv/38fD7BwEA8qKcnv6qpKb/S0VG/hYQEvpuamj6EgwM/7u1tv8bFRT+/vr4+9vV1P7SzM7+6uTm/qqkpv9XUVD7CwUE/9vV1v4mIiL26uTm/vLs7v9va2j6dnBw+kpERP6GgoLy6uTm/m5qaPo+Ojr6WlRU/nJsbv6GgoDyKiQm//fx8PsHAQDyopye/qqkpv9LRUb+FhAS+m5qaPg==",
-      "vectorSha256": "6acfef29acfb122d02d29b1b606278675d15e650d8386f4c7db8bd9d9419408a",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "92d93108a5426bbfa862970c6a8d95c69572ba5786e32b7ac9e296695b4c288b",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0808": {
       "vector": "lZQUvoSDA7+ZmJi9/v19v6inJz+8uzu/+vl5v5ybG7/v7u4+xMNDv6KhIb/a2Vk/wL8/v/Py8j7Hxsa+yMdHP4OCgj7p6Oi96Odnv4OCgj7Qz08/vLs7P9jXV7/OzU0/o6KiPrCvLz+1tDS+k5KSvpWUFD78+3u/8/LyPpiXFz+VlBS+hIMDv5mYmL3+/X2/qKcnP7y7O7/6+Xm/nJsbv+/u7j7Ew0O/oqEhv9rZWT/Avz+/8/LyPsfGxr7Ix0c/g4KCPuno6L3o52e/g4KCPtDPTz+8uzs/2NdXv87NTT+joqI+sK8vP7W0NL6TkpK+lZQUPvz7e7/z8vI+mJcXPw==",
       "vectorSha256": "75b2c9ef56234f534722c327e41fc4bdb4a6f2440602ec047d9b591428fa465f",
@@ -7160,24 +6998,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "c1b009eb020a14d60654b1159fb72bb1002a60f0954da57b4600ad1f62676c84",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0810": {
-      "vector": "u7q6PtrZWT/S0VE/kI8PP6GgoLy6uTm/yMdHv4aFBT/k42O/xMNDv/HwcD3h4OA8q6qqPszLSz8AAIA/1dRUvtzbW7/U01M/trU1P7u6uj6XlpY+9vV1v7++vr78+3u/iokJP+XkZD68uzs/6+rqPuHg4LyKiQk/lpUVv4GAgDu7uro+2tlZP9LRUT+Qjw8/oaCgvLq5Ob/Ix0e/hoUFP+TjY7/Ew0O/8fBwPeHg4Dyrqqo+zMtLPwAAgD/V1FS+3Ntbv9TTUz+2tTU/u7q6PpeWlj729XW/v76+vvz7e7+KiQk/5eRkPry7Oz/r6uo+4eDgvIqJCT+WlRW/gYCAOw==",
-      "vectorSha256": "e0c926d32159b41cb47aebdc9cf5ca310baf25c738b148c58bb463e88e74ed1e",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "ff742ce77844f022759d6f065c639b2f170073c0dcbb4f6f18759175bbde16d8",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0812": {
-      "vector": "9vV1P9PS0j6UkxO/sbAwvfX0dL6hoKA8x8bGPqqpKT/r6uq+0dBQvZeWlr6KiQk/iYiIPcLBQb+trCw+t7a2vvv6+r7+/X0/rq0tP6empj6NjAy+2tlZP+fm5j6Lioq+7OtrP6SjI7+enR0/w8LCvpWUFL6HhoY+4uFhP9jXVz/29XU/09LSPpSTE7+xsDC99fR0vqGgoDzHxsY+qqkpP+vq6r7R0FC9l5aWvoqJCT+JiIg9wsFBv62sLD63tra++/r6vv79fT+urS0/p6amPo2MDL7a2Vk/5+bmPouKir7s62s/pKMjv56dHT/DwsK+lZQUvoeGhj7i4WE/2NdXPw==",
-      "vectorSha256": "c325f9617dee524cd1af3f0315112925318182399ba131596d4976f2e48bc9f6",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "41bef813145369ca78679d10362bb4f58e9d7abf655c2b6aa4473e5347d7f1fd",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0813": {
@@ -7196,15 +7016,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "b5d8786be895e07a634c5e6222b25fac09d8b29fbbb2f047cf4639861f8381f9",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0816": {
-      "vector": "5+bmvsPCwr7i4WG/i4qKvpGQED3NzEy+n56evpGQED2trCw+hIMDv6+urr719HS+y8rKPqKhIb+BgIA7/Pt7v9XUVD6vrq6+pKMjP83MTL7i4WG/hIMDv7i3Nz+joqK+i4qKvsC/Pz/29XU/6OdnP9HQUL2NjAy+6ulpP6GgoDzn5ua+w8LCvuLhYb+Lioq+kZAQPc3MTL6fnp6+kZAQPa2sLD6EgwO/r66uvvX0dL7Lyso+oqEhv4GAgDv8+3u/1dRUPq+urr6koyM/zcxMvuLhYb+EgwO/uLc3P6Oior6Lioq+wL8/P/b1dT/o52c/0dBQvY2MDL7q6Wk/oaCgPA==",
-      "vectorSha256": "a24053d40fa60dc9c35e1b653c47a61108fef6cd398728605e021e58b787b99b",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "58cebb6582e1d0e2814e00e14f2e7904c2476c60939a4559b5e75408252f0322",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0817": {
@@ -7376,15 +7187,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "c1f5171ffcfb9807b86e5e0a6b19ae757a7c1551040714735ef7d62062bf517c",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0837": {
-      "vector": "+/r6PuDfX7+opye/x8bGvpKRET/GxUW/iokJP66tLb/k42M/397ePrCvLz+gnx+/1tVVv7GwML2hoKA85+bmvsjHRz/l5GS+hYQEPpWUFL7v7u4+0M9Pv+LhYT+JiIi98vFxv5STEz/r6uo+h4aGvuDfXz+enR2/urk5v5aVFb/7+vo+4N9fv6inJ7/Hxsa+kpERP8bFRb+KiQk/rq0tv+TjYz/f3t4+sK8vP6CfH7/W1VW/sbAwvaGgoDzn5ua+yMdHP+XkZL6FhAQ+lZQUvu/u7j7Qz0+/4uFhP4mIiL3y8XG/lJMTP+vq6j6Hhoa+4N9fP56dHb+6uTm/lpUVvw==",
-      "vectorSha256": "108ef19df2bc64971c73a1c1bd95782149233ed3a49dab0a6ef6dd2cd1e3c895",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "bb2876a420317c775dd4b18beb3803a0742b3787f703c3c58537f5801898bedc",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0838": {
@@ -7574,15 +7376,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "8d5f892748545d8a467a2eb3c00e7e816f0c1e70c838e2e95661c1b5af329770",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0860": {
-      "vector": "goEBv+7tbT+joqK+sK8vP4aFBT+4tzc/m5qavqyrK7+xsDA9tLMzv/HwcD2dnBw+wcBAPLy7Oz/a2Vm/np0dv8jHR7+ysTE/wL8/P66tLT/V1FQ+8/LyvpaVFb/i4WG/pKMjP6uqqj7083O/+Pd3P7GwML2Hhoa+3t1dP8rJST+CgQG/7u1tP6Oior6wry8/hoUFP7i3Nz+bmpq+rKsrv7GwMD20szO/8fBwPZ2cHD7BwEA8vLs7P9rZWb+enR2/yMdHv7KxMT/Avz8/rq0tP9XUVD7z8vK+lpUVv+LhYb+koyM/q6qqPvTzc7/493c/sbAwvYeGhr7e3V0/yslJPw==",
-      "vectorSha256": "96093fee9ce7148990af0602dceb18ce5a53f3e74b933e345b83434abbcaa518",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "0d93f1526e0def5e4d078465effe25756db083e576dafaf8a8be31e9fcbde9ec",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0861": {

--- a/data/jokes-embeddings-openai.json
+++ b/data/jokes-embeddings-openai.json
@@ -3,8 +3,8 @@
     "provider": "openai",
     "model": "text-embedding-3-large",
     "dimensions": 64,
-    "generatedAt": "2025-09-22T01:50:07.859Z",
-    "recordCount": 888
+    "generatedAt": "2025-09-22T23:16:21.852Z",
+    "recordCount": 865
   },
   "records": {
     "j-0001": {
@@ -2851,15 +2851,6 @@
       "textHash": "2e7cbaa621c65b1b0a89d0bfe4d1814f0f0d5194fbb75009fede86c77110c20a",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0317": {
-      "vector": "y8rKvuLhYT/5+Pg9qqkpv9PS0r6VlBS+qqkpv5STEz+fnp6+yslJv9rZWT/j4uI+6ejovfTzc7/R0FC9mZiYPd/e3j6gnx+/kZAQPbOysj7DwsI+goEBv/j3d7/z8vI+uLc3v97dXb+0szO/19bWvuTjYz/c21s/8O9vP9jXVz/Lysq+4uFhP/n4+D2qqSm/09LSvpWUFL6qqSm/lJMTP5+enr7KyUm/2tlZP+Pi4j7p6Oi99PNzv9HQUL2ZmJg9397ePqCfH7+RkBA9s7KyPsPCwj6CgQG/+Pd3v/Py8j64tze/3t1dv7SzM7/X1ta+5ONjP9zbWz/w728/2NdXPw==",
-      "vectorSha256": "3e2db19ee73f160ed5f7f73d33cc3e8fc2a03353c603e38b288c2ebd2e3a5f51",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "3d322d3250dbcf92a4edd45cced926832c328e88981bfef4b1d53034016ad772",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0318": {
       "vector": "8vFxv/r5eb/KyUk/9/b2vufm5r7FxEQ+zcxMvoWEBD7S0VG/6Odnv/j3d7+3tra+tLMzP7++vr7Z2Ni9u7q6vp+enr7y8XG/urk5P/j3dz/l5GS+qKcnv52cHD7Hxsa+vLs7P5CPDz/R0FC99/b2vurpaT+8uzu/goEBv/j3dz/y8XG/+vl5v8rJST/39va+5+bmvsXERD7NzEy+hYQEPtLRUb/o52e/+Pd3v7e2tr60szM/v76+vtnY2L27urq+n56evvLxcb+6uTk/+Pd3P+XkZL6opye/nZwcPsfGxr68uzs/kI8PP9HQUL339va+6ulpP7y7O7+CgQG/+Pd3Pw==",
       "vectorSha256": "7d53492e8bf5fe244db63a7f4b6afa29fe2af02e3fe5fda94f3ad70f00779370",
@@ -3850,15 +3841,6 @@
       "textHash": "2a1dfe1645d5e6edcf4afe8d23a0f516fea52ec9ace243501dca35b9df465036",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0428": {
-      "vector": "7exsvpKRET/R0FA9ubi4vYmIiL2SkRE/kZAQveno6D3k42O/jYwMPsTDQ7/8+3s/0dBQvYOCgj6WlRW/oqEhP6qpKb+vrq6+vbw8PsLBQb+Lioo+j46OPpGQED3HxsY+np0dv9rZWT+KiQk/q6qqPtPS0j6zsrI+/Pt7v9PS0j7t7Gy+kpERP9HQUD25uLi9iYiIvZKRET+RkBC96ejoPeTjY7+NjAw+xMNDv/z7ez/R0FC9g4KCPpaVFb+ioSE/qqkpv6+urr69vDw+wsFBv4uKij6Pjo4+kZAQPcfGxj6enR2/2tlZP4qJCT+rqqo+09LSPrOysj78+3u/09LSPg==",
-      "vectorSha256": "e2306caa317144567de05df134c416c41095dbfd05291ddacb29ed4f7ee38808",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "10993f06cbc0b3e8f14153315fc713e6c50e3c1b8d258fde45020572d45392c5",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0429": {
       "vector": "mpkZv52cHD7FxEQ+lZQUPtXUVD7z8vK+r66uPoqJCb/R0FC9lpUVv5WUFL6koyO/x8bGPuzra7+6uTk/l5aWvtXUVD6koyM/6ejoPaKhIT/p6Og9xsVFv9/e3j7Y11e/vLs7v4KBAb/Ix0c/y8rKPvLxcT/NzEw+3t1dP7CvL7+amRm/nZwcPsXERD6VlBQ+1dRUPvPy8r6vrq4+iokJv9HQUL2WlRW/lZQUvqSjI7/HxsY+7Otrv7q5OT+Xlpa+1dRUPqSjIz/p6Og9oqEhP+no6D3GxUW/397ePtjXV7+8uzu/goEBv8jHRz/Lyso+8vFxP83MTD7e3V0/sK8vvw==",
       "vectorSha256": "2708bdcd493c30630291c14809f745556f7932afdeb8aefad7320b9f9c6b9eb6",
@@ -4676,15 +4658,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "5d5bb2db70d28d42f07b1ce702540e1142952896f67c30e1ee9358b5501a749c",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0521": {
-      "vector": "vbw8vvTzcz+UkxO/rawsPtPS0j7Hxsa+qKcnv5KREb/z8vK+vr09P6WkJL7X1tY+oqEhP5CPDz+SkRE/6+rqvsTDQ7/X1ta++/r6Pu7tbb/v7u6+9PNzP8/Ozj7e3V2/xsVFv5ybGz+4tze/nZwcPtva2r7f3t4+y8rKvuXkZL69vDy+9PNzP5STE7+trCw+09LSPsfGxr6opye/kpERv/Py8r6+vT0/paQkvtfW1j6ioSE/kI8PP5KRET/r6uq+xMNDv9fW1r77+vo+7u1tv+/u7r7083M/z87OPt7dXb/GxUW/nJsbP7i3N7+dnBw+29ravt/e3j7Lysq+5eRkvg==",
-      "vectorSha256": "8f6fb8f5b8f3246cbd6aedd6f582e29067c0f2346ebf40ab5ea4b77116e62704",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "69d23236d2409920cdf496f3c410c326d64d447694a53c0267440f10c1edc68e",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0522": {
@@ -6163,15 +6136,6 @@
       "textHash": "dc9a7fea085ae7e6d6666f61aa2ee6599a5aa7edbaddfe809860252b7d48cb25",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0688": {
-      "vector": "2NdXv8TDQz+3trY+tbQ0PqqpKb/Ew0M///7+vsjHR7/BwEA8y8rKPszLS7/T0tI+m5qaPuzra7+OjQ2/iYiIPfDvbz/5+Pi9m5qavp2cHL6dnBy+/fx8vqOioj6Ylxc/0dBQPZeWlj7R0FC9oqEhv5eWlj6lpCQ+AACAP5mYmD3Y11e/xMNDP7e2tj61tDQ+qqkpv8TDQz///v6+yMdHv8HAQDzLyso+zMtLv9PS0j6bmpo+7Otrv46NDb+JiIg98O9vP/n4+L2bmpq+nZwcvp2cHL79/Hy+o6KiPpiXFz/R0FA9l5aWPtHQUL2ioSG/l5aWPqWkJD4AAIA/mZiYPQ==",
-      "vectorSha256": "fb52c90b31b3ebd6e2e26c92333bed15421f32f2e5a9cba00c63728ad4241922",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "0bd36d37f14e18b7dfc57a28517744dab95565897cd58c7780e117d0c62bb965",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0689": {
       "vector": "wL8/P4eGhj6enR2/xcREPpmYmD3R0FA9gYCAO6SjI7/Lysq+sK8vP/n4+D2vrq4+oaCgvL69Pb/My0u/s7KyvoqJCb/493c/iIcHP62sLD66uTm/i4qKvvn4+D3//v4+hIMDv6KhIT/KyUk/wsFBP7CvL7+UkxM/1dRUPqempr7Avz8/h4aGPp6dHb/FxEQ+mZiYPdHQUD2BgIA7pKMjv8vKyr6wry8/+fj4Pa+urj6hoKC8vr09v8zLS7+zsrK+iokJv/j3dz+Ihwc/rawsPrq5Ob+Lioq++fj4Pf/+/j6EgwO/oqEhP8rJST/CwUE/sK8vv5STEz/V1FQ+p6amvg==",
       "vectorSha256": "58c36c74c65a5023ed54df41fd0d752ccac09f66bdaa2a1aa8409be9c4e77865",
@@ -6262,15 +6226,6 @@
       "textHash": "6eb935d001203eff2fe076cca7a7c171f1771b3f4d1a44b9a975b9a6d07fb354",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0700": {
-      "vector": "qqkpv7e2tr6amRk/kpERv6SjI7+urS0/09LSvri3N7/Ix0e/j46OPq2sLL7Pzs4+xsVFP5uamj7S0VG/rKsrv8LBQT/GxUW/sK8vv+3sbD7z8vK+kZAQPZeWlj7a2Vk/jIsLv+XkZL7p6Oi9tbQ0Pu3sbL7GxUW/7Otrv4aFBT+qqSm/t7a2vpqZGT+SkRG/pKMjv66tLT/T0tK+uLc3v8jHR7+Pjo4+rawsvs/Ozj7GxUU/m5qaPtLRUb+sqyu/wsFBP8bFRb+wry+/7exsPvPy8r6RkBA9l5aWPtrZWT+Miwu/5eRkvuno6L21tDQ+7exsvsbFRb/s62u/hoUFPw==",
-      "vectorSha256": "4b8a05d66909871b576e68d478819e2d0b3ec826c041d4c20bcc7cd044345563",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "2d9fd38cf95d80941777ffb2f1b62e1cb897d128c7335de78e033c040e6fa07a",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0701": {
       "vector": "iYiIvdHQUD2ZmJi9lZQUPoGAgDvHxsa+lZQUvuTjYz+qqSk/ubi4vYOCgj6ZmJi92djYvfPy8r79/Hw+o6Kivurpab/BwEC8n56evrm4uL22tTU/09LSvszLS7+bmpo+wsFBv7W0NL7DwsI+sbAwvf79fb+5uLg96Odnv4+Ojr6JiIi90dBQPZmYmL2VlBQ+gYCAO8fGxr6VlBS+5ONjP6qpKT+5uLi9g4KCPpmYmL3Z2Ni98/Lyvv38fD6joqK+6ulpv8HAQLyfnp6+ubi4vba1NT/T0tK+zMtLv5uamj7CwUG/tbQ0vsPCwj6xsDC9/v19v7m4uD3o52e/j46Ovg==",
       "vectorSha256": "c5233337051f43c805e43806ee80402b0eb6793c57db3fd51b17f49d076de8af",
@@ -6314,15 +6269,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "e963c62c16fd2ab183cd2ff0018220269112b18d77fa6a74fe7c27826934cdb5",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0706": {
-      "vector": "4eDgvISDA7/h4OC8iokJP6WkJL6dnBy+//7+PpWUFD6Ihwe/gYCAu5qZGT/5+Pi9vLs7v+XkZL6CgQG/vr09v8LBQT/g31+//v19v4qJCb/My0u/kpERP6moqD3u7W2/5ONjP9/e3r7Y11e/l5aWPs3MTD7GxUW/q6qqPq2sLL7h4OC8hIMDv+Hg4LyKiQk/paQkvp2cHL7//v4+lZQUPoiHB7+BgIC7mpkZP/n4+L28uzu/5eRkvoKBAb++vT2/wsFBP+DfX7/+/X2/iokJv8zLS7+SkRE/qaioPe7tbb/k42M/397evtjXV7+XlpY+zcxMPsbFRb+rqqo+rawsvg==",
-      "vectorSha256": "f640e18c3c11f5fe43e618365b92f0a63c842f9ed0b67fb02781ef333f17ed66",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "c71d8a07d29e3121a8ae9746b8964f41c941f04baacd71b2dab3bd417d45f459",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0707": {
@@ -6404,15 +6350,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "de73ac7910cff31987295f895986ac85392d1a9a7bf95c538e4f7bed124739e6",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0718": {
-      "vector": "3NtbP4eGhr6qqSm/6Odnv8fGxr7u7W0/lpUVv6alJT/Avz+/rawsvqWkJD6EgwO/iokJv6moqL3+/X0/9/b2Pv/+/r65uLi9+vl5P/79fb+Qjw+/yMdHP4uKij6pqKg9xsVFv8vKyj6SkRG/trU1P5qZGb+SkRG/sbAwvd/e3r7c21s/h4aGvqqpKb/o52e/x8bGvu7tbT+WlRW/pqUlP8C/P7+trCy+paQkPoSDA7+KiQm/qaiovf79fT/39vY+//7+vrm4uL36+Xk//v19v5CPD7/Ix0c/i4qKPqmoqD3GxUW/y8rKPpKREb+2tTU/mpkZv5KREb+xsDC9397evg==",
-      "vectorSha256": "eb12cb53439493e52f0732c49bef7c234a84dcecc5d34c15dcfa3b7795396019",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "456645fb565637e84fe9cdd4fda2360f6e1938d22092a8b4bba8c77fd152e09d",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0719": {
@@ -6505,15 +6442,6 @@
       "textHash": "7e0c789a0442f27ca15d54980a72dd1445a37237327cb5d568f48e77a6f041fd",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0729": {
-      "vector": "oaCgPLm4uD2urS0/8O9vv4iHBz/493c/3t1dv/X0dD6RkBA9rKsrP5+enj6EgwM/kpERv/j3d7++vT2/yslJv4uKij6JiIi9hoUFP7y7O7/493c/s7KyPq2sLD7CwUE/5uVlv/f29j7Avz+/29ravr++vr6SkRE/4N9fP+vq6r6hoKA8ubi4Pa6tLT/w72+/iIcHP/j3dz/e3V2/9fR0PpGQED2sqys/n56ePoSDAz+SkRG/+Pd3v769Pb/KyUm/i4qKPomIiL2GhQU/vLs7v/j3dz+zsrI+rawsPsLBQT/m5WW/9/b2PsC/P7/b2tq+v76+vpKRET/g318/6+rqvg==",
-      "vectorSha256": "8f6d093d6f07ad627a2639991fbc9a21ea77962eadfb28b6bc8b382d4fe79f8c",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "83f89a927a4300df12702a50833ab3fb04e974dfe1ee55030e01643715c97f5f",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0730": {
       "vector": "xsVFP/n4+D2joqI+ycjIva+urr6zsrI+jo0Nv6GgoDzX1ta+7+7uPoKBAT+0szO/nJsbP4WEBL7Y11c/397ePvb1db/Y11c/tLMzv62sLD7//v6+iokJP6empj7e3V0/i4qKPrm4uD3V1FQ+8fBwPa+urr6GhQW/6ejovdTTUz/GxUU/+fj4PaOioj7JyMi9r66uvrOysj6OjQ2/oaCgPNfW1r7v7u4+goEBP7SzM7+cmxs/hYQEvtjXVz/f3t4+9vV1v9jXVz+0szO/rawsPv/+/r6KiQk/p6amPt7dXT+Lioo+ubi4PdXUVD7x8HA9r66uvoaFBb/p6Oi91NNTPw==",
       "vectorSha256": "b48a1af81a67fb20726a22d2b5818b7f60302c2bf298bbc724f708333e8be891",
@@ -6550,15 +6478,6 @@
       "textHash": "abc390e916cdc4b698783c3214110de61b984b418552bb9162833b490ae97beb",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0734": {
-      "vector": "u7q6Pt3cXD68uzu/2tlZP+DfXz/y8XG/2NdXv9/e3j6hoKC87OtrP6qpKT/n5uY+z87OvvDvb7/5+Pi9xMNDP8vKyr7w72+/k5KSPpmYmL3V1FS+09LSvp+enj79/Hy+4+LivsC/Pz+zsrK+1tVVP+no6L3My0s/o6KiPuno6D27uro+3dxcPry7O7/a2Vk/4N9fP/Lxcb/Y11e/397ePqGgoLzs62s/qqkpP+fm5j7Pzs6+8O9vv/n4+L3Ew0M/y8rKvvDvb7+TkpI+mZiYvdXUVL7T0tK+n56ePv38fL7j4uK+wL8/P7Oysr7W1VU/6ejovczLSz+joqI+6ejoPQ==",
-      "vectorSha256": "b21c1a123de374811e4993a5a49f96a4413f4941b69635c5964bda90a0f83410",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "c63a610e84def940b8db734f1e5c79fef7f66fa31719497842b368e1947c2295",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0735": {
       "vector": "t7a2Ps7NTT/Lyso+qKcnv9va2r6lpCS+qaioPbi3Nz+Pjo6+yslJP769PT+FhAQ+hYQEvri3N7/j4uI+z87OvrOysj6qqSm/jIsLv4eGhr7S0VE/nZwcPpCPD7/GxUW/kI8PP7GwML329XW//Pt7v+jnZz+zsrK+4uFhP4GAgDu3trY+zs1NP8vKyj6opye/29ravqWkJL6pqKg9uLc3P4+Ojr7KyUk/vr09P4WEBD6FhAS+uLc3v+Pi4j7Pzs6+s7KyPqqpKb+Miwu/h4aGvtLRUT+dnBw+kI8Pv8bFRb+Qjw8/sbAwvfb1db/8+3u/6OdnP7Oysr7i4WE/gYCAOw==",
       "vectorSha256": "c48adedfd93e2e0adc8be1e83e5b64508c8690121e2476f96fb64615f31a0ce1",
@@ -6584,15 +6503,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "2ab56142ea720b794504a5f2590fa7fe45a754d4ff3712732add82a8a8ef855b",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0740": {
-      "vector": "xsVFv6KhIT+UkxO/lpUVv4qJCT/CwUG/t7a2PqSjIz+zsrK+np0dP9va2j64tzc/iYiIPeLhYb/GxUU/zMtLv/v6+r6SkRE/3dxcPvX0dD6koyM/trU1P6KhIb/Z2Ng9rKsrv7u6ur7BwEA8xMNDv6moqD27urq+1NNTv8zLS7/GxUW/oqEhP5STE7+WlRW/iokJP8LBQb+3trY+pKMjP7Oysr6enR0/29raPri3Nz+JiIg94uFhv8bFRT/My0u/+/r6vpKRET/d3Fw+9fR0PqSjIz+2tTU/oqEhv9nY2D2sqyu/u7q6vsHAQDzEw0O/qaioPbu6ur7U01O/zMtLvw==",
-      "vectorSha256": "98a731193b7ffcdb2caddeabd20c7a17c831a74007122564ae95d9159778659a",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "11db585c7670fdd7e46bcf8802103443f3921fbbbbabfcabbbafef5b15d7291b",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0741": {
@@ -6811,24 +6721,6 @@
       "textHash": "0a8d011f4bd0f57f9c4d5b0e91bb8659e1ea839efb5415532df2016c355d0c4b",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0767": {
-      "vector": "trU1v6qpKb+fnp6+vr09P6qpKb/OzU2/+fj4Pd3cXL7FxES+yslJP5WUFD7Avz+/nJsbP5+enj6Qjw8/2tlZP//+/j6urS2/6ejovdDPT7+ZmJg9x8bGvqinJz+wry+/4+LiPtHQUD2urS0/wL8/P6SjIz+CgQE/zs1Nv+TjY7+2tTW/qqkpv5+enr6+vT0/qqkpv87NTb/5+Pg93dxcvsXERL7KyUk/lZQUPsC/P7+cmxs/n56ePpCPDz/a2Vk///7+Pq6tLb/p6Oi90M9Pv5mYmD3Hxsa+qKcnP7CvL7/j4uI+0dBQPa6tLT/Avz8/pKMjP4KBAT/OzU2/5ONjvw==",
-      "vectorSha256": "099ae114648e593567a0e650f248497c5080f772b8e69b47a860a908e49a1b37",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "a34368ed4fe7995bf9569fbf783c350199d58c8a412c48b7210b8ff5855cb7ab",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0768": {
-      "vector": "9fR0Puzraz+amRk/hoUFv5OSkj62tTU/urk5v4qJCb+8uzu/6+rqPp+enj7l5GS+6ulpv8jHRz/h4OA8xcREPu7tbT/n5ua+6Odnv8HAQLzBwEA8u7q6vuzraz+7uro+/fx8PrGwML3U01M/jIsLv46NDT+VlBS+srExv8fGxr719HQ+7OtrP5qZGT+GhQW/k5KSPra1NT+6uTm/iokJv7y7O7/r6uo+n56ePuXkZL7q6Wm/yMdHP+Hg4DzFxEQ+7u1tP+fm5r7o52e/wcBAvMHAQDy7urq+7OtrP7u6uj79/Hw+sbAwvdTTUz+Miwu/jo0NP5WUFL6ysTG/x8bGvg==",
-      "vectorSha256": "32ae375d9445d399dd47f576e42af8ee318d846d531a1e14283fc3c329dd75e5",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "004b86d985130fde39c850a47e38bc65542531b21b72ccbf8fedacb48a290ad5",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0769": {
       "vector": "sK8vv7i3N7/p6Oi9qKcnP4SDA7/Lysq+mpkZv7++vr719HQ+nJsbP7m4uL3w728/+vl5v6KhIT/+/X0/2djYPc3MTL6/vr4+4N9fv66tLT+ioSE/kpERP42MDD6ioSE/k5KSPoWEBD7DwsI+9PNzP7Oysj6Ihwc/9vV1P/LxcT+wry+/uLc3v+no6L2opyc/hIMDv8vKyr6amRm/v76+vvX0dD6cmxs/ubi4vfDvbz/6+Xm/oqEhP/79fT/Z2Ng9zcxMvr++vj7g31+/rq0tP6KhIT+SkRE/jYwMPqKhIT+TkpI+hYQEPsPCwj7083M/s7KyPoiHBz/29XU/8vFxPw==",
       "vectorSha256": "27ff6d29f7a2f458f960c39db5778e295962eee21979a3111877c0f0488ce8c0",
@@ -6845,15 +6737,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "0a868ec1f17fac1812c10ea026c46641d39f6903fe61a632ddc393f0057ad1dc",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0771": {
-      "vector": "p6amPpGQEL3l5GQ+zcxMPublZb/S0VG/sK8vv4iHBz+GhQW/iokJP6Oioj7u7W0/qKcnv8HAQDyJiIg94N9fP/Lxcb+opyc/8fBwvYGAgDu7urq+kZAQPaWkJL6Miwu/srExv97dXb/083M/qaiovd/e3r6ZmJg92tlZP9DPTz+npqY+kZAQveXkZD7NzEw+5uVlv9LRUb+wry+/iIcHP4aFBb+KiQk/o6KiPu7tbT+opye/wcBAPImIiD3g318/8vFxv6inJz/x8HC9gYCAO7u6ur6RkBA9paQkvoyLC7+ysTG/3t1dv/Tzcz+pqKi9397evpmYmD3a2Vk/0M9PPw==",
-      "vectorSha256": "5d3503e30294d4887869e93a153c34fe0896738d5caebe14d589de4fb38e7a18",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "51388aa2b83016102b19f27cd861d9e8b1775e93a3f072e79bf2cec508ef6fc3",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0772": {
@@ -6919,15 +6802,6 @@
       "textHash": "c4cccb6375dae89054f76cdf7195e25195002010c3d034eccb1e53aba54fac0f",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0779": {
-      "vector": "iYiIPaOioj6amRk/iokJv/Tzcz+ysTE/4uFhv7y7O7+VlBQ+hIMDv4uKir78+3s/t7a2PrCvL7/e3V2//fx8vtnY2L27urq+6ulpP//+/r75+Pi9ubi4vQAAgL+DgoK++fj4vdHQUL2NjAy+j46OPo2MDD6ysTE/qKcnv+vq6r6JiIg9o6KiPpqZGT+KiQm/9PNzP7KxMT/i4WG/vLs7v5WUFD6EgwO/i4qKvvz7ez+3trY+sK8vv97dXb/9/Hy+2djYvbu6ur7q6Wk///7+vvn4+L25uLi9AACAv4OCgr75+Pi90dBQvY2MDL6Pjo4+jYwMPrKxMT+opye/6+rqvg==",
-      "vectorSha256": "a941901304c8b754ebb2e23d560eb739fdb9ebe88590144278486b16af70b4d0",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "3d283d7cda842784ac5aaf9734556ef24aa7532180b2ef61acef1d52b156e8b3",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0780": {
       "vector": "v76+vtva2j7c21s/p6amvsTDQz+sqys/1tVVP7m4uL3W1VW/z87OPtTTU7+Hhoa+6ejovZiXF7+SkRG/mZiYvfHwcL2wry+/wsFBP6KhIT/u7W2/+/r6Po6NDT+amRm/qaiova6tLb/f3t6+ubi4PczLS7/R0FA9hYQEPoGAgLu/vr6+29raPtzbWz+npqa+xMNDP6yrKz/W1VU/ubi4vdbVVb/Pzs4+1NNTv4eGhr7p6Oi9mJcXv5KREb+ZmJi98fBwvbCvL7/CwUE/oqEhP+7tbb/7+vo+jo0NP5qZGb+pqKi9rq0tv9/e3r65uLg9zMtLv9HQUD2FhAQ+gYCAuw==",
       "vectorSha256": "7eb211ed5d806eb16d3f689019a343febb3b74f8a1f263e388a1d662ee8ec5a8",
@@ -6935,24 +6809,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "2bc565d2049c1ec2a89e2e4bc8c3f65f7be7355dcb9c5f31de711b5506aa9d50",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0781": {
-      "vector": "lpUVv9HQUL3S0VE/ycjIverpaT/t7Gw+o6KiPpKRET/j4uK+qKcnP5qZGT/Ix0e/9vV1P4eGhr6wry8/rKsrP+zra7/q6Wk/jYwMvtjXVz+0szM/sbAwvaGgoLz19HQ+6ejovQAAgD/Ix0c/ubi4vYKBAT+XlpY+sK8vP6KhIb+WlRW/0dBQvdLRUT/JyMi96ulpP+3sbD6joqI+kpERP+Pi4r6opyc/mpkZP8jHR7/29XU/h4aGvrCvLz+sqys/7Otrv+rpaT+NjAy+2NdXP7SzMz+xsDC9oaCgvPX0dD7p6Oi9AACAP8jHRz+5uLi9goEBP5eWlj6wry8/oqEhvw==",
-      "vectorSha256": "bbc7fba6fa6278084f62d68eb142c9ba3e324b82bcae9b6ddb36b2020489e9d6",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "b88cd1e621b502064e4c945273c49dd6a8105af96b8f91108724f8fef682ae26",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0782": {
-      "vector": "6ulpv9TTU7/x8HA9urk5v5uamr6Miwu//v19P5CPD7/m5WU//v19P9va2j6hoKA82tlZv56dHT+2tTU/w8LCvtjXV7+0szM/vr09v8LBQb+1tDS+m5qavq6tLT/29XW/0tFRP7y7O7/My0u/qqkpP4iHB7+trCw+3dxcPuDfX7/q6Wm/1NNTv/HwcD26uTm/m5qavoyLC7/+/X0/kI8Pv+blZT/+/X0/29raPqGgoDza2Vm/np0dP7a1NT/DwsK+2NdXv7SzMz++vT2/wsFBv7W0NL6bmpq+rq0tP/b1db/S0VE/vLs7v8zLS7+qqSk/iIcHv62sLD7d3Fw+4N9fvw==",
-      "vectorSha256": "2da576b8a0e95ae49c9c53a8e63cba899a71be36db2ebb1af8ce10bf0482f0c4",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "8533e1cb18619f5f5877d638197224b07b1461aa27ade73d6f26a97fda29b846",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0783": {
@@ -7108,15 +6964,6 @@
       "textHash": "a4444d95fb1ae8419e343ad8a5ef31c34e47a512b4a84cf11b6e8679268639b8",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0802": {
-      "vector": "xcREvu/u7j6trCw+oqEhv/f29j7GxUW/sbAwverpaT/r6uq+kZAQvbm4uD3+/X2/srExP9fW1r79/Hw+lpUVv9PS0r7My0u/8O9vv6CfHz/z8vK+jYwMPsTDQ7+urS0/2tlZP+vq6r7r6uq+0M9PP9DPT7/k42M/yMdHv769PT/FxES+7+7uPq2sLD6ioSG/9/b2PsbFRb+xsDC96ulpP+vq6r6RkBC9ubi4Pf79fb+ysTE/19bWvv38fD6WlRW/09LSvszLS7/w72+/oJ8fP/Py8r6NjAw+xMNDv66tLT/a2Vk/6+rqvuvq6r7Qz08/0M9Pv+TjYz/Ix0e/vr09Pw==",
-      "vectorSha256": "dad8c7bcd881f99919dfb1d575436ab3cfd5243d5a472f1caed6cf5a01c0e045",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "a100424b941a5fdcd2d71806d027da8cd942e7ccaf082a5996c513ab563dfabe",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0803": {
       "vector": "hIMDP/v6+j7JyMi95uVlP4uKir78+3u/19bWPsbFRT+NjAy+hYQEvvf29r6mpSU/wcBAvJuamj66uTk/zMtLP9LRUb/o52c/oJ8fv7GwMD2OjQ0/3NtbP8XERD7CwUE/mZiYPdva2j729XW/mpkZv6qpKb/d3Fw+wcBAvNzbWz+EgwM/+/r6PsnIyL3m5WU/i4qKvvz7e7/X1tY+xsVFP42MDL6FhAS+9/b2vqalJT/BwEC8m5qaPrq5OT/My0s/0tFRv+jnZz+gnx+/sbAwPY6NDT/c21s/xcREPsLBQT+ZmJg929raPvb1db+amRm/qqkpv93cXD7BwEC83NtbPw==",
       "vectorSha256": "8e6a657cec59feef53caa2837ef6d173e115cb22eed5ee87fb98abece6cfbb71",
@@ -7144,15 +6991,6 @@
       "textHash": "add96b451187078e3879032409672fcff138f9fd8ae4905d0b0d7057f9f91843",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0807": {
-      "vector": "pKMjv7Oysr7CwUG/w8LCPsfGxr7DwsI+vLs7P4qJCT+2tTU/paQkPoqJCb+qqSk/hoUFv9rZWb/6+Xm/mpkZP8/Ozr7GxUW/nZwcPqinJz+Lioq+19bWPqqpKb/n5ua+19bWvouKir62tTW/5uVlP5eWlr76+Xk/1dRUvsjHR7+koyO/s7KyvsLBQb/DwsI+x8bGvsPCwj68uzs/iokJP7a1NT+lpCQ+iokJv6qpKT+GhQW/2tlZv/r5eb+amRk/z87OvsbFRb+dnBw+qKcnP4uKir7X1tY+qqkpv+fm5r7X1ta+i4qKvra1Nb/m5WU/l5aWvvr5eT/V1FS+yMdHvw==",
-      "vectorSha256": "6156c5c89d1e0f1a82458bd646802442eeebd98b64cdc01d87ede54846535947",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "92d93108a5426bbfa862970c6a8d95c69572ba5786e32b7ac9e296695b4c288b",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
     "j-0808": {
       "vector": "w8LCPq+urj6bmpq+mpkZv4eGhj6EgwO/oqEhv4SDAz+6uTk/hYQEvvj3d7+VlBS+hoUFP8PCwr7X1ta+9vV1P9HQUD3X1tY+oJ8fP/X0dL6cmxs/wcBAvKWkJD6EgwM/5uVlv9PS0r739va+goEBv7a1Nb/+/X2///7+PpSTE7/DwsI+r66uPpuamr6amRm/h4aGPoSDA7+ioSG/hIMDP7q5OT+FhAS++Pd3v5WUFL6GhQU/w8LCvtfW1r729XU/0dBQPdfW1j6gnx8/9fR0vpybGz/BwEC8paQkPoSDAz/m5WW/09LSvvf29r6CgQG/trU1v/79fb///v4+lJMTvw==",
       "vectorSha256": "3d2aa94b0bf9f113e474180cb847fcf6d85220873cd6040c026ff3e4df9c72cc",
@@ -7160,24 +6998,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "c1b009eb020a14d60654b1159fb72bb1002a60f0954da57b4600ad1f62676c84",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0810": {
-      "vector": "29raPufm5j7u7W2/mZiYPeno6L2XlpY+jIsLv769Pb/19HS+trU1P6SjIz+npqa+gYCAO6CfH7/Y11c/3Ntbv8C/Pz+qqSm/oqEhv9zbWz+WlRW/+Pd3v6alJT/s62s/s7KyvtbVVb+4tze/srExP4GAgLv7+vq+4+LiPvLxcb/b2to+5+bmPu7tbb+ZmJg96ejovZeWlj6Miwu/vr09v/X0dL62tTU/pKMjP6empr6BgIA7oJ8fv9jXVz/c21u/wL8/P6qpKb+ioSG/3NtbP5aVFb/493e/pqUlP+zraz+zsrK+1tVVv7i3N7+ysTE/gYCAu/v6+r7j4uI+8vFxvw==",
-      "vectorSha256": "a44a8c44019a00a9f6d09b9a80727c3939d84b60915076e2a05d0df0fc447019",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "ff742ce77844f022759d6f065c639b2f170073c0dcbb4f6f18759175bbde16d8",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0812": {
-      "vector": "1NNTP7GwMD2zsrI+v76+Pufm5j6enR0/mJcXP8XERD79/Hw+tbQ0vuXkZL7FxES+5ONjv8bFRb+6uTk/8fBwvcHAQLz19HQ+lJMTP/LxcT+JiIg9/v19P9TTUz+enR0/2tlZP6KhIb/7+vo+4uFhP4+Ojr6/vr6+np0dP8jHR7/U01M/sbAwPbOysj6/vr4+5+bmPp6dHT+Ylxc/xcREPv38fD61tDS+5eRkvsXERL7k42O/xsVFv7q5OT/x8HC9wcBAvPX0dD6UkxM/8vFxP4mIiD3+/X0/1NNTP56dHT/a2Vk/oqEhv/v6+j7i4WE/j46Ovr++vr6enR0/yMdHvw==",
-      "vectorSha256": "c9d7113a0de5a487c48c0fa93b2138c36b2df887b23f3e646061e6b16a629db7",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "41bef813145369ca78679d10362bb4f58e9d7abf655c2b6aa4473e5347d7f1fd",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0813": {
@@ -7196,15 +7016,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "b5d8786be895e07a634c5e6222b25fac09d8b29fbbb2f047cf4639861f8381f9",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0816": {
-      "vector": "l5aWPra1NT+cmxu/o6KiPufm5j7S0VG/lJMTv6CfHz/U01O/xMNDP5ybGz+pqKi95+bmvr28PD6fnp4+qaiovbKxMT/5+Pi9n56ePpqZGb+NjAy+7exsPtPS0j6CgQG/tLMzv/Tzc7+5uLg919bWvsbFRT+xsDA9hYQEPqWkJL6XlpY+trU1P5ybG7+joqI+5+bmPtLRUb+UkxO/oJ8fP9TTU7/Ew0M/nJsbP6moqL3n5ua+vbw8Pp+enj6pqKi9srExP/n4+L2fnp4+mpkZv42MDL7t7Gw+09LSPoKBAb+0szO/9PNzv7m4uD3X1ta+xsVFP7GwMD2FhAQ+paQkvg==",
-      "vectorSha256": "7d8cf81457a986d51ad6b05ee2cdd42b7aee8a6e7f5e618417d9025855fe72d6",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "58cebb6582e1d0e2814e00e14f2e7904c2476c60939a4559b5e75408252f0322",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0817": {
@@ -7376,15 +7187,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "c1f5171ffcfb9807b86e5e0a6b19ae757a7c1551040714735ef7d62062bf517c",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0837": {
-      "vector": "l5aWPvr5eT+WlRW/trU1v+DfX7/e3V0/iYiIvcC/P7/a2Vk/0M9Pv4uKij7My0u//Pt7v5STE7/DwsI+2tlZP8zLS7+gnx8/8/LyvuXkZL6zsrK+5ONjv5STE7+mpSW/wsFBP+zra7+5uLi9//7+vqinJ7/x8HC9pqUlP4SDAz+XlpY++vl5P5aVFb+2tTW/4N9fv97dXT+JiIi9wL8/v9rZWT/Qz0+/i4qKPszLS7/8+3u/lJMTv8PCwj7a2Vk/zMtLv6CfHz/z8vK+5eRkvrOysr7k42O/lJMTv6alJb/CwUE/7Otrv7m4uL3//v6+qKcnv/HwcL2mpSU/hIMDPw==",
-      "vectorSha256": "9debac2bc83aa2878777eb8874ce4699080a842b4253675002ea71bb2c2fb53f",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "bb2876a420317c775dd4b18beb3803a0742b3787f703c3c58537f5801898bedc",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0838": {
@@ -7574,15 +7376,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "8d5f892748545d8a467a2eb3c00e7e816f0c1e70c838e2e95661c1b5af329770",
-      "updatedAt": "2025-09-21T23:10:32.417Z"
-    },
-    "j-0860": {
-      "vector": "4eDgPOjnZ7/u7W0/mZiYPe/u7r6RkBA9sK8vP7++vr60szO/o6KiPpmYmL3h4OA8oaCgPNnY2L0AAIA/iYiIveXkZL63tra+rq0tP5eWlj6Qjw+/19bWPqOior7JyMg96ulpv7Oysr6Lioo+kI8PP6CfHz/p6Og9vr09v5KREb/h4OA86Odnv+7tbT+ZmJg97+7uvpGQED2wry8/v76+vrSzM7+joqI+mZiYveHg4DyhoKA82djYvQAAgD+JiIi95eRkvre2tr6urS0/l5aWPpCPD7/X1tY+o6KivsnIyD3q6Wm/s7KyvouKij6Qjw8/oJ8fP+no6D2+vT2/kpERvw==",
-      "vectorSha256": "9beecf2f0bbfae775c89e2a5f9fc9b070af50b6f6ca9d3cec409e181e0137346",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "0d93f1526e0def5e4d078465effe25756db083e576dafaf8a8be31e9fcbde9ec",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
     "j-0861": {

--- a/data/jokes-embeddings.json
+++ b/data/jokes-embeddings.json
@@ -3,8 +3,8 @@
     "provider": "synthetic",
     "model": "synthetic-64",
     "dimensions": 64,
-    "generatedAt": "2025-09-22T01:50:07.859Z",
-    "recordCount": 888
+    "generatedAt": "2025-09-22T23:16:21.837Z",
+    "recordCount": 865
   },
   "records": {
     "j-0001": {
@@ -2851,15 +2851,6 @@
       "textHash": "2e7cbaa621c65b1b0a89d0bfe4d1814f0f0d5194fbb75009fede86c77110c20a",
       "updatedAt": "2025-09-20T22:27:41.524Z"
     },
-    "j-0317": {
-      "vector": "hoUFv5ybG7+mpSW/nJsbv7++vr64tzc/oJ8fP5WUFD6TkpI+3NtbP6qpKT+Pjo6+np0dP7SzMz+0szO/4eDgPKinJ7+cmxu/6ejoPYmIiD3FxEQ+yslJv/79fT/q6Wk/x8bGPqyrKz+gnx+/mJcXv/79fb+trCy+sK8vP9nY2L2GhQW/nJsbv6alJb+cmxu/v76+vri3Nz+gnx8/lZQUPpOSkj7c21s/qqkpP4+Ojr6enR0/tLMzP7SzM7/h4OA8qKcnv5ybG7/p6Og9iYiIPcXERD7KyUm//v19P+rpaT/HxsY+rKsrP6CfH7+Ylxe//v19v62sLL6wry8/2djYvQ==",
-      "vectorSha256": "a278be6d7f5fa994007aea3bafb895c737e9752041efc6aa5f13363fea8b6d7f",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "3d322d3250dbcf92a4edd45cced926832c328e88981bfef4b1d53034016ad772",
-      "updatedAt": "2025-09-20T22:27:41.524Z"
-    },
     "j-0318": {
       "vector": "7exsvtrZWT/o52c/g4KCvpSTE7++vT0/sK8vv8vKyr7CwUE/nZwcPoqJCb+FhAQ+l5aWPtfW1r7W1VW/goEBv4mIiL2WlRU/6Odnv6+urj7FxES+zMtLv87NTb/n5uY++fj4PerpaT+npqY+/fx8vra1NT+mpSW/h4aGvr28PL7t7Gy+2tlZP+jnZz+DgoK+lJMTv769PT+wry+/y8rKvsLBQT+dnBw+iokJv4WEBD6XlpY+19bWvtbVVb+CgQG/iYiIvZaVFT/o52e/r66uPsXERL7My0u/zs1Nv+fm5j75+Pg96ulpP6empj79/Hy+trU1P6alJb+Hhoa+vbw8vg==",
       "vectorSha256": "73aecf9575100e174f07f570ca2f995b3e2ecf63e8a30a512ee0ea9a45c1e4e7",
@@ -3850,15 +3841,6 @@
       "textHash": "2a1dfe1645d5e6edcf4afe8d23a0f516fea52ec9ace243501dca35b9df465036",
       "updatedAt": "2025-09-20T22:27:41.533Z"
     },
-    "j-0428": {
-      "vector": "4N9fv83MTD6CgQG/9PNzv5iXFz+CgQE/z87OPtLRUT/k42M/+/r6vrOysr6enR2/g4KCvpCPDz/a2Vm/zs1NP4yLCz/k42O/iIcHv8rJSb/Z2Ng9trU1v/n4+D2+vT0/6+rqvvz7e7/29XW/2djYvaqpKT+zsrK+lZQUPoyLCz/g31+/zcxMPoKBAb/083O/mJcXP4KBAT/Pzs4+0tFRP+TjYz/7+vq+s7Kyvp6dHb+DgoK+kI8PP9rZWb/OzU0/jIsLP+TjY7+Ihwe/yslJv9nY2D22tTW/+fj4Pb69PT/r6uq+/Pt7v/b1db/Z2Ni9qqkpP7Oysr6VlBQ+jIsLPw==",
-      "vectorSha256": "66bd48857ec5e500869b16b4adfe1f23667d651e54705ce0cb00cf26bde68244",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "10993f06cbc0b3e8f14153315fc713e6c50e3c1b8d258fde45020572d45392c5",
-      "updatedAt": "2025-09-20T22:27:41.533Z"
-    },
     "j-0429": {
       "vector": "uLc3v5KREb/493c/pKMjv9jXVz/g31+/i4qKvpiXF7+OjQ0/rKsrv7KxMT/Ew0M/5uVlv+TjYz/Y11c/sK8vP87NTb/Ix0c/3t1dP6SjI7+opye/kpERv6KhIT+8uzs/wsFBv+LhYb/5+Pg9gYCAu9LRUb/i4WE/srExv9va2r64tze/kpERv/j3dz+koyO/2NdXP+DfX7+Lioq+mJcXv46NDT+sqyu/srExP8TDQz/m5WW/5ONjP9jXVz+wry8/zs1Nv8jHRz/e3V0/pKMjv6inJ7+SkRG/oqEhP7y7Oz/CwUG/4uFhv/n4+D2BgIC70tFRv+LhYT+ysTG/29ravg==",
       "vectorSha256": "76c44066ecc4a2cd402b40bbaeb9b441bf72ebe50ed40605f3ab8705efaca4c6",
@@ -4676,15 +4658,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "5d5bb2db70d28d42f07b1ce702540e1142952896f67c30e1ee9358b5501a749c",
-      "updatedAt": "2025-09-20T22:27:41.535Z"
-    },
-    "j-0521": {
-      "vector": "tbQ0vqalJT+cmxu/lJMTv6alJT///v6+zcxMPsC/P7+cmxs/6ulpP7W0ND7o52c/iokJP+DfX7+Ihwc/tLMzv66tLT/Lysq+7+7uvpmYmL2lpCQ+l5aWPoiHB7/8+3u/xcREvu/u7r7i4WG/4N9fv4SDAz/c21s/jo0NP+no6D21tDS+pqUlP5ybG7+UkxO/pqUlP//+/r7NzEw+wL8/v5ybGz/q6Wk/tbQ0PujnZz+KiQk/4N9fv4iHBz+0szO/rq0tP8vKyr7v7u6+mZiYvaWkJD6XlpY+iIcHv/z7e7/FxES+7+7uvuLhYb/g31+/hIMDP9zbWz+OjQ0/6ejoPQ==",
-      "vectorSha256": "86963172ccc275d8e4352fd849227a3838dbfc0c35ece3fa04939975f66255dd",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "69d23236d2409920cdf496f3c410c326d64d447694a53c0267440f10c1edc68e",
       "updatedAt": "2025-09-20T22:27:41.535Z"
     },
     "j-0522": {
@@ -6163,15 +6136,6 @@
       "textHash": "dc9a7fea085ae7e6d6666f61aa2ee6599a5aa7edbaddfe809860252b7d48cb25",
       "updatedAt": "2025-09-20T22:27:41.539Z"
     },
-    "j-0688": {
-      "vector": "6ulpv6inJz+VlBS+kpERv+TjYz/Hxsa+0M9Pv9/e3j7Avz8/jIsLP7GwML2wry+/u7q6vomIiL3v7u6+trU1P+fm5j6rqqq+1dRUvpmYmD3h4OC8rKsrP8nIyD2JiIi9gYCAO8TDQz/S0VG/oqEhP46NDT+qqSm/5+bmPtXUVL7q6Wm/qKcnP5WUFL6SkRG/5ONjP8fGxr7Qz0+/397ePsC/Pz+Miws/sbAwvbCvL7+7urq+iYiIve/u7r62tTU/5+bmPquqqr7V1FS+mZiYPeHg4Lysqys/ycjIPYmIiL2BgIA7xMNDP9LRUb+ioSE/jo0NP6qpKb/n5uY+1dRUvg==",
-      "vectorSha256": "aa9b90186f16b311a3568f1bb998dd4db5b9c6cc9cafca2bcae87b4f2db2bdb5",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "0bd36d37f14e18b7dfc57a28517744dab95565897cd58c7780e117d0c62bb965",
-      "updatedAt": "2025-09-20T22:27:41.539Z"
-    },
     "j-0689": {
       "vector": "mpkZv5aVFb+sqyu/8vFxv/n4+L3NzEy+rq0tP5KREb+dnBy+8/LyvvX0dD7q6Wm/lJMTv+rpaT+DgoI+//7+vpmYmL3My0s/0dBQvf/+/j7DwsK+m5qaPoSDAz/v7u4+tLMzP9zbWz/Z2Ng9v76+vquqqr7a2Vm/k5KSPvHwcD2amRm/lpUVv6yrK7/y8XG/+fj4vc3MTL6urS0/kpERv52cHL7z8vK+9fR0Purpab+UkxO/6ulpP4OCgj7//v6+mZiYvczLSz/R0FC9//7+PsPCwr6bmpo+hIMDP+/u7j60szM/3NtbP9nY2D2/vr6+q6qqvtrZWb+TkpI+8fBwPQ==",
       "vectorSha256": "a079381fb55474c0def999023f569c12dc4eedf316f6b9e16d5dcb1e87980916",
@@ -6262,15 +6226,6 @@
       "textHash": "6eb935d001203eff2fe076cca7a7c171f1771b3f4d1a44b9a975b9a6d07fb354",
       "updatedAt": "2025-09-20T22:27:41.539Z"
     },
-    "j-0700": {
-      "vector": "pqUlv/38fD6opyc/ycjIPfTzcz+Lioq+gYCAO6WkJD7S0VG/iYiIvQAAgD/Lyso+5ONjP9va2j6koyO/yMdHv+Pi4j69vDw+pKMjP7CvL7+Qjw8/mpkZv4uKir7Qz08/6ejoPfr5eb+Ihwe/+Pd3v+TjY7+FhAS+g4KCPrGwML2mpSW//fx8PqinJz/JyMg99PNzP4uKir6BgIA7paQkPtLRUb+JiIi9AACAP8vKyj7k42M/29raPqSjI7/Ix0e/4+LiPr28PD6koyM/sK8vv5CPDz+amRm/i4qKvtDPTz/p6Og9+vl5v4iHB7/493e/5ONjv4WEBL6DgoI+sbAwvQ==",
-      "vectorSha256": "acd18cf8a952bff98d4105a57fedb891cfbd8d0014c270677160781573abb29a",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "2d9fd38cf95d80941777ffb2f1b62e1cb897d128c7335de78e033c040e6fa07a",
-      "updatedAt": "2025-09-20T22:27:41.539Z"
-    },
     "j-0701": {
       "vector": "u7q6vra1Nb/6+Xm/xMNDP52cHD6mpSW/pqUlv8fGxj729XW//v19v9DPT7+1tDS+mpkZv8fGxr7r6uq+nJsbP9/e3j7KyUm/trU1P6qpKT+9vDw+u7q6Po6NDT/9/Hy+rawsPoaFBT/v7u4+1NNTP+LhYb+UkxM/4uFhv/n4+D27urq+trU1v/r5eb/Ew0M/nZwcPqalJb+mpSW/x8bGPvb1db/+/X2/0M9Pv7W0NL6amRm/x8bGvuvq6r6cmxs/397ePsrJSb+2tTU/qqkpP728PD67uro+jo0NP/38fL6trCw+hoUFP+/u7j7U01M/4uFhv5STEz/i4WG/+fj4PQ==",
       "vectorSha256": "625b57da04ccdd9e0a618206ac276c4d915bcc94b15466055ca83dd129959ea5",
@@ -6314,15 +6269,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "e963c62c16fd2ab183cd2ff0018220269112b18d77fa6a74fe7c27826934cdb5",
-      "updatedAt": "2025-09-20T22:27:41.540Z"
-    },
-    "j-0706": {
-      "vector": "kI8PP8bFRb+pqKg98vFxv6alJT/19HQ+np0dv769Pb+joqI+u7q6Pr28PD7n5ua+4+LiPrW0ND7DwsK++/r6vpSTEz/7+vq+4uFhP9PS0r6rqqo+nJsbP+no6L3Lyso+trU1P8/Ozj739vY++/r6vqGgoLzr6uq+6ulpP5uamr6Qjw8/xsVFv6moqD3y8XG/pqUlP/X0dD6enR2/vr09v6Oioj67uro+vbw8Pufm5r7j4uI+tbQ0PsPCwr77+vq+lJMTP/v6+r7i4WE/09LSvquqqj6cmxs/6ejovcvKyj62tTU/z87OPvf29j77+vq+oaCgvOvq6r7q6Wk/m5qavg==",
-      "vectorSha256": "ed7d6f243d69bed63ef80e6fa7a4f746d5417cf14f9e4d36f6341cb034fb4212",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "c71d8a07d29e3121a8ae9746b8964f41c941f04baacd71b2dab3bd417d45f459",
       "updatedAt": "2025-09-20T22:27:41.540Z"
     },
     "j-0707": {
@@ -6404,15 +6350,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "de73ac7910cff31987295f895986ac85392d1a9a7bf95c538e4f7bed124739e6",
-      "updatedAt": "2025-09-20T22:27:41.540Z"
-    },
-    "j-0718": {
-      "vector": "6+rqvs3MTL7r6uq++Pd3P6empr6npqa+kpERv9LRUT/DwsK+1NNTP5ybGz+qqSk//Pt7P4uKij6UkxO/4uFhv42MDL7OzU2/kI8Pv6alJT/Avz+/lZQUPqOioj7T0tI+7+7uPqOioj6Qjw8/gYCAu6SjIz+3tra+wsFBP+3sbD7r6uq+zcxMvuvq6r7493c/p6amvqempr6SkRG/0tFRP8PCwr7U01M/nJsbP6qpKT/8+3s/i4qKPpSTE7/i4WG/jYwMvs7NTb+Qjw+/pqUlP8C/P7+VlBQ+o6KiPtPS0j7v7u4+o6KiPpCPDz+BgIC7pKMjP7e2tr7CwUE/7exsPg==",
-      "vectorSha256": "ab7306f36f77462b4158ae173856fcaa0804017410d19325c2b2dd8cacb108f3",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "456645fb565637e84fe9cdd4fda2360f6e1938d22092a8b4bba8c77fd152e09d",
       "updatedAt": "2025-09-20T22:27:41.540Z"
     },
     "j-0719": {
@@ -6505,15 +6442,6 @@
       "textHash": "7e0c789a0442f27ca15d54980a72dd1445a37237327cb5d568f48e77a6f041fd",
       "updatedAt": "2025-09-20T22:27:41.541Z"
     },
-    "j-0729": {
-      "vector": "4eDgPPLxcT/V1FQ+lZQUPrGwML3z8vK+AACAv8C/Pz/c21u/+fj4vayrK7+/vr6+4eDgPIyLC7/Pzs4++Pd3P/j3d7/U01M/ubi4vcC/Pz/Ew0M/3t1dP6uqqr76+Xm/5ONjv/79fb/d3Fy+kpERv9bVVb+UkxM/gYCAu4OCgr7h4OA88vFxP9XUVD6VlBQ+sbAwvfPy8r4AAIC/wL8/P9zbW7/5+Pi9rKsrv7++vr7h4OA8jIsLv8/Ozj7493c/+Pd3v9TTUz+5uLi9wL8/P8TDQz/e3V0/q6qqvvr5eb/k42O//v19v93cXL6SkRG/1tVVv5STEz+BgIC7g4KCvg==",
-      "vectorSha256": "6a2eaf11770497fe37e356d698dbf05c5b6555fa4b1718667bc1ec1fa394a381",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "83f89a927a4300df12702a50833ab3fb04e974dfe1ee55030e01643715c97f5f",
-      "updatedAt": "2025-09-20T22:27:41.541Z"
-    },
     "j-0730": {
       "vector": "wsFBv8jHR7/z8vI+vbw8PsjHRz/KyUk/k5KSPuTjYz/My0u/9PNzv5OSkj6+vT2/j46OPvf29r7s62s/oqEhP7GwML2UkxM/g4KCvtDPTz+Xlpa+srExv/v6+j6FhAQ+/fx8PuPi4j7v7u6+u7q6PuPi4j6OjQ0/7+7uvqSjIz/CwUG/yMdHv/Py8j69vDw+yMdHP8rJST+TkpI+5ONjP8zLS7/083O/k5KSPr69Pb+Pjo4+9/b2vuzraz+ioSE/sbAwvZSTEz+DgoK+0M9PP5eWlr6ysTG/+/r6PoWEBD79/Hw+4+LiPu/u7r67uro+4+LiPo6NDT/v7u6+pKMjPw==",
       "vectorSha256": "3cf329c80d7426686731b91b610461f5447cec7ae235380b0014a742d2cda381",
@@ -6550,15 +6478,6 @@
       "textHash": "abc390e916cdc4b698783c3214110de61b984b418552bb9162833b490ae97beb",
       "updatedAt": "2025-09-20T22:27:41.541Z"
     },
-    "j-0734": {
-      "vector": "jo0NP4yLC7/19HS+5ONjv5GQED2+vT0/9PNzP//+/r7j4uI+uLc3P8nIyL3DwsK+xMNDv4+Ojr7R0FC9/v19P/Dvbz/u7W0/hYQEvo+Ojj7S0VG/zs1Nv9va2r7x8HC99/b2vs/Ozj69vDy+xMNDP6WkJD7h4OC8vLs7v62sLD6OjQ0/jIsLv/X0dL7k42O/kZAQPb69PT/083M///7+vuPi4j64tzc/ycjIvcPCwr7Ew0O/j46OvtHQUL3+/X0/8O9vP+7tbT+FhAS+j46OPtLRUb/OzU2/29ravvHwcL339va+z87OPr28PL7Ew0M/paQkPuHg4Ly8uzu/rawsPg==",
-      "vectorSha256": "8f6c06d184cfb5f89db4de054d1145210f38cbd2f801f360fd0cea7ba2e4f32e",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "c63a610e84def940b8db734f1e5c79fef7f66fa31719497842b368e1947c2295",
-      "updatedAt": "2025-09-20T22:27:41.541Z"
-    },
     "j-0735": {
       "vector": "zs1NP+rpab+joqI+jIsLv5GQED2hoKC85uVlP9XUVL6mpSW/6ejoPa+urj6FhAS+rq0tv5mYmD2OjQ2/0tFRv8vKyr6OjQ2/n56evpSTE7+3trY+mJcXv+XkZD7p6Oi9sK8vv//+/j6Qjw8/xcREPpiXF7/KyUk/2NdXP/f29r7OzU0/6ulpv6Oioj6Miwu/kZAQPaGgoLzm5WU/1dRUvqalJb/p6Og9r66uPoWEBL6urS2/mZiYPY6NDb/S0VG/y8rKvo6NDb+fnp6+lJMTv7e2tj6Ylxe/5eRkPuno6L2wry+///7+PpCPDz/FxEQ+mJcXv8rJST/Y11c/9/b2vg==",
       "vectorSha256": "ee458728223954badbe8e4987c702d393cef50e790117386069d3b4822d44811",
@@ -6584,15 +6503,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "2ab56142ea720b794504a5f2590fa7fe45a754d4ff3712732add82a8a8ef855b",
-      "updatedAt": "2025-09-20T22:27:41.541Z"
-    },
-    "j-0740": {
-      "vector": "3t1dv7i3Nz+fnp6+j46OvpmYmL35+Pi9/Pt7P7CvLz/KyUk/paQkvqCfHz+JiIg9/Pt7v+DfX7+Ylxe/8/LyvujnZz+VlBQ+wsFBv+/u7j7v7u4+r66uPvr5eT+vrq4+7+7uPr++vj7g318/k5KSvtbVVb+wry8/rq0tv8rJSb/e3V2/uLc3P5+enr6Pjo6+mZiYvfn4+L38+3s/sK8vP8rJST+lpCS+oJ8fP4mIiD38+3u/4N9fv5iXF7/z8vK+6OdnP5WUFD7CwUG/7+7uPu/u7j6vrq4++vl5P6+urj7v7u4+v76+PuDfXz+TkpK+1tVVv7CvLz+urS2/yslJvw==",
-      "vectorSha256": "8c2edcbf9aafc681e7cd3fe6b2bc6f0abe7c5107c519e472666919b1495cf3de",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "11db585c7670fdd7e46bcf8802103443f3921fbbbbabfcabbbafef5b15d7291b",
       "updatedAt": "2025-09-20T22:27:41.541Z"
     },
     "j-0741": {
@@ -6811,24 +6721,6 @@
       "textHash": "0a8d011f4bd0f57f9c4d5b0e91bb8659e1ea839efb5415532df2016c355d0c4b",
       "updatedAt": "2025-09-20T22:27:41.541Z"
     },
-    "j-0767": {
-      "vector": "j46OPvPy8r69vDy+3NtbP8PCwr7Qz08/zcxMPpOSkr7083M/p6amvv38fD7//v4+8fBwvYiHB7+WlRW//v19v83MTD6sqys/ycjIPamoqD37+vq+qKcnv9/e3r7f3t4+vr09v+rpab/5+Pg97OtrP7GwMD2Pjo6+397ePq+urj6Pjo4+8/Lyvr28PL7c21s/w8LCvtDPTz/NzEw+k5KSvvTzcz+npqa+/fx8Pv/+/j7x8HC9iIcHv5aVFb/+/X2/zcxMPqyrKz/JyMg9qaioPfv6+r6opye/397evt/e3j6+vT2/6ulpv/n4+D3s62s/sbAwPY+Ojr7f3t4+r66uPg==",
-      "vectorSha256": "2d78dde195c4a14da1dc54a87a6de7331c3378b4826c0f78de37b3ffff4aa5fc",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "a34368ed4fe7995bf9569fbf783c350199d58c8a412c48b7210b8ff5855cb7ab",
-      "updatedAt": "2025-09-20T22:27:41.541Z"
-    },
-    "j-0768": {
-      "vector": "AACAv9PS0r7R0FA9tLMzP7GwMD3a2Vm/4uFhv769PT+OjQ2/kpERP7++vr6TkpI+wcBAvJCPD7/z8vI+1dRUvq+urr62tTW/np0dv8vKyj7KyUm/2djYvZqZGT///v4++fj4PdzbWz+zsrI+09LSPqmoqD2urS2/7Otrv6yrKz8AAIC/09LSvtHQUD20szM/sbAwPdrZWb/i4WG/vr09P46NDb+SkRE/v76+vpOSkj7BwEC8kI8Pv/Py8j7V1FS+r66uvra1Nb+enR2/y8rKPsrJSb/Z2Ni9mpkZP//+/j75+Pg93NtbP7Oysj7T0tI+qaioPa6tLb/s62u/rKsrPw==",
-      "vectorSha256": "cd3dc3d67b52beb649400bc80d95cb2cc0e1f656673f84e61c6374c3d81aec17",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "004b86d985130fde39c850a47e38bc65542531b21b72ccbf8fedacb48a290ad5",
-      "updatedAt": "2025-09-20T22:27:41.541Z"
-    },
     "j-0769": {
       "vector": "3Ntbv97dXb+joqK+oJ8fP5uamr6enR2/4eDgPLW0NL6+vT0/+/r6voeGhj6RkBC9rKsrv52cHD7Z2Ng9t7a2vt/e3r719HS+srExP5aVFb/V1FS+9PNzP5CPDz+joqI+6ejoPZCPDz/m5WU/qaioPf/+/j6qqSk/o6KiPoyLCz/c21u/3t1dv6Oior6gnx8/m5qavp6dHb/h4OA8tbQ0vr69PT/7+vq+h4aGPpGQEL2sqyu/nZwcPtnY2D23tra+397evvX0dL6ysTE/lpUVv9XUVL7083M/kI8PP6Oioj7p6Og9kI8PP+blZT+pqKg9//7+PqqpKT+joqI+jIsLPw==",
       "vectorSha256": "f1c33caaf47a81e69a2a621e11008dca86ddcef6e42305a69e852033163b0143",
@@ -6846,15 +6738,6 @@
       "dimensions": 64,
       "textHash": "0a868ec1f17fac1812c10ea026c46641d39f6903fe61a632ddc393f0057ad1dc",
       "updatedAt": "2025-09-20T22:27:41.541Z"
-    },
-    "j-0771": {
-      "vector": "u7q6vpCPD7+pqKg9i4qKPuPi4j6gnx+/1NNTv+DfX7+qqSm/zs1Nv+blZT/h4OC8srExP/X0dL60szM/0tFRP8fGxj6JiIi9h4aGvp2cHD6Pjo4+4uFhP9nY2L3Qz08/3dxcPublZT+enR0/jIsLP/Dvb7/g318/hYQEvoiHBz+7urq+kI8Pv6moqD2Lioo+4+LiPqCfH7/U01O/4N9fv6qpKb/OzU2/5uVlP+Hg4LyysTE/9fR0vrSzMz/S0VE/x8bGPomIiL2Hhoa+nZwcPo+Ojj7i4WE/2djYvdDPTz/d3Fw+5uVlP56dHT+Miws/8O9vv+DfXz+FhAS+iIcHPw==",
-      "vectorSha256": "89397a803e63205d027f4b44e078694b7381cc362bd64900ff93f53fa097bf35",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "51388aa2b83016102b19f27cd861d9e8b1775e93a3f072e79bf2cec508ef6fc3",
-      "updatedAt": "2025-09-20T22:27:41.542Z"
     },
     "j-0772": {
       "vector": "6ulpv5+enr6cmxu/8fBwPZ6dHT/y8XG/qqkpv/Tzc7/v7u4+/Pt7P5aVFb+BgIA7+vl5v+no6L2RkBA9l5aWPpuamj7V1FQ+AACAv5STEz/8+3u/kpERv+/u7j7//v4+4+Livt3cXL6Xlpa+g4KCPublZT+joqK+sbAwvfPy8j7q6Wm/n56evpybG7/x8HA9np0dP/Lxcb+qqSm/9PNzv+/u7j78+3s/lpUVv4GAgDv6+Xm/6ejovZGQED2XlpY+m5qaPtXUVD4AAIC/lJMTP/z7e7+SkRG/7+7uPv/+/j7j4uK+3dxcvpeWlr6DgoI+5uVlP6Oior6xsDC98/LyPg==",
@@ -6919,15 +6802,6 @@
       "textHash": "c4cccb6375dae89054f76cdf7195e25195002010c3d034eccb1e53aba54fac0f",
       "updatedAt": "2025-09-20T22:27:41.542Z"
     },
-    "j-0779": {
-      "vector": "hoUFv7CvL7+GhQW/4eDgvLa1NT+RkBA9srExv5GQED2zsrI+l5aWvr++vj69vDw+mJcXv6uqqr6NjAy+5uVlP9fW1r6fnp4+s7Kyvr69Pb+BgIA7y8rKPuDfXz/19HS+s7KyPuDfXz/GxUW/t7a2vsfGxj6npqa+0tFRP8/Ozj6GhQW/sK8vv4aFBb/h4OC8trU1P5GQED2ysTG/kZAQPbOysj6Xlpa+v76+Pr28PD6Ylxe/q6qqvo2MDL7m5WU/19bWvp+enj6zsrK+vr09v4GAgDvLyso+4N9fP/X0dL6zsrI+4N9fP8bFRb+3tra+x8bGPqempr7S0VE/z87OPg==",
-      "vectorSha256": "48b36fde78d2f0991588d429013032d54ea1f6eada22f6271dc6d070ebc7ef27",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "3d283d7cda842784ac5aaf9734556ef24aa7532180b2ef61acef1d52b156e8b3",
-      "updatedAt": "2025-09-20T22:27:41.542Z"
-    },
     "j-0780": {
       "vector": "qqkpv4yLCz/V1FS+pqUlP/j3d7/l5GQ+xMNDv4aFBT+joqI+9fR0PqSjI7/T0tK+kpERP4iHBz/u7W0/g4KCvpGQEL3Qz08/lpUVv4uKir6Ylxc/5eRkPoOCgr6enR2/vr09P+no6L3KyUm/q6qqvvTzc7+rqqo+7exsPr++vr6qqSm/jIsLP9XUVL6mpSU/+Pd3v+XkZD7Ew0O/hoUFP6Oioj719HQ+pKMjv9PS0r6SkRE/iIcHP+7tbT+DgoK+kZAQvdDPTz+WlRW/i4qKvpiXFz/l5GQ+g4KCvp6dHb++vT0/6ejovcrJSb+rqqq+9PNzv6uqqj7t7Gw+v76+vg==",
       "vectorSha256": "faa64b2a2b9f2f57921de54b9f9efd42ff713ed9580fce2d32a7d0aa545a86ea",
@@ -6935,24 +6809,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "2bc565d2049c1ec2a89e2e4bc8c3f65f7be7355dcb9c5f31de711b5506aa9d50",
-      "updatedAt": "2025-09-20T22:27:41.542Z"
-    },
-    "j-0781": {
-      "vector": "4+LiPsnIyD2koyM/zs1NP769Pb/X1tY+/Pt7v/Tzc7/Hxsa+z87OvqWkJD63tra+ycjIvYqJCT/t7Gw+rq0tP6Oioj7g31+/l5aWvvTzcz+lpCS++fj4PY2MDD7g31+/8fBwPbi3N7/y8XE//v19P+7tbT+hoKA8u7q6PrSzM7/j4uI+ycjIPaSjIz/OzU0/vr09v9fW1j78+3u/9PNzv8fGxr7Pzs6+paQkPre2tr7JyMi9iokJP+3sbD6urS0/o6KiPuDfX7+Xlpa+9PNzP6WkJL75+Pg9jYwMPuDfX7/x8HA9uLc3v/LxcT/+/X0/7u1tP6GgoDy7uro+tLMzvw==",
-      "vectorSha256": "5c918cd07f307ea8167f6e3c5ad61c5a116bf4c92cb2d7ab2e9ea02d9056e320",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "b88cd1e621b502064e4c945273c49dd6a8105af96b8f91108724f8fef682ae26",
-      "updatedAt": "2025-09-20T22:27:41.542Z"
-    },
-    "j-0782": {
-      "vector": "sbAwPZqZGb/Ew0M/mJcXP9DPT7/19HS+/fx8PoOCgr6fnp6+iYiIva6tLT+Qjw+/zs1Nv9nY2L24tze/w8LCPpGQEL3Y11e/9fR0vquqqj6ysTG/t7a2PtDPTz+GhQW/hYQEvrSzM7+npqY+gYCAu7a1NT+urS2/4+LiPufm5r6xsDA9mpkZv8TDQz+Ylxc/0M9Pv/X0dL79/Hw+g4KCvp+enr6JiIi9rq0tP5CPD7/OzU2/2djYvbi3N7/DwsI+kZAQvdjXV7/19HS+q6qqPrKxMb+3trY+0M9PP4aFBb+FhAS+tLMzv6empj6BgIC7trU1P66tLb/j4uI+5+bmvg==",
-      "vectorSha256": "ba606466997a78f09d311588300767cc92e3fa2cc6005268affaebbe774fbcac",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "8533e1cb18619f5f5877d638197224b07b1461aa27ade73d6f26a97fda29b846",
       "updatedAt": "2025-09-20T22:27:41.542Z"
     },
     "j-0783": {
@@ -7108,15 +6964,6 @@
       "textHash": "a4444d95fb1ae8419e343ad8a5ef31c34e47a512b4a84cf11b6e8679268639b8",
       "updatedAt": "2025-09-20T22:27:41.542Z"
     },
-    "j-0802": {
-      "vector": "h4aGPgAAgL/39va+09LSvqWkJD7My0u/g4KCvrq5OT+mpSU/sK8vP9DPT7/083O/oqEhP7KxMb+2tTU/ycjIPbSzMz/39va+0M9PP5qZGT+/vr4+8O9vv6yrK7+bmpq+tbQ0PoyLCz/a2Vm/r66uPqempr6GhQW/9vV1P/v6+j6HhoY+AACAv/f29r7T0tK+paQkPszLS7+DgoK+urk5P6alJT+wry8/0M9Pv/Tzc7+ioSE/srExv7a1NT/JyMg9tLMzP/f29r7Qz08/mpkZP7++vj7w72+/rKsrv5uamr61tDQ+jIsLP9rZWb+vrq4+p6amvoaFBb/29XU/+/r6Pg==",
-      "vectorSha256": "52162787fb154545bce6cc61bc12ee36117c52c6136f45def58ee76621f56009",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "a100424b941a5fdcd2d71806d027da8cd942e7ccaf082a5996c513ab563dfabe",
-      "updatedAt": "2025-09-20T22:27:41.542Z"
-    },
     "j-0803": {
       "vector": "yslJv+Pi4r7j4uK+k5KSvoaFBb+9vDy+uLc3P5iXFz/29XW/AACAv6empr6opyc/srExv4iHB7+8uzs/jIsLv728PL61tDS+5+bmPtHQUD2Pjo4+uLc3P8jHRz+amRm/2NdXv9bVVb/h4OA8uLc3P62sLD7U01M/k5KSvv/+/j7KyUm/4+LivuPi4r6TkpK+hoUFv728PL64tzc/mJcXP/b1db8AAIC/p6amvqinJz+ysTG/iIcHv7y7Oz+Miwu/vbw8vrW0NL7n5uY+0dBQPY+Ojj64tzc/yMdHP5qZGb/Y11e/1tVVv+Hg4Dy4tzc/rawsPtTTUz+TkpK+//7+Pg==",
       "vectorSha256": "3eaf37500fbdb517835349ad5f67d866d9930853b9e9fb21d9fa809fb1005d17",
@@ -7144,15 +6991,6 @@
       "textHash": "add96b451187078e3879032409672fcff138f9fd8ae4905d0b0d7057f9f91843",
       "updatedAt": "2025-09-20T22:27:41.542Z"
     },
-    "j-0807": {
-      "vector": "lZQUPrSzMz+enR2/8O9vv5eWlj739va+paQkvv/+/j6joqI+7exsvr28PD7o52e/rawsvtnY2D2trCw+jo0NP62sLD7Z2Ni96+rqPqOior7R0FA9yMdHP6qpKb+xsDC9lJMTP8bFRT+1tDQ+tbQ0vpOSkr7Pzs6+sK8vv7m4uD2VlBQ+tLMzP56dHb/w72+/l5aWPvf29r6lpCS+//7+PqOioj7t7Gy+vbw8PujnZ7+trCy+2djYPa2sLD6OjQ0/rawsPtnY2L3r6uo+o6KivtHQUD3Ix0c/qqkpv7GwML2UkxM/xsVFP7W0ND61tDS+k5KSvs/Ozr6wry+/ubi4PQ==",
-      "vectorSha256": "e30d7de7a9a509ef3c80fa33c9f11908468e1f83de1991e9bff1acdb31e9dc3f",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "92d93108a5426bbfa862970c6a8d95c69572ba5786e32b7ac9e296695b4c288b",
-      "updatedAt": "2025-09-20T22:27:41.542Z"
-    },
     "j-0808": {
       "vector": "hIMDP8PCwj7u7W2/2NdXP/z7e7/s62u/2NdXv66tLT/083O/r66uvsfGxj7W1VW//fx8Pt/e3j6qqSm/x8bGPgAAgL+sqyu//fx8vuLhYT+trCw+y8rKvpeWlj6RkBC95+bmvgAAgL+3trY+wsFBv+3sbL7FxES+nZwcvpGQED2EgwM/w8LCPu7tbb/Y11c//Pt7v+zra7/Y11e/rq0tP/Tzc7+vrq6+x8bGPtbVVb/9/Hw+397ePqqpKb/HxsY+AACAv6yrK7/9/Hy+4uFhP62sLD7Lysq+l5aWPpGQEL3n5ua+AACAv7e2tj7CwUG/7exsvsXERL6dnBy+kZAQPQ==",
       "vectorSha256": "c4d9d18f9c9e258c4197ffceb53b15de28101ce32bb12f678af48c51a1f0d83c",
@@ -7160,24 +6998,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "c1b009eb020a14d60654b1159fb72bb1002a60f0954da57b4600ad1f62676c84",
-      "updatedAt": "2025-09-20T22:27:41.542Z"
-    },
-    "j-0810": {
-      "vector": "AACAP7m4uL2opye/0M9PP/HwcL3v7u6+4uFhP7y7O7+pqKi97exsPoWEBL7083O/j46OvuXkZL7d3Fw+oqEhv9LRUb8AAIC/ycjIvYKBAT+6uTk/7+7uPsPCwr6FhAS+0M9Pv6moqL2NjAw+qaiove/u7j6+vT0/1NNTv7KxMT8AAIA/ubi4vainJ7/Qz08/8fBwve/u7r7i4WE/vLs7v6moqL3t7Gw+hYQEvvTzc7+Pjo6+5eRkvt3cXD6ioSG/0tFRvwAAgL/JyMi9goEBP7q5OT/v7u4+w8LCvoWEBL7Qz0+/qaiovY2MDD6pqKi97+7uPr69PT/U01O/srExPw==",
-      "vectorSha256": "da32261017a13f91f0eb14038cee54cb844da342454ea6389381a539def5504a",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "ff742ce77844f022759d6f065c639b2f170073c0dcbb4f6f18759175bbde16d8",
-      "updatedAt": "2025-09-20T22:27:41.542Z"
-    },
-    "j-0812": {
-      "vector": "+/r6vvv6+j7y8XE/2tlZv9jXV7+zsrK+tbQ0vpaVFT/x8HC9xcREvu3sbD7g31+/lJMTv6qpKb/T0tI+7OtrP+no6D3t7Gw+sbAwvf/+/j7V1FS+j46OvqqpKb+trCy+k5KSPuPi4r6EgwO/s7KyvuPi4r6wry8/5ONjP/z7ez/7+vq++/r6PvLxcT/a2Vm/2NdXv7Oysr61tDS+lpUVP/HwcL3FxES+7exsPuDfX7+UkxO/qqkpv9PS0j7s62s/6ejoPe3sbD6xsDC9//7+PtXUVL6Pjo6+qqkpv62sLL6TkpI+4+LivoSDA7+zsrK+4+LivrCvLz/k42M//Pt7Pw==",
-      "vectorSha256": "cb652c1a58432880807c19192f20880677605ee8081dcc9fd4b196f162a36422",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "41bef813145369ca78679d10362bb4f58e9d7abf655c2b6aa4473e5347d7f1fd",
       "updatedAt": "2025-09-20T22:27:41.542Z"
     },
     "j-0813": {
@@ -7196,15 +7016,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "b5d8786be895e07a634c5e6222b25fac09d8b29fbbb2f047cf4639861f8381f9",
-      "updatedAt": "2025-09-20T22:27:41.542Z"
-    },
-    "j-0816": {
-      "vector": "n56evp6dHT/v7u4+1dRUvqGgoDzEw0M/oqEhP8bFRT/BwEA8x8bGvgAAgL/Ew0M/w8LCvqSjI7/R0FC9+Pd3v4aFBT/j4uK+nZwcvv38fL6dnBw+1dRUPuvq6r6bmpq+19bWPtDPTz+vrq6+8O9vv7a1Nb+ioSG/+vl5v7y7O7+fnp6+np0dP+/u7j7V1FS+oaCgPMTDQz+ioSE/xsVFP8HAQDzHxsa+AACAv8TDQz/DwsK+pKMjv9HQUL3493e/hoUFP+Pi4r6dnBy+/fx8vp2cHD7V1FQ+6+rqvpuamr7X1tY+0M9PP6+urr7w72+/trU1v6KhIb/6+Xm/vLs7vw==",
-      "vectorSha256": "9e2a1283088a8f3133e9e8afa50933d057c7f423086ddb243b1aeee7066530f4",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "58cebb6582e1d0e2814e00e14f2e7904c2476c60939a4559b5e75408252f0322",
       "updatedAt": "2025-09-20T22:27:41.542Z"
     },
     "j-0817": {
@@ -7376,15 +7187,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "c1f5171ffcfb9807b86e5e0a6b19ae757a7c1551040714735ef7d62062bf517c",
-      "updatedAt": "2025-09-21T03:21:38.303Z"
-    },
-    "j-0837": {
-      "vector": "7+7uPrCvL7+ZmJi9k5KSPsC/P7+enR2/4eDgvImIiL2Lioq+qqkpP8fGxj65uLg92NdXP5CPD7/6+Xm/g4KCPrm4uL2qqSm/kpERv/HwcD3w728/+vl5v4iHBz+Miws/sbAwPZKREb/s62s/gYCAO9DPT7/FxEQ++/r6Prq5OT/v7u4+sK8vv5mYmL2TkpI+wL8/v56dHb/h4OC8iYiIvYuKir6qqSk/x8bGPrm4uD3Y11c/kI8Pv/r5eb+DgoI+ubi4vaqpKb+SkRG/8fBwPfDvbz/6+Xm/iIcHP4yLCz+xsDA9kpERv+zraz+BgIA70M9Pv8XERD77+vo+urk5Pw==",
-      "vectorSha256": "eda3cd2439ed74618abeb0c443e55be782c93b4f7a3b27ede178ed135b35f868",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "bb2876a420317c775dd4b18beb3803a0742b3787f703c3c58537f5801898bedc",
       "updatedAt": "2025-09-21T03:21:38.303Z"
     },
     "j-0838": {
@@ -7574,15 +7376,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "8d5f892748545d8a467a2eb3c00e7e816f0c1e70c838e2e95661c1b5af329770",
-      "updatedAt": "2025-09-21T03:21:38.305Z"
-    },
-    "j-0860": {
-      "vector": "5uVlv52cHD7k42M/t7a2vo2MDL7m5WW/4N9fP4eGhr7Lysq+8vFxv5GQED3V1FS+4N9fP/79fT+2tTW/qaiovZWUFL7DwsI+4eDgPMzLSz+ZmJi9trU1P/b1dT/y8XE/o6KiPvv6+j6enR2/1NNTP/r5eT/39vY+1NNTP9rZWT/m5WW/nZwcPuTjYz+3tra+jYwMvublZb/g318/h4aGvsvKyr7y8XG/kZAQPdXUVL7g318//v19P7a1Nb+pqKi9lZQUvsPCwj7h4OA8zMtLP5mYmL22tTU/9vV1P/LxcT+joqI++/r6Pp6dHb/U01M/+vl5P/f29j7U01M/2tlZPw==",
-      "vectorSha256": "29bc09355a1ec5d17ac7a96d39ab99e48f1a7e2975cf2654795cfbd1a7f2c11d",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "0d93f1526e0def5e4d078465effe25756db083e576dafaf8a8be31e9fcbde9ec",
       "updatedAt": "2025-09-21T03:21:38.305Z"
     },
     "j-0861": {

--- a/data/jokes-manifest.json
+++ b/data/jokes-manifest.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "generatedAt": "2025-09-22T01:51:00.474Z",
-    "total": 888,
+    "generatedAt": "2025-09-22T23:16:21.809Z",
+    "total": 865,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",
     "fields": [
@@ -6646,27 +6646,6 @@
         "updatedAt": "2025-09-20T22:27:41.524Z"
       }
     },
-    "j-0317": {
-      "hashes": {
-        "setup": "3fe4218b2d6cfbebd91f6373a58f82e0e539f375fee5d1f3ace0401e1364fb8e",
-        "punchline": "57a10103d560459e6e07f89c75d2ccb05b340d4b3d0a419514d84cda8db810ae",
-        "combined": "a7c44a2a8c92584a170ce195f356b56deaceaf2ad2f852c9d8ed60a5efcf40e7",
-        "tokenSignature": "ahead-around-can-did-go-hang-hat-i-just-ll-on-say-scarf-the-to-what-you"
-      },
-      "lengths": {
-        "joke": 55,
-        "punchline": 22
-      },
-      "source": {
-        "sequence": 317
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a278be6d7f5fa994007aea3bafb895c737e9752041efc6aa5f13363fea8b6d7f",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
-      }
-    },
     "j-0318": {
       "hashes": {
         "setup": "599c73cbbbcee631cb1eb0a06f9be7faa4806ec615613d74d4cc6111dee27020",
@@ -8977,27 +8956,6 @@
         "updatedAt": "2025-09-20T22:27:41.533Z"
       }
     },
-    "j-0428": {
-      "hashes": {
-        "setup": "ba28988d88511a1a6ca7beebc89c13a8e048ae864a382b93a06b72cc00863db0",
-        "punchline": "ff8d9f73f6feee7079610926ca1ea8b6454b2efa59ba6ba582c6c8616f1bf365",
-        "combined": "1d09940788d83b70518b2864aca81e97b8f076896861d94ac85b64d021d7b329",
-        "tokenSignature": "because-bees-don-ever-hum-it-know-s-t-the-they-why-wondered-words"
-      },
-      "lengths": {
-        "joke": 27,
-        "punchline": 39
-      },
-      "source": {
-        "sequence": 428
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "66bd48857ec5e500869b16b4adfe1f23667d651e54705ce0cb00cf26bde68244",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
-      }
-    },
     "j-0429": {
       "hashes": {
         "setup": "289806e5ae02b7c9a8effcbf86dd59a82c784db1eb33eefe333b8fc817ff7614",
@@ -10906,27 +10864,6 @@
         "status": "ready",
         "model": "synthetic-64",
         "vectorSha256": "0493995de949b2c0de6ca255fbd53459b925500ce395fd5e6c25037a642d404c",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
-      }
-    },
-    "j-0521": {
-      "hashes": {
-        "setup": "0246326cd7bec0b3dd655876f321392382eeff44d7a259cfa448c73047c3f28a",
-        "punchline": "f731a9e79e83825f74d3257d9ce2c369c0f0a0525289d9916e861aeec9bc0d02",
-        "combined": "57d061f0fe7f923dad663de58ee0dabe705327eec83999790ff7675a40736f48",
-        "tokenSignature": "a-after-but-can-car-dad-his-just-says-son-sponge-t-the-use-washes-while-why-with-you"
-      },
-      "lengths": {
-        "joke": 34,
-        "punchline": 67
-      },
-      "source": {
-        "sequence": 520
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "86963172ccc275d8e4352fd849227a3838dbfc0c35ece3fa04939975f66255dd",
         "updatedAt": "2025-09-20T22:27:41.535Z"
       }
     },
@@ -14374,27 +14311,6 @@
         "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
-    "j-0688": {
-      "hashes": {
-        "setup": "7b7cc7e5d5c24b0c94ed659afe177f44eb1d916f1e04343d01dd81d77166bdfb",
-        "punchline": "d90893c35f1501680cfa221aaf5083e433905c2d321d5309e31b9558e3bb7bf4",
-        "combined": "22e7a1c57266e0b1359d8e60540e7f923c8d6e87bc4874dace3e9721a38dc78d",
-        "tokenSignature": "a-about-did-ended-hear-in-it-race-silk-the-tie-two-worms-you"
-      },
-      "lengths": {
-        "joke": 48,
-        "punchline": 18
-      },
-      "source": {
-        "sequence": 685
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "aa9b90186f16b311a3568f1bb998dd4db5b9c6cc9cafca2bcae87b4f2db2bdb5",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
-      }
-    },
     "j-0689": {
       "hashes": {
         "setup": "1704f287293e56c3167eac6b4093266c3e6ae91eb361781580946db100ccb945",
@@ -14605,27 +14521,6 @@
         "updatedAt": "2025-09-20T22:27:41.539Z"
       }
     },
-    "j-0700": {
-      "hashes": {
-        "setup": "24367ca15151319e39dac74978c99aded07885f11aa25090332324809ba19a3e",
-        "punchline": "6ff1a02afb0fd223466e67239aed45f25098f21e155fc86157bc61a34315ffc1",
-        "combined": "0d8c1bd2cdd069c72baaa472c34963fc828c7e835f31bffa55bb98cddcd8e20b",
-        "tokenSignature": "cooked-did-first-france-french-fries-greece-in-know-t-the-they-were-weren-you"
-      },
-      "lengths": {
-        "joke": 61,
-        "punchline": 26
-      },
-      "source": {
-        "sequence": 696
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "acd18cf8a952bff98d4105a57fedb891cfbd8d0014c270677160781573abb29a",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
-      }
-    },
     "j-0701": {
       "hashes": {
         "setup": "4ad34c24df6bd971d8c4831e7cf703c10fb9e494f527554138d109ed76ce3b19",
@@ -14728,27 +14623,6 @@
         "status": "ready",
         "model": "synthetic-64",
         "vectorSha256": "c7920ca23923709b3b41a892075c984e0b385d5bd4855945a4e9b6c98964b999",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
-      }
-    },
-    "j-0706": {
-      "hashes": {
-        "setup": "b4128cf80a48ce46518076c3e4cb859f1f44d2f4e316e5def87d728741d21fcf",
-        "punchline": "f6e4f86148dcdee1e9b7ae71949ef47ded2211c4dbf0ca8a455eae61f8d801c7",
-        "combined": "76c5fc6d41386e4c4ddd9c0b6165cb464660837ab6401649b9622c4cce2623aa",
-        "tokenSignature": "a-about-anti-book-down-gravity-i-impossible-it-m-put-reading-s-to"
-      },
-      "lengths": {
-        "joke": 40,
-        "punchline": 27
-      },
-      "source": {
-        "sequence": 702
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ed7d6f243d69bed63ef80e6fa7a4f746d5417cf14f9e4d36f6341cb034fb4212",
         "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
@@ -14938,27 +14812,6 @@
         "status": "ready",
         "model": "synthetic-64",
         "vectorSha256": "11b62431a07341bf42249771a70dc5b0eab5bb341cc9e9a1ac7d340348459dd7",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
-      }
-    },
-    "j-0718": {
-      "hashes": {
-        "setup": "835dd0bd928e6913fce77b9e8fd98bee421a728213a1067ece7ba4b8d6b8e344",
-        "punchline": "bbf6a640d54a863c5a71900d33c03910f5378a33c8cd672347b90e1d15974cae",
-        "combined": "a22b0a72032a16f8427c4c4337ee6cd064bec3bcaba4ce94ebc1e7a209e035d7",
-        "tokenSignature": "a-are-cemetery-dad-did-drives-dying-get-graveyard-in-just-know-past-people-popular-s-that-there-to-when-yep-you"
-      },
-      "lengths": {
-        "joke": 75,
-        "punchline": 42
-      },
-      "source": {
-        "sequence": 712
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ab7306f36f77462b4158ae173856fcaa0804017410d19325c2b2dd8cacb108f3",
         "updatedAt": "2025-09-20T22:27:41.540Z"
       }
     },
@@ -15172,27 +15025,6 @@
         "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
-    "j-0729": {
-      "hashes": {
-        "setup": "50202d3d188e5dd2096c077f8ccfa48fd56ead011c1252c2ed1e8d2bb04fa8d6",
-        "punchline": "b53dcc6f17a28042146f9c90b53760348756383015f96fe38284ca6ad48bdffc",
-        "combined": "0d335bffe78680b06fc2b6010da4512653c5418fa66a80f0e9041781b053c892",
-        "tokenSignature": "about-cheese-dairy-did-hear-it-legend-saved-story-that-the-was-world-you"
-      },
-      "lengths": {
-        "joke": 61,
-        "punchline": 20
-      },
-      "source": {
-        "sequence": 723
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6a2eaf11770497fe37e356d698dbf05c5b6555fa4b1718667bc1ec1fa394a381",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
-      }
-    },
     "j-0730": {
       "hashes": {
         "setup": "137352b369d5bc148a07e7ecf2e36d6c9062253ad37bdec6f0dde82e008e7cb8",
@@ -15277,27 +15109,6 @@
         "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
-    "j-0734": {
-      "hashes": {
-        "setup": "098797d527b83cad533859879b3018ba7c91badad6a37d7bcf7c96fa9a25274f",
-        "punchline": "350c6fcb0b368801b81219a24c7e2d3ad1751e65104577bcf2d33ab82c7737fb",
-        "combined": "1a1df9fb75001f13a7af26d926bb4e84c3f70ed9919a154b91b71e2fa454ccf1",
-        "tokenSignature": "a-at-booked-couldn-fully-get-i-library-reservation-t-the-they-were"
-      },
-      "lengths": {
-        "joke": 46,
-        "punchline": 23
-      },
-      "source": {
-        "sequence": 728
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8f6c06d184cfb5f89db4de054d1145210f38cbd2f801f360fd0cea7ba2e4f32e",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
-      }
-    },
     "j-0735": {
       "hashes": {
         "setup": "2d1baff68b7133c94dd79cc662cd756354b166e1324618a6cadfc97f76a20fac",
@@ -15358,27 +15169,6 @@
         "status": "ready",
         "model": "synthetic-64",
         "vectorSha256": "45de56d1fcbe9575d1ac9872c732f220c13b21e80e769dcd87ac57c3c47c4d9e",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
-      }
-    },
-    "j-0740": {
-      "hashes": {
-        "setup": "f90546c74b6637bca789cedd33bf3c53f8dd689d62cce2bfefabe965e4202e52",
-        "punchline": "322be6b147f67d75d43a0a329cbc8dab32ad879819d7cd421947645f32153098",
-        "combined": "424561e86a4d18d2de036c5c48380b78f720075eae6d03a328600aa25c218bef",
-        "tokenSignature": "but-can-don-i-it-on-t-the-turn-tv-watch-yes"
-      },
-      "lengths": {
-        "joke": 19,
-        "punchline": 26
-      },
-      "source": {
-        "sequence": 732
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8c2edcbf9aafc681e7cd3fe6b2bc6f0abe7c5107c519e472666919b1495cf3de",
         "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
@@ -15886,48 +15676,6 @@
         "updatedAt": "2025-09-20T22:27:41.541Z"
       }
     },
-    "j-0767": {
-      "hashes": {
-        "setup": "6d0620adbd0c48d39ec19a253ca9a2c033d7e3902430fb55b9ac374f921e549d",
-        "punchline": "ef15a992bf1a8da5f4b7f890eaaa7aa715abc0cbc1088bb7d098b25aad97a599",
-        "combined": "b1cc353d1c200a9aa9dad1c6dfa9468c6c4095cd6dd3d3901750c5dc29e52301",
-        "tokenSignature": "because-crack-don-each-eggs-jokes-other-t-tell-they-up-why-would"
-      },
-      "lengths": {
-        "joke": 26,
-        "punchline": 39
-      },
-      "source": {
-        "sequence": 757
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2d78dde195c4a14da1dc54a87a6de7331c3378b4826c0f78de37b3ffff4aa5fc",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
-      }
-    },
-    "j-0768": {
-      "hashes": {
-        "setup": "ea18d09a8b293068c2d1103b8af8c5874d2d78f0247362f5ed2a520e10e9abd8",
-        "punchline": "4882645d942c5829e5b5ffde5e78cc7aededbe62337dbaed0a5ffb599215b25c",
-        "combined": "cc39ef732d305b0c9f0504b02d4c5adae56f2bad6ae94b0858bb8a9ca5b9c2ab",
-        "tokenSignature": "add-and-disappear-do-g-gone-how-it-letter-make-number-one-s-the-you"
-      },
-      "lengths": {
-        "joke": 41,
-        "punchline": 33
-      },
-      "source": {
-        "sequence": 758
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cd3dc3d67b52beb649400bc80d95cb2cc0e1f656673f84e61c6374c3d81aec17",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
-      }
-    },
     "j-0769": {
       "hashes": {
         "setup": "dd3c52fbdcf1165f44be7bede76d844290ad4403425159b458e448d1587d912e",
@@ -15968,27 +15716,6 @@
         "model": "synthetic-64",
         "vectorSha256": "9491bed5afbaf7854de146c23e10bce1dccbfed858337ffe35d7582b6b5e49ea",
         "updatedAt": "2025-09-20T22:27:41.541Z"
-      }
-    },
-    "j-0771": {
-      "hashes": {
-        "setup": "6d369997773a894bf726c402d089774c22e4e65c2174f2c34b3f431a7e8fbce7",
-        "punchline": "ed05a2624b0cc99b63c28a2c287ddb37eb1f42b7b95e67856bd354850949a71d",
-        "combined": "58d91d81ce360b0382b06f0535ff66abd25e402877b8d4ec63c766ae7c9feee3",
-        "tokenSignature": "did-fly-kid-out-so-the-throw-time-watch-why-window-would"
-      },
-      "lengths": {
-        "joke": 47,
-        "punchline": 18
-      },
-      "source": {
-        "sequence": 761
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "89397a803e63205d027f4b44e078694b7381cc362bd64900ff93f53fa097bf35",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
     "j-0772": {
@@ -16138,27 +15865,6 @@
         "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
-    "j-0779": {
-      "hashes": {
-        "setup": "1bcb4f014a8102216395c45d1609671668e0733a3999c6032a1e046592ec132d",
-        "punchline": "a4be21f4d35f902bdca4a5797841be91382c80960b225303c8ad0ccaa107f008",
-        "combined": "fd0cc3243dcc8515338e8cb7258d20cb885b5e16a64f4a751365cc05f88acd4e",
-        "tokenSignature": "a-asked-bag-carton-cashier-fine-grocery-her-i-if-in-like-milk-my-no-store-thanks-the-told-works-would"
-      },
-      "lengths": {
-        "joke": 63,
-        "punchline": 47
-      },
-      "source": {
-        "sequence": 769
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "48b36fde78d2f0991588d429013032d54ea1f6eada22f6271dc6d070ebc7ef27",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
-      }
-    },
     "j-0780": {
       "hashes": {
         "setup": "b2518fc5325f67d86a04cd68c233222863284cd0043d915272fd0b9df65f3c54",
@@ -16177,48 +15883,6 @@
         "status": "ready",
         "model": "synthetic-64",
         "vectorSha256": "faa64b2a2b9f2f57921de54b9f9efd42ff713ed9580fce2d32a7d0aa545a86ea",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
-      }
-    },
-    "j-0781": {
-      "hashes": {
-        "setup": "4426db68dd6d5f4ba44be2bcd5611c0a36c2e69ec5bf08da2de10f2b433447e9",
-        "punchline": "34629a76a86e6043bf7c430549e0181c38fee0f788fda98c19e89f96c371e6b7",
-        "combined": "1dfe6b4e1eb00534a246fbe0ab47bc86c462cd07fc0841feb9d25e811c1f15d6",
-        "tokenSignature": "at-enough-factory-fired-from-got-i-in-job-just-keyboard-me-my-putting-shifts-t-the-they-told-wasn"
-      },
-      "lengths": {
-        "joke": 53,
-        "punchline": 47
-      },
-      "source": {
-        "sequence": 771
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5c918cd07f307ea8167f6e3c5ad61c5a116bf4c92cb2d7ab2e9ea02d9056e320",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
-      }
-    },
-    "j-0782": {
-      "hashes": {
-        "setup": "71ef58b3817e3a43dbf95f72c470e4241eec112d6d8227449783128eada36e83",
-        "punchline": "4de4cb9911107c3d5083625784ea7ff74a42340558391062de6357ba64011417",
-        "combined": "e84ad14400205ebc8e58647bdab74666665a1031e5237069f70dfad37f5949f1",
-        "tokenSignature": "are-areas-aren-funny-hill-just-mountains-see-t-they-you"
-      },
-      "lengths": {
-        "joke": 37,
-        "punchline": 20
-      },
-      "source": {
-        "sequence": 772
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ba606466997a78f09d311588300767cc92e3fa2cc6005268affaebbe774fbcac",
         "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
@@ -16579,27 +16243,6 @@
         "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
-    "j-0802": {
-      "hashes": {
-        "setup": "4733e35dc985bf2fa2019c50dcb7fee919ecd96d90e734cb5f8a5e92001cb435",
-        "punchline": "789315824e52d11c7f941ae7988e8443851884c777ed78f82d5fb9ac6a8d73e2",
-        "combined": "5ac86a058c138fda601d16fcb773384acf411c015c64d2997dead077f2704aec",
-        "tokenSignature": "bicycle-by-couldn-it-itself-stand-t-the-tired-two-up-was-why"
-      },
-      "lengths": {
-        "joke": 44,
-        "punchline": 17
-      },
-      "source": {
-        "sequence": 790
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "52162787fb154545bce6cc61bc12ee36117c52c6136f45def58ee76621f56009",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
-      }
-    },
     "j-0803": {
       "hashes": {
         "setup": "8548bc771407d24b394c5f032c3e3164568d0c838641571985a1795ebe46b91b",
@@ -16663,27 +16306,6 @@
         "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
-    "j-0807": {
-      "hashes": {
-        "setup": "e0926209ba078d6e20091dfadb80097c3570e4e1b76036330b2a1e079c1d9bc3",
-        "punchline": "857a6670161dfdf1803018b21d4f52e685142660dbad847320721e2abf9f3161",
-        "combined": "5e4c199e2eb313de8b8d80b6763402c168d4acd417b928497c4dd39e8035fb5e",
-        "tokenSignature": "a-about-best-big-but-don-flag-i-is-know-plus-s-switzerland-t-the-their-thing-what"
-      },
-      "lengths": {
-        "joke": 40,
-        "punchline": 43
-      },
-      "source": {
-        "sequence": 794
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e30d7de7a9a509ef3c80fa33c9f11908468e1f83de1991e9bff1acdb31e9dc3f",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
-      }
-    },
     "j-0808": {
       "hashes": {
         "setup": "a82eddf136a9f62f0d7e62905958edaf1761b00bc126167546715d08c615c626",
@@ -16702,48 +16324,6 @@
         "status": "ready",
         "model": "synthetic-64",
         "vectorSha256": "c4d9d18f9c9e258c4197ffceb53b15de28101ce32bb12f678af48c51a1f0d83c",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
-      }
-    },
-    "j-0810": {
-      "hashes": {
-        "setup": "9ac28f2ed7b6488c5f740f704bbb5009a3b5160c49f26ebc44f12521b8554c65",
-        "punchline": "eb4e3bba7846a47b1fa79f454df693a242025e799ace6649263a190f9c2c659b",
-        "combined": "c180d4760dacd8bb85afdfce3ca731aaba576cecacad31e8feebb530b3adf947",
-        "tokenSignature": "atoms-because-don-everything-make-scientists-t-they-trust-up-why"
-      },
-      "lengths": {
-        "joke": 33,
-        "punchline": 32
-      },
-      "source": {
-        "sequence": 796
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "da32261017a13f91f0eb14038cee54cb844da342454ea6389381a539def5504a",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
-      }
-    },
-    "j-0812": {
-      "hashes": {
-        "setup": "8d2724551dd3d981e4ed577e3f28bcdab93904ebbad26e1e4c26e46e3a51a65d",
-        "punchline": "43f96185410869223321356f92baad7ea38d3efa9787e198a1dece8215dfab51",
-        "combined": "9b9c059a3125d27ca606ddadf56cd5d2e861e5917a66b9dd3654c65d8316fe94",
-        "tokenSignature": "because-cookie-crumbly-did-doctor-feeling-go-it-the-to-was-why"
-      },
-      "lengths": {
-        "joke": 36,
-        "punchline": 31
-      },
-      "source": {
-        "sequence": 797
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cb652c1a58432880807c19192f20880677605ee8081dcc9fd4b196f162a36422",
         "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
@@ -16786,27 +16366,6 @@
         "status": "ready",
         "model": "synthetic-64",
         "vectorSha256": "bf2f7302c429257e99ca7ff6195006509dd1fdb3c3fa6f37479d3e925faa13f8",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
-      }
-    },
-    "j-0816": {
-      "hashes": {
-        "setup": "e95931d3455b660786da3f547f2bd2a70cc7b0bb7c7f99583aff901fc1e3bbf2",
-        "punchline": "6567138f1b89dcd96ba62d048ecd7a32ac27a312be7a00342e3d7d639c686cb6",
-        "combined": "35003a75bdaf2c4d6356233f07a472e9615e2f6d4cce9e91e2e79cae6ae9282f",
-        "tokenSignature": "all-broke-cache-developer-did-go-kept-spending-the-their-they-why"
-      },
-      "lengths": {
-        "joke": 31,
-        "punchline": 35
-      },
-      "source": {
-        "sequence": 800
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9e2a1283088a8f3133e9e8afa50933d057c7f423086ddb243b1aeee7066530f4",
         "updatedAt": "2025-09-20T22:27:41.542Z"
       }
     },
@@ -17206,27 +16765,6 @@
         "status": "ready",
         "model": "synthetic-64",
         "vectorSha256": "96a13b9c8f12389e99bad1d8c1a01bb885df5a062bac77e745f14c324231c737",
-        "updatedAt": "2025-09-21T03:21:38.303Z"
-      }
-    },
-    "j-0837": {
-      "hashes": {
-        "setup": "1f93da15a541792cd14be3e52f7c60be9139d2d79926f4a7e81934f795b436ac",
-        "punchline": "c9286de21e9841094bfd801fed594042b4b905667018125049e119c2f4170fbf",
-        "combined": "b1b70ac8e9be0e63d114aca639d1499f18731c65886765dcc03dc9bbaced2d19",
-        "tokenSignature": "because-c-do-glasses-need-programmers-they-to-wear-why"
-      },
-      "lengths": {
-        "joke": 32,
-        "punchline": 24
-      },
-      "source": {
-        "sequence": 820
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "eda3cd2439ed74618abeb0c443e55be782c93b4f7a3b27ede178ed135b35f868",
         "updatedAt": "2025-09-21T03:21:38.303Z"
       }
     },
@@ -17668,27 +17206,6 @@
         "status": "ready",
         "model": "synthetic-64",
         "vectorSha256": "a8488f178d28c2d1f13ad030bb62363de3124ee27fdaa9f367274c012aad4984",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
-      }
-    },
-    "j-0860": {
-      "hashes": {
-        "setup": "0d8f81ef4e9de3ae307178e3454716947dadfb31e50660ef8b89df6b73d90a66",
-        "punchline": "856f2e4f1d6ab4c36e10c1bed4fb2e78d7550a9fff72aa78a20b7c0c0a25277e",
-        "combined": "9d923d1f908f1a71a8e94368d8b735350548e89def8368f4cd7354389c665f52",
-        "tokenSignature": "a-call-do-kittens-meowntain-of-pile-what-you"
-      },
-      "lengths": {
-        "joke": 35,
-        "punchline": 12
-      },
-      "source": {
-        "sequence": 842
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "29bc09355a1ec5d17ac7a96d39ab99e48f1a7e2975cf2654795cfbd1a7f2c11d",
         "updatedAt": "2025-09-21T03:21:38.305Z"
       }
     },

--- a/data/quotes-embeddings-openai.json
+++ b/data/quotes-embeddings-openai.json
@@ -3,8 +3,8 @@
     "provider": "openai",
     "model": "text-embedding-3-large",
     "dimensions": 64,
-    "generatedAt": "2025-09-22T01:32:15.502Z",
-    "recordCount": 657
+    "generatedAt": "2025-09-22T23:16:21.908Z",
+    "recordCount": 653
   },
   "records": {
     "adventure-01": {
@@ -1717,15 +1717,6 @@
       "textHash": "0a8e21e52e1de939743b570234ef0eb52aa84ef50dd1b2be2b3957b87d8b17b8",
       "updatedAt": "2025-09-21T23:10:32.460Z"
     },
-    "growth-09": {
-      "vector": "8fBwveLhYT+SkRG/y8rKPomIiL3b2tq+jYwMPri3N7+3trY+AACAP5ybG7+enR0/qqkpv/Dvbz/z8vK+qaioPZKRET+dnBy+8/LyvtXUVD7Z2Ni9xMNDP/79fb/39vY+4N9fv7i3N78AAIA//fx8vv79fb+OjQ2/iYiIva+urj7x8HC94uFhP5KREb/Lyso+iYiIvdva2r6NjAw+uLc3v7e2tj4AAIA/nJsbv56dHT+qqSm/8O9vP/Py8r6pqKg9kpERP52cHL7z8vK+1dRUPtnY2L3Ew0M//v19v/f29j7g31+/uLc3vwAAgD/9/Hy+/v19v46NDb+JiIi9r66uPg==",
-      "vectorSha256": "2804a6549d0bb40374bb144f82a5fa2e9c2a6f55a75f6b9366c3ae3d8001a4a9",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "1928d1ce89426fed5b749a690650372f78d621092d5dd7b6b293b0315e09c799",
-      "updatedAt": "2025-09-21T23:10:32.460Z"
-    },
     "growth-10": {
       "vector": "9PNzv8XERL6vrq6+oaCgPIeGhj6RkBC9wcBAvMPCwr729XW/19bWvt7dXb/u7W2/7exsPvf29r7k42O/+/r6PrW0ND61tDS+9/b2PpCPDz/BwEA82djYPf79fT+lpCS+pKMjP+no6L3OzU2/sbAwvbOysr6hoKA8mZiYvbCvLz/083O/xcREvq+urr6hoKA8h4aGPpGQEL3BwEC8w8LCvvb1db/X1ta+3t1dv+7tbb/t7Gw+9/b2vuTjY7/7+vo+tbQ0PrW0NL739vY+kI8PP8HAQDzZ2Ng9/v19P6WkJL6koyM/6ejovc7NTb+xsDC9s7KyvqGgoDyZmJi9sK8vPw==",
       "vectorSha256": "7a5b33cdf05a610d71cb3a593a1f63e486bffa73a7212335ab397f7df7eb5ea0",
@@ -2309,15 +2300,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "a9f5ca67ca389e12db5e5a143114ef90ebe0a80b121f3a61d0acf9e1aad69ab4",
-      "updatedAt": "2025-09-21T23:10:32.460Z"
-    },
-    "joy-04": {
-      "vector": "nJsbP8/Ozj60szM/397evv38fL6joqK+l5aWvpOSkj6zsrK+4uFhP728PD6Lioo+xMNDv9TTU7+zsrI+i4qKPr69Pb+wry+/yslJv5iXF7/T0tI+6ulpP9nY2D2OjQ0/yslJP9LRUb/DwsI+paQkPtrZWb/Avz+/4+LiPpGQEL2cmxs/z87OPrSzMz/f3t6+/fx8vqOior6Xlpa+k5KSPrOysr7i4WE/vbw8PouKij7Ew0O/1NNTv7Oysj6Lioo+vr09v7CvL7/KyUm/mJcXv9PS0j7q6Wk/2djYPY6NDT/KyUk/0tFRv8PCwj6lpCQ+2tlZv8C/P7/j4uI+kZAQvQ==",
-      "vectorSha256": "948112a5b5ff7c08aa941628335c4ce2800b9fc1cd73f51534a3a710a7b24ec8",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "c0c357704fe23017c699b4662c7dd9d218596c4d9792271a9faca49db8787a80",
       "updatedAt": "2025-09-21T23:10:32.460Z"
     },
     "joy-05": {
@@ -4966,15 +4948,6 @@
       "textHash": "be315d9901c675547584adbab4b30b8fd47b8b41d6156336a30ff2b64965b183",
       "updatedAt": "2025-09-21T23:10:32.460Z"
     },
-    "resilience-02": {
-      "vector": "lJMTv6Oior6DgoK+xsVFP62sLL7Pzs6+tbQ0vry7O7/v7u4+kpERv8HAQLyzsrI+trU1P5uamr6/vr6+8/LyPrq5Ob+ysTG/yslJv5CPD7/y8XG/h4aGvouKij76+Xm/iYiIPeblZb+zsrI+oqEhP5ybGz+VlBQ+wL8/v83MTL6UkxO/o6KivoOCgr7GxUU/rawsvs/Ozr61tDS+vLs7v+/u7j6SkRG/wcBAvLOysj62tTU/m5qavr++vr7z8vI+urk5v7KxMb/KyUm/kI8Pv/Lxcb+Hhoa+i4qKPvr5eb+JiIg95uVlv7Oysj6ioSE/nJsbP5WUFD7Avz+/zcxMvg==",
-      "vectorSha256": "9e4a4e4292a8ad80553eef6c1c8d58d09cd7d063978c5b4473bda0a1afcb2e7e",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "a677e490018107d61cf944a45c9a3bc30125884aca474389e81d579cfa84dc9a",
-      "updatedAt": "2025-09-21T23:10:32.460Z"
-    },
     "resilience-03": {
       "vector": "mZiYPcrJST+1tDQ+4eDgvOfm5r6Lioq+4N9fP7SzMz/6+Xk/1tVVP4iHBz/w728/9vV1v/38fD6enR0/kZAQvczLSz+gnx+/n56ePtfW1j68uzu/3dxcPqinJz/Qz0+/i4qKvt7dXT+wry8/1dRUvoGAgLvIx0c/lJMTv6inJ7+ZmJg9yslJP7W0ND7h4OC85+bmvouKir7g318/tLMzP/r5eT/W1VU/iIcHP/Dvbz/29XW//fx8Pp6dHT+RkBC9zMtLP6CfH7+fnp4+19bWPry7O7/d3Fw+qKcnP9DPT7+Lioq+3t1dP7CvLz/V1FS+gYCAu8jHRz+UkxO/qKcnvw==",
       "vectorSha256": "cb32c4c8fed15b48131335a8943cb335a723d730d6aa7384aab1b50b9e2eda42",
@@ -5531,15 +5504,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "2c32725f349b14eff9838983c6f257d6e8729e5b199bfbfd7323b4b94abba05f",
-      "updatedAt": "2025-09-21T23:10:32.460Z"
-    },
-    "travel-05": {
-      "vector": "p6amvrq5Ob+FhAS+kpERP56dHT/CwUG/pKMjv9DPT7+DgoI+vr09P7++vj7CwUE/qaioPbCvL7/DwsI+qqkpP6Oioj7b2tq+4eDgPLGwMD3w728/yMdHP8fGxj7GxUW/1dRUPqWkJD7KyUk/4uFhv/Py8j7OzU0/jo0NP/79fT+npqa+urk5v4WEBL6SkRE/np0dP8LBQb+koyO/0M9Pv4OCgj6+vT0/v76+PsLBQT+pqKg9sK8vv8PCwj6qqSk/o6KiPtva2r7h4OA8sbAwPfDvbz/Ix0c/x8bGPsbFRb/V1FQ+paQkPsrJST/i4WG/8/LyPs7NTT+OjQ0//v19Pw==",
-      "vectorSha256": "7bf0844a4325c47bacb0234f34060a5ddc1e6b04a5fa3c6fce4116a95cd9caf6",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "d2d44e1d6cc0d5831c55473ee57393d93b2cf3b877715af18a8ea01a1762f4b0",
       "updatedAt": "2025-09-21T23:10:32.460Z"
     },
     "travel-07": {

--- a/data/quotes-embeddings.json
+++ b/data/quotes-embeddings.json
@@ -3,8 +3,8 @@
     "provider": "synthetic",
     "model": "synthetic-64",
     "dimensions": 64,
-    "generatedAt": "2025-09-22T01:31:43.622Z",
-    "recordCount": 657
+    "generatedAt": "2025-09-22T23:16:21.899Z",
+    "recordCount": 653
   },
   "records": {
     "adventure-01": {
@@ -2246,15 +2246,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "2c32725f349b14eff9838983c6f257d6e8729e5b199bfbfd7323b4b94abba05f",
-      "updatedAt": "2025-09-20T22:28:15.453Z"
-    },
-    "travel-05": {
-      "vector": "pqUlP6qpKT/Hxsa+xsVFv52cHL6CgQE/rKsrP+Hg4DzIx0e/q6qqvuPi4r6EgwO/zMtLP8nIyL2dnBw+tLMzP4qJCb+opye/6OdnP+Pi4j6JiIi96ejovZeWlr7k42M/qaioPeno6D2DgoI+zMtLv9LRUb/t7Gy+6ulpP8PCwj6mpSU/qqkpP8fGxr7GxUW/nZwcvoKBAT+sqys/4eDgPMjHR7+rqqq+4+LivoSDA7/My0s/ycjIvZ2cHD60szM/iokJv6inJ7/o52c/4+LiPomIiL3p6Oi9l5aWvuTjYz+pqKg96ejoPYOCgj7My0u/0tFRv+3sbL7q6Wk/w8LCPg==",
-      "vectorSha256": "2fa19280ba06641e9575ec0f47f3e169a2f7c429633cbe20a609a51dc13d82ef",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "d2d44e1d6cc0d5831c55473ee57393d93b2cf3b877715af18a8ea01a1762f4b0",
       "updatedAt": "2025-09-20T22:28:15.453Z"
     },
     "travel-07": {
@@ -4894,15 +4885,6 @@
       "textHash": "be315d9901c675547584adbab4b30b8fd47b8b41d6156336a30ff2b64965b183",
       "updatedAt": "2025-09-21T03:05:51.948Z"
     },
-    "resilience-02": {
-      "vector": "m5qaPomIiL3KyUk/hYQEPv79fb/BwEA88vFxv66tLT/Ix0e/9PNzP+/u7r6TkpI+j46OvtXUVD6KiQm/iIcHP/79fb+2tTW/iYiIPdfW1r6WlRU/4+LivvPy8r6ZmJg90tFRP8bFRb+joqK+5eRkPvb1dT+RkBA9urk5P9XUVD6bmpo+iYiIvcrJST+FhAQ+/v19v8HAQDzy8XG/rq0tP8jHR7/083M/7+7uvpOSkj6Pjo6+1dRUPoqJCb+Ihwc//v19v7a1Nb+JiIg919bWvpaVFT/j4uK+8/LyvpmYmD3S0VE/xsVFv6Oior7l5GQ+9vV1P5GQED26uTk/1dRUPg==",
-      "vectorSha256": "b68be5a8b7e4ce1a48e2a26cf976a9d40b7f81dd3084f413b07379127b33e02b",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "a677e490018107d61cf944a45c9a3bc30125884aca474389e81d579cfa84dc9a",
-      "updatedAt": "2025-09-21T03:05:51.951Z"
-    },
     "resilience-03": {
       "vector": "2NdXv+zra7/y8XE/s7KyvrW0NL739vY+zMtLP5WUFD7R0FA9/Pt7v66tLT+xsDA9wL8/P+/u7r6SkRG//Pt7P9XUVL7Z2Ng92NdXv93cXD6vrq6+paQkPoSDA7/KyUm/0M9Pv6SjIz/q6Wk/5uVlP52cHL6UkxM/sbAwPevq6r7Y11e/7Otrv/LxcT+zsrK+tbQ0vvf29j7My0s/lZQUPtHQUD38+3u/rq0tP7GwMD3Avz8/7+7uvpKREb/8+3s/1dRUvtnY2D3Y11e/3dxcPq+urr6lpCQ+hIMDv8rJSb/Qz0+/pKMjP+rpaT/m5WU/nZwcvpSTEz+xsDA96+rqvg==",
       "vectorSha256": "7659e7add19b9b89dee9883a98ddcea11a9dce5ed213d9c5f994f8eaf67ad38f",
@@ -5281,15 +5263,6 @@
       "textHash": "0a8e21e52e1de939743b570234ef0eb52aa84ef50dd1b2be2b3957b87d8b17b8",
       "updatedAt": "2025-09-21T03:05:51.953Z"
     },
-    "growth-09": {
-      "vector": "zs1Nv7CvL7+koyM/np0dP5mYmD339va+hYQEvtzbWz+TkpK+ubi4vdXUVD61tDS+9PNzv7++vr6SkRG/oqEhv/HwcL2urS0/vr09v+7tbb+mpSW/i4qKvrCvLz/b2to+y8rKPp2cHD7DwsI+np0dv4eGhr7u7W2/kI8PP83MTD7OzU2/sK8vv6SjIz+enR0/mZiYPff29r6FhAS+3NtbP5OSkr65uLi91dRUPrW0NL7083O/v76+vpKREb+ioSG/8fBwva6tLT++vT2/7u1tv6alJb+Lioq+sK8vP9va2j7Lyso+nZwcPsPCwj6enR2/h4aGvu7tbb+Qjw8/zcxMPg==",
-      "vectorSha256": "1c2bda31790a4a1d2be0427e747f8d262c6519f5087d8e9f83344e28ed2b2d15",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "1928d1ce89426fed5b749a690650372f78d621092d5dd7b6b293b0315e09c799",
-      "updatedAt": "2025-09-21T03:05:51.953Z"
-    },
     "growth-10": {
       "vector": "4eDgvKmoqD2dnBy+7+7uPoqJCb/u7W0/trU1v7q5OT/19HS+3dxcvqSjIz/a2Vk/iokJP4OCgr6pqKg9xsVFP7a1NT+zsrI+2djYPeno6D2ZmJg9wL8/P4yLCz+urS2/qaiovbW0NL7x8HA9AACAv5KREb+fnp4+5eRkvo6NDb/h4OC8qaioPZ2cHL7v7u4+iokJv+7tbT+2tTW/urk5P/X0dL7d3Fy+pKMjP9rZWT+KiQk/g4KCvqmoqD3GxUU/trU1P7Oysj7Z2Ng96ejoPZmYmD3Avz8/jIsLP66tLb+pqKi9tbQ0vvHwcD0AAIC/kpERv5+enj7l5GS+jo0Nvw==",
       "vectorSha256": "8589811571a12a0257580187e13ef1f9ff0ebb9c1cfe2663698d6e892714424f",
@@ -5342,15 +5315,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "a9f5ca67ca389e12db5e5a143114ef90ebe0a80b121f3a61d0acf9e1aad69ab4",
-      "updatedAt": "2025-09-21T03:05:51.955Z"
-    },
-    "joy-04": {
-      "vector": "goEBP4iHBz+joqK++fj4vcPCwr7GxUU/oJ8fv9LRUb+OjQ0/zcxMPtPS0j7NzEy+qKcnv6GgoLy0szM/pqUlP9DPT7+bmpq+nZwcvsvKyr69vDw+lZQUPrKxMb/My0u//fx8PrOysj6TkpI+7exsPuPi4j7x8HC9sbAwvYGAgDuCgQE/iIcHP6Oior75+Pi9w8LCvsbFRT+gnx+/0tFRv46NDT/NzEw+09LSPs3MTL6opye/oaCgvLSzMz+mpSU/0M9Pv5uamr6dnBy+y8rKvr28PD6VlBQ+srExv8zLS7/9/Hw+s7KyPpOSkj7t7Gw+4+LiPvHwcL2xsDC9gYCAOw==",
-      "vectorSha256": "43444dfa7db310a1b94dd4e6bd8f0eb2a55578abeaf4c2eb87f918916bb7ad93",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "c0c357704fe23017c699b4662c7dd9d218596c4d9792271a9faca49db8787a80",
       "updatedAt": "2025-09-21T03:05:51.955Z"
     },
     "joy-05": {

--- a/data/quotes-manifest.json
+++ b/data/quotes-manifest.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "generatedAt": "2025-09-22T01:31:19.636Z",
-    "total": 657,
+    "generatedAt": "2025-09-22T23:16:21.888Z",
+    "total": 653,
     "categories": 22,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",
@@ -5481,28 +5481,6 @@
       "source": {
         "categoryId": "travel",
         "sequence": 2
-      },
-      "embedding": {
-        "status": "pending",
-        "model": null,
-        "vectorSha256": null,
-        "updatedAt": null
-      }
-    },
-    "travel-05": {
-      "hashes": {
-        "text": "f7d8dc1c82cf3e0ec1b159e4e99de1e8ad9a3266a1cd068f8cb983f9304e5b10",
-        "author": "118d3a27ea9af6f75da5dbde1dc9213cc68273dcbde57fdf45c92c9b5c3fb14f",
-        "combined": "cc9a55b77fba263ea4e23669d1674fb3fdcc19f0fcd6d27663db2decc9044ab6",
-        "tokenSignature": "but-dies-every-lives-man-not-really-wallace-william"
-      },
-      "lengths": {
-        "text": 47,
-        "author": 15
-      },
-      "source": {
-        "categoryId": "travel",
-        "sequence": 3
       },
       "embedding": {
         "status": "pending",
@@ -11979,28 +11957,6 @@
         "updatedAt": null
       }
     },
-    "resilience-02": {
-      "hashes": {
-        "text": "a23f611cf949c8d44f6783949759be06cbc0c6cdb3ef017c200b65e23806588c",
-        "author": "ff8aac824046b8c4a4237be9238b83fd8a06c533c5ed687094071cfef9f080ea",
-        "combined": "d240c061a1d02b83940f941002da96b9911ff931932db478388cb404c51ba80f",
-        "tokenSignature": "anais-courage-expands-in-life-nin-one-or-proportion-s-shrinks-to"
-      },
-      "lengths": {
-        "text": 55,
-        "author": 9
-      },
-      "source": {
-        "categoryId": "resilience",
-        "sequence": 2
-      },
-      "embedding": {
-        "status": "pending",
-        "model": null,
-        "vectorSha256": null,
-        "updatedAt": null
-      }
-    },
     "resilience-03": {
       "hashes": {
         "text": "792c9ca9ccd6abe0feb80dcf96cce729fe5e4e9bd13df53542dca6fd789d8437",
@@ -12969,28 +12925,6 @@
         "updatedAt": null
       }
     },
-    "growth-09": {
-      "hashes": {
-        "text": "f9729a9dc25d084005419cdc6af02291f427951353f90ee1c0fea986e98e7c04",
-        "author": "ce03832e27cf16a81e36a57811560af5da63441d4c3a7549266f0483f55120dc",
-        "combined": "85471fa2d96f63c26d7d1c0441bfa04bdb20c5abfb7f01f7970e9cc07ffffd5c",
-        "tokenSignature": "actually-andy-but-change-changes-have-say-that-them-they-things-time-to-warhol-you-yourself"
-      },
-      "lengths": {
-        "text": 81,
-        "author": 11
-      },
-      "source": {
-        "categoryId": "growth",
-        "sequence": 9
-      },
-      "embedding": {
-        "status": "pending",
-        "model": null,
-        "vectorSha256": null,
-        "updatedAt": null
-      }
-    },
     "growth-10": {
       "hashes": {
         "text": "f058873ba680b6854642aa2a481200ea318f44e3d7f76ddea6a39ae69e54bc92",
@@ -13115,28 +13049,6 @@
       "source": {
         "categoryId": "joy",
         "sequence": 3
-      },
-      "embedding": {
-        "status": "pending",
-        "model": null,
-        "vectorSha256": null,
-        "updatedAt": null
-      }
-    },
-    "joy-04": {
-      "hashes": {
-        "text": "0a0e7250cf5915bd27fece9bd0cfce1fd2a1a23f923cc496c3f5fa8a08e1794e",
-        "author": "49bde1fc12cf5024d1ac249ec66e86a4f98cb1c27c2d6854bc6ba89de5e0022c",
-        "combined": "2269767fda223bdc383bd3ca522cbd7b18451a0ec3074ab235c2d00b88f8783f",
-        "tokenSignature": "enjoy-john-lennon-not-time-was-wasted-wasting-you"
-      },
-      "lengths": {
-        "text": 39,
-        "author": 11
-      },
-      "source": {
-        "categoryId": "joy",
-        "sequence": 4
       },
       "embedding": {
         "status": "pending",

--- a/data/similarity-overrides.json
+++ b/data/similarity-overrides.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "description": "Manual overrides for cosine similarity reports. Pairs listed here were reviewed and should not be treated as duplicates.",
+    "updatedAt": "2025-09-22T23:16:21.950Z"
+  },
+  "datasets": {
+    "jokes": {
+      "protectedPairs": []
+    },
+    "quotes": {
+      "protectedPairs": [
+        {
+          "ids": [
+            "positive-11",
+            "purpose-09"
+          ],
+          "label": "Keep both",
+          "reason": "Distinct Walt Disney quotes that land on similar optimism but with different language."
+        },
+        {
+          "ids": [
+            "resilience-08",
+            "purpose-11"
+          ],
+          "label": "Keep both",
+          "reason": "Different Benjamin Disraeli quotes that focus on perseverance versus purpose."
+        }
+      ]
+    }
+  }
+}

--- a/data/similarity-report-cross-deck-cohere.json
+++ b/data/similarity-report-cross-deck-cohere.json
@@ -1,7 +1,7 @@
 {
   "dataset": "cross-deck",
   "threshold": 0.5,
-  "generatedAt": "2025-09-22T00:02:49.928Z",
+  "generatedAt": "2025-09-22T23:19:57.715Z",
   "provider": "cohere",
   "model": "embed-english-v3.0",
   "matches": [
@@ -69,13 +69,6 @@
       "previewB": "Every night at 11:11 • I make a wish that someone will come fix my broken clock."
     },
     {
-      "idA": "growth-09",
-      "idB": "j-0569",
-      "similarity": 0.523008934254,
-      "previewA": "They say that time changes things, but you actually have to change them yourself. — Andy Warhol",
-      "previewB": "\"What time is it?\" I don't know... • it keeps changing."
-    },
-    {
       "idA": "humor-08",
       "idB": "j-0213",
       "similarity": 0.516756676617,
@@ -95,13 +88,6 @@
       "similarity": 0.507020022431,
       "previewA": "You can’t turn back the clock. But you can wind it up again. — Bonnie Prudden",
       "previewB": "Why did the kid throw the clock out the window? • He wanted to see time fly!"
-    },
-    {
-      "idA": "travel-20",
-      "idB": "j-0782",
-      "similarity": 0.50264396454,
-      "previewA": "The mountains are calling and I must go. — John Muir",
-      "previewB": "You see, mountains aren't just funny. • They are hill areas."
     },
     {
       "idA": "music-04",

--- a/data/similarity-report-cross-deck-openai.json
+++ b/data/similarity-report-cross-deck-openai.json
@@ -1,7 +1,7 @@
 {
   "dataset": "cross-deck",
   "threshold": 0.5,
-  "generatedAt": "2025-09-21T23:10:32.460Z",
+  "generatedAt": "2025-09-22T23:19:57.715Z",
   "provider": "openai",
   "model": "text-embedding-3-large",
   "matches": [
@@ -151,13 +151,6 @@
       "similarity": 0.645827771463,
       "previewA": "The road leading to a goal does not separate you from the destination; it is essentially a part of it. — Charles DeLint",
       "previewB": "Why did the programmer's wife leave him? • He didn't know how to commit."
-    },
-    {
-      "idA": "family-04",
-      "idB": "j-0718",
-      "similarity": 0.645342413654,
-      "previewA": "We may have our differences, but nothing’s more important than family. — Coco",
-      "previewB": "When a dad drives past a graveyard: Did you know that's a popular cemetery? • Yep, people are just dying to get in there"
     },
     {
       "idA": "time-30",

--- a/data/similarity-report-cross-deck.json
+++ b/data/similarity-report-cross-deck.json
@@ -1,7 +1,7 @@
 {
   "dataset": "cross-deck",
   "threshold": 0.5,
-  "generatedAt": "2025-09-21T02:09:52.000Z",
+  "generatedAt": "2025-09-22T23:19:57.714Z",
   "provider": "hfspace",
   "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
   "matches": [

--- a/data/similarity-report-jokes-cohere.json
+++ b/data/similarity-report-jokes-cohere.json
@@ -1,178 +1,10 @@
 {
   "dataset": "jokes",
   "threshold": 0.5,
-  "generatedAt": "2025-09-22T00:02:23.953Z",
+  "generatedAt": "2025-09-22T23:19:57.679Z",
   "provider": "cohere",
   "model": "embed-english-v3.0",
   "matches": [
-    {
-      "idA": "j-0462",
-      "idB": "j-0700",
-      "similarity": 0.987060170246,
-      "previewA": "Did you know the first French fries weren't actually cooked in France? • They were cooked in Greece.",
-      "previewB": "did you know the first French fries weren't cooked in France? • they were cooked in Greece"
-    },
-    {
-      "idA": "j-0537",
-      "idB": "j-0734",
-      "similarity": 0.981981235599,
-      "previewA": "I couldn't get a reservation at the library. • They were completely booked.",
-      "previewB": "I couldn't get a reservation at the library... • They were fully booked."
-    },
-    {
-      "idA": "j-0381",
-      "idB": "j-0782",
-      "similarity": 0.980104219995,
-      "previewA": "Mountains aren't just funny • they are hill areas",
-      "previewB": "You see, mountains aren't just funny. • They are hill areas."
-    },
-    {
-      "idA": "j-0241",
-      "idB": "j-0767",
-      "similarity": 0.977474563589,
-      "previewA": "Why don't eggs tell jokes? • They'd crack each other up",
-      "previewB": "Why don't eggs tell jokes? • Because they would crack each other up."
-    },
-    {
-      "idA": "j-0214",
-      "idB": "j-0706",
-      "similarity": 0.977106968918,
-      "previewA": "I’ve just been reading a book about anti-gravity • it’s impossible to put down!",
-      "previewB": "I'm reading a book about anti-gravity... • It's impossible to put down"
-    },
-    {
-      "idA": "j-0142",
-      "idB": "j-0428",
-      "similarity": 0.975522488898,
-      "previewA": "Why do bees hum? • Because they don't know the words.",
-      "previewB": "Ever wondered why bees hum? • It's because they don't know the words."
-    },
-    {
-      "idA": "j-0509",
-      "idB": "j-0729",
-      "similarity": 0.952541627376,
-      "previewA": "Did you hear about the cheese who saved the world? • It was Legend-dairy!",
-      "previewB": "Did you hear the story about the cheese that saved the world? • It was legend dairy."
-    },
-    {
-      "idA": "j-0032",
-      "idB": "j-0781",
-      "similarity": 0.941442982861,
-      "previewA": "I was fired from the keyboard factory yesterday. • I wasn't putting in enough shifts.",
-      "previewB": "I just got fired from my job at the keyboard factory. • They told me I wasn't putting in enough shifts."
-    },
-    {
-      "idA": "j-0484",
-      "idB": "j-0521",
-      "similarity": 0.931053034441,
-      "previewA": "A man is washing the car with his son. The son asks...... • \"Dad, can’t you just use a sponge?\"",
-      "previewB": "A dad washes his car with his son. • But after a while, the son says, \"why can't you just use a sponge?\""
-    },
-    {
-      "idA": "j-0274",
-      "idB": "j-0317",
-      "similarity": 0.923467095845,
-      "previewA": "What did the scarf say to the hat? • You go on ahead, I am going to hang around a bit longer.",
-      "previewB": "What did the hat say to the scarf? You can hang around. • I'll just go on ahead."
-    },
-    {
-      "idA": "j-0703",
-      "idB": "j-0837",
-      "similarity": 0.921816109288,
-      "previewA": "Why do Java programmers wear glasses? • Because they don't C#.",
-      "previewB": "Why do programmers wear glasses? • Because they need to C#."
-    },
-    {
-      "idA": "j-0418",
-      "idB": "j-0740",
-      "similarity": 0.916346573862,
-      "previewA": "Can I watch the TV? • Dad: Yes, but don’t turn it on.",
-      "previewB": "Can I watch the TV? • Yes, but don’t turn it on."
-    },
-    {
-      "idA": "j-0466",
-      "idB": "j-0688",
-      "similarity": 0.896128307121,
-      "previewA": "Two silk worms had a race. • They ended up in a tie.",
-      "previewB": "Did you hear about the two silk worms in a race? • It ended in a tie."
-    },
-    {
-      "idA": "j-0038",
-      "idB": "j-0771",
-      "similarity": 0.890651117478,
-      "previewA": "Why did the kid throw the clock out the window? • He wanted to see time fly!",
-      "previewB": "Why did the kid throw the watch out the window? • So time would fly."
-    },
-    {
-      "idA": "j-0144",
-      "idB": "j-0810",
-      "similarity": 0.877334523675,
-      "previewA": "Don't trust atoms. • They make up everything.",
-      "previewB": "Why don't scientists trust atoms? • Because they make up everything."
-    },
-    {
-      "idA": "j-0164",
-      "idB": "j-0860",
-      "similarity": 0.87363226715,
-      "previewA": "What do you call a pile of cats? • A Meowtain.",
-      "previewB": "What do you call a pile of kittens? • A meowntain."
-    },
-    {
-      "idA": "j-0342",
-      "idB": "j-0802",
-      "similarity": 0.867765864591,
-      "previewA": "Why can't a bicycle stand on its own? • It's two-tired.",
-      "previewB": "Why couldn't the bicycle stand up by itself? • It was two-tired."
-    },
-    {
-      "idA": "j-0322",
-      "idB": "j-0807",
-      "similarity": 0.857946199542,
-      "previewA": "What’s the advantage of living in Switzerland? • Well, the flag is a big plus.",
-      "previewB": "What's the best thing about Switzerland? • I don't know, but their flag is a big plus."
-    },
-    {
-      "idA": "j-0326",
-      "idB": "j-0768",
-      "similarity": 0.855836565165,
-      "previewA": "How do you make a 'one' disappear? • You add a 'g' and it's 'gone'",
-      "previewB": "How do you make the number one disappear? • Add the letter G and it’s “gone”!"
-    },
-    {
-      "idA": "j-0798",
-      "idB": "j-0816",
-      "similarity": 0.846762092719,
-      "previewA": "Why did the programmer go broke? • He used up all his cache",
-      "previewB": "Why did the developer go broke? • They kept spending all their cache."
-    },
-    {
-      "idA": "j-0324",
-      "idB": "j-0812",
-      "similarity": 0.842114018439,
-      "previewA": "Why did the cookie cry? • It was feeling crumby.",
-      "previewB": "Why did the cookie go to the doctor? • Because it was feeling crumbly."
-    },
-    {
-      "idA": "j-0110",
-      "idB": "j-0779",
-      "similarity": 0.823318091858,
-      "previewA": "Whenever the cashier at the grocery store asks my dad if he would like the milk in a bag he replies, ‘No • just leave it in the carton!’",
-      "previewB": "A grocery store cashier asked if I would like my milk in a bag. • I told her 'No, thanks. The carton works fine.'"
-    },
-    {
-      "idA": "j-0759",
-      "idB": "j-0837",
-      "similarity": 0.817837735459,
-      "previewA": "Why dot net developers don't wear glasses? • Because they see sharp.",
-      "previewB": "Why do programmers wear glasses? • Because they need to C#."
-    },
-    {
-      "idA": "j-0414",
-      "idB": "j-0718",
-      "similarity": 0.801247027751,
-      "previewA": "You know that cemetery up the road? • People are dying to get in there.",
-      "previewB": "When a dad drives past a graveyard: Did you know that's a popular cemetery? • Yep, people are just dying to get in there"
-    },
     {
       "idA": "j-0108",
       "idB": "j-0672",
@@ -468,13 +300,6 @@
       "previewB": "Why did the chicken cross the road, roll in the mud and cross the road again? • He was a dirty double-crosser!"
     },
     {
-      "idA": "j-0211",
-      "idB": "j-0767",
-      "similarity": 0.672065674035,
-      "previewA": "Why can't eggs have love? • They will break up too soon.",
-      "previewB": "Why don't eggs tell jokes? • Because they would crack each other up."
-    },
-    {
       "idA": "j-0447",
       "idB": "j-0570",
       "similarity": 0.671995671114,
@@ -531,13 +356,6 @@
       "previewB": "What do you get when you cross a chicken with a skunk? • A fowl smell!"
     },
     {
-      "idA": "j-0597",
-      "idB": "j-0812",
-      "similarity": 0.664461413797,
-      "previewA": "Why did the cookie cry? • Because his mother was a wafer so long",
-      "previewB": "Why did the cookie go to the doctor? • Because it was feeling crumbly."
-    },
-    {
       "idA": "j-0559",
       "idB": "j-0827",
       "similarity": 0.659508198832,
@@ -578,13 +396,6 @@
       "similarity": 0.652115638561,
       "previewA": "How many hipsters does it take to change a lightbulb? • Oh, it's a really obscure number. You've probably never heard of it.",
       "previewB": "How many programmers does it take to change a lightbulb? • None that's a hardware problem"
-    },
-    {
-      "idA": "j-0607",
-      "idB": "j-0718",
-      "similarity": 0.651270875133,
-      "previewA": "Why is there always a gate around cemeteries? • Because people are always dying to get in.",
-      "previewB": "When a dad drives past a graveyard: Did you know that's a popular cemetery? • Yep, people are just dying to get in there"
     },
     {
       "idA": "j-0346",
@@ -648,13 +459,6 @@
       "similarity": 0.635482602493,
       "previewA": "Knock knock. Who's there? Opportunity. • That is impossible. Opportunity doesn’t come knocking twice!",
       "previewB": "Knock-knock. • A race condition. Who is there?"
-    },
-    {
-      "idA": "j-0467",
-      "idB": "j-0781",
-      "similarity": 0.632784972792,
-      "previewA": "I got fired from the transmission factor • turns out I didn't put on enough shifts...",
-      "previewB": "I just got fired from my job at the keyboard factory. • They told me I wasn't putting in enough shifts."
     },
     {
       "idA": "j-0237",
@@ -797,13 +601,6 @@
       "previewB": "Why do you never see elephants hiding in trees? • Because they're so good at it."
     },
     {
-      "idA": "j-0794",
-      "idB": "j-0816",
-      "similarity": 0.599510843966,
-      "previewA": "Why did the developer go broke buying Bitcoin? • He kept calling it bytecoin and didn't get any.",
-      "previewB": "Why did the developer go broke? • They kept spending all their cache."
-    },
-    {
       "idA": "j-0171",
       "idB": "j-0885",
       "similarity": 0.599022296201,
@@ -823,13 +620,6 @@
       "similarity": 0.597954688809,
       "previewA": "A SQL query walks into a bar, walks up to two tables and asks... • 'Can I join you?'",
       "previewB": "3 SQL statements walk into a NoSQL bar. Soon, they walk out • They couldn't find a table."
-    },
-    {
-      "idA": "j-0826",
-      "idB": "j-0837",
-      "similarity": 0.597334422183,
-      "previewA": "Why did the programmer always carry a pencil? • They preferred to write in C#.",
-      "previewB": "Why do programmers wear glasses? • Because they need to C#."
     },
     {
       "idA": "j-0048",
@@ -1000,25 +790,11 @@
       "previewB": "\"Dad, I'm hungry.\" Hello, Hungry. • I'm Dad."
     },
     {
-      "idA": "j-0567",
-      "idB": "j-0812",
-      "similarity": 0.583327198318,
-      "previewA": "What did the doctor say to the gingerbread man who broke his leg? • Try icing it.",
-      "previewB": "Why did the cookie go to the doctor? • Because it was feeling crumbly."
-    },
-    {
       "idA": "j-0226",
       "idB": "j-0754",
       "similarity": 0.583031358705,
       "previewA": "I saw an ad in a shop window, \"Television for sale, $1, volume stuck on full\", I thought • \"I can't turn that down\".",
       "previewB": "I saw a nice stereo on Craigslist for $1. Seller says the volume is stuck on ‘high’ • I couldn’t turn it down."
-    },
-    {
-      "idA": "j-0816",
-      "idB": "j-0825",
-      "similarity": 0.582481100676,
-      "previewA": "Why did the developer go broke? • They kept spending all their cache.",
-      "previewB": "Why did the developer break up with their keyboard? • It just wasn't their type anymore."
     },
     {
       "idA": "j-0331",
@@ -1231,13 +1007,6 @@
       "previewB": "Why did the programmer always carry a pencil? • They preferred to write in C#."
     },
     {
-      "idA": "j-0816",
-      "idB": "j-0822",
-      "similarity": 0.563839377996,
-      "previewA": "Why did the developer go broke? • They kept spending all their cache.",
-      "previewB": "Why did the developer go to therapy? • They had too many unresolved issues."
-    },
-    {
       "idA": "j-0213",
       "idB": "j-0727",
       "similarity": 0.563730473483,
@@ -1299,13 +1068,6 @@
       "similarity": 0.561783718168,
       "previewA": "A ghost walks into a bar and asks for a glass of vodka but the bar tender says • “sorry we don’t serve spirits”",
       "previewB": "A ham sandwhich walks into a bar and orders a beer. The bartender says... • I'm sorry, we don't serve food here"
-    },
-    {
-      "idA": "j-0428",
-      "idB": "j-0755",
-      "similarity": 0.561307132163,
-      "previewA": "Ever wondered why bees hum? • It's because they don't know the words.",
-      "previewB": "What do you call a bee that can't make up its mind? • A maybe."
     },
     {
       "idA": "j-0021",
@@ -1448,39 +1210,11 @@
       "previewB": "How many optometrists does it take to change a light bulb? 1 or 2? • 1... or 2?"
     },
     {
-      "idA": "j-0176",
-      "idB": "j-0718",
-      "similarity": 0.555055312227,
-      "previewA": "Why are graveyards so noisy? • Because of all the coffin.",
-      "previewB": "When a dad drives past a graveyard: Did you know that's a popular cemetery? • Yep, people are just dying to get in there"
-    },
-    {
-      "idA": "j-0370",
-      "idB": "j-0860",
-      "similarity": 0.554617848068,
-      "previewA": "What do you call a group of disorganized cats? • A cat-tastrophe.",
-      "previewB": "What do you call a pile of kittens? • A meowntain."
-    },
-    {
       "idA": "j-0458",
       "idB": "j-0872",
       "similarity": 0.55328954372,
       "previewA": "Why is no one friends with Dracula? • Because he's a pain in the neck.",
       "previewB": "What's it like to be kissed by a vampire? • It's a pain in the neck."
-    },
-    {
-      "idA": "j-0737",
-      "idB": "j-0837",
-      "similarity": 0.552418197302,
-      "previewA": "Why do C# and Java developers keep breaking their keyboards? • Because they use a strongly typed language.",
-      "previewB": "Why do programmers wear glasses? • Because they need to C#."
-    },
-    {
-      "idA": "j-0355",
-      "idB": "j-0729",
-      "similarity": 0.552385289383,
-      "previewA": "Did you hear about the cheese factory that exploded in France? • There was nothing left but de Brie.",
-      "previewB": "Did you hear the story about the cheese that saved the world? • It was legend dairy."
     },
     {
       "idA": "j-0042",
@@ -1623,13 +1357,6 @@
       "previewB": "Why did the programmer always carry a pencil? • They preferred to write in C#."
     },
     {
-      "idA": "j-0428",
-      "idB": "j-0644",
-      "similarity": 0.54482088812,
-      "previewA": "Ever wondered why bees hum? • It's because they don't know the words.",
-      "previewB": "Why do bees have sticky hair? • Because they use honey combs!"
-    },
-    {
       "idA": "j-0213",
       "idB": "j-0357",
       "similarity": 0.544470471915,
@@ -1728,20 +1455,6 @@
       "previewB": "Why did the house go to the doctor? • It was having window panes."
     },
     {
-      "idA": "j-0816",
-      "idB": "j-0824",
-      "similarity": 0.538145380842,
-      "previewA": "Why did the developer go broke? • They kept spending all their cache.",
-      "previewB": "Why did the programmer bring a broom to work? • To clean up all the bugs."
-    },
-    {
-      "idA": "j-0748",
-      "idB": "j-0837",
-      "similarity": 0.537789967376,
-      "previewA": "A programmer puts two glasses on his bedside table before going to sleep. • A full one, in case he gets thirsty, and an empty one, in case he doesn’t.",
-      "previewB": "Why do programmers wear glasses? • Because they need to C#."
-    },
-    {
       "idA": "j-0583",
       "idB": "j-0824",
       "similarity": 0.537681270385,
@@ -1831,13 +1544,6 @@
       "similarity": 0.533658039026,
       "previewA": "Why would a guitarist become a good programmer? • He's adept at riffing in C#.",
       "previewB": "Why did the programmer quit his job? • Because he didn't get arrays."
-    },
-    {
-      "idA": "j-0816",
-      "idB": "j-0834",
-      "similarity": 0.533145067118,
-      "previewA": "Why did the developer go broke? • They kept spending all their cache.",
-      "previewB": "Why did the JavaScript heap close shop? • It ran out of memory."
     },
     {
       "idA": "j-0309",
@@ -2064,13 +1770,6 @@
       "previewB": "A man walked in to a bar with some asphalt on his arm. • He said “Two beers please, one for me and one for the road.”"
     },
     {
-      "idA": "j-0068",
-      "idB": "j-0812",
-      "similarity": 0.522817598708,
-      "previewA": "Why did the banana go to the doctor? • He was not \"peeling\" well.",
-      "previewB": "Why did the cookie go to the doctor? • Because it was feeling crumbly."
-    },
-    {
       "idA": "j-0040",
       "idB": "j-0358",
       "similarity": 0.522721171543,
@@ -2293,13 +1992,6 @@
       "similarity": 0.514872607375,
       "previewA": "What time did the man go to the dentist? • Tooth hurt-y.",
       "previewB": "What kind of award did the dentist receive? • A little plaque."
-    },
-    {
-      "idA": "j-0213",
-      "idB": "j-0771",
-      "similarity": 0.514832530427,
-      "previewA": "They're making a movie about clocks. • It's about time",
-      "previewB": "Why did the kid throw the watch out the window? • So time would fly."
     },
     {
       "idA": "j-0237",

--- a/data/similarity-report-jokes-openai.json
+++ b/data/similarity-report-jokes-openai.json
@@ -1,7 +1,7 @@
 {
   "dataset": "jokes",
   "threshold": 0.5,
-  "generatedAt": "2025-09-21T23:10:32.417Z",
+  "generatedAt": "2025-09-22T23:19:57.672Z",
   "provider": "openai",
   "model": "text-embedding-3-large",
   "matches": [
@@ -109,13 +109,6 @@
       "similarity": 0.643096296265,
       "previewA": "Why don't sharks eat clowns? • Because they taste funny.",
       "previewB": "My friend keeps telling me \"Cheer up. • You aren't stuck in a deep hole in the ground, filled with water.\" I know he mea"
-    },
-    {
-      "idA": "j-0350",
-      "idB": "j-0812",
-      "similarity": 0.641189739102,
-      "previewA": "A man was caught stealing in a supermarket today while balanced on the shoulders of a couple of vampires. • He was charg",
-      "previewB": "Why did the cookie go to the doctor? • Because it was feeling crumbly."
     },
     {
       "idA": "j-0009",
@@ -783,13 +776,6 @@
       "previewB": "I went to the zoo the other day, there was only one dog in it. • It was a shitzu."
     },
     {
-      "idA": "j-0531",
-      "idB": "j-0771",
-      "similarity": 0.569073406997,
-      "previewA": "Why do wizards clean their teeth three times a day? • To prevent bat breath!",
-      "previewB": "Why did the kid throw the watch out the window? • So time would fly."
-    },
-    {
       "idA": "j-0081",
       "idB": "j-0152",
       "similarity": 0.568372003614,
@@ -802,20 +788,6 @@
       "similarity": 0.568304742539,
       "previewA": "What do you call cheese by itself? • Provolone.",
       "previewB": "Did you hear about the bread factory burning down? • They say the business is toast."
-    },
-    {
-      "idA": "j-0401",
-      "idB": "j-0779",
-      "similarity": 0.568007629063,
-      "previewA": "I used to work in a shoe recycling shop. • It was sole destroying.",
-      "previewB": "A grocery store cashier asked if I would like my milk in a bag. • I told her 'No, thanks. The carton works fine.'"
-    },
-    {
-      "idA": "j-0435",
-      "idB": "j-0779",
-      "similarity": 0.566908165515,
-      "previewA": "I’ve deleted the phone numbers of all the Germans I know from my mobile phone. • Now it’s Hans free.",
-      "previewB": "A grocery store cashier asked if I would like my milk in a bag. • I told her 'No, thanks. The carton works fine.'"
     },
     {
       "idA": "j-0154",
@@ -916,13 +888,6 @@
       "previewB": "What kind of motorbike does Santa ride? • A Holly Davidson!"
     },
     {
-      "idA": "j-0065",
-      "idB": "j-0816",
-      "similarity": 0.564065281419,
-      "previewA": "I got a reversible jacket for Christmas • I can't wait to see how it turns out.",
-      "previewB": "Why did the developer go broke? • They kept spending all their cache."
-    },
-    {
       "idA": "j-0202",
       "idB": "j-0838",
       "similarity": 0.563855122946,
@@ -991,13 +956,6 @@
       "similarity": 0.561370132468,
       "previewA": "What do you call a factory that sells passable products? • A satisfactory",
       "previewB": "Why did the programmer bring a broom to work? • To clean up all the bugs."
-    },
-    {
-      "idA": "j-0669",
-      "idB": "j-0816",
-      "similarity": 0.560806381927,
-      "previewA": "Have you heard about corduroy pillows? • They're making headlines!",
-      "previewB": "Why did the developer go broke? • They kept spending all their cache."
     },
     {
       "idA": "j-0120",

--- a/data/similarity-report-jokes.json
+++ b/data/similarity-report-jokes.json
@@ -1,7 +1,7 @@
 {
   "dataset": "jokes",
   "threshold": 0.5,
-  "generatedAt": "2025-09-21T03:25:51.227Z",
+  "generatedAt": "2025-09-22T23:19:57.669Z",
   "provider": "hfspace",
   "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
   "matches": [
@@ -158,13 +158,6 @@
       "similarity": 0.6653848909210538,
       "previewA": "What do you get if you cross a turkey with a ghost? • A poultry-geist!",
       "previewB": "What do you get when you cross a chicken with a skunk? • A fowl smell!"
-    },
-    {
-      "idA": "j-0597",
-      "idB": "j-0812",
-      "similarity": 0.664461413796912,
-      "previewA": "Why did the cookie cry? • Because his mother was a wafer so long",
-      "previewB": "Why did the cookie go to the doctor? • Because it was feeling crumbly."
     },
     {
       "idA": "j-0559",
@@ -398,13 +391,6 @@
       "previewB": "A ham sandwhich walks into a bar and orders a beer. The bartender says... • I'm sorry, we don't serve food here"
     },
     {
-      "idA": "j-0428",
-      "idB": "j-0755",
-      "similarity": 0.5613069754657056,
-      "previewA": "Ever wondered why bees hum? • It's because they don't know the words.",
-      "previewB": "What do you call a bee that can't make up its mind? • A maybe."
-    },
-    {
       "idA": "j-0683",
       "idB": "j-0826",
       "similarity": 0.5587112843234565,
@@ -510,25 +496,11 @@
       "previewB": "Where do bees go to the bathroom? • The BP station."
     },
     {
-      "idA": "j-0816",
-      "idB": "j-0824",
-      "similarity": 0.5381453808416483,
-      "previewA": "Why did the developer go broke? • They kept spending all their cache.",
-      "previewB": "Why did the programmer bring a broom to work? • To clean up all the bugs."
-    },
-    {
       "idA": "j-0687",
       "idB": "j-0824",
       "similarity": 0.5356864038428624,
       "previewA": "Why did the programmer quit his job? • Because he didn't get arrays.",
       "previewB": "Why did the programmer bring a broom to work? • To clean up all the bugs."
-    },
-    {
-      "idA": "j-0816",
-      "idB": "j-0834",
-      "similarity": 0.5331451321761588,
-      "previewA": "Why did the developer go broke? • They kept spending all their cache.",
-      "previewB": "Why did the JavaScript heap close shop? • It ran out of memory."
     },
     {
       "idA": "j-0192",
@@ -585,13 +557,6 @@
       "similarity": 0.5237665256846151,
       "previewA": "Why do trees seem suspicious on sunny days? • Dunno, they're just a bit shady.",
       "previewB": "Why do you never see elephants hiding in trees? • Because they're so good at it."
-    },
-    {
-      "idA": "j-0068",
-      "idB": "j-0812",
-      "similarity": 0.522817692593297,
-      "previewA": "Why did the banana go to the doctor? • He was not \"peeling\" well.",
-      "previewB": "Why did the cookie go to the doctor? • Because it was feeling crumbly."
     },
     {
       "idA": "j-0129",

--- a/data/similarity-report-quotes-cohere.json
+++ b/data/similarity-report-quotes-cohere.json
@@ -1,38 +1,10 @@
 {
   "dataset": "quotes",
   "threshold": 0.5,
-  "generatedAt": "2025-09-22T00:02:49.928Z",
+  "generatedAt": "2025-09-22T23:19:57.697Z",
   "provider": "cohere",
   "model": "embed-english-v3.0",
   "matches": [
-    {
-      "idA": "motivation-37",
-      "idB": "resilience-02",
-      "similarity": 0.997051670604,
-      "previewA": "Life shrinks or expands in proportion to one’s courage. — Anais Nin",
-      "previewB": "Life shrinks or expands in proportion to one's courage. — Anais Nin"
-    },
-    {
-      "idA": "adventure-16",
-      "idB": "travel-05",
-      "similarity": 0.992743000508,
-      "previewA": "Every man dies. Not every man really lives. — William Wallace",
-      "previewB": "Every man dies, but not every man really lives. — William Wallace"
-    },
-    {
-      "idA": "time-38",
-      "idB": "joy-04",
-      "similarity": 0.951974557573,
-      "previewA": "Time you enjoy wasted was not time wasted. — John Lennon",
-      "previewB": "Time you enjoy wasting, was not wasted. — John Lennon"
-    },
-    {
-      "idA": "time-24",
-      "idB": "growth-09",
-      "similarity": 0.912285160637,
-      "previewA": "They always say time changes things, but you actually have to change them yourself. — Andy Warhol, The Philosophy of Andy Warhol",
-      "previewB": "They say that time changes things, but you actually have to change them yourself. — Andy Warhol"
-    },
     {
       "idA": "resilience-08",
       "idB": "purpose-11",
@@ -690,13 +662,6 @@
       "similarity": 0.631665035859,
       "previewA": "Every time you smile at someone, it is an action of love, a gift to that person, a beautiful thing. — Mother Teresa",
       "previewB": "Sometimes your joy is the source of your smile, but sometimes your smile can be the source of your joy. — Thich Nhat Hanh"
-    },
-    {
-      "idA": "time-41",
-      "idB": "growth-09",
-      "similarity": 0.631428375834,
-      "previewA": "Time, which changes people, does not alter the image we have of them. — Marcel Proust",
-      "previewB": "They say that time changes things, but you actually have to change them yourself. — Andy Warhol"
     },
     {
       "idA": "motivation-24",
@@ -3926,13 +3891,6 @@
       "previewB": "Friendship is the hardest thing in the world to explain. It’s not something you learn in school. But if you haven’t learned the meaning of friendship, you reall"
     },
     {
-      "idA": "time-05",
-      "idB": "growth-09",
-      "similarity": 0.546729124742,
-      "previewA": "Time has a wonderful way of showing us what really matters. — Margaret Peters",
-      "previewB": "They say that time changes things, but you actually have to change them yourself. — Andy Warhol"
-    },
-    {
       "idA": "kindness-07",
       "idB": "kindness-11",
       "similarity": 0.546608451565,
@@ -4822,13 +4780,6 @@
       "previewB": "Scatter joy. — Ralph Waldo Emerson"
     },
     {
-      "idA": "love-52",
-      "idB": "joy-04",
-      "similarity": 0.535967050236,
-      "previewA": "Love is the flower you've got to let grow. — John Lennon",
-      "previewB": "Time you enjoy wasting, was not wasted. — John Lennon"
-    },
-    {
       "idA": "music-05",
       "idB": "music-07",
       "similarity": 0.535941782541,
@@ -5690,13 +5641,6 @@
       "previewB": "Music . . . can name the unnameable and communicate the unknowable. — Leonard Bernstein"
     },
     {
-      "idA": "time-25",
-      "idB": "joy-04",
-      "similarity": 0.52765511139,
-      "previewA": "Time is a waste of money. — Oscar Wilde",
-      "previewB": "Time you enjoy wasting, was not wasted. — John Lennon"
-    },
-    {
       "idA": "humor-22",
       "idB": "money-49",
       "similarity": 0.527653988959,
@@ -6073,13 +6017,6 @@
       "similarity": 0.524254884408,
       "previewA": "Whoever said that money can’t buy happiness, simply didn’t know where to go shopping. — Bo Derek",
       "previewB": "Too many people spend money they earned to buy things they don’t want, to impress people they don’t like. — Will Rogers"
-    },
-    {
-      "idA": "time-48",
-      "idB": "growth-09",
-      "similarity": 0.524206391693,
-      "previewA": "Own time, or time will own you. — Brian Norgard",
-      "previewB": "They say that time changes things, but you actually have to change them yourself. — Andy Warhol"
     },
     {
       "idA": "family-05",
@@ -6586,13 +6523,6 @@
       "previewB": "Sometimes your joy is the source of your smile, but sometimes your smile can be the source of your joy. — Thich Nhat Hanh"
     },
     {
-      "idA": "time-37",
-      "idB": "growth-09",
-      "similarity": 0.520494967297,
-      "previewA": "The only reason for time is so that everything doesn’t happen at once. — Albert Einstein",
-      "previewB": "They say that time changes things, but you actually have to change them yourself. — Andy Warhol"
-    },
-    {
       "idA": "humor-22",
       "idB": "happiness-01",
       "similarity": 0.520451082196,
@@ -6822,13 +6752,6 @@
       "similarity": 0.518995804065,
       "previewA": "If you don’t find a way to make money while you sleep, you will work until the day you die. — Warren Buffett",
       "previewB": "If you cannot control your emotions, you cannot control your money. — Warren Buffett"
-    },
-    {
-      "idA": "time-29",
-      "idB": "growth-09",
-      "similarity": 0.518971642891,
-      "previewA": "Time and tide wait for no man, but time always stands still for a woman of 30. — Robert Frost",
-      "previewB": "They say that time changes things, but you actually have to change them yourself. — Andy Warhol"
     },
     {
       "idA": "motivation-22",
@@ -7368,13 +7291,6 @@
       "similarity": 0.515056436801,
       "previewA": "How is it that music can, without words, evoke our laughter, our fears, our highest aspirations? — Jane Swan",
       "previewB": "The most exciting rhythms seem unexpected and complex, the most beautiful melodies simple and inevitable. — W. H. Auden"
-    },
-    {
-      "idA": "positive-27",
-      "idB": "joy-04",
-      "similarity": 0.515049666197,
-      "previewA": "The most wasted of days is one without laughter. — E. E. Cummings",
-      "previewB": "Time you enjoy wasting, was not wasted. — John Lennon"
     },
     {
       "idA": "money-16",
@@ -8119,13 +8035,6 @@
       "previewB": "Leave the road, take the trails. — Pythagoras"
     },
     {
-      "idA": "time-22",
-      "idB": "growth-09",
-      "similarity": 0.509159796298,
-      "previewA": "You will never find time for anything. If you want time, you must make it. — Charles Buxton",
-      "previewB": "They say that time changes things, but you actually have to change them yourself. — Andy Warhol"
-    },
-    {
       "idA": "travel-07",
       "idB": "gratitude-07",
       "similarity": 0.509105870474,
@@ -8334,13 +8243,6 @@
       "similarity": 0.507788725113,
       "previewA": "People say that money is not the key to happiness, but I always figured if you have enough money, you can have a key made. — Joan Rivers",
       "previewB": "Having money isn’t everything, not having it, is. — Kanye West"
-    },
-    {
-      "idA": "adventure-19",
-      "idB": "resilience-02",
-      "similarity": 0.507728832151,
-      "previewA": "It is not length of life, but depth of life. — Ralph Waldo Emerson",
-      "previewB": "Life shrinks or expands in proportion to one's courage. — Anais Nin"
     },
     {
       "idA": "music-01",
@@ -8572,13 +8474,6 @@
       "similarity": 0.506312180173,
       "previewA": "Music, once admitted to the soul, becomes a sort of spirit, and never dies. — Edward Bulwer-Lytton",
       "previewB": "Music is the language of the spirit. It opens the secret of life bringing peace, abolishing strife. — Kahlil Gibran"
-    },
-    {
-      "idA": "creativity-11",
-      "idB": "resilience-02",
-      "similarity": 0.506243132554,
-      "previewA": "Sadness may be part of life but there is no need to let it dominate your entire life. — Byron Pulsifer",
-      "previewB": "Life shrinks or expands in proportion to one's courage. — Anais Nin"
     },
     {
       "idA": "friendship-41",
@@ -9057,13 +8952,6 @@
       "previewB": "Sadness may be part of life but there is no need to let it dominate your entire life. — Byron Pulsifer"
     },
     {
-      "idA": "time-25",
-      "idB": "growth-09",
-      "similarity": 0.503112808127,
-      "previewA": "Time is a waste of money. — Oscar Wilde",
-      "previewB": "They say that time changes things, but you actually have to change them yourself. — Andy Warhol"
-    },
-    {
       "idA": "positive-20",
       "idB": "happiness-03",
       "similarity": 0.503087573084,
@@ -9188,13 +9076,6 @@
       "similarity": 0.502393039266,
       "previewA": "Without music, life would be a mistake — Friedrich Nietzsche",
       "previewB": "A man should hear a little music, read a little poetry, and see a fine picture every day of his life, in order that worldly cares may not obliterate the sense o"
-    },
-    {
-      "idA": "resilience-02",
-      "idB": "leadership-07",
-      "similarity": 0.502292598162,
-      "previewA": "Life shrinks or expands in proportion to one's courage. — Anais Nin",
-      "previewB": "Character cannot be developed in ease and quiet. Only through experience of trial and suffering can the soul be strengthened, vision cleared, ambition inspired,"
     },
     {
       "idA": "mindfulness-10",

--- a/data/similarity-report-quotes-openai.json
+++ b/data/similarity-report-quotes-openai.json
@@ -1,7 +1,7 @@
 {
   "dataset": "quotes",
   "threshold": 0.5,
-  "generatedAt": "2025-09-21T23:10:32.460Z",
+  "generatedAt": "2025-09-22T23:19:57.684Z",
   "provider": "openai",
   "model": "text-embedding-3-large",
   "matches": [

--- a/data/similarity-report-quotes.json
+++ b/data/similarity-report-quotes.json
@@ -1,7 +1,7 @@
 {
   "dataset": "quotes",
   "threshold": 0.5,
-  "generatedAt": "2025-09-21T02:09:47.926Z",
+  "generatedAt": "2025-09-22T23:19:57.683Z",
   "provider": "hfspace",
   "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
   "matches": [


### PR DESCRIPTION
## Summary
- prune high-similarity duplicates from the jokes and quotes decks, regenerating their manifests and embedding stores to match the new totals
- add a similarity-overrides data file to track manually reviewed, non-duplicate pairs
- teach the Cosine Similarity Lab UI to load overrides, badge protected pairs, and hide pairs explicitly marked to ignore

## Testing
- node --check apps/jokes/jokes.js
- node -e "global.window = {}; require('./apps/jokes/jokes.js'); console.log(Array.isArray(window.jokes), window.jokes.length);"
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d6a6f0bc832885abc0c8c7ff2407