### PR TITLE
Revamp home layout and add home navigation

### DIFF
--- a/apps/jokes/all-jokes-compact.html
+++ b/apps/jokes/all-jokes-compact.html
@@ -43,6 +43,16 @@
         border-color: rgba(148, 163, 209, 0.4);
         color: inherit;
       }
+
+      .home-link {
+        border-color: rgba(148, 163, 209, 0.45);
+        background: rgba(148, 163, 209, 0.18);
+      }
+
+      .home-link:hover {
+        background: rgba(148, 163, 209, 0.26);
+        box-shadow: 0 14px 28px rgba(2, 6, 23, 0.45);
+      }
     }
 
     body {
@@ -72,6 +82,41 @@
       display: flex;
       flex-direction: column;
       gap: 8px;
+    }
+
+    .home-nav {
+      display: flex;
+      justify-content: flex-start;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid rgba(74, 99, 255, 0.35);
+      text-decoration: none;
+      color: inherit;
+      font-weight: 600;
+      background: rgba(74, 99, 255, 0.12);
+      transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    }
+
+    .home-link span[aria-hidden="true"] {
+      font-size: 1.2rem;
+    }
+
+    .home-link:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 28px rgba(15, 23, 42, 0.22);
+      background: rgba(74, 99, 255, 0.18);
+    }
+
+    .home-link:focus-visible {
+      outline: 2px solid rgba(112, 132, 255, 0.6);
+      outline-offset: 3px;
+      box-shadow: 0 0 0 3px rgba(112, 132, 255, 0.28);
     }
 
     header.page-header h1 {
@@ -217,6 +262,12 @@
 </head>
 <body data-compact="true">
   <main>
+    <nav class="home-nav" aria-label="Home navigation">
+      <a class="home-link" href="../../">
+        <span aria-hidden="true">←</span>
+        <span>Home</span>
+      </a>
+    </nav>
     <header class="page-header">
       <h1>All Jokes (Compact)</h1>
       <p>Condensed view with tighter spacing for quicker scanning. <span class="badge">Showing <span data-count>0</span> of <span data-total>0</span> jokes</span></p>

--- a/apps/jokes/all-jokes.html
+++ b/apps/jokes/all-jokes.html
@@ -37,6 +37,16 @@
         background: rgba(255, 255, 255, 0.08);
       }
 
+      .home-link {
+        border-color: rgba(241, 245, 255, 0.35);
+        background: rgba(255, 255, 255, 0.08);
+      }
+
+      .home-link:hover {
+        background: rgba(255, 255, 255, 0.14);
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+      }
+
       .filter input[type="search"] {
         background: rgba(18, 18, 18, 0.9);
         border-color: rgba(241, 245, 255, 0.35);
@@ -47,6 +57,42 @@
     main {
       max-width: 960px;
       margin: 0 auto;
+    }
+
+    .home-nav {
+      display: flex;
+      justify-content: flex-start;
+      margin-bottom: 1.5rem;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid rgba(48, 86, 211, 0.4);
+      text-decoration: none;
+      color: inherit;
+      font-weight: 600;
+      background: rgba(48, 86, 211, 0.08);
+      transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    }
+
+    .home-link span[aria-hidden="true"] {
+      font-size: 1.2rem;
+    }
+
+    .home-link:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(48, 86, 211, 0.18);
+      background: rgba(48, 86, 211, 0.14);
+    }
+
+    .home-link:focus-visible {
+      outline: 2px solid rgba(48, 86, 211, 0.6);
+      outline-offset: 3px;
+      box-shadow: 0 0 0 3px rgba(48, 86, 211, 0.25);
     }
 
     h1 {
@@ -127,6 +173,12 @@
 </head>
 <body>
   <main>
+    <nav class="home-nav" aria-label="Home navigation">
+      <a class="home-link" href="../../">
+        <span aria-hidden="true">←</span>
+        <span>Home</span>
+      </a>
+    </nav>
     <h1>All Jokes</h1>
     <p>Every joke from the dataset in one place. Use the filter to zero in on a favourite.</p>
     <p class="count">Showing <span data-count>0</span> of <span data-total>0</span> jokes</p>

--- a/apps/jokes/index.html
+++ b/apps/jokes/index.html
@@ -75,6 +75,41 @@
       gap: 20px;
     }
 
+    .home-nav {
+      display: flex;
+      justify-content: flex-start;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid var(--accent);
+      text-decoration: none;
+      color: var(--accent);
+      font-weight: 600;
+      background: transparent;
+      transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    }
+
+    .home-link span[aria-hidden="true"] {
+      font-size: 1.2rem;
+    }
+
+    .home-link:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 24px rgba(48, 86, 211, 0.28);
+      background: rgba(48, 86, 211, 0.1);
+    }
+
+    .home-link:focus-visible {
+      outline: 2px solid rgba(112, 132, 255, 0.65);
+      outline-offset: 3px;
+      box-shadow: 0 0 0 3px rgba(112, 132, 255, 0.25);
+    }
+
     #joke-setup {
       margin: 0;
       font-size: clamp(1.35rem, 2.4vw + 1rem, 2.2rem);
@@ -174,8 +209,14 @@
     }
   </style>
 </head>
-<body>
+  <body>
   <main aria-label="Random jokes">
+    <nav class="home-nav" aria-label="Home navigation">
+      <a class="home-link" href="../../">
+        <span aria-hidden="true">←</span>
+        <span>Home</span>
+      </a>
+    </nav>
     <article class="card" aria-live="polite">
       <div class="card__content">
         <p id="joke-setup">Loading joke…</p>

--- a/apps/quotes/all-quotes.html
+++ b/apps/quotes/all-quotes.html
@@ -40,6 +40,16 @@
         border-color: rgba(255, 255, 255, 0.2);
       }
 
+      .home-link {
+        border-color: rgba(241, 245, 255, 0.35);
+        background: rgba(255, 255, 255, 0.08);
+      }
+
+      .home-link:hover {
+        background: rgba(255, 255, 255, 0.14);
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+      }
+
       .filter input[type="search"] {
         background: rgba(18, 18, 18, 0.9);
         border-color: rgba(241, 245, 255, 0.35);
@@ -50,6 +60,42 @@
     main {
       max-width: 960px;
       margin: 0 auto;
+    }
+
+    .home-nav {
+      display: flex;
+      justify-content: flex-start;
+      margin-bottom: 1.5rem;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid rgba(48, 86, 211, 0.4);
+      text-decoration: none;
+      color: inherit;
+      font-weight: 600;
+      background: rgba(48, 86, 211, 0.08);
+      transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    }
+
+    .home-link span[aria-hidden="true"] {
+      font-size: 1.2rem;
+    }
+
+    .home-link:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(48, 86, 211, 0.18);
+      background: rgba(48, 86, 211, 0.14);
+    }
+
+    .home-link:focus-visible {
+      outline: 2px solid rgba(48, 86, 211, 0.6);
+      outline-offset: 3px;
+      box-shadow: 0 0 0 3px rgba(48, 86, 211, 0.25);
     }
 
     h1 {
@@ -147,6 +193,12 @@
 </head>
 <body>
   <main>
+    <nav class="home-nav" aria-label="Home navigation">
+      <a class="home-link" href="../../">
+        <span aria-hidden="true">←</span>
+        <span>Home</span>
+      </a>
+    </nav>
     <h1>All Quotes</h1>
     <p>Flip through every quote across the themed decks in one place.</p>
     <p class="count">Showing <span data-count>0</span> of <span data-total>0</span> quotes</p>

--- a/apps/quotes/index.html
+++ b/apps/quotes/index.html
@@ -73,6 +73,41 @@
       margin: 0;
     }
 
+    .home-nav {
+      display: flex;
+      justify-content: flex-start;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid rgba(48, 86, 211, 0.4);
+      text-decoration: none;
+      color: inherit;
+      font-weight: 600;
+      background: rgba(48, 86, 211, 0.08);
+      transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    }
+
+    .home-link span[aria-hidden="true"] {
+      font-size: 1.2rem;
+    }
+
+    .home-link:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 24px rgba(48, 86, 211, 0.18);
+      background: rgba(48, 86, 211, 0.14);
+    }
+
+    .home-link:focus-visible {
+      outline: 2px solid rgba(48, 86, 211, 0.6);
+      outline-offset: 3px;
+      box-shadow: 0 0 0 3px rgba(48, 86, 211, 0.25);
+    }
+
     .quote-meta {
       font-family: var(--quote-author-font);
       color: var(--quote-author-color);
@@ -178,8 +213,14 @@
     }
   </style>
 </head>
-<body>
+  <body>
   <main aria-label="Quotes">
+    <nav class="home-nav" aria-label="Home navigation">
+      <a class="home-link" href="../../">
+        <span aria-hidden="true">←</span>
+        <span>Home</span>
+      </a>
+    </nav>
     <div class="card" role="group" aria-live="polite">
       <blockquote>
         <p id="quote-text">Loading quote…</p>

--- a/apps/similarity-report/index.html
+++ b/apps/similarity-report/index.html
@@ -106,6 +106,43 @@
       gap: clamp(20px, 4vw, 36px);
     }
 
+    .home-nav {
+      display: flex;
+      justify-content: flex-start;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid var(--accent-active);
+      text-decoration: none;
+      color: var(--accent-active);
+      font-weight: 600;
+      background: transparent;
+      transition: background 0.18s ease, color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+    }
+
+    .home-link span[aria-hidden="true"] {
+      font-size: 1.2rem;
+    }
+
+    .home-link:hover {
+      transform: translateY(-1px);
+      color: var(--accent-contrast);
+      background: var(--accent-active);
+      box-shadow: 0 14px 28px color-mix(in srgb, var(--accent-active) 45%, transparent);
+    }
+
+    .home-link:focus-visible {
+      outline: none;
+      color: var(--accent-contrast);
+      background: var(--accent-active);
+      box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.45), 0 0 0 5px rgba(14, 165, 233, 0.35);
+    }
+
     .page-header {
       display: flex;
       flex-direction: column;
@@ -890,6 +927,12 @@
 </head>
 <body data-active-dataset="jokes">
   <main>
+    <nav class="home-nav" aria-label="Home navigation">
+      <a class="home-link" href="../../">
+        <span aria-hidden="true">←</span>
+        <span>Home</span>
+      </a>
+    </nav>
     <header class="page-header">
       <p class="eyebrow">Vector insights</p>
       <h1>Cosine Similarity Lab</h1>

--- a/apps/value-formatter/index.html
+++ b/apps/value-formatter/index.html
@@ -14,6 +14,31 @@
 			display: flex;
 			flex-direction: column;
 		}
+
+		.home-nav {
+			padding: 12px;
+		}
+
+		.home-link {
+			display: inline-flex;
+			align-items: center;
+			gap: 8px;
+			padding: 8px 14px;
+			border-radius: 8px;
+			background: #3056d3;
+			color: #ffffff;
+			text-decoration: none;
+			font-weight: 600;
+		}
+
+		.home-link:hover {
+			background: #2745a6;
+		}
+
+		.home-link:focus-visible {
+			outline: 2px solid rgba(48, 86, 211, 0.6);
+			outline-offset: 3px;
+		}
 		#outputText {
 			flex-grow: 1;
 			resize: none;
@@ -22,6 +47,11 @@
 	</style>
 </head>
 <body>
+	<nav class="home-nav" aria-label="Home navigation">
+		<a class="home-link" href="../../">
+			← Home
+		</a>
+	</nav>
 	<div id="inputContainer">
 		<select id="presets">
 			<option value="t.[_] = s.[_]">t.[_] = s.[_]</option>

--- a/index.html
+++ b/index.html
@@ -100,24 +100,30 @@
 
     ul.apps li {
       margin: 0;
-    }
-
-    a.app-card {
       display: flex;
       flex-direction: column;
+      gap: 12px;
+    }
+
+    a.app-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       gap: 14px;
-      padding: 12px;
-      border-radius: 20px;
+      padding: 18px 22px;
+      border-radius: 999px;
       background: var(--card-background);
       text-decoration: none;
       color: inherit;
       box-shadow: var(--card-shadow);
-      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
       border: 1px solid transparent;
+      font-size: 1.1rem;
+      font-weight: 600;
     }
 
-    a.app-card:hover,
-    a.app-card:focus-visible {
+    a.app-button:hover,
+    a.app-button:focus-visible {
       transform: translateY(-6px);
       box-shadow: var(--card-hover-shadow);
       background: var(--card-hover-background);
@@ -125,17 +131,44 @@
       border-color: rgba(115, 135, 255, 0.45);
     }
 
-    a.app-card h2 {
-      margin: 0;
-      font-size: 1.32rem;
-      font-weight: 600;
+    a.app-button span[aria-hidden="true"] {
+      font-size: 1.5rem;
     }
 
-    a.app-card p {
-      margin: 0;
-      color: var(--text-secondary);
-      line-height: 1.5;
-      font-size: 0.98rem;
+    .app-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    a.app-secondary,
+    a.dev-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: var(--dev-link-background);
+      color: inherit;
+      text-decoration: none;
+      font-weight: 500;
+      transition: transform 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+      box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+    }
+
+    a.app-secondary:hover,
+    a.app-secondary:focus-visible,
+    a.dev-link:hover,
+    a.dev-link:focus-visible {
+      background: var(--dev-link-hover);
+      transform: translateY(-2px);
+      outline: none;
+      box-shadow: 0 16px 34px rgba(15, 23, 42, 0.18);
+    }
+
+    a.app-secondary span[aria-hidden="true"],
+    a.dev-link span[aria-hidden="true"] {
+      font-size: 1.2rem;
     }
 
     section.dev-tools {
@@ -146,40 +179,15 @@
       margin-top: clamp(18px, 3vw, 28px);
     }
 
-    a.dev-link {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 12px 18px;
-      border-radius: 999px;
-      background: var(--dev-link-background);
-      color: inherit;
-      text-decoration: none;
-      font-weight: 500;
-      transition: transform 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
-      box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
-    }
-
-    a.dev-link:hover,
-    a.dev-link:focus-visible {
-      background: var(--dev-link-hover);
-      transform: translateY(-2px);
-      outline: none;
-      box-shadow: 0 16px 34px rgba(15, 23, 42, 0.18);
-    }
-
     a.dev-link:focus-visible,
-    a.app-card:focus-visible {
+    a.app-button:focus-visible,
+    a.app-secondary:focus-visible {
       box-shadow: 0 0 0 3px rgba(121, 134, 255, 0.35), inset 0 0 0 1px rgba(121, 134, 255, 0.6);
     }
 
     @media (max-width: 640px) {
       main {
         padding: clamp(12px, 4vw, 18px);
-      }
-
-      a.app-card {
-        padding: 10px;
       }
 
       header.site-header h1 {
@@ -192,28 +200,41 @@
   <main aria-label="Apps">
     <ul class="apps">
       <li>
-        <a class="app-card" href="apps/jokes/">
-          <h2>Dad Jokes</h2>
-          <p>Shuffle developer-friendly jokes, step back for another look, and reveal punchlines when you are ready.</p>
+        <a class="app-button" href="apps/jokes/">
+          <span aria-hidden="true">😂</span>
+          <span class="app-label">Dad Jokes</span>
         </a>
+        <div class="app-links" aria-label="Dad jokes extras">
+          <a class="app-secondary" href="apps/jokes/all-jokes.html">
+            <span aria-hidden="true">📚</span>
+            <span>All Jokes</span>
+          </a>
+        </div>
       </li>
       <li>
-        <a class="app-card" href="apps/quotes/">
-          <h2>Quotes</h2>
-          <p>Shuffle through themed quote decks, jump back, and switch categories without losing momentum.</p>
+        <a class="app-button" href="apps/quotes/">
+          <span aria-hidden="true">💬</span>
+          <span class="app-label">Quotes</span>
         </a>
+        <div class="app-links" aria-label="Quote extras">
+          <a class="app-secondary" href="apps/quotes/all-quotes.html">
+            <span aria-hidden="true">🗂️</span>
+            <span>All Quotes</span>
+          </a>
+        </div>
       </li>
       <li>
-        <a class="app-card" href="apps/similarity-report/">
-          <h2>Cosine Similarity Lab</h2>
-          <p>Review 0.50+ cosine matches across jokes, quotes, and cross-deck mashups, filter by score or text, and inspect each pair’s geeky vector stats.</p>
+        <a class="app-button" href="apps/similarity-report/">
+          <span aria-hidden="true">🧪</span>
+          <span class="app-label">Cosine Similarity Lab</span>
         </a>
       </li>
     </ul>
     <section class="dev-tools" aria-label="Utility pages">
-      <a class="dev-link" href="apps/value-formatter/">Value Formatter — Quick mapping for long lists.</a>
-      <a class="dev-link" href="apps/jokes/all-jokes.html">All Jokes</a>
-      <a class="dev-link" href="apps/quotes/all-quotes.html">All Quotes</a>
+      <a class="dev-link" href="apps/value-formatter/">
+        <span aria-hidden="true">🧮</span>
+        <span>Value Formatter</span>
+      </a>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- update the landing page to display emoji app buttons and nest the All Jokes and All Quotes links beside their primary apps.
- add a home navigation pill to each jokes, quotes, similarity, and value formatter page so visitors can jump back to the landing view.
- style the new home buttons to match each app’s existing theme in both light and dark modes.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f212a1748328b8d0bf7306ce9fa4