### PR TITLE
Move Gen Alpha usage hints outside quote styling

### DIFF
--- a/apps/gen-alpha/app.js
+++ b/apps/gen-alpha/app.js
@@ -59,21 +59,20 @@
     meaningEl.setAttribute('aria-hidden', visible ? 'false' : 'true');
     revealButton.setAttribute('aria-pressed', visible ? 'true' : 'false');
 
+    const hasExample = currentEntry && typeof currentEntry.example === 'string' && currentEntry.example.length > 0;
+    const hasHint = currentEntry && typeof currentEntry.hint === 'string' && currentEntry.hint.length > 0;
+
     if (exampleWrapper) {
-      const hasExample = currentEntry && typeof currentEntry.example === 'string' && currentEntry.example.length > 0;
-      const hasHint = currentEntry && typeof currentEntry.hint === 'string' && currentEntry.hint.length > 0;
-      const hasUsage = hasExample || hasHint;
-      const shouldShowWrapper = visible && hasUsage;
+      const shouldShowExample = visible && hasExample;
+      exampleWrapper.classList.toggle('is-visible', shouldShowExample);
+      exampleWrapper.hidden = !shouldShowExample;
+      exampleWrapper.setAttribute('aria-hidden', shouldShowExample ? 'false' : 'true');
+    }
 
-      exampleWrapper.classList.toggle('is-visible', shouldShowWrapper);
-      exampleWrapper.hidden = !shouldShowWrapper;
-      exampleWrapper.setAttribute('aria-hidden', shouldShowWrapper ? 'false' : 'true');
-
-      if (hintWrapper) {
-        const shouldShowHint = visible && hasHint;
-        hintWrapper.hidden = !shouldShowHint;
-        hintWrapper.setAttribute('aria-hidden', shouldShowHint ? 'false' : 'true');
-      }
+    if (hintWrapper) {
+      const shouldShowHint = visible && hasHint;
+      hintWrapper.hidden = !shouldShowHint;
+      hintWrapper.setAttribute('aria-hidden', shouldShowHint ? 'false' : 'true');
     }
   }
 

--- a/apps/gen-alpha/index.html
+++ b/apps/gen-alpha/index.html
@@ -161,7 +161,7 @@
     }
 
     .card__hint {
-      margin: 16px 0 0;
+      margin: 0;
       display: grid;
       gap: 6px;
       color: var(--meaning-color);
@@ -292,13 +292,13 @@
           <p id="slang-term">Loading slang…</p>
         </div>
         <p id="slang-meaning" aria-hidden="true"></p>
-        <figure id="slang-example-wrapper" class="card__example" aria-hidden="true">
+        <figure id="slang-example-wrapper" class="card__example" aria-hidden="true" hidden>
           <blockquote id="slang-example" class="card__quote"></blockquote>
-          <figcaption id="slang-hint-wrapper" class="card__hint">
-            <span class="card__hint-label">Usage hint</span>
-            <span id="slang-hint" class="card__hint-text"></span>
-          </figcaption>
         </figure>
+        <div id="slang-hint-wrapper" class="card__hint" aria-hidden="true" hidden>
+          <span class="card__hint-label">Usage hint</span>
+          <span id="slang-hint" class="card__hint-text"></span>
+        </div>
       </div>
     </article>
     <div class="controls">

--- a/data/genalpha-manifest.json
+++ b/data/genalpha-manifest.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "generatedAt": "2025-09-23T03:29:57.835Z",
+    "generatedAt": "2025-09-23T03:47:35.601Z",
     "total": 45,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",


### PR DESCRIPTION
## Summary
- hide the usage hint outside the blockquote container so it no longer appears inside the styled quote
- update the app logic to toggle example and hint visibility independently
- refresh the Gen Alpha manifest metadata

## Testing
- node --check apps/gen-alpha/slang.js
- node -e "global.window = {}; require('./apps/gen-alpha/slang.js'); console.log(Array.isArray(window.genAlphaSlang), window.genAlphaSlang.length);"
- node tools/update-content-metadata.js --dataset=genalpha
- npx playwright test tests/gen-alpha-app.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d21735abb483289d23d1adb5bf4f47