### PR TITLE
Fix Gen Alpha navigation and add Playwright coverage

### DIFF
--- a/apps/gen-alpha/AGENTS.md
+++ b/apps/gen-alpha/AGENTS.md
@@ -4,12 +4,13 @@ Keep the slang dataset valid JavaScript assigned to `window.genAlphaSlang`.
 Stick to double quotes and the generated indentation so diffs stay focused on
 the records.
 
-After editing the entries, run:
+After editing the entries or tweaking the navigator UI, run:
 
 ```bash
 node --check apps/gen-alpha/slang.js
 node -e "global.window = {}; require('./apps/gen-alpha/slang.js'); console.log(Array.isArray(window.genAlphaSlang), window.genAlphaSlang.length);"
 node tools/update-content-metadata.js --dataset=genalpha
+npx playwright test tests/gen-alpha-app.spec.js
 ```
 
 Regenerate the embeddings stores we use for duplicate protection with:

--- a/apps/gen-alpha/app.js
+++ b/apps/gen-alpha/app.js
@@ -4,11 +4,10 @@
   const prevButton = document.getElementById('prev-button');
   const nextButton = document.getElementById('next-button');
   const revealButton = document.getElementById('reveal-button');
-  const shuffleButton = document.getElementById('shuffle-button');
   const exampleWrapper = document.getElementById('slang-example-wrapper');
   const exampleText = document.getElementById('slang-example');
 
-  if (!termEl || !meaningEl || !prevButton || !nextButton || !revealButton || !shuffleButton) {
+  if (!termEl || !meaningEl || !prevButton || !nextButton || !revealButton) {
     return;
   }
 
@@ -83,7 +82,7 @@
       revealButton.hidden = true;
       prevButton.disabled = true;
       nextButton.disabled = true;
-      shuffleButton.disabled = true;
+      revealButton.disabled = true;
       currentEntry = null;
 
       if (exampleWrapper && exampleText) {
@@ -105,6 +104,7 @@
     termEl.textContent = current.term;
     meaningEl.textContent = definitionText;
     revealButton.hidden = false;
+    revealButton.disabled = false;
 
     if (exampleWrapper && exampleText) {
       if (hasExample) {

--- a/data/genalpha-manifest.json
+++ b/data/genalpha-manifest.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "generatedAt": "2025-09-23T01:49:31.211Z",
+    "generatedAt": "2025-09-23T02:57:42.622Z",
     "total": 45,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",

--- a/tests/gen-alpha-app.spec.js
+++ b/tests/gen-alpha-app.spec.js
@@ -1,0 +1,80 @@
+const { test, expect } = require('@playwright/test');
+
+const deterministicRandomInitScript = () => {
+  const values = [0.14, 0.68, 0.32, 0.84, 0.26];
+  let index = 0;
+  Math.random = () => {
+    const value = values[index % values.length];
+    index += 1;
+    return value;
+  };
+};
+
+test.describe('Gen Alpha slang app', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(deterministicRandomInitScript);
+  });
+
+  test('shuffles terms, allows navigation, and reveals definitions with examples', async ({ page }) => {
+    await page.goto('/apps/gen-alpha/');
+
+    const term = page.locator('#slang-term');
+    const meaning = page.locator('#slang-meaning');
+    const exampleWrapper = page.locator('#slang-example-wrapper');
+    const example = page.locator('#slang-example');
+    const revealButton = page.locator('#reveal-button');
+    const nextButton = page.locator('#next-button');
+    const prevButton = page.locator('#prev-button');
+
+    await expect(term).not.toHaveText(/Loading slang…?/i);
+    await expect(meaning).not.toHaveClass(/is-visible/);
+    await expect(meaning).toHaveAttribute('aria-hidden', 'true');
+    await expect(exampleWrapper).not.toHaveClass(/is-visible/);
+    await expect(exampleWrapper).toHaveAttribute('aria-hidden', 'true');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'false');
+    await expect(revealButton).toBeEnabled();
+    await expect(nextButton).toBeEnabled();
+    await expect(prevButton).toBeEnabled();
+
+    const firstTerm = ((await term.textContent()) || '').trim();
+    expect(firstTerm.length).toBeGreaterThan(0);
+
+    await revealButton.click();
+
+    await expect(meaning).toHaveClass(/is-visible/);
+    await expect(meaning).toHaveAttribute('aria-hidden', 'false');
+    const definitionText = ((await meaning.textContent()) || '').trim();
+    expect(definitionText.length).toBeGreaterThan(0);
+
+    await expect(exampleWrapper).toHaveClass(/is-visible/);
+    await expect(exampleWrapper).toHaveAttribute('aria-hidden', 'false');
+    const exampleText = ((await example.textContent()) || '').trim();
+    expect(exampleText.length).toBeGreaterThan(0);
+
+    await nextButton.click();
+
+    await expect(meaning).not.toHaveClass(/is-visible/);
+    await expect(meaning).toHaveAttribute('aria-hidden', 'true');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'false');
+    await expect(exampleWrapper).not.toHaveClass(/is-visible/);
+
+    const secondTerm = ((await term.textContent()) || '').trim();
+    expect(secondTerm.length).toBeGreaterThan(0);
+    expect(secondTerm).not.toBe(firstTerm);
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(term).toHaveText(firstTerm);
+
+    await page.evaluate(() => {
+      const active = document.activeElement;
+      if (active && typeof active.blur === 'function') {
+        active.blur();
+      }
+    });
+
+    await page.keyboard.press('Space');
+    await expect(revealButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(meaning).toHaveClass(/is-visible/);
+    await expect(exampleWrapper).toHaveClass(/is-visible/);
+  });
+});


### PR DESCRIPTION
## Summary
- remove the unused shuffle button dependency so the Gen Alpha navigator loads entries, keeps navigation buttons usable, and resets the reveal state correctly
- cover the navigator with a deterministic Playwright test that exercises shuffling, back navigation, and the meaning/example reveal flow in one pass
- document the new smoke test in the Gen Alpha agent instructions and refresh the manifest metadata

## Testing
- node --check apps/gen-alpha/slang.js
- node -e "global.window = {}; require('./apps/gen-alpha/slang.js'); console.log(Array.isArray(window.genAlphaSlang), window.genAlphaSlang.length);"
- node tools/update-content-metadata.js --dataset=genalpha
- npx playwright test tests/gen-alpha-app.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d20bb61bb0832889e353bcfadcde4e