### PR TITLE
Shuffle Gen Alpha all slang deck on load

### DIFF
--- a/apps/gen-alpha/render-all.js
+++ b/apps/gen-alpha/render-all.js
@@ -15,6 +15,15 @@
     });
   }
 
+  function shuffle(array) {
+    const copy = array.slice();
+    for (let i = copy.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [copy[i], copy[j]] = [copy[j], copy[i]];
+    }
+    return copy;
+  }
+
   const rawEntries = Array.isArray(window.genAlphaSlang)
     ? window.genAlphaSlang
         .map((entry) => {
@@ -40,7 +49,7 @@
         .filter(Boolean)
     : [];
 
-  const deck = rawEntries.slice().sort((a, b) => a.term.localeCompare(b.term));
+  const deck = shuffle(rawEntries);
   const totalCount = deck.length;
 
   if (totalTarget) {

--- a/data/genalpha-manifest.json
+++ b/data/genalpha-manifest.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "generatedAt": "2025-09-23T03:47:35.601Z",
+    "generatedAt": "2025-09-23T03:54:41.052Z",
     "total": 45,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",


### PR DESCRIPTION
## Summary
- add an inline shuffle helper to the Gen Alpha all slang renderer
- randomize the deck instead of sorting so the table order changes on each load

## Testing
- node --check apps/gen-alpha/slang.js
- node -e "global.window = {}; require('./apps/gen-alpha/slang.js'); console.log(Array.isArray(window.genAlphaSlang), window.genAlphaSlang.length);"
- node tools/update-content-metadata.js --dataset=genalpha
- npx playwright test tests/gen-alpha-app.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d219c13e4c8328812cf429efca1dc4