### PR TITLE
Add Playwright tests for interactive apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,22 @@ This starts a server on <http://localhost:3000> (or the next available port).
 
 ## Testing
 
-Install the dev dependencies once and run the Playwright smoke checks whenever you touch the interactive apps:
+Install the dev dependencies and download the Playwright browser bundle the first time you set up the repo:
 
 ```bash
 npm install
 npx playwright install
+```
+
+On fresh machines that lack the Chromium dependencies, run `npx playwright install --with-deps chromium` instead of the plain install above.
+
+With the tooling in place, execute the full suite:
+
+```bash
 npm test
 ```
 
-The test runner launches a temporary `python -m http.server` instance, loads the Cosine Similarity Lab, and asserts that the dynamic thresholding and Levenshtein metrics render. Use `npm run test:ui` if you want to watch the checks in the Playwright inspector while iterating locally. `npx playwright install --with-deps` is handy the first time you set things up on a fresh machine that needs the browser dependencies.
+The tests spin up a temporary `python -m http.server` instance and exercise every interactive app: Random Jokes (deck navigation and punchline reveal), Quotes (category filtering and keyboard shortcuts), Value Formatter (preset transforms and localStorage persistence), and the Cosine Similarity Lab (dataset toggles and Levenshtein metrics). Use `npm run test:ui` if you want to watch the checks in the Playwright inspector while iterating locally.
 
 ## Data maintenance
 

--- a/tests/jokes.spec.js
+++ b/tests/jokes.spec.js
@@ -1,0 +1,66 @@
+const { test, expect } = require('@playwright/test');
+
+const deterministicRandomInitScript = () => {
+  const values = [0.12, 0.76, 0.38, 0.94, 0.52];
+  let index = 0;
+  Math.random = () => {
+    const value = values[index % values.length];
+    index += 1;
+    return value;
+  };
+};
+
+test.describe('Random Jokes app', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(deterministicRandomInitScript);
+  });
+
+  test('reveals punchlines, resets when moving, and honours keyboard shortcuts', async ({ page }) => {
+    await page.goto('/apps/jokes/');
+
+    const setup = page.locator('#joke-setup');
+    const punchline = page.locator('#joke-punchline');
+    const revealButton = page.locator('#reveal-button');
+    const nextButton = page.locator('#next-button');
+    const prevButton = page.locator('#prev-button');
+
+    await expect(setup).not.toHaveText(/Loading joke…?/i);
+    await expect(punchline).not.toHaveClass(/is-visible/);
+    await expect(punchline).toHaveAttribute('aria-hidden', 'true');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'false');
+    await expect(nextButton).toBeEnabled();
+    await expect(prevButton).toBeEnabled();
+
+    await revealButton.click();
+    await expect(punchline).toHaveClass(/is-visible/);
+    await expect(punchline).toHaveAttribute('aria-hidden', 'false');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'true');
+
+    const firstSetup = (await setup.textContent())?.trim() || '';
+    expect(firstSetup.length).toBeGreaterThan(0);
+
+    await nextButton.click();
+
+    await expect(punchline).not.toHaveClass(/is-visible/);
+    await expect(punchline).toHaveAttribute('aria-hidden', 'true');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'false');
+
+    const secondSetup = (await setup.textContent())?.trim() || '';
+    expect(secondSetup.length).toBeGreaterThan(0);
+    expect(secondSetup).not.toBe(firstSetup);
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(setup).toHaveText(firstSetup);
+
+    await page.evaluate(() => {
+      const active = document.activeElement;
+      if (active && typeof active.blur === 'function') {
+        active.blur();
+      }
+    });
+
+    await page.keyboard.press('Space');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(punchline).toHaveClass(/is-visible/);
+  });
+});

--- a/tests/quotes.spec.js
+++ b/tests/quotes.spec.js
@@ -1,0 +1,85 @@
+const { test, expect } = require('@playwright/test');
+
+const deterministicRandomInitScript = () => {
+  const values = [0.18, 0.6, 0.34, 0.82, 0.26];
+  let index = 0;
+  Math.random = () => {
+    const value = values[index % values.length];
+    index += 1;
+    return value;
+  };
+};
+
+test.describe('Quotes app', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(deterministicRandomInitScript);
+  });
+
+  test('navigates shuffled decks and filters by category', async ({ page }) => {
+    await page.goto('/apps/quotes/');
+
+    const quote = page.locator('#quote-text');
+    const author = page.locator('#quote-author');
+    const meta = page.locator('#quote-meta');
+    const nextButton = page.locator('#next-button');
+    const prevButton = page.locator('#prev-button');
+    const select = page.locator('#category-select');
+
+    await expect(quote).not.toHaveText(/Loading quote…?/i);
+    await expect(meta).toBeVisible();
+    await expect(author).not.toHaveText('');
+    await expect(nextButton).toBeEnabled();
+    await expect(prevButton).toBeEnabled();
+
+    const optionValues = await select.evaluate((node) =>
+      Array.from(node.options).map((option) => option.value),
+    );
+    expect(optionValues).toContain('any');
+    expect(optionValues).toContain('adventure');
+
+    const firstQuote = (await quote.textContent())?.trim() || '';
+    expect(firstQuote.length).toBeGreaterThan(0);
+
+    await nextButton.click();
+    const secondQuote = (await quote.textContent())?.trim() || '';
+    expect(secondQuote.length).toBeGreaterThan(0);
+    expect(secondQuote).not.toBe(firstQuote);
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(quote).toHaveText(firstQuote);
+
+    await select.selectOption('adventure');
+    await expect(select).toHaveValue('adventure');
+    await expect(meta).toBeVisible();
+
+    const currentQuote = (await quote.textContent())?.trim() || '';
+    const currentAuthor = (await author.textContent())?.trim() || '';
+    expect(currentQuote.length).toBeGreaterThan(0);
+    expect(currentAuthor.length).toBeGreaterThan(0);
+
+    const adventureDeck = await page.evaluate(() => {
+      const category = window.quotesData.find((entry) => entry.id === 'adventure');
+      if (!category) {
+        return { texts: [], authors: [] };
+      }
+      return {
+        texts: category.quotes.map((entry) => entry.text),
+        authors: category.quotes.map((entry) => entry.author),
+      };
+    });
+
+    expect(adventureDeck.texts).toContain(currentQuote);
+    expect(adventureDeck.authors).toContain(currentAuthor);
+
+    await page.evaluate(() => {
+      const active = document.activeElement;
+      if (active && typeof active.blur === 'function') {
+        active.blur();
+      }
+    });
+
+    await page.keyboard.press('Space');
+    const followUpQuote = (await quote.textContent())?.trim() || '';
+    expect(adventureDeck.texts).toContain(followUpQuote);
+  });
+});

--- a/tests/value-formatter.spec.js
+++ b/tests/value-formatter.spec.js
@@ -1,0 +1,40 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Value Formatter app', () => {
+  test('applies presets, custom transforms, and persists the input field', async ({ page }) => {
+    await page.goto('/apps/value-formatter/');
+    await page.waitForFunction(() => typeof window.run === 'function');
+
+    const input = page.locator('#inputText');
+    const output = page.locator('#outputText');
+    const presets = page.locator('#presets');
+    const transformer = page.locator('#transformerValue');
+    const joinValue = page.locator('#joinValue');
+
+    await expect(output).toHaveValue('t.[1] = s.[1],\nt.[2] = s.[2],\nt.[3] = s.[3]');
+
+    await presets.selectOption('_');
+    await expect(transformer).toHaveValue('_');
+    await expect(output).toHaveValue('1,\n2,\n3');
+
+    await joinValue.fill(' | ');
+    await page.evaluate(() => window.run());
+    await expect(output).toHaveValue('1 | 2 | 3');
+
+    await transformer.fill('value(_);');
+    await page.evaluate(() => window.run());
+    await expect(output).toHaveValue('value(1); | value(2); | value(3);');
+
+    await input.fill('alpha beta');
+    await page.evaluate(() => window.run());
+    await expect(output).toHaveValue('value(alpha); | value(beta);');
+
+    const storedInput = await page.evaluate(() => window.localStorage.getItem('inputText'));
+    expect(storedInput).toBe('alpha beta');
+
+    await page.reload();
+
+    await expect(input).toHaveValue('alpha beta');
+    await expect(output).toHaveValue('t.[alpha] = s.[alpha],\nt.[beta] = s.[beta]');
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic Playwright coverage for the Random Jokes app, including navigation and punchline toggling
- cover the Quotes deck filters and keyboard controls with a dedicated Playwright test
- exercise the Value Formatter transformations, persist behaviour, and document the expanded test suite in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f2b944488328a2f7c75c57952492