### PR TITLE
Add Playwright telemetry console and expand testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A collection of lightweight browser apps served from a single landing page. Each
 - **Quotes** – Shuffle themed quote decks, step back whenever you like, and explore every line in the all-in-one archive.
 - **Cosine Similarity Lab** – Explore the 0.50+ cosine matches across jokes, quotes, and cross-deck blends, tweak the minimum score, and compare entries side by side with vector stats.
 - **Value Formatter** – Turn newline-separated entries into formatted key-value pairs for quick copy/paste in code reviews or data preparation.
+- **Playwright Run Telemetry** – Inspect JSON-backed timelines from the automated smoke tests, filter statuses, and review per-spec activity logs directly from the bundled JSON report.
 
 ## Usage
 
@@ -25,15 +26,44 @@ This starts a server on <http://localhost:3000> (or the next available port).
 
 ## Testing
 
-Install the dev dependencies once and run the Playwright smoke checks whenever you touch the interactive apps:
+Install the dev dependencies and download the Playwright browser bundle the first time you set up the repo:
 
 ```bash
 npm install
 npx playwright install
+```
+
+On fresh machines that lack the Chromium dependencies, run `npx playwright install --with-deps chromium` instead of the plain install above.
+
+With the tooling in place, execute the full suite:
+
+```bash
 npm test
 ```
 
-The test runner launches a temporary `python -m http.server` instance, loads the Cosine Similarity Lab, and asserts that the dynamic thresholding and Levenshtein metrics render. Use `npm run test:ui` if you want to watch the checks in the Playwright inspector while iterating locally. `npx playwright install --with-deps` is handy the first time you set things up on a fresh machine that needs the browser dependencies.
+The tests spin up a temporary `python -m http.server` instance and exercise every interactive surface:
+
+- `tests/index.spec.js` keeps the landing grid honest so newly added apps remain discoverable.
+- `tests/jokes.spec.js` and `tests/quotes.spec.js` cover the deck navigation, punchline reveals, category filtering, and keyboard shortcuts.
+- `tests/value-formatter.spec.js` validates preset transforms, ad-hoc scripts, and persistence.
+- `tests/similarity-report.spec.js` exercises dataset toggles, thresholds, and similarity overlays.
+- `tests/run-telemetry.spec.js` walks through the telemetry console filters, detail panel, and refresh flow.
+
+Use `npm run test:ui` if you want to watch the checks in the Playwright inspector while iterating locally. To focus on a single spec, pass its filename to Playwright, for example:
+
+```bash
+npx playwright test tests/run-telemetry.spec.js
+```
+
+### Refreshing the telemetry console
+
+Run the dedicated recording script whenever you want to update the live log that powers `apps/run-telemetry/`:
+
+```bash
+npm run test:record
+```
+
+The helper executes the full suite with the line reporter, normalizes absolute paths inside the generated JSON, and writes the result to `data/test-runs/latest.json`. The telemetry console fetches this file (or falls back to the bundled snapshot when you are offline) and surfaces each spec’s timeline, errors, and attachments. Commit the refreshed JSON when you want the static site to showcase the latest run.
 
 ## Data maintenance
 

--- a/apps/run-telemetry/app.js
+++ b/apps/run-telemetry/app.js
@@ -1,0 +1,615 @@
+(() => {
+  const selectors = {
+    runStart: document.querySelector('[data-run-start]'),
+    runDuration: document.querySelector('[data-run-duration]'),
+    runTotal: document.querySelector('[data-run-total]'),
+    refreshButton: document.querySelector('[data-refresh-button]'),
+    filterButtons: document.querySelectorAll('[data-filter-button]'),
+    filterCounts: document.querySelectorAll('[data-filter-count]'),
+    testList: document.querySelector('[data-test-list]'),
+    emptyState: document.querySelector('[data-empty-state]'),
+    detailPanel: document.querySelector('[data-detail-panel]'),
+    detailTitle: document.querySelector('[data-detail-title]'),
+    detailLocation: document.querySelector('[data-detail-location]'),
+    detailStart: document.querySelector('[data-detail-start]'),
+    detailDuration: document.querySelector('[data-detail-duration]'),
+    detailProject: document.querySelector('[data-detail-project]'),
+    detailPill: document.querySelector('[data-detail-pill]'),
+    errorSection: document.querySelector('[data-detail-errors]'),
+    errorList: document.querySelector('[data-error-list]'),
+    logList: document.querySelector('[data-log-list]'),
+    attachmentSection: document.querySelector('[data-detail-attachments]'),
+    attachmentList: document.querySelector('[data-attachment-list]'),
+  };
+
+  if (!selectors.runStart || !selectors.testList || !selectors.detailPanel) {
+    return;
+  }
+
+  const statusLabels = {
+    all: 'All',
+    passed: 'Passed',
+    failed: 'Failed',
+    timedOut: 'Timed out',
+    interrupted: 'Interrupted',
+    flaky: 'Flaky',
+    skipped: 'Skipped',
+    unknown: 'Unknown',
+  };
+
+  const statusOrder = ['failed', 'flaky', 'timedOut', 'interrupted', 'skipped', 'passed', 'unknown'];
+
+  const state = {
+    tests: [],
+    filteredStatus: 'all',
+    selectedId: null,
+    stats: null,
+    lastReport: null,
+  };
+
+  const fallbackReport = typeof window !== 'undefined' ? window.playwrightRunLogFallback || null : null;
+
+  const reportUrl = (() => {
+    try {
+      return new URL('../../data/test-runs/latest.json', window.location.href);
+    } catch (error) {
+      return null;
+    }
+  })();
+
+  const formatDuration = (milliseconds) => {
+    const ms = typeof milliseconds === 'number' ? milliseconds : Number(milliseconds);
+    if (!Number.isFinite(ms) || ms < 0) {
+      return '—';
+    }
+    if (ms < 1000) {
+      return `${Math.round(ms)} ms`;
+    }
+    const seconds = ms / 1000;
+    if (seconds < 60) {
+      return `${seconds.toFixed(seconds < 10 ? 2 : 1)} s`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    if (minutes < 60) {
+      return `${minutes} min ${remainingSeconds.toFixed(remainingSeconds < 10 ? 1 : 0)} s`;
+    }
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    return `${hours} h ${remainingMinutes} min`;
+  };
+
+  const formatTimestamp = (isoString) => {
+    if (typeof isoString !== 'string' || !isoString) {
+      return '—';
+    }
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+    const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    const day = date.toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' });
+    return `${day} · ${time}`;
+  };
+
+  const createLogEntry = (type, label, text) => ({
+    type,
+    label,
+    text,
+  });
+
+  const normalizePath = (pathValue) => {
+    if (typeof pathValue !== 'string') {
+      return '';
+    }
+    return pathValue.replace(/^\.\/?/, '').replace(/\\/g, '/');
+  };
+
+  const computeDisplayTitle = (breadcrumbs, specTitle) => {
+    const filtered = breadcrumbs.filter((crumb, index) => {
+      if (!crumb) {
+        return false;
+      }
+      if (index === 0 && /\.spec\./i.test(crumb)) {
+        return false;
+      }
+      return true;
+    });
+    const parts = [...filtered, specTitle].filter(Boolean);
+    return parts.join(' › ') || specTitle;
+  };
+
+  const flattenReport = (report) => {
+    const tests = [];
+
+    const walkSuites = (suite, ancestors = []) => {
+      if (!suite || typeof suite !== 'object') {
+        return;
+      }
+      const nextAncestors = Array.isArray(ancestors) ? [...ancestors] : [];
+      if (suite.title) {
+        nextAncestors.push(suite.title);
+      }
+
+      if (Array.isArray(suite.specs)) {
+        suite.specs.forEach((spec) => {
+          if (!spec || typeof spec !== 'object' || !Array.isArray(spec.tests)) {
+            return;
+          }
+          spec.tests.forEach((testInstance, index) => {
+            const results = Array.isArray(testInstance?.results) ? testInstance.results : [];
+            const latestResult = results.length > 0 ? results[results.length - 1] : null;
+            const status = latestResult?.status || testInstance?.expectedStatus || 'unknown';
+            const startTime = latestResult?.startTime || null;
+            const duration = typeof latestResult?.duration === 'number' ? latestResult.duration : null;
+            const errors = Array.isArray(latestResult?.errors) ? latestResult.errors : [];
+            const stdout = Array.isArray(latestResult?.stdout) ? latestResult.stdout : [];
+            const stderr = Array.isArray(latestResult?.stderr) ? latestResult.stderr : [];
+            const attachments = Array.isArray(latestResult?.attachments) ? latestResult.attachments : [];
+
+            const breadcrumbs = computeDisplayTitle(nextAncestors, spec.title).split(' › ');
+            const displayTitle = computeDisplayTitle(nextAncestors, spec.title);
+            const locationPath = normalizePath(spec.file || suite.file || '');
+            const baseId = spec.id || `${displayTitle}-${index}`;
+            const projectId = testInstance?.projectId || 'default';
+            const testId = `${baseId}-${projectId}`;
+            const workerIndex = typeof latestResult?.workerIndex === 'number' ? latestResult.workerIndex : null;
+            const parallelIndex = typeof latestResult?.parallelIndex === 'number' ? latestResult.parallelIndex : null;
+
+            const logEntries = [];
+            if (startTime) {
+              const workerLabel = Number.isInteger(workerIndex) ? `worker #${workerIndex}` : 'worker';
+              logEntries.push(
+                createLogEntry(
+                  'synthetic',
+                  'Started',
+                  `${workerLabel} booted ${formatTimestamp(startTime)} (parallel slot ${Number.isInteger(parallelIndex) ? parallelIndex : 0}).`,
+                ),
+              );
+            }
+
+            stdout.forEach((entry) => {
+              if (!entry) {
+                return;
+              }
+              if (typeof entry.text === 'string' && entry.text.trim()) {
+                logEntries.push(createLogEntry('stdout', 'Console', entry.text.trim()));
+              } else if (typeof entry.base64 === 'string') {
+                logEntries.push(createLogEntry('stdout', 'Console', '[binary stdout omitted]'));
+              }
+            });
+
+            stderr.forEach((entry) => {
+              if (!entry) {
+                return;
+              }
+              if (typeof entry.text === 'string' && entry.text.trim()) {
+                logEntries.push(createLogEntry('stderr', 'stderr', entry.text.trim()));
+              } else if (typeof entry.base64 === 'string') {
+                logEntries.push(createLogEntry('stderr', 'stderr', '[binary stderr omitted]'));
+              }
+            });
+
+            if (errors.length === 0) {
+              logEntries.push(
+                createLogEntry(
+                  'synthetic',
+                  'Status',
+                  `${statusLabels[status] || status} in ${formatDuration(duration)}.`,
+                ),
+              );
+            }
+
+            tests.push({
+              id: testId,
+              displayTitle,
+              breadcrumbs,
+              specTitle: spec.title,
+              file: locationPath,
+              line: spec.line,
+              column: spec.column,
+              status,
+              expectedStatus: testInstance?.expectedStatus || 'passed',
+              projectName: testInstance?.projectName || '',
+              duration,
+              startTime,
+              errors: errors.map((errorEntry) => ({
+                message: typeof errorEntry?.message === 'string' ? errorEntry.message : '',
+                stack: typeof errorEntry?.stack === 'string' ? errorEntry.stack : '',
+              })),
+              logs: logEntries,
+              attachments: attachments.map((attachment) => ({
+                name: attachment?.name || 'Attachment',
+                contentType: attachment?.contentType || '',
+                path: normalizePath(attachment?.path || ''),
+              })),
+            });
+          });
+        });
+      }
+
+      if (Array.isArray(suite.suites)) {
+        suite.suites.forEach((child) => walkSuites(child, nextAncestors));
+      }
+    };
+
+    if (Array.isArray(report?.suites)) {
+      report.suites.forEach((suite) => walkSuites(suite, []));
+    }
+
+    return tests;
+  };
+
+  const computeStatusCounts = (tests) => {
+    const counts = {
+      passed: 0,
+      failed: 0,
+      flaky: 0,
+      timedOut: 0,
+      interrupted: 0,
+      skipped: 0,
+      unknown: 0,
+    };
+
+    tests.forEach((test) => {
+      const status = statusLabels[test.status] ? test.status : 'unknown';
+      counts[status] += 1;
+    });
+
+    counts.all = tests.length;
+    return counts;
+  };
+
+  const updateFilterCounts = (counts) => {
+    selectors.filterCounts.forEach((countNode) => {
+      const status = countNode.getAttribute('data-filter-count');
+      const value = typeof counts[status] === 'number' ? counts[status] : 0;
+      countNode.textContent = String(value);
+    });
+  };
+
+  const applyFilterButtonState = () => {
+    selectors.filterButtons.forEach((button) => {
+      const status = button.getAttribute('data-filter-button');
+      button.classList.toggle('is-active', status === state.filteredStatus);
+    });
+  };
+
+  const renderSummary = () => {
+    const { stats } = state;
+    const tests = state.tests;
+    const earliest = tests
+      .map((test) => (test.startTime ? new Date(test.startTime).getTime() : Number.POSITIVE_INFINITY))
+      .filter((value) => Number.isFinite(value));
+    const startTime = stats?.startTime || (earliest.length > 0 ? new Date(Math.min(...earliest)).toISOString() : null);
+    selectors.runStart.textContent = formatTimestamp(startTime);
+    selectors.runDuration.textContent = formatDuration(stats?.duration);
+    selectors.runTotal.textContent = String(tests.length);
+  };
+
+  const renderTestList = () => {
+    const list = selectors.testList;
+    if (!list) {
+      return;
+    }
+    list.innerHTML = '';
+
+    const filtered = state.tests.filter((test) => {
+      if (state.filteredStatus === 'all') {
+        return true;
+      }
+      return test.status === state.filteredStatus;
+    });
+
+    const sorted = [...filtered].sort((a, b) => {
+      const aTime = a.startTime ? new Date(a.startTime).getTime() : 0;
+      const bTime = b.startTime ? new Date(b.startTime).getTime() : 0;
+      if (aTime !== bTime) {
+        return bTime - aTime;
+      }
+      const aIndex = statusOrder.indexOf(a.status);
+      const bIndex = statusOrder.indexOf(b.status);
+      if (aIndex !== bIndex) {
+        return aIndex - bIndex;
+      }
+      return a.displayTitle.localeCompare(b.displayTitle);
+    });
+
+    if (!state.selectedId && sorted.length > 0) {
+      state.selectedId = sorted[0].id;
+    }
+
+    const selectionStillVisible = sorted.some((test) => test.id === state.selectedId);
+    if (!selectionStillVisible && sorted.length > 0) {
+      state.selectedId = sorted[0].id;
+    }
+
+    sorted.forEach((test) => {
+      const listItem = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.setAttribute('data-test-id', test.id);
+      button.setAttribute('data-status', test.status);
+      if (test.id === state.selectedId) {
+        button.setAttribute('aria-current', 'true');
+      }
+
+      button.addEventListener('click', () => {
+        selectTest(test.id);
+        button.focus({ preventScroll: true });
+      });
+
+      const label = document.createElement('span');
+      label.className = 'test-label';
+      const dot = document.createElement('span');
+      dot.className = `status-dot ${test.status}`;
+      label.appendChild(dot);
+      label.appendChild(document.createTextNode(test.displayTitle));
+
+      const meta = document.createElement('div');
+      meta.className = 'test-meta';
+      if (test.duration !== null) {
+        const durationSpan = document.createElement('span');
+        durationSpan.textContent = formatDuration(test.duration);
+        meta.appendChild(durationSpan);
+      }
+      if (test.file) {
+        const locationSpan = document.createElement('span');
+        locationSpan.textContent = test.file;
+        meta.appendChild(locationSpan);
+      }
+
+      button.appendChild(label);
+      button.appendChild(meta);
+      listItem.appendChild(button);
+      list.appendChild(listItem);
+    });
+
+    if (sorted.length === 0) {
+      selectors.emptyState.removeAttribute('hidden');
+    } else {
+      selectors.emptyState.setAttribute('hidden', 'hidden');
+    }
+  };
+
+  const renderErrors = (test) => {
+    const hasErrors = Array.isArray(test.errors) && test.errors.length > 0;
+    if (!hasErrors) {
+      selectors.errorSection?.setAttribute('hidden', 'hidden');
+      selectors.errorList.innerHTML = '';
+      return;
+    }
+    selectors.errorSection?.removeAttribute('hidden');
+    selectors.errorList.innerHTML = '';
+    test.errors.forEach((error) => {
+      const item = document.createElement('li');
+      const message = document.createElement('pre');
+      message.textContent = error.message || 'Unknown error';
+      item.appendChild(message);
+      if (error.stack) {
+        const stack = document.createElement('pre');
+        stack.textContent = error.stack;
+        item.appendChild(stack);
+      }
+      selectors.errorList.appendChild(item);
+    });
+  };
+
+  const renderLogs = (test) => {
+    selectors.logList.innerHTML = '';
+    const entries = Array.isArray(test.logs) && test.logs.length > 0
+      ? test.logs
+      : [createLogEntry('synthetic', 'Status', `${statusLabels[test.status] || test.status}.`)];
+    entries.forEach((entry) => {
+      const item = document.createElement('li');
+      item.className = `log-entry ${entry.type}`;
+      item.setAttribute('data-log-entry', entry.type);
+      const badge = document.createElement('span');
+      badge.className = 'badge';
+      badge.textContent = entry.label;
+      const text = document.createElement('span');
+      text.textContent = entry.text;
+      item.appendChild(badge);
+      item.appendChild(text);
+      selectors.logList.appendChild(item);
+    });
+  };
+
+  const renderAttachments = (test) => {
+    const hasAttachments = Array.isArray(test.attachments) && test.attachments.length > 0;
+    if (!hasAttachments) {
+      selectors.attachmentSection?.setAttribute('hidden', 'hidden');
+      selectors.attachmentList.innerHTML = '';
+      return;
+    }
+    selectors.attachmentSection?.removeAttribute('hidden');
+    selectors.attachmentList.innerHTML = '';
+    test.attachments.forEach((attachment) => {
+      const item = document.createElement('li');
+      item.className = 'attachment-item';
+      const name = document.createElement('strong');
+      name.textContent = attachment.name;
+      item.appendChild(name);
+      if (attachment.path) {
+        const link = document.createElement('a');
+        link.href = `../../${attachment.path}`;
+        link.textContent = 'Open attachment';
+        link.target = '_blank';
+        link.rel = 'noreferrer noopener';
+        item.appendChild(link);
+      } else if (attachment.contentType) {
+        const details = document.createElement('span');
+        details.textContent = attachment.contentType;
+        item.appendChild(details);
+      }
+      selectors.attachmentList.appendChild(item);
+    });
+  };
+
+  const renderDetail = () => {
+    const active = state.tests.find((test) => test.id === state.selectedId);
+    if (!active) {
+      selectors.detailTitle.textContent = 'Pick a test to explore its timeline';
+      selectors.detailLocation.textContent = '';
+      selectors.detailStart.textContent = '--';
+      selectors.detailDuration.textContent = '--';
+      selectors.detailProject.textContent = '--';
+      selectors.detailPill.textContent = 'Waiting';
+      selectors.detailPill.className = 'pill';
+      selectors.logList.innerHTML = '';
+      selectors.errorList.innerHTML = '';
+      selectors.attachmentList.innerHTML = '';
+      selectors.errorSection?.setAttribute('hidden', 'hidden');
+      selectors.attachmentSection?.setAttribute('hidden', 'hidden');
+      return;
+    }
+
+    const pill = selectors.detailPill;
+    pill.textContent = statusLabels[active.status] || active.status;
+    pill.className = `pill ${active.status}`;
+
+    selectors.detailTitle.textContent = active.displayTitle;
+    const locationParts = [];
+    if (active.file) {
+      locationParts.push(active.file);
+    }
+    if (Number.isInteger(active.line)) {
+      locationParts.push(`L${active.line}`);
+    }
+    selectors.detailLocation.textContent = locationParts.join(' · ');
+    selectors.detailStart.textContent = formatTimestamp(active.startTime);
+    selectors.detailDuration.textContent = formatDuration(active.duration);
+    selectors.detailProject.textContent = active.projectName || 'default';
+
+    renderErrors(active);
+    renderLogs(active);
+    renderAttachments(active);
+  };
+
+  const selectTest = (testId) => {
+    state.selectedId = testId;
+    renderTestList();
+    renderDetail();
+  };
+
+  const attachFilterListeners = () => {
+    selectors.filterButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const status = button.getAttribute('data-filter-button') || 'all';
+        state.filteredStatus = status;
+        applyFilterButtonState();
+        renderTestList();
+        renderDetail();
+      });
+    });
+  };
+
+  const attachListKeyboardNavigation = () => {
+    selectors.testList.addEventListener('keydown', (event) => {
+      const { key } = event;
+      if (!['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(key)) {
+        return;
+      }
+      const buttons = Array.from(selectors.testList.querySelectorAll('button'));
+      if (buttons.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      const currentIndex = buttons.findIndex((button) => button === document.activeElement);
+      let targetIndex = currentIndex;
+      if (key === 'ArrowDown') {
+        targetIndex = currentIndex < buttons.length - 1 ? currentIndex + 1 : 0;
+      } else if (key === 'ArrowUp') {
+        targetIndex = currentIndex > 0 ? currentIndex - 1 : buttons.length - 1;
+      } else if (key === 'Home') {
+        targetIndex = 0;
+      } else if (key === 'End') {
+        targetIndex = buttons.length - 1;
+      }
+      const target = buttons[targetIndex];
+      if (target) {
+        target.focus({ preventScroll: true });
+        target.click();
+      }
+    });
+  };
+
+  const fetchReport = async () => {
+    if (!reportUrl) {
+      return null;
+    }
+    try {
+      const response = await fetch(reportUrl.toString(), { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.warn('Failed to load Playwright report, falling back to snapshot.', error);
+      return null;
+    }
+  };
+
+  const normalizeReport = (report) => {
+    if (!report || typeof report !== 'object') {
+      return null;
+    }
+    const stats = report.stats || {};
+    return {
+      stats: {
+        startTime: stats.startTime || null,
+        duration: stats.duration || null,
+        expected: stats.expected || null,
+        unexpected: stats.unexpected || null,
+      },
+      suites: Array.isArray(report.suites) ? report.suites : [],
+    };
+  };
+
+  const loadReport = async () => {
+    selectors.refreshButton.disabled = true;
+    selectors.refreshButton.setAttribute('aria-busy', 'true');
+    const liveReport = await fetchReport();
+    const report = normalizeReport(liveReport) || normalizeReport(fallbackReport);
+    if (!report) {
+      state.tests = [];
+      state.stats = null;
+      state.selectedId = null;
+      selectors.detailTitle.textContent = 'Unable to load Playwright logs.';
+      selectors.detailPill.textContent = 'Offline';
+      selectors.detailPill.className = 'pill skipped';
+      selectors.runStart.textContent = '—';
+      selectors.runDuration.textContent = '—';
+      selectors.runTotal.textContent = '0';
+      selectors.testList.innerHTML = '';
+      selectors.emptyState.removeAttribute('hidden');
+      selectors.refreshButton.disabled = false;
+      selectors.refreshButton.removeAttribute('aria-busy');
+      return;
+    }
+
+    state.lastReport = report;
+    state.tests = flattenReport(report);
+    state.stats = report.stats || null;
+    state.selectedId = null;
+    state.filteredStatus = 'all';
+
+    const counts = computeStatusCounts(state.tests);
+    updateFilterCounts(counts);
+    applyFilterButtonState();
+    renderSummary();
+    renderTestList();
+    renderDetail();
+
+    selectors.refreshButton.disabled = false;
+    selectors.refreshButton.removeAttribute('aria-busy');
+  };
+
+  attachFilterListeners();
+  attachListKeyboardNavigation();
+  selectors.refreshButton.addEventListener('click', () => {
+    loadReport();
+  });
+
+  loadReport();
+})();

--- a/apps/run-telemetry/index.html
+++ b/apps/run-telemetry/index.html
@@ -1,0 +1,621 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Playwright Run Telemetry</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      --background: radial-gradient(circle at top, rgba(84, 112, 225, 0.18), rgba(15, 21, 40, 0.08) 60%);
+      --background-solid: #f5f7ff;
+      --text-primary: #10172a;
+      --text-secondary: rgba(16, 23, 42, 0.66);
+      --surface: rgba(255, 255, 255, 0.92);
+      --surface-border: rgba(15, 23, 42, 0.08);
+      --surface-shadow: 0 30px 80px rgba(15, 23, 42, 0.15);
+      --accent: #465fff;
+      --accent-soft: rgba(70, 95, 255, 0.12);
+      --accent-soft-hover: rgba(70, 95, 255, 0.2);
+      --passed: #1f9b56;
+      --failed: #e23c4a;
+      --flaky: #c47b0b;
+      --timed: #ba51d8;
+      --skipped: #6b7280;
+      --muted-border: rgba(16, 23, 42, 0.08);
+      --scroll-thumb: rgba(15, 23, 42, 0.18);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --background: radial-gradient(circle at top, rgba(121, 145, 255, 0.34), rgba(8, 14, 30, 0.92) 65%);
+        --background-solid: #090d18;
+        --text-primary: #f5f7ff;
+        --text-secondary: rgba(245, 247, 255, 0.68);
+        --surface: rgba(16, 22, 42, 0.82);
+        --surface-border: rgba(245, 247, 255, 0.08);
+        --surface-shadow: 0 32px 90px rgba(0, 0, 0, 0.4);
+        --accent: #90a2ff;
+        --accent-soft: rgba(144, 162, 255, 0.18);
+        --accent-soft-hover: rgba(144, 162, 255, 0.28);
+        --passed: #34d399;
+        --failed: #f97373;
+        --flaky: #f4a261;
+        --timed: #c084fc;
+        --skipped: #a1a1aa;
+        --muted-border: rgba(245, 247, 255, 0.12);
+        --scroll-thumb: rgba(144, 162, 255, 0.28);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      background: var(--background);
+      background-color: var(--background-solid);
+      color: var(--text-primary);
+      padding: clamp(18px, 5vw, 40px);
+    }
+
+    main {
+      width: min(1100px, 100%);
+      display: flex;
+      flex-direction: column;
+      gap: clamp(20px, 3vw, 28px);
+      background: var(--surface);
+      border-radius: 28px;
+      padding: clamp(18px, 3vw, 32px);
+      box-shadow: var(--surface-shadow);
+      border: 1px solid var(--surface-border);
+      backdrop-filter: blur(16px);
+    }
+
+    .page-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .page-header h1 {
+      margin: 0;
+      font-size: clamp(1.9rem, 2vw + 1.3rem, 2.6rem);
+      font-weight: 700;
+    }
+
+    .page-header p {
+      margin: 0;
+      color: var(--text-secondary);
+      line-height: 1.6;
+      font-size: 1rem;
+    }
+
+    .run-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px clamp(16px, 3vw, 28px);
+      align-items: center;
+      padding: 12px clamp(14px, 3vw, 22px);
+      border-radius: 18px;
+      background: var(--accent-soft);
+      border: 1px solid var(--muted-border);
+    }
+
+    .run-meta div {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 120px;
+    }
+
+    .run-meta span.meta-label {
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-secondary);
+    }
+
+    .run-meta button {
+      margin-left: auto;
+      padding: 10px 16px;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      background: var(--accent);
+      color: #ffffff;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.18s ease, box-shadow 0.18s ease;
+    }
+
+    .run-meta button:hover,
+    .run-meta button:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 40px rgba(70, 95, 255, 0.36);
+      outline: none;
+    }
+
+    .run-instructions {
+      border-radius: 22px;
+      border: 1px dashed var(--muted-border);
+      padding: clamp(16px, 3vw, 24px);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      background: rgba(70, 95, 255, 0.08);
+    }
+
+    .run-instructions h2 {
+      margin: 0;
+      font-size: 1.22rem;
+      font-weight: 600;
+    }
+
+    .run-instructions p {
+      margin: 0;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .run-instructions pre {
+      margin: 0;
+      padding: 12px;
+      border-radius: 14px;
+      background: rgba(15, 23, 42, 0.08);
+      overflow: auto;
+      font-size: 0.95rem;
+    }
+
+    .run-instructions code {
+      font-family: "Fira Code", "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+    }
+
+    .run-instructions .note {
+      font-size: 0.92rem;
+      color: var(--text-secondary);
+    }
+
+    .filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .filter-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid var(--muted-border);
+      background: rgba(255, 255, 255, 0.6);
+      color: inherit;
+      cursor: pointer;
+      font-weight: 500;
+      transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .filter-button .count {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 8px;
+      min-width: 28px;
+      height: 24px;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.08);
+      font-size: 0.85rem;
+    }
+
+    .filter-button.is-active {
+      background: var(--accent);
+      color: #ffffff;
+      border-color: transparent;
+      transform: translateY(-1px);
+    }
+
+    .filter-button:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(70, 95, 255, 0.45);
+    }
+
+    .console {
+      display: grid;
+      grid-template-columns: minmax(240px, 320px) 1fr;
+      gap: clamp(18px, 3vw, 28px);
+    }
+
+    .test-list {
+      border-radius: 22px;
+      border: 1px solid var(--muted-border);
+      background: rgba(255, 255, 255, 0.72);
+      padding: clamp(12px, 2.6vw, 18px);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      max-height: 520px;
+      overflow: hidden;
+    }
+
+    .test-list ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      overflow-y: auto;
+      scrollbar-width: thin;
+      scrollbar-color: var(--scroll-thumb) transparent;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .test-list ul::-webkit-scrollbar {
+      width: 8px;
+    }
+
+    .test-list ul::-webkit-scrollbar-thumb {
+      background: var(--scroll-thumb);
+      border-radius: 999px;
+    }
+
+    .test-list button {
+      width: 100%;
+      border: 1px solid transparent;
+      background: rgba(15, 23, 42, 0.04);
+      border-radius: 16px;
+      padding: 12px;
+      text-align: left;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      cursor: pointer;
+      transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+      color: inherit;
+    }
+
+    .test-list button:hover,
+    .test-list button:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(70, 95, 255, 0.4);
+      outline: none;
+      background: rgba(70, 95, 255, 0.12);
+    }
+
+    .test-list button[aria-current="true"] {
+      border-color: var(--accent);
+      background: rgba(70, 95, 255, 0.18);
+      box-shadow: inset 0 0 0 1px rgba(70, 95, 255, 0.4);
+    }
+
+    .test-label {
+      font-weight: 600;
+      font-size: 0.95rem;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .test-meta {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      display: inline-flex;
+      background: var(--skipped);
+      flex-shrink: 0;
+    }
+
+    .status-dot.passed {
+      background: var(--passed);
+    }
+
+    .status-dot.failed {
+      background: var(--failed);
+    }
+
+    .status-dot.flaky {
+      background: var(--flaky);
+    }
+
+    .status-dot.timedOut,
+    .status-dot.interrupted {
+      background: var(--timed);
+    }
+
+    .empty-state {
+      margin: 0;
+      font-size: 0.95rem;
+      color: var(--text-secondary);
+    }
+
+    .detail-panel {
+      border-radius: 24px;
+      border: 1px solid var(--muted-border);
+      background: rgba(255, 255, 255, 0.75);
+      padding: clamp(16px, 2.8vw, 24px);
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+      min-height: 420px;
+      position: relative;
+    }
+
+    .detail-panel header {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .detail-panel h2 {
+      margin: 0;
+      font-size: 1.4rem;
+    }
+
+    .detail-panel .detail-status {
+      margin: 0;
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-secondary);
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .detail-panel .detail-location {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-weight: 600;
+      font-size: 0.78rem;
+    }
+
+    .pill.passed {
+      background: rgba(31, 155, 86, 0.15);
+      color: var(--passed);
+    }
+
+    .pill.failed {
+      background: rgba(226, 60, 74, 0.15);
+      color: var(--failed);
+    }
+
+    .pill.flaky {
+      background: rgba(196, 123, 11, 0.18);
+      color: var(--flaky);
+    }
+
+    .pill.timedOut,
+    .pill.interrupted {
+      background: rgba(186, 81, 216, 0.2);
+      color: var(--timed);
+    }
+
+    .pill.skipped {
+      background: rgba(107, 114, 128, 0.2);
+      color: var(--skipped);
+    }
+
+    .detail-meta {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+      margin: 0;
+    }
+
+    .detail-meta div {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 10px 12px;
+      border-radius: 14px;
+      background: rgba(15, 23, 42, 0.05);
+    }
+
+    .detail-meta dt {
+      margin: 0;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-secondary);
+    }
+
+    .detail-meta dd {
+      margin: 0;
+      font-size: 0.98rem;
+      font-weight: 600;
+    }
+
+    .detail-section h3 {
+      margin: 0 0 10px;
+      font-size: 1.05rem;
+    }
+
+    .detail-section ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .log-entry {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 10px;
+      padding: 12px;
+      border-radius: 14px;
+      background: rgba(15, 23, 42, 0.05);
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .log-entry .badge {
+      font-size: 0.75rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+      align-self: start;
+    }
+
+    .log-entry.stderr {
+      border-left: 4px solid var(--failed);
+    }
+
+    .log-entry.stdout {
+      border-left: 4px solid var(--accent);
+    }
+
+    .log-entry.synthetic {
+      border-left: 4px solid var(--skipped);
+    }
+
+    .attachment-item {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 12px;
+      border-radius: 14px;
+      background: rgba(15, 23, 42, 0.05);
+      font-size: 0.9rem;
+    }
+
+    .attachment-item a {
+      color: inherit;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .attachment-item a:hover,
+    .attachment-item a:focus-visible {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 880px) {
+      .console {
+        grid-template-columns: 1fr;
+      }
+
+      .test-list {
+        max-height: 320px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main aria-label="Playwright telemetry console">
+    <header class="page-header">
+      <h1>Playwright Run Telemetry</h1>
+      <p>Peek behind the curtain of the agentic smoke tests. Every run of <code>npm run test:record</code> stores a JSON stream that keeps this console alive, even on a static site.</p>
+      <div class="run-meta" data-run-meta>
+        <div>
+          <span class="meta-label">Captured</span>
+          <time data-run-start aria-live="polite">--</time>
+        </div>
+        <div>
+          <span class="meta-label">Duration</span>
+          <span data-run-duration>--</span>
+        </div>
+        <div>
+          <span class="meta-label">Total tests</span>
+          <span data-run-total>0</span>
+        </div>
+        <button type="button" data-refresh-button aria-label="Refresh Playwright logs">Refresh</button>
+      </div>
+    </header>
+    <section class="run-instructions" aria-label="How to update the logs">
+      <h2>Update the feed</h2>
+      <p>Record a fresh log whenever you tweak the suite. The script runs the inspector-friendly line reporter and emits a normalized JSON artefact.</p>
+      <pre><code>npm run test:record</code></pre>
+      <p class="note">The command writes <code>data/test-runs/latest.json</code>, which this console fetches (or falls back to the bundled snapshot when you are offline).</p>
+    </section>
+    <section class="filters" aria-label="Filter tests by status">
+      <button class="filter-button is-active" type="button" data-filter-button="all">
+        <span>All</span>
+        <span class="count" data-filter-count="all">0</span>
+      </button>
+      <button class="filter-button" type="button" data-filter-button="passed">
+        <span>Passed</span>
+        <span class="count" data-filter-count="passed">0</span>
+      </button>
+      <button class="filter-button" type="button" data-filter-button="failed">
+        <span>Failed</span>
+        <span class="count" data-filter-count="failed">0</span>
+      </button>
+      <button class="filter-button" type="button" data-filter-button="flaky">
+        <span>Flaky</span>
+        <span class="count" data-filter-count="flaky">0</span>
+      </button>
+      <button class="filter-button" type="button" data-filter-button="skipped">
+        <span>Skipped</span>
+        <span class="count" data-filter-count="skipped">0</span>
+      </button>
+    </section>
+    <div class="console">
+      <aside class="test-list" aria-label="Recorded Playwright tests">
+        <ul data-test-list></ul>
+        <p class="empty-state" data-empty-state hidden>No tests were found for this filter.</p>
+      </aside>
+      <section class="detail-panel" aria-live="polite" data-detail-panel>
+        <header>
+          <p class="detail-status">
+            <span class="pill" data-detail-pill>Waiting</span>
+          </p>
+          <h2 data-detail-title>Pick a test to explore its timeline</h2>
+          <p class="detail-location" data-detail-location></p>
+        </header>
+        <dl class="detail-meta">
+          <div>
+            <dt>Started</dt>
+            <dd data-detail-start>--</dd>
+          </div>
+          <div>
+            <dt>Duration</dt>
+            <dd data-detail-duration>--</dd>
+          </div>
+          <div>
+            <dt>Project</dt>
+            <dd data-detail-project>--</dd>
+          </div>
+        </dl>
+        <section class="detail-section detail-errors" data-detail-errors hidden>
+          <h3>Errors</h3>
+          <ul data-error-list></ul>
+        </section>
+        <section class="detail-section detail-log" data-detail-log>
+          <h3>Activity log</h3>
+          <ul data-log-list></ul>
+        </section>
+        <section class="detail-section detail-attachments" data-detail-attachments hidden>
+          <h3>Attachments</h3>
+          <ul data-attachment-list></ul>
+        </section>
+      </section>
+    </div>
+  </main>
+  <script src="log-data.js" defer></script>
+  <script src="app.js" defer></script>
+</body>
+</html>

--- a/apps/run-telemetry/log-data.js
+++ b/apps/run-telemetry/log-data.js
@@ -1,0 +1,376 @@
+window.playwrightRunLogFallback = {
+  "config": {
+    "configFile": "playwright.config.js",
+    "rootDir": "tests",
+    "forbidOnly": false,
+    "fullyParallel": true,
+    "globalSetup": null,
+    "globalTeardown": null,
+    "globalTimeout": 0,
+    "grep": {},
+    "grepInvert": null,
+    "maxFailures": 0,
+    "metadata": {
+      "actualWorkers": 2
+    },
+    "preserveOutput": "always",
+    "reporter": [
+      [
+        "json"
+      ]
+    ],
+    "reportSlowTests": {
+      "max": 5,
+      "threshold": 300000
+    },
+    "quiet": false,
+    "projects": [
+      {
+        "outputDir": "test-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "actualWorkers": 2
+        },
+        "id": "",
+        "name": "",
+        "testDir": "tests",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      }
+    ],
+    "shard": null,
+    "updateSnapshots": "missing",
+    "updateSourceMethod": "patch",
+    "version": "1.55.0",
+    "workers": 2,
+    "webServer": {
+      "command": "python -m http.server 4173",
+      "url": "http://127.0.0.1:4173",
+      "reuseExistingServer": true,
+      "stdout": "pipe",
+      "stderr": "pipe"
+    }
+  },
+  "suites": [
+    {
+      "title": "index.spec.js",
+      "file": "index.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Landing page",
+          "file": "index.spec.js",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "lists every app including the telemetry console",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 568,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:05.704Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "ffca65896366658e04f2-dbc271f7560944b59faf",
+              "file": "index.spec.js",
+              "line": 4,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "jokes.spec.js",
+      "file": "jokes.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Random Jokes app",
+          "file": "jokes.spec.js",
+          "line": 13,
+          "column": 6,
+          "specs": [
+            {
+              "title": "reveals punchlines, resets when moving, and honours keyboard shortcuts",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 790,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:05.691Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "02837f281c861f1f3f2f-84fabb5d4f615d29ee31",
+              "file": "jokes.spec.js",
+              "line": 18,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "quotes.spec.js",
+      "file": "quotes.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Quotes app",
+          "file": "quotes.spec.js",
+          "line": 13,
+          "column": 6,
+          "specs": [
+            {
+              "title": "navigates shuffled decks and filters by category",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 666,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:06.587Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "52892e90bc80ef7f93e3-f12a55fd8db0bcb70a6e",
+              "file": "quotes.spec.js",
+              "line": 18,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "run-telemetry.spec.js",
+      "file": "run-telemetry.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Playwright Run Telemetry console",
+          "file": "run-telemetry.spec.js",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "renders summaries, supports filters, and exposes the activity log",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 1811,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:06.845Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "93bf15e4e22678e4dbe2-6843ed3a8496c8de6ada",
+              "file": "run-telemetry.spec.js",
+              "line": 4,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "similarity-report.spec.js",
+      "file": "similarity-report.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Cosine Similarity Lab",
+          "file": "similarity-report.spec.js",
+          "line": 11,
+          "column": 6,
+          "specs": [
+            {
+              "title": "loads similarity data with Levenshtein metrics and range controls",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 5695,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:07.332Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "39e27dd49605a46c31e6-c335ca3a90f48574c142",
+              "file": "similarity-report.spec.js",
+              "line": 12,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "value-formatter.spec.js",
+      "file": "value-formatter.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Value Formatter app",
+          "file": "value-formatter.spec.js",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "applies presets, custom transforms, and persists the input field",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 496,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:08.697Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "3a4141919f418f3b1cdb-92226a802dca8599dd4d",
+              "file": "value-formatter.spec.js",
+              "line": 4,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": [],
+  "stats": {
+    "startTime": "2025-09-23T01:47:03.947Z",
+    "duration": 9263.449,
+    "expected": 6,
+    "skipped": 0,
+    "unexpected": 0,
+    "flaky": 0
+  },
+  "generatedAt": "2025-09-23T01:47:13.267Z"
+};

--- a/data/test-runs/latest.json
+++ b/data/test-runs/latest.json
@@ -1,0 +1,376 @@
+{
+  "config": {
+    "configFile": "playwright.config.js",
+    "rootDir": "tests",
+    "forbidOnly": false,
+    "fullyParallel": true,
+    "globalSetup": null,
+    "globalTeardown": null,
+    "globalTimeout": 0,
+    "grep": {},
+    "grepInvert": null,
+    "maxFailures": 0,
+    "metadata": {
+      "actualWorkers": 2
+    },
+    "preserveOutput": "always",
+    "reporter": [
+      [
+        "json"
+      ]
+    ],
+    "reportSlowTests": {
+      "max": 5,
+      "threshold": 300000
+    },
+    "quiet": false,
+    "projects": [
+      {
+        "outputDir": "test-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "actualWorkers": 2
+        },
+        "id": "",
+        "name": "",
+        "testDir": "tests",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      }
+    ],
+    "shard": null,
+    "updateSnapshots": "missing",
+    "updateSourceMethod": "patch",
+    "version": "1.55.0",
+    "workers": 2,
+    "webServer": {
+      "command": "python -m http.server 4173",
+      "url": "http://127.0.0.1:4173",
+      "reuseExistingServer": true,
+      "stdout": "pipe",
+      "stderr": "pipe"
+    }
+  },
+  "suites": [
+    {
+      "title": "index.spec.js",
+      "file": "index.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Landing page",
+          "file": "index.spec.js",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "lists every app including the telemetry console",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 568,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:05.704Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "ffca65896366658e04f2-dbc271f7560944b59faf",
+              "file": "index.spec.js",
+              "line": 4,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "jokes.spec.js",
+      "file": "jokes.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Random Jokes app",
+          "file": "jokes.spec.js",
+          "line": 13,
+          "column": 6,
+          "specs": [
+            {
+              "title": "reveals punchlines, resets when moving, and honours keyboard shortcuts",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 790,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:05.691Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "02837f281c861f1f3f2f-84fabb5d4f615d29ee31",
+              "file": "jokes.spec.js",
+              "line": 18,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "quotes.spec.js",
+      "file": "quotes.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Quotes app",
+          "file": "quotes.spec.js",
+          "line": 13,
+          "column": 6,
+          "specs": [
+            {
+              "title": "navigates shuffled decks and filters by category",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 666,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:06.587Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "52892e90bc80ef7f93e3-f12a55fd8db0bcb70a6e",
+              "file": "quotes.spec.js",
+              "line": 18,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "run-telemetry.spec.js",
+      "file": "run-telemetry.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Playwright Run Telemetry console",
+          "file": "run-telemetry.spec.js",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "renders summaries, supports filters, and exposes the activity log",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 1811,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:06.845Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "93bf15e4e22678e4dbe2-6843ed3a8496c8de6ada",
+              "file": "run-telemetry.spec.js",
+              "line": 4,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "similarity-report.spec.js",
+      "file": "similarity-report.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Cosine Similarity Lab",
+          "file": "similarity-report.spec.js",
+          "line": 11,
+          "column": 6,
+          "specs": [
+            {
+              "title": "loads similarity data with Levenshtein metrics and range controls",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 5695,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:07.332Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "39e27dd49605a46c31e6-c335ca3a90f48574c142",
+              "file": "similarity-report.spec.js",
+              "line": 12,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "value-formatter.spec.js",
+      "file": "value-formatter.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Value Formatter app",
+          "file": "value-formatter.spec.js",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "applies presets, custom transforms, and persists the input field",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "",
+                  "projectName": "",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 496,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-23T01:47:08.697Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "3a4141919f418f3b1cdb-92226a802dca8599dd4d",
+              "file": "value-formatter.spec.js",
+              "line": 4,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": [],
+  "stats": {
+    "startTime": "2025-09-23T01:47:03.947Z",
+    "duration": 9263.449,
+    "expected": 6,
+    "skipped": 0,
+    "unexpected": 0,
+    "flaky": 0
+  },
+  "generatedAt": "2025-09-23T01:47:13.267Z"
+}

--- a/index.html
+++ b/index.html
@@ -209,6 +209,12 @@
           <p>Review 0.50+ cosine matches across jokes, quotes, and cross-deck mashups, filter by score or text, and inspect each pair’s geeky vector stats.</p>
         </a>
       </li>
+      <li>
+        <a class="app-card" href="apps/run-telemetry/">
+          <h2>Playwright Run Telemetry</h2>
+          <p>Inspect JSON-backed timelines from the automated Playwright smoke tests, filter their status, and drill into the per-spec activity log.</p>
+        </a>
+      </li>
     </ul>
     <section class="dev-tools" aria-label="Utility pages">
       <a class="dev-link" href="apps/value-formatter/">Value Formatter — Quick mapping for long lists.</a>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "playwright test",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "test:record": "node tools/record-playwright-log.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,0 +1,24 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Landing page', () => {
+  test('lists every app including the telemetry console', async ({ page }) => {
+    await page.goto('/');
+
+    const cards = page.locator('.app-card');
+    await expect(cards).toHaveCount(4);
+
+    const telemetryCard = page.locator('.app-card', {
+      has: page.locator('h2', { hasText: 'Playwright Run Telemetry' }),
+    });
+
+    await expect(telemetryCard).toBeVisible();
+    await expect(telemetryCard).toHaveAttribute('href', 'apps/run-telemetry/');
+    await expect(telemetryCard.locator('p')).toContainText(/Playwright/i);
+
+    const devLinks = page.locator('.dev-tools a');
+    await expect(devLinks).toHaveCount(3);
+    await expect(devLinks.nth(0)).toContainText('Value Formatter');
+    await expect(devLinks.nth(1)).toContainText('All Jokes');
+    await expect(devLinks.nth(2)).toContainText('All Quotes');
+  });
+});

--- a/tests/jokes.spec.js
+++ b/tests/jokes.spec.js
@@ -1,0 +1,66 @@
+const { test, expect } = require('@playwright/test');
+
+const deterministicRandomInitScript = () => {
+  const values = [0.12, 0.76, 0.38, 0.94, 0.52];
+  let index = 0;
+  Math.random = () => {
+    const value = values[index % values.length];
+    index += 1;
+    return value;
+  };
+};
+
+test.describe('Random Jokes app', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(deterministicRandomInitScript);
+  });
+
+  test('reveals punchlines, resets when moving, and honours keyboard shortcuts', async ({ page }) => {
+    await page.goto('/apps/jokes/');
+
+    const setup = page.locator('#joke-setup');
+    const punchline = page.locator('#joke-punchline');
+    const revealButton = page.locator('#reveal-button');
+    const nextButton = page.locator('#next-button');
+    const prevButton = page.locator('#prev-button');
+
+    await expect(setup).not.toHaveText(/Loading joke…?/i);
+    await expect(punchline).not.toHaveClass(/is-visible/);
+    await expect(punchline).toHaveAttribute('aria-hidden', 'true');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'false');
+    await expect(nextButton).toBeEnabled();
+    await expect(prevButton).toBeEnabled();
+
+    await revealButton.click();
+    await expect(punchline).toHaveClass(/is-visible/);
+    await expect(punchline).toHaveAttribute('aria-hidden', 'false');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'true');
+
+    const firstSetup = (await setup.textContent())?.trim() || '';
+    expect(firstSetup.length).toBeGreaterThan(0);
+
+    await nextButton.click();
+
+    await expect(punchline).not.toHaveClass(/is-visible/);
+    await expect(punchline).toHaveAttribute('aria-hidden', 'true');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'false');
+
+    const secondSetup = (await setup.textContent())?.trim() || '';
+    expect(secondSetup.length).toBeGreaterThan(0);
+    expect(secondSetup).not.toBe(firstSetup);
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(setup).toHaveText(firstSetup);
+
+    await page.evaluate(() => {
+      const active = document.activeElement;
+      if (active && typeof active.blur === 'function') {
+        active.blur();
+      }
+    });
+
+    await page.keyboard.press('Space');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(punchline).toHaveClass(/is-visible/);
+  });
+});

--- a/tests/quotes.spec.js
+++ b/tests/quotes.spec.js
@@ -1,0 +1,85 @@
+const { test, expect } = require('@playwright/test');
+
+const deterministicRandomInitScript = () => {
+  const values = [0.18, 0.6, 0.34, 0.82, 0.26];
+  let index = 0;
+  Math.random = () => {
+    const value = values[index % values.length];
+    index += 1;
+    return value;
+  };
+};
+
+test.describe('Quotes app', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(deterministicRandomInitScript);
+  });
+
+  test('navigates shuffled decks and filters by category', async ({ page }) => {
+    await page.goto('/apps/quotes/');
+
+    const quote = page.locator('#quote-text');
+    const author = page.locator('#quote-author');
+    const meta = page.locator('#quote-meta');
+    const nextButton = page.locator('#next-button');
+    const prevButton = page.locator('#prev-button');
+    const select = page.locator('#category-select');
+
+    await expect(quote).not.toHaveText(/Loading quote…?/i);
+    await expect(meta).toBeVisible();
+    await expect(author).not.toHaveText('');
+    await expect(nextButton).toBeEnabled();
+    await expect(prevButton).toBeEnabled();
+
+    const optionValues = await select.evaluate((node) =>
+      Array.from(node.options).map((option) => option.value),
+    );
+    expect(optionValues).toContain('any');
+    expect(optionValues).toContain('adventure');
+
+    const firstQuote = (await quote.textContent())?.trim() || '';
+    expect(firstQuote.length).toBeGreaterThan(0);
+
+    await nextButton.click();
+    const secondQuote = (await quote.textContent())?.trim() || '';
+    expect(secondQuote.length).toBeGreaterThan(0);
+    expect(secondQuote).not.toBe(firstQuote);
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(quote).toHaveText(firstQuote);
+
+    await select.selectOption('adventure');
+    await expect(select).toHaveValue('adventure');
+    await expect(meta).toBeVisible();
+
+    const currentQuote = (await quote.textContent())?.trim() || '';
+    const currentAuthor = (await author.textContent())?.trim() || '';
+    expect(currentQuote.length).toBeGreaterThan(0);
+    expect(currentAuthor.length).toBeGreaterThan(0);
+
+    const adventureDeck = await page.evaluate(() => {
+      const category = window.quotesData.find((entry) => entry.id === 'adventure');
+      if (!category) {
+        return { texts: [], authors: [] };
+      }
+      return {
+        texts: category.quotes.map((entry) => entry.text),
+        authors: category.quotes.map((entry) => entry.author),
+      };
+    });
+
+    expect(adventureDeck.texts).toContain(currentQuote);
+    expect(adventureDeck.authors).toContain(currentAuthor);
+
+    await page.evaluate(() => {
+      const active = document.activeElement;
+      if (active && typeof active.blur === 'function') {
+        active.blur();
+      }
+    });
+
+    await page.keyboard.press('Space');
+    const followUpQuote = (await quote.textContent())?.trim() || '';
+    expect(adventureDeck.texts).toContain(followUpQuote);
+  });
+});

--- a/tests/run-telemetry.spec.js
+++ b/tests/run-telemetry.spec.js
@@ -1,0 +1,44 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Playwright Run Telemetry console', () => {
+  test('renders summaries, supports filters, and exposes the activity log', async ({ page }) => {
+    await page.goto('/apps/run-telemetry/');
+
+    await page.waitForSelector('[data-test-list] button[data-test-id]');
+
+    await expect(page.locator('[data-run-start]')).not.toHaveText('--');
+    await expect(page.locator('[data-run-duration]')).not.toHaveText('--');
+    await expect(page.locator('[data-run-total]')).not.toHaveText('0');
+
+    const testButtons = page.locator('[data-test-list] button[data-test-id]');
+    const total = await testButtons.count();
+    expect(total).toBeGreaterThan(0);
+
+    const detailTitle = page.locator('[data-detail-title]');
+    await expect(detailTitle).not.toHaveText(/Pick a test/i);
+
+    if (total > 1) {
+      await testButtons.nth(1).click();
+      await expect(testButtons.nth(1)).toHaveAttribute('aria-current', 'true');
+    }
+
+    await page.locator('[data-filter-button="passed"]').click();
+    await expect(page.locator('[data-filter-button="passed"]')).toHaveClass(/is-active/);
+    const passedCount = await page.locator('[data-test-list] button[data-test-id]').count();
+    expect(passedCount).toBeGreaterThan(0);
+
+    await page.locator('[data-filter-button="failed"]').click();
+    await expect(page.locator('[data-empty-state]')).toBeVisible();
+
+    await page.locator('[data-filter-button="all"]').click();
+    await expect(page.locator('[data-filter-button="all"]').first()).toHaveClass(/is-active/);
+
+    const logEntries = page.locator('[data-log-entry]');
+    expect(await logEntries.count()).toBeGreaterThan(0);
+    await expect(logEntries.first()).toBeVisible();
+
+    const refresh = page.locator('[data-refresh-button]');
+    await refresh.click();
+    await expect(refresh).not.toHaveAttribute('aria-busy', 'true');
+  });
+});

--- a/tests/value-formatter.spec.js
+++ b/tests/value-formatter.spec.js
@@ -1,0 +1,40 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Value Formatter app', () => {
+  test('applies presets, custom transforms, and persists the input field', async ({ page }) => {
+    await page.goto('/apps/value-formatter/');
+    await page.waitForFunction(() => typeof window.run === 'function');
+
+    const input = page.locator('#inputText');
+    const output = page.locator('#outputText');
+    const presets = page.locator('#presets');
+    const transformer = page.locator('#transformerValue');
+    const joinValue = page.locator('#joinValue');
+
+    await expect(output).toHaveValue('t.[1] = s.[1],\nt.[2] = s.[2],\nt.[3] = s.[3]');
+
+    await presets.selectOption('_');
+    await expect(transformer).toHaveValue('_');
+    await expect(output).toHaveValue('1,\n2,\n3');
+
+    await joinValue.fill(' | ');
+    await page.evaluate(() => window.run());
+    await expect(output).toHaveValue('1 | 2 | 3');
+
+    await transformer.fill('value(_);');
+    await page.evaluate(() => window.run());
+    await expect(output).toHaveValue('value(1); | value(2); | value(3);');
+
+    await input.fill('alpha beta');
+    await page.evaluate(() => window.run());
+    await expect(output).toHaveValue('value(alpha); | value(beta);');
+
+    const storedInput = await page.evaluate(() => window.localStorage.getItem('inputText'));
+    expect(storedInput).toBe('alpha beta');
+
+    await page.reload();
+
+    await expect(input).toHaveValue('alpha beta');
+    await expect(output).toHaveValue('t.[alpha] = s.[alpha],\nt.[beta] = s.[beta]');
+  });
+});

--- a/tools/record-playwright-log.js
+++ b/tools/record-playwright-log.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+const { spawn } = require('node:child_process');
+const { mkdirSync, readFileSync, writeFileSync, unlinkSync } = require('node:fs');
+const { resolve, relative } = require('node:path');
+
+const rootDir = resolve(__dirname, '..');
+const outputDir = resolve(rootDir, 'data', 'test-runs');
+const finalReportPath = resolve(outputDir, 'latest.json');
+const tempReportPath = resolve(outputDir, `latest-${Date.now()}.tmp.json`);
+
+const command = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const args = ['playwright', 'test', '--reporter=line', '--reporter=json'];
+
+const formatDuration = (milliseconds) => {
+  if (!Number.isFinite(milliseconds)) {
+    return 'unknown duration';
+  }
+  if (milliseconds < 1000) {
+    return `${Math.round(milliseconds)} ms`;
+  }
+  const seconds = milliseconds / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(seconds < 10 ? 2 : 1)} s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) {
+    return `${minutes} min ${remainingSeconds.toFixed(remainingSeconds < 10 ? 1 : 0)} s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours} h ${remainingMinutes} min`;
+};
+
+const normalizePaths = (value) => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizePaths(entry));
+  }
+  if (value && typeof value === 'object') {
+    for (const key of Object.keys(value)) {
+      value[key] = normalizePaths(value[key]);
+    }
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalizedRoot = rootDir.replace(/\\/g, '/');
+    const normalizedValue = value.replace(/\\/g, '/');
+    if (normalizedValue.startsWith(normalizedRoot)) {
+      const relativePath = normalizedValue.slice(normalizedRoot.length).replace(/^\/?/, '');
+      return relativePath || '.';
+    }
+    return value;
+  }
+  return value;
+};
+
+const summarize = (report) => {
+  if (!report || typeof report !== 'object') {
+    return 'Report unavailable.';
+  }
+  const stats = report.stats || {};
+  const expected = typeof stats.expected === 'number' ? stats.expected : 0;
+  const unexpected = typeof stats.unexpected === 'number' ? stats.unexpected : 0;
+  const duration = typeof stats.duration === 'number' ? stats.duration : NaN;
+  return `Recorded ${expected} test${expected === 1 ? '' : 's'} in ${formatDuration(duration)} (${unexpected} unexpected).`;
+};
+
+const ensureOutputDir = () => {
+  mkdirSync(outputDir, { recursive: true });
+};
+
+const writeNormalizedReport = () => {
+  const raw = readFileSync(tempReportPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  const normalized = normalizePaths(parsed);
+  normalized.generatedAt = new Date().toISOString();
+  const pretty = `${JSON.stringify(normalized, null, 2)}\n`;
+  writeFileSync(finalReportPath, pretty, 'utf8');
+  unlinkSync(tempReportPath);
+  return normalized;
+};
+
+const run = () => {
+  ensureOutputDir();
+  const child = spawn(command, args, {
+    cwd: rootDir,
+    env: { ...process.env, PLAYWRIGHT_JSON_OUTPUT_FILE: tempReportPath },
+    stdio: 'inherit',
+  });
+
+  child.on('exit', (code) => {
+    if (code !== 0) {
+      console.error(`Playwright exited with code ${code}. Leaving the previous log intact.`);
+      process.exit(code ?? 1);
+    }
+
+    try {
+      const report = writeNormalizedReport();
+      const summary = summarize(report);
+      console.log(`\n${summary}`);
+      console.log(`JSON log saved to ${relative(process.cwd(), finalReportPath)}.`);
+      console.log('Open apps/run-telemetry/ to explore the run timeline.');
+    } catch (error) {
+      console.error('Failed to normalize Playwright report:', error);
+      process.exit(1);
+    }
+  });
+};
+
+run();


### PR DESCRIPTION
## Summary
- add a Playwright Run Telemetry app with refreshed styles, filter controls, and bundled fallback data for offline viewing
- expose a `npm run test:record` helper that records the suite with list+json reporters and writes `data/test-runs/latest.json`
- cover the landing grid and telemetry console in Playwright specs and document the workflow in the README

## Testing
- npm run test:record
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f2b944488328a2f7c75c57952492