### PR TITLE
Simplify landing clusters and refresh telemetry guidance

### DIFF
--- a/apps/run-telemetry/index.html
+++ b/apps/run-telemetry/index.html
@@ -77,6 +77,38 @@
       backdrop-filter: blur(16px);
     }
 
+    .home-nav {
+      display: flex;
+      justify-content: flex-start;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border-radius: 999px;
+      text-decoration: none;
+      color: inherit;
+      background: rgba(70, 95, 255, 0.12);
+      border: 1px solid rgba(70, 95, 255, 0.24);
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+    }
+
+    .home-link span[aria-hidden="true"] {
+      font-size: 1.1rem;
+    }
+
+    .home-link:hover,
+    .home-link:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 30px rgba(70, 95, 255, 0.28);
+      background: rgba(70, 95, 255, 0.18);
+      outline: none;
+    }
+
     .page-header {
       display: flex;
       flex-direction: column;
@@ -146,7 +178,7 @@
       padding: clamp(16px, 3vw, 24px);
       display: flex;
       flex-direction: column;
-      gap: 10px;
+      gap: 12px;
       background: rgba(70, 95, 255, 0.08);
     }
 
@@ -156,10 +188,38 @@
       font-weight: 600;
     }
 
+    .run-instructions h3 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
     .run-instructions p {
       margin: 0;
       color: var(--text-secondary);
       line-height: 1.5;
+    }
+
+    .instruction-checklist {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .instruction-checklist li {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      font-size: 0.95rem;
+      line-height: 1.5;
+      color: var(--text-secondary);
+    }
+
+    .instruction-checklist span[aria-hidden="true"] {
+      font-size: 1rem;
+      line-height: 1.4;
     }
 
     .run-instructions pre {
@@ -526,6 +586,12 @@
 </head>
 <body>
   <main aria-label="Playwright telemetry console">
+    <nav class="home-nav" aria-label="Home navigation">
+      <a class="home-link" href="../../">
+        <span aria-hidden="true">←</span>
+        <span>Home</span>
+      </a>
+    </nav>
     <header class="page-header">
       <h1>Playwright Run Telemetry</h1>
       <p>Peek behind the curtain of the agentic smoke tests. Every run of <code>npm run test:record</code> stores a JSON stream that keeps this console alive, even on a static site.</p>
@@ -545,9 +611,25 @@
         <button type="button" data-refresh-button aria-label="Refresh Playwright logs">Refresh</button>
       </div>
     </header>
-    <section class="run-instructions" aria-label="How to update the logs">
-      <h2>Update the feed</h2>
-      <p>Record a fresh log whenever you tweak the suite. The script runs the inspector-friendly line reporter and emits a normalized JSON artefact.</p>
+    <section class="run-instructions" aria-label="How to keep the suite healthy">
+      <h2>Keep the suite healthy</h2>
+      <p>Run through this checklist after every Playwright change so the dashboard keeps reflecting reality.</p>
+      <ul class="instruction-checklist">
+        <li>
+          <span aria-hidden="true">👀</span>
+          <span><strong>Scan the filters:</strong> Flip to the Failed and Flaky tabs to make sure they stay empty before you merge.</span>
+        </li>
+        <li>
+          <span aria-hidden="true">🗂️</span>
+          <span><strong>Inspect details:</strong> Open the slowest tests, read through the activity log, and download attachments when anomalies pop up.</span>
+        </li>
+        <li>
+          <span aria-hidden="true">⏱️</span>
+          <span><strong>Watch the timers:</strong> Compare the captured duration against recent runs so creeping regressions do not slip in.</span>
+        </li>
+      </ul>
+      <h3>Record a fresh snapshot</h3>
+      <p>Whenever you adjust assertions or fix flakes, capture a new log. The recorder uses the line reporter and emits a normalized JSON artefact.</p>
       <pre><code>npm run test:record</code></pre>
       <p class="note">The command writes <code>data/test-runs/latest.json</code>, which this console fetches (or falls back to the bundled snapshot when you are offline).</p>
     </section>

--- a/index.html
+++ b/index.html
@@ -15,14 +15,21 @@
       --surface: rgba(255, 255, 255, 0.94);
       --surface-shadow: 0 28px 70px rgba(15, 23, 42, 0.14);
       --surface-border: rgba(15, 23, 42, 0.08);
-      --card-background: rgba(255, 255, 255, 0.88);
-      --card-hover-background: rgba(255, 255, 255, 0.96);
-      --card-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
-      --card-hover-shadow: 0 26px 52px rgba(15, 23, 42, 0.16);
-      --accent: #4a63ff;
-      --accent-contrast: #0b1020;
-      --dev-link-background: rgba(74, 99, 255, 0.12);
-      --dev-link-hover: rgba(74, 99, 255, 0.18);
+      --row-background: rgba(255, 255, 255, 0.86);
+      --row-border: rgba(74, 99, 255, 0.22);
+      --row-hover: rgba(255, 255, 255, 0.94);
+      --row-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+      --row-shadow-hover: 0 24px 42px rgba(15, 23, 42, 0.18);
+      --label-pill: rgba(74, 99, 255, 0.14);
+      --label-text: #10172a;
+      --button-primary-background: linear-gradient(135deg, #4a63ff, #7687ff);
+      --button-primary-text: #0b1020;
+      --button-secondary-background: rgba(74, 99, 255, 0.12);
+      --button-secondary-text: #12172b;
+      --button-border: rgba(74, 99, 255, 0.45);
+      --button-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+      --button-shadow-hover: 0 14px 28px rgba(15, 23, 42, 0.16);
+      --focus-ring: rgba(121, 134, 255, 0.38);
     }
 
     @media (prefers-color-scheme: dark) {
@@ -34,15 +41,26 @@
         --surface: rgba(12, 17, 31, 0.85);
         --surface-shadow: 0 30px 80px rgba(0, 0, 0, 0.35);
         --surface-border: rgba(255, 255, 255, 0.04);
-        --card-background: rgba(255, 255, 255, 0.06);
-        --card-hover-background: rgba(255, 255, 255, 0.1);
-        --card-shadow: 0 20px 40px rgba(12, 18, 40, 0.3);
-        --card-hover-shadow: 0 28px 54px rgba(12, 18, 40, 0.38);
-        --accent: #9ba9ff;
-        --accent-contrast: #0a1020;
-        --dev-link-background: rgba(255, 255, 255, 0.08);
-        --dev-link-hover: rgba(255, 255, 255, 0.12);
+        --row-background: rgba(255, 255, 255, 0.08);
+        --row-border: rgba(155, 169, 255, 0.26);
+        --row-hover: rgba(255, 255, 255, 0.12);
+        --row-shadow: 0 20px 42px rgba(0, 0, 0, 0.32);
+        --row-shadow-hover: 0 28px 56px rgba(0, 0, 0, 0.4);
+        --label-pill: rgba(155, 169, 255, 0.18);
+        --label-text: #f5f7ff;
+        --button-primary-background: linear-gradient(135deg, #7f8dff, #a7b5ff);
+        --button-primary-text: #050914;
+        --button-secondary-background: rgba(155, 169, 255, 0.16);
+        --button-secondary-text: #f5f7ff;
+        --button-border: rgba(155, 169, 255, 0.5);
+        --button-shadow: 0 14px 30px rgba(0, 0, 0, 0.32);
+        --button-shadow-hover: 0 18px 36px rgba(0, 0, 0, 0.38);
+        --focus-ring: rgba(155, 169, 255, 0.52);
       }
+    }
+
+    * {
+      box-sizing: border-box;
     }
 
     body {
@@ -53,7 +71,7 @@
       align-items: center;
       background: var(--body-gradient);
       background-color: var(--body-base);
-      padding: clamp(12px, 2.5vw, 28px);
+      padding: clamp(14px, 2.8vw, 32px);
       color: var(--text-primary);
     }
 
@@ -64,16 +82,18 @@
       box-shadow: var(--surface-shadow);
       backdrop-filter: blur(14px);
       border: 1px solid var(--surface-border);
-      padding: clamp(12px, 2vw, 24px) clamp(16px, 2.5vw, 30px) clamp(16px, 2.5vw, 30px);
+      padding: clamp(14px, 2vw, 24px) clamp(18px, 2.8vw, 32px) clamp(18px, 2.8vw, 32px);
       display: flex;
       flex-direction: column;
-      gap: clamp(14px, 2.5vw, 22px);
+      gap: clamp(18px, 3vw, 32px);
     }
 
     header.site-header {
       display: flex;
       flex-direction: column;
       gap: 8px;
+      padding-bottom: 4px;
+      border-bottom: 1px solid rgba(74, 99, 255, 0.12);
     }
 
     header.site-header h1 {
@@ -82,172 +102,138 @@
       font-weight: 700;
     }
 
-    header.site-header p {
+    .section-title {
       margin: 0;
+      font-size: clamp(0.95rem, 0.4vw + 0.9rem, 1.1rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
       color: var(--text-secondary);
-      font-size: 1rem;
-      line-height: 1.5;
     }
 
-    ul.apps {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: grid;
-      gap: 24px;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    }
-
-    ul.apps li {
-      margin: 0;
+    .app-groups {
       display: flex;
       flex-direction: column;
-      gap: 12px;
+      gap: 18px;
     }
 
-    a.app-card {
+    .app-groups__list,
+    .tool-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
       display: flex;
       flex-direction: column;
       gap: 16px;
-      padding: clamp(22px, 2vw + 16px, 28px);
-      border-radius: 20px;
-      background: var(--card-background);
-      text-decoration: none;
-      color: inherit;
-      border: 1px solid transparent;
-      box-shadow: var(--card-shadow);
-      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
     }
 
-    a.app-card:hover,
-    a.app-card:focus-visible {
-      transform: translateY(-6px);
-      box-shadow: var(--card-hover-shadow);
-      background: var(--card-hover-background);
-      border-color: rgba(115, 135, 255, 0.45);
-      outline: none;
-    }
-
-    .app-card__icon {
-      font-size: clamp(1.8rem, 4vw, 2.4rem);
-    }
-
-    .app-card__content {
+    .app-row {
       display: flex;
-      flex-direction: column;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: clamp(12px, 1vw + 8px, 18px);
+      padding: clamp(8px, 1vw + 6px, 14px) 0;
+      border-bottom: 1px solid rgba(74, 99, 255, 0.12);
+    }
+
+    .app-row:last-child {
+      border-bottom: none;
+    }
+
+    .app-row__title {
+      display: inline-flex;
+      align-items: center;
       gap: 10px;
-    }
-
-    .app-card__content h2 {
       margin: 0;
-      font-size: clamp(1.2rem, 1.2vw + 1.1rem, 1.6rem);
+      font-size: clamp(1.05rem, 0.5vw + 1rem, 1.2rem);
       font-weight: 600;
+      letter-spacing: 0.01em;
+      color: var(--label-text);
     }
 
-    .app-card__content p {
-      margin: 0;
-      color: var(--text-secondary);
-      line-height: 1.6;
+    .app-row__title span[aria-hidden="true"] {
+      font-size: 1.3rem;
     }
 
-    .app-card__cta {
+    .app-row__actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-left: auto;
+      justify-content: flex-end;
+    }
+
+    a.app-button {
       display: inline-flex;
       align-items: center;
       gap: 8px;
-      font-weight: 600;
-      color: var(--accent);
-    }
-
-    .app-card__cta svg {
-      width: 1.15rem;
-      height: 1.15rem;
-      transition: transform 0.18s ease;
-    }
-
-    a.app-card:hover .app-card__cta svg,
-    a.app-card:focus-visible .app-card__cta svg {
-      transform: translateX(3px);
-    }
-
-    .app-links {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-
-    a.app-secondary {
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      padding: 10px 16px;
+      padding: 10px 18px;
       border-radius: 999px;
-      background: var(--dev-link-background);
-      color: inherit;
       text-decoration: none;
-      font-weight: 500;
-      transition: transform 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
-      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      border: 1px solid var(--button-border);
+      color: var(--button-secondary-text);
+      background: var(--button-secondary-background);
+      box-shadow: var(--button-shadow);
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
     }
 
-    a.app-secondary:hover,
-    a.app-secondary:focus-visible {
-      background: var(--dev-link-hover);
-      transform: translateY(-2px);
-      outline: none;
-      box-shadow: 0 14px 28px rgba(15, 23, 42, 0.16);
-    }
-
-    a.app-secondary span[aria-hidden="true"] {
+    a.app-button span[aria-hidden="true"] {
       font-size: 1.1rem;
     }
 
-    a.dev-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      padding: 12px 18px;
-      border-radius: 999px;
-      background: var(--dev-link-background);
-      color: inherit;
-      text-decoration: none;
-      font-weight: 500;
-      transition: transform 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
-      box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+    a.app-button:hover {
+      transform: translateY(-1px);
+      box-shadow: var(--button-shadow-hover);
     }
 
-    a.dev-link:hover,
-    a.dev-link:focus-visible {
-      background: var(--dev-link-hover);
-      transform: translateY(-2px);
+    a.app-button:focus-visible {
       outline: none;
-      box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
+      transform: translateY(-1px);
+      box-shadow: 0 0 0 3px var(--focus-ring), var(--button-shadow-hover);
     }
 
-    a.dev-link span[aria-hidden="true"] {
-      font-size: 1.2rem;
+    a.app-button--primary {
+      background: var(--button-primary-background);
+      color: var(--button-primary-text);
+      border-color: transparent;
     }
 
-    section.dev-tools {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 12px;
-      margin-top: clamp(18px, 3vw, 28px);
+    a.app-button--primary:hover,
+    a.app-button--primary:focus-visible {
+      background: linear-gradient(135deg, #6377ff, #8f9fff);
     }
 
-    a.app-card:focus-visible,
-    a.app-secondary:focus-visible,
-    a.dev-link:focus-visible {
-      box-shadow: 0 0 0 3px rgba(121, 134, 255, 0.35), inset 0 0 0 1px rgba(121, 134, 255, 0.6);
+    a.app-button--secondary:hover,
+    a.app-button--secondary:focus-visible {
+      background: rgba(74, 99, 255, 0.2);
     }
 
-    @media (max-width: 640px) {
-      main {
-        padding: clamp(12px, 4vw, 18px);
+    .tool-list li {
+      margin: 0;
+    }
+
+    a.app-button--wide {
+      width: 100%;
+      justify-content: flex-start;
+      font-size: clamp(1rem, 0.35vw + 0.95rem, 1.12rem);
+      padding: clamp(12px, 2vw + 8px, 18px) clamp(16px, 2vw + 12px, 24px);
+    }
+
+    @media (max-width: 720px) {
+      .app-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
       }
 
-      header.site-header h1 {
-        font-size: clamp(1.6rem, 4vw + 1rem, 2.2rem);
+      .app-row__actions {
+        width: 100%;
+        justify-content: flex-start;
+      }
+
+      .app-row__actions a.app-button {
+        flex: 1 1 auto;
       }
     }
   </style>
@@ -256,111 +242,79 @@
   <main aria-label="Apps">
     <header class="site-header">
       <h1>Toolbox</h1>
-      <p>Choose an app to explore curated decks, formatting helpers, and other quick experiments.</p>
     </header>
-    <ul class="apps">
-      <li>
-        <a class="app-card" href="apps/jokes/">
-          <span class="app-card__icon" aria-hidden="true">😂</span>
-          <div class="app-card__content">
-            <h2>Dad Jokes</h2>
-            <p>Cycle through curated dad jokes, revisit punchlines, and only reveal the payoff when you want.</p>
+    <section class="app-groups" aria-labelledby="deck-section">
+      <h2 id="deck-section" class="section-title">Deck collections</h2>
+      <ul class="app-groups__list">
+        <li class="app-row" data-group="jokes" role="group" aria-labelledby="group-jokes-title">
+          <h3 class="app-row__title" id="group-jokes-title">
+            <span aria-hidden="true">😂</span>
+            <span>Jokes</span>
+          </h3>
+          <div class="app-row__actions" aria-labelledby="group-jokes-title">
+            <a class="app-button app-button--primary" href="apps/jokes/">
+              <span aria-hidden="true">😂</span>
+              <span>Dad Jokes</span>
+            </a>
+            <a class="app-button app-button--secondary" href="apps/jokes/all-jokes.html">
+              <span>All Jokes</span>
+            </a>
           </div>
-          <span class="app-card__cta">
-            Open app
-            <svg aria-hidden="true" viewBox="0 0 24 24">
-              <path d="M9 5l7 7-7 7" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"></path>
-            </svg>
-          </span>
-        </a>
-        <div class="app-links" aria-label="Dad jokes extras">
-          <a class="app-secondary" href="apps/jokes/all-jokes.html">
-            <span aria-hidden="true">📚</span>
-            <span>All Jokes</span>
+        </li>
+        <li class="app-row" data-group="quotes" role="group" aria-labelledby="group-quotes-title">
+          <h3 class="app-row__title" id="group-quotes-title">
+            <span aria-hidden="true">💬</span>
+            <span>Quotes</span>
+          </h3>
+          <div class="app-row__actions" aria-labelledby="group-quotes-title">
+            <a class="app-button app-button--primary" href="apps/quotes/">
+              <span aria-hidden="true">💬</span>
+              <span>Quotes</span>
+            </a>
+            <a class="app-button app-button--secondary" href="apps/quotes/all-quotes.html">
+              <span>All Quotes</span>
+            </a>
+          </div>
+        </li>
+        <li class="app-row" data-group="gen-alpha" role="group" aria-labelledby="group-gen-alpha-title">
+          <h3 class="app-row__title" id="group-gen-alpha-title">
+            <span aria-hidden="true">🧒</span>
+            <span>Gen Alpha</span>
+          </h3>
+          <div class="app-row__actions" aria-labelledby="group-gen-alpha-title">
+            <a class="app-button app-button--primary" href="apps/gen-alpha/">
+              <span aria-hidden="true">🧒</span>
+              <span>Gen Alpha Slang</span>
+            </a>
+            <a class="app-button app-button--secondary" href="apps/gen-alpha/all-slang.html">
+              <span>All Slang</span>
+            </a>
+          </div>
+        </li>
+      </ul>
+    </section>
+    <section class="app-groups" aria-labelledby="tools-section">
+      <h2 id="tools-section" class="section-title">Labs &amp; tools</h2>
+      <ul class="tool-list">
+        <li>
+          <a class="app-button app-button--primary app-button--wide" href="apps/similarity-report/">
+            <span aria-hidden="true">🧪</span>
+            <span>Cosine Similarity Lab</span>
           </a>
-        </div>
-      </li>
-      <li>
-        <a class="app-card" href="apps/gen-alpha/">
-          <span class="app-card__icon" aria-hidden="true">🧒</span>
-          <div class="app-card__content">
-            <h2>Gen Alpha Slang</h2>
-            <p>Browse Gen Alpha slang cards, move back for a refresher, and reveal the meaning only when you’re ready.</p>
-          </div>
-          <span class="app-card__cta">
-            Open app
-            <svg aria-hidden="true" viewBox="0 0 24 24">
-              <path d="M9 5l7 7-7 7" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"></path>
-            </svg>
-          </span>
-        </a>
-        <div class="app-links" aria-label="Gen Alpha slang extras">
-          <a class="app-secondary" href="apps/gen-alpha/all-slang.html">
-            <span aria-hidden="true">🗂️</span>
-            <span>All Slang</span>
+        </li>
+        <li>
+          <a class="app-button app-button--wide" href="apps/run-telemetry/">
+            <span aria-hidden="true">📈</span>
+            <span>Playwright Run Telemetry</span>
           </a>
-        </div>
-      </li>
-      <li>
-        <a class="app-card" href="apps/quotes/">
-          <span class="app-card__icon" aria-hidden="true">💬</span>
-          <div class="app-card__content">
-            <h2>Quotes</h2>
-            <p>Shuffle themed quote decks, jump back through the flow, and switch categories without losing context.</p>
-          </div>
-          <span class="app-card__cta">
-            Open app
-            <svg aria-hidden="true" viewBox="0 0 24 24">
-              <path d="M9 5l7 7-7 7" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"></path>
-            </svg>
-          </span>
-        </a>
-        <div class="app-links" aria-label="Quote extras">
-          <a class="app-secondary" href="apps/quotes/all-quotes.html">
-            <span aria-hidden="true">🗂️</span>
-            <span>All Quotes</span>
+        </li>
+        <li>
+          <a class="app-button app-button--wide" href="apps/value-formatter/">
+            <span aria-hidden="true">🧰</span>
+            <span>Value Formatter</span>
           </a>
-        </div>
-      </li>
-      <li>
-        <a class="app-card" href="apps/similarity-report/">
-          <span class="app-card__icon" aria-hidden="true">🧪</span>
-          <div class="app-card__content">
-            <h2>Cosine Similarity Lab</h2>
-            <p>Compare embeddings, inspect dataset metadata, and sanity-check similarity reports in the browser.</p>
-          </div>
-          <span class="app-card__cta">
-            Open app
-            <svg aria-hidden="true" viewBox="0 0 24 24">
-              <path d="M9 5l7 7-7 7" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"></path>
-            </svg>
-          </span>
-        </a>
-      </li>
-      <li>
-        <a class="app-card" href="apps/run-telemetry/">
-          <h2>Playwright Run Telemetry</h2>
-          <p>Inspect JSON-backed timelines from the automated Playwright smoke tests, filter their status, and drill into the per-spec activity log.</p>
-        </a>
-      </li>
-    </ul>
-    <section class="dev-tools" aria-label="Utility pages">
-      <a class="dev-link" href="apps/value-formatter/">
-        <span aria-hidden="true">🧰</span>
-        <span>Value Formatter — Quick mapping for long lists.</span>
-      </a>
-      <a class="dev-link" href="apps/jokes/all-jokes.html">
-        <span aria-hidden="true">😂</span>
-        <span>All Jokes</span>
-      </a>
-      <a class="dev-link" href="apps/quotes/all-quotes.html">
-        <span aria-hidden="true">💬</span>
-        <span>All Quotes</span>
-      </a>
-      <a class="dev-link" href="apps/gen-alpha/all-slang.html">
-        <span aria-hidden="true">🧾</span>
-        <span>All Gen Alpha Slang</span>
-      </a>
+        </li>
+      </ul>
     </section>
   </main>
 </body>

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -1,59 +1,46 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('Landing page', () => {
-  test('lists main apps with shortcuts and utility links', async ({ page }) => {
+  test('presents grouped deck buttons and lab shortcuts', async ({ page }) => {
     await page.goto('/');
 
     const header = page.locator('main[aria-label="Apps"] > header.site-header');
     await expect(header.locator('h1')).toHaveText('Toolbox');
 
-    const cards = page.locator('a.app-card');
-    await expect(cards).toHaveCount(4);
+    const deckRows = page.locator('.app-row');
+    await expect(deckRows).toHaveCount(3);
+    await expect(deckRows.first()).toHaveAttribute('role', 'group');
 
-    const expectedApps = [
-      { title: 'Dad Jokes', href: 'apps/jokes/' },
-      { title: 'Gen Alpha Slang', href: 'apps/gen-alpha/' },
-      { title: 'Quotes', href: 'apps/quotes/' },
-      { title: 'Cosine Similarity Lab', href: 'apps/similarity-report/' },
-    ];
+    const groupLabels = await deckRows.locator('.app-row__title span:last-child').allTextContents();
+    const normalizedLabels = groupLabels.map((text) => text.trim());
+    expect(normalizedLabels).toEqual(['Jokes', 'Quotes', 'Gen Alpha']);
 
-    for (const { title, href } of expectedApps) {
-      const card = cards.filter({ has: page.locator('h2', { hasText: title }) });
-      await expect(card).toHaveCount(1);
-      await expect(card).toHaveAttribute('href', href);
-      await expect(card.locator('.app-card__cta svg')).toHaveCount(1);
-    }
+    const deckLinkSets = await deckRows.evaluateAll((nodes) =>
+      nodes.map((node) =>
+        Array.from(node.querySelectorAll('a.app-button')).map((link) => ({
+          href: link.getAttribute('href'),
+          text: (link.textContent || '').replace(/\s+/g, ' ').trim(),
+        })),
+      ),
+    );
 
-    const shortcutGroups = page.locator('.app-links');
-    await expect(shortcutGroups).toHaveCount(3);
-    const shortcutLinks = shortcutGroups.locator('a.app-secondary');
-    await expect(shortcutLinks).toHaveCount(3);
-
-    const shortcutTexts = await shortcutLinks.allTextContents();
-    const normalizedShortcuts = shortcutTexts.map((text) => text.replace(/\s+/g, ' ').trim());
-    expect(normalizedShortcuts).toEqual([
-      '📚 All Jokes',
-      '🗂️ All Slang',
-      '🗂️ All Quotes',
+    expect(deckLinkSets).toEqual([
+      [
+        { href: 'apps/jokes/', text: '😂 Dad Jokes' },
+        { href: 'apps/jokes/all-jokes.html', text: 'All Jokes' },
+      ],
+      [
+        { href: 'apps/quotes/', text: '💬 Quotes' },
+        { href: 'apps/quotes/all-quotes.html', text: 'All Quotes' },
+      ],
+      [
+        { href: 'apps/gen-alpha/', text: '🧒 Gen Alpha Slang' },
+        { href: 'apps/gen-alpha/all-slang.html', text: 'All Slang' },
+      ],
     ]);
 
-    const devLinks = page.locator('section.dev-tools a.dev-link');
-    await expect(devLinks).toHaveCount(4);
-
-    const devLinkTargets = await devLinks.evaluateAll((nodes) =>
-      nodes.map((node) => ({
-        href: node.getAttribute('href'),
-        text: node.textContent?.replace(/\s+/g, ' ').trim() || '',
-      })),
-    );
-
-    expect(devLinkTargets).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ href: 'apps/value-formatter/', text: expect.stringContaining('Value Formatter') }),
-        expect.objectContaining({ href: 'apps/jokes/all-jokes.html', text: expect.stringContaining('All Jokes') }),
-        expect.objectContaining({ href: 'apps/quotes/all-quotes.html', text: expect.stringContaining('All Quotes') }),
-        expect.objectContaining({ href: 'apps/gen-alpha/all-slang.html', text: expect.stringContaining('All Gen Alpha Slang') }),
-      ]),
-    );
+    await expect(page.locator('a.app-card')).toHaveCount(0);
+    await expect(page.locator('.dev-tools')).toHaveCount(0);
+    await expect(page.locator('.app-links')).toHaveCount(0);
   });
 });

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,24 +1,82 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('Landing page', () => {
-  test('lists every app including the telemetry console', async ({ page }) => {
+  test('shows grouped deck buttons with clear shortcuts', async ({ page }) => {
     await page.goto('/');
 
-    const cards = page.locator('.app-card');
-    await expect(cards).toHaveCount(4);
+    const groupedRows = page.locator('[data-group]');
+    await expect(groupedRows).toHaveCount(3);
 
-    const telemetryCard = page.locator('.app-card', {
-      has: page.locator('h2', { hasText: 'Playwright Run Telemetry' }),
-    });
+    const expectedRows = [
+      {
+        group: 'jokes',
+        heading: 'Jokes',
+        texts: ['😂 Dad Jokes', 'All Jokes'],
+        hrefs: ['apps/jokes/', 'apps/jokes/all-jokes.html'],
+      },
+      {
+        group: 'quotes',
+        heading: 'Quotes',
+        texts: ['💬 Quotes', 'All Quotes'],
+        hrefs: ['apps/quotes/', 'apps/quotes/all-quotes.html'],
+      },
+      {
+        group: 'gen-alpha',
+        heading: 'Gen Alpha',
+        texts: ['🧒 Gen Alpha Slang', 'All Slang'],
+        hrefs: ['apps/gen-alpha/', 'apps/gen-alpha/all-slang.html'],
+      },
+    ];
 
-    await expect(telemetryCard).toBeVisible();
-    await expect(telemetryCard).toHaveAttribute('href', 'apps/run-telemetry/');
-    await expect(telemetryCard.locator('p')).toContainText(/Playwright/i);
+    for (const { group, heading: expectedHeading, texts, hrefs } of expectedRows) {
+      const row = page.locator(`[data-group="${group}"]`);
+      await expect(row).toBeVisible();
 
-    const devLinks = page.locator('.dev-tools a');
-    await expect(devLinks).toHaveCount(3);
-    await expect(devLinks.nth(0)).toContainText('Value Formatter');
-    await expect(devLinks.nth(1)).toContainText('All Jokes');
-    await expect(devLinks.nth(2)).toContainText('All Quotes');
+      const heading = row.locator('.app-row__title span:last-child');
+      await expect(heading).toHaveText(expectedHeading);
+
+      const buttons = row.locator('a.app-button');
+      await expect(buttons).toHaveCount(texts.length);
+
+      const buttonTexts = await buttons.allTextContents();
+      const normalizedTexts = buttonTexts.map((text) => text.replace(/\s+/g, ' ').trim());
+      expect(normalizedTexts).toEqual(texts);
+
+      const buttonHrefs = await buttons.evaluateAll((nodes) =>
+        nodes.map((node) => node.getAttribute('href')),
+      );
+      expect(buttonHrefs).toEqual(hrefs);
+
+      await expect(buttons.first()).toHaveClass(/app-button--primary/);
+    }
+  });
+
+  test('lists labs and utilities as concise buttons without descriptions', async ({ page }) => {
+    await page.goto('/');
+
+    const toolSection = page.locator('section.app-groups').nth(1);
+    const toolButtons = toolSection.locator('a.app-button');
+    await expect(toolButtons).toHaveCount(3);
+
+    const toolInfo = await toolButtons.evaluateAll((nodes) =>
+      nodes.map((node) => ({
+        text: (node.textContent || '').replace(/\s+/g, ' ').trim(),
+        href: node.getAttribute('href'),
+      })),
+    );
+
+    expect(toolInfo).toEqual([
+      { text: '🧪 Cosine Similarity Lab', href: 'apps/similarity-report/' },
+      { text: '📈 Playwright Run Telemetry', href: 'apps/run-telemetry/' },
+      { text: '🧰 Value Formatter', href: 'apps/value-formatter/' },
+    ]);
+
+    const valueFormatterButton = toolButtons.filter({ hasText: 'Value Formatter' });
+    await expect(valueFormatterButton).toHaveCount(1);
+    await expect(valueFormatterButton).not.toContainText('Quick');
+    await expect(valueFormatterButton).not.toContainText('—');
+
+    const allButtons = page.locator('a.app-button');
+    await expect(allButtons).toHaveCount(9);
   });
 });

--- a/tests/run-telemetry.spec.js
+++ b/tests/run-telemetry.spec.js
@@ -1,6 +1,14 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('Playwright Run Telemetry console', () => {
+  test('includes a home navigation shortcut', async ({ page }) => {
+    await page.goto('/apps/run-telemetry/');
+
+    const homeLink = page.locator('.home-link');
+    await expect(homeLink).toHaveAttribute('href', '../../');
+    await expect(homeLink).toHaveText(/Home/);
+  });
+
   test('renders summaries, supports filters, and exposes the activity log', async ({ page }) => {
     await page.goto('/apps/run-telemetry/');
 
@@ -36,6 +44,10 @@ test.describe('Playwright Run Telemetry console', () => {
     const logEntries = page.locator('[data-log-entry]');
     expect(await logEntries.count()).toBeGreaterThan(0);
     await expect(logEntries.first()).toBeVisible();
+
+    const checklistItems = page.locator('.instruction-checklist li');
+    await expect(checklistItems).toHaveCount(3);
+    await expect(checklistItems.first()).toContainText('Scan the filters');
 
     const refresh = page.locator('[data-refresh-button]');
     await refresh.click();


### PR DESCRIPTION
## Summary
- replace the landing page cards with slim two-button rows per deck and keep the lab list button-only
- add a home shortcut and checklist/update instructions to the Playwright run telemetry console
- extend Playwright coverage for the new layout details and telemetry navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1fe4da8a08328bdc7b79c88764d65