### PR TITLE
Prune duplicate jokes and update similarity data

### DIFF
--- a/apps/jokes/jokes.js
+++ b/apps/jokes/jokes.js
@@ -3374,74 +3374,6 @@ window.jokes = [
             "joke": "Who hides in the bakery at Christmas?",
             "punchline": "A mince spy!"
         }, {
-            "id": "j-0889",
-            "joke": "I got fired from a florist",
-            "punchline": "apparently I took too many leaves."
-        }, {
-            "id": "j-0890",
-            "joke": "What did the fish say when it hit the wall?",
-            "punchline": "Dam."
-        }, {
-            "id": "j-0891",
-            "joke": "Why can't bicycles stand on their own?",
-            "punchline": "They are two tired"
-        }, {
-            "id": "j-0892",
-            "joke": "What happens to a frog's car when it breaks down?",
-            "punchline": "It gets toad away"
-        }, {
-            "id": "j-0893",
-            "joke": "I bought some shoes from a drug dealer.",
-            "punchline": "I don't know what he laced them with, but I was tripping all day!"
-        }, {
-            "id": "j-0894",
-            "joke": "Why do chicken coops only have two doors?",
-            "punchline": "Because if they had four, they would be chicken sedans"
-        }, {
-            "id": "j-0895",
-            "joke": "What do you give to a lemon in need?",
-            "punchline": "Lemonaid."
-        }, {
-            "id": "j-0896",
-            "joke": "Hey, dad, did you get a haircut?",
-            "punchline": "No, I got them all cut."
-        }, {
-            "id": "j-0897",
-            "joke": "What time is it?",
-            "punchline": "I don't know... it keeps changing."
-        }, {
-            "id": "j-0898",
-            "joke": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before. What can I get for you?\"",
-            "punchline": "Pop,goes the weasel."
-        }, {
-            "id": "j-0899",
-            "joke": "How many optometrists does it take to change a light bulb?",
-            "punchline": "1 or 2? 1... or 2?"
-        }, {
-            "id": "j-0900",
-            "joke": "How many seconds are in a year?",
-            "punchline": "12. January 2nd, February 2nd, March 2nd, April 2nd.... etc"
-        }, {
-            "id": "j-0901",
-            "joke": "What did the spaghetti say to the other spaghetti?",
-            "punchline": "Pasta la vista, baby!"
-        }, {
-            "id": "j-0902",
-            "joke": "Where’s the bin?",
-            "punchline": "I haven’t been anywhere!"
-        }, {
-            "id": "j-0903",
-            "joke": "Why did the developer quit his job?",
-            "punchline": "Because he didn't get arrays."
-        }, {
-            "id": "j-0904",
-            "joke": "Why did the programmer always mix up Halloween and Christmas?",
-            "punchline": "Because Oct 31 equals Dec 25."
-        }, {
-            "id": "j-0905",
-            "joke": "What did one ocean say to the other ocean?",
-            "punchline": "Nothing, they just waved."
-        }, {
             "id": "j-0906",
             "joke": "Why did the chicken cross the playground?",
             "punchline": "To get to the other slide."
@@ -3449,18 +3381,6 @@ window.jokes = [
             "id": "j-0907",
             "joke": "Why don't oysters give to charity?",
             "punchline": "Because they're shellfish."
-        }, {
-            "id": "j-0908",
-            "joke": "Why did the golfer wear two pairs of pants?",
-            "punchline": "In case he got a hole in one."
-        }, {
-            "id": "j-0909",
-            "joke": "Why did the programmer quit their job?",
-            "punchline": "They didn't get arrays."
-        }, {
-            "id": "j-0910",
-            "joke": "Why don't programmers like nature?",
-            "punchline": "Too many bugs."
         }, {
             "id": "j-0911",
             "joke": "Why was the keyboard always calm during meetings?",

--- a/data/jokes-embeddings-cohere.json
+++ b/data/jokes-embeddings-cohere.json
@@ -3,8 +3,8 @@
     "provider": "cohere",
     "model": "embed-english-v3.0",
     "dimensions": 64,
-    "generatedAt": "2025-09-22T23:16:21.862Z",
-    "recordCount": 865
+    "generatedAt": "2025-09-23T04:06:44.318Z",
+    "recordCount": 845
   },
   "records": {
     "j-0001": {
@@ -7594,159 +7594,6 @@
       "textHash": "3ff4a9952ca7f94b81d9d226e9735b5b6b39a36746999089b720350a26403e31",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
-    "j-0889": {
-      "vector": "rKsrv9fW1j7o52c/oJ8fP728PD6Miws/z87Ovquqqj6Qjw8/v76+Pufm5r6CgQG/rawsvri3N7/V1FQ+xMNDv5ybG7+enR0/7exsPq+urj6qqSm/29raPu7tbb/+/X0/6ejovaqpKb/z8vK+rq0tP/f29j7Avz8/xMNDv4aFBT+sqyu/19bWPujnZz+gnx8/vbw8PoyLCz/Pzs6+q6qqPpCPDz+/vr4+5+bmvoKBAb+trCy+uLc3v9XUVD7Ew0O/nJsbv56dHT/t7Gw+r66uPqqpKb/b2to+7u1tv/79fT/p6Oi9qqkpv/Py8r6urS0/9/b2PsC/Pz/Ew0O/hoUFPw==",
-      "vectorSha256": "104af4dafe84019ee64b6e8422eb5621beb8a98e6fae077673c3f849c3281627",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "ed0c6b14de90e5500f3e34a022f9e9249f3bce248e56cbff50a5499c671330bb",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0890": {
-      "vector": "xsVFv4+Ojj7CwUE/6+rqPsTDQz/p6Og9paQkvsHAQLz5+Pi9mJcXP6SjIz/5+Pg9rKsrv6uqqj61tDS+xsVFv4SDAz+qqSm/yMdHv5iXF7+ioSE/2tlZv5WUFL6xsDA9jYwMPsHAQLzZ2Ni9ubi4Pc7NTb/v7u6+ubi4vaalJT/GxUW/j46OPsLBQT/r6uo+xMNDP+no6D2lpCS+wcBAvPn4+L2Ylxc/pKMjP/n4+D2sqyu/q6qqPrW0NL7GxUW/hIMDP6qpKb/Ix0e/mJcXv6KhIT/a2Vm/lZQUvrGwMD2NjAw+wcBAvNnY2L25uLg9zs1Nv+/u7r65uLi9pqUlPw==",
-      "vectorSha256": "3ed0fa6f94a893cf74cab464a8de1ee4fabff16d353bde38d86f883b23ba59a4",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "f3acaeb1192888bca83350273cc3973662787ea5e9ba6e7cc7e54a58230f43de",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0891": {
-      "vector": "qqkpP97dXT+lpCS+jYwMPsPCwr7t7Gy++fj4vZiXF7/U01O/8O9vv56dHb+ZmJi9r66uvt/e3j7NzEy+sK8vP5aVFT/a2Vm/5uVlv9nY2D3V1FQ+mZiYPefm5j7BwEC8l5aWvt/e3j7h4OC88/LyPri3N7///v6+hIMDP5+enr6qqSk/3t1dP6WkJL6NjAw+w8LCvu3sbL75+Pi9mJcXv9TTU7/w72+/np0dv5mYmL2vrq6+397ePs3MTL6wry8/lpUVP9rZWb/m5WW/2djYPdXUVD6ZmJg95+bmPsHAQLyXlpa+397ePuHg4Lzz8vI+uLc3v//+/r6EgwM/n56evg==",
-      "vectorSha256": "7d8d0114c4444b8470bfda751ebfbf5775bd4e0ee3ffbea038b027ac947a7852",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "2aaaa0872eed160c5368df52edc15a4b5de0b8efd6caff259ade395b57b83975",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0892": {
-      "vector": "/v19v5STEz+trCw+9fR0vvLxcT/FxEQ+oqEhv9va2r4AAIA/8O9vv97dXT/Ew0M/k5KSPvv6+r7Ix0e/9PNzP7++vj7n5uY+t7a2PsfGxr6qqSm/rawsPoSDA7+mpSW/wcBAvIOCgj4AAIA/397evpqZGb/BwEC8jo0NP5GQED3+/X2/lJMTP62sLD719HS+8vFxP8XERD6ioSG/29ravgAAgD/w72+/3t1dP8TDQz+TkpI++/r6vsjHR7/083M/v76+Pufm5j63trY+x8bGvqqpKb+trCw+hIMDv6alJb/BwEC8g4KCPgAAgD/f3t6+mpkZv8HAQLyOjQ0/kZAQPQ==",
-      "vectorSha256": "e66bb84001d0e13e8f2ad9ded37a0f1b204bb202f8b3e6090779ec851ec3b8eb",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "944e85cc8930886dabcc4ff88ecd1391d96cad76c12667c4ba62caa7e81086ed",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0893": {
-      "vector": "9PNzP9HQUL2/vr6++Pd3P/b1db/Ew0O/+fj4vaCfH7/GxUU/hYQEPquqqj7x8HA9trU1v8TDQ7/Pzs4++vl5v+zra7+vrq6+s7KyPuDfXz+opye/q6qqPry7Oz+Pjo4+wcBAvNjXVz+Pjo6+6ulpv/r5eT/t7Gw+sbAwPayrK7/083M/0dBQvb++vr7493c/9vV1v8TDQ7/5+Pi9oJ8fv8bFRT+FhAQ+q6qqPvHwcD22tTW/xMNDv8/Ozj76+Xm/7Otrv6+urr6zsrI+4N9fP6inJ7+rqqo+vLs7P4+Ojj7BwEC82NdXP4+Ojr7q6Wm/+vl5P+3sbD6xsDA9rKsrvw==",
-      "vectorSha256": "b1e1bc019e2e5e1b9a1671a258a4844638ef200972409faf9e28217e50225739",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "325d0d21d09149336d25ebf4c8393e53feaf7fcd6aff27584bd298ea1431f2d9",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0894": {
-      "vector": "9vV1v/f29j7BwEC8q6qqvoOCgj6sqyu/t7a2PrGwML3FxES+uLc3P+vq6r7z8vK+z87OPtva2r6DgoI++Pd3v7a1Nb/BwEA86ulpP+TjY7++vT2/v76+PtfW1r6/vr4+2tlZP7y7Oz+2tTU//v19P97dXT+Qjw+/5uVlv52cHL729XW/9/b2PsHAQLyrqqq+g4KCPqyrK7+3trY+sbAwvcXERL64tzc/6+rqvvPy8r7Pzs4+29ravoOCgj7493e/trU1v8HAQDzq6Wk/5ONjv769Pb+/vr4+19bWvr++vj7a2Vk/vLs7P7a1NT/+/X0/3t1dP5CPD7/m5WW/nZwcvg==",
-      "vectorSha256": "3dee4a12c601322cdd1fd08ad209347263ef1516ebc71b4bb1c5f38b5698d249",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "63baefc057555a513f82bf9f9280535517ab23c54ba48981c522eeec055b7450",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0895": {
-      "vector": "r66uPo6NDT+pqKg929raPuLhYT+sqys//Pt7P7q5Ob/m5WU/x8bGvtDPTz/o52c/h4aGPq2sLL719HS+lZQUPt7dXT/083O/jYwMPr++vj67urq+x8bGvq2sLD7493e/gYCAu8HAQLysqyu/6ejoPbu6uj6wry+/0dBQPZ+enr6vrq4+jo0NP6moqD3b2to+4uFhP6yrKz/8+3s/urk5v+blZT/Hxsa+0M9PP+jnZz+HhoY+rawsvvX0dL6VlBQ+3t1dP/Tzc7+NjAw+v76+Pru6ur7Hxsa+rawsPvj3d7+BgIC7wcBAvKyrK7/p6Og9u7q6PrCvL7/R0FA9n56evg==",
-      "vectorSha256": "00c2729a931fbc836d393a951f106155f1007875e43c449ec75cb32275b7675a",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "5d7e87eefbea85b91da89ab980a86eb4df3041fdeda829ad418dbd6149c317dc",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0896": {
-      "vector": "oqEhv62sLD6SkRG/+Pd3P4qJCb+rqqo+3t1dP7KxMb+NjAw+oqEhv7y7Oz+cmxs/9PNzv7GwML2DgoK+5eRkPsPCwr7n5uY+mJcXP4SDAz/y8XE/u7q6vs7NTT/083O/7u1tP8LBQb/z8vI+9fR0voyLC7/l5GS+tLMzv6KhIb+ioSG/rawsPpKREb/493c/iokJv6uqqj7e3V0/srExv42MDD6ioSG/vLs7P5ybGz/083O/sbAwvYOCgr7l5GQ+w8LCvufm5j6Ylxc/hIMDP/LxcT+7urq+zs1NP/Tzc7/u7W0/wsFBv/Py8j719HS+jIsLv+XkZL60szO/oqEhvw==",
-      "vectorSha256": "82d975b9da8a3f32cd57ef9af487bc5e4625fc96304c33ac92ff91fbe0a4d4bb",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "1f90fb42f37f618d462544626772e504a548b26784a3a5a026e6b7ba2619d2a7",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0897": {
-      "vector": "3dxcPoWEBD6SkRE/8O9vP5WUFD7U01M/5+bmPrGwMD2hoKC8t7a2vu3sbD6pqKi9oqEhv52cHD7Lysq+8/LyPpOSkr6JiIi9rq0tv769Pb+UkxM/sK8vv8jHRz/c21s/kZAQPfX0dD6mpSU/+vl5v6SjIz/Ew0M/5eRkPujnZ7/d3Fw+hYQEPpKRET/w728/lZQUPtTTUz/n5uY+sbAwPaGgoLy3tra+7exsPqmoqL2ioSG/nZwcPsvKyr7z8vI+k5KSvomIiL2urS2/vr09v5STEz+wry+/yMdHP9zbWz+RkBA99fR0PqalJT/6+Xm/pKMjP8TDQz/l5GQ+6Odnvw==",
-      "vectorSha256": "cc3f030b6ad5d8657eafb1f264874b4e2e9722914e664825aca437ce9b46b817",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "19cc1509257c4fc8dfa1367a8244e58f117ec82cd2adcdf8a476c2ac4d5851df",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0898": {
-      "vector": "wcBAvOHg4DyVlBS+0dBQvY6NDb+opyc/2NdXP7i3N7/GxUW/n56evoWEBD6TkpI+trU1P8/Ozr78+3s/5ONjv+XkZL6Pjo4+ubi4vYSDA7/j4uI+2tlZP8bFRT+WlRW/oaCgPJqZGT8AAIC/7u1tv/b1db/U01O/2tlZv+blZb/BwEC84eDgPJWUFL7R0FC9jo0Nv6inJz/Y11c/uLc3v8bFRb+fnp6+hYQEPpOSkj62tTU/z87Ovvz7ez/k42O/5eRkvo+Ojj65uLi9hIMDv+Pi4j7a2Vk/xsVFP5aVFb+hoKA8mpkZPwAAgL/u7W2/9vV1v9TTU7/a2Vm/5uVlvw==",
-      "vectorSha256": "c6d608eb1c38e15ccc405d8a229301aa97645a3fd862068ba69a46b2c9ab25f9",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "230395adc8c2df2a31aee166e1f312d64d96583bbd76861699beea433f48f021",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0899": {
-      "vector": "mpkZvwAAgL+HhoY+7exsPsfGxj6Miws/oqEhv4SDA7+7uro+7exsvs/Ozj7W1VU/kZAQPfj3dz+7uro+oJ8fP+fm5r7Hxsa+jYwMvsPCwr7m5WU/jIsLv7SzMz+cmxu/4N9fv9/e3j7//v6+6+rqvqmoqL36+Xk/zcxMPsHAQDyamRm/AACAv4eGhj7t7Gw+x8bGPoyLCz+ioSG/hIMDv7u6uj7t7Gy+z87OPtbVVT+RkBA9+Pd3P7u6uj6gnx8/5+bmvsfGxr6NjAy+w8LCvublZT+Miwu/tLMzP5ybG7/g31+/397ePv/+/r7r6uq+qaiovfr5eT/NzEw+wcBAPA==",
-      "vectorSha256": "602329cf48022dd9d55c23b98ac1736ea91ede22f29b45214683a14fa446b240",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "2f2bf3c6800b312dd0eff0f5cb952a72d82f7ba0206c588216a3276b6c499b29",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0900": {
-      "vector": "4uFhv4yLC78AAIC/z87OPpeWlr7493e/4uFhP46NDT/j4uI+mJcXv7m4uD3g318/s7KyPsLBQb+CgQG/5ONjv+DfXz/m5WW/4uFhv9PS0j7o52e/0tFRP46NDT+KiQk/iYiIPfLxcT/t7Gw+uLc3P5iXFz/19HS+wsFBv9rZWT/i4WG/jIsLvwAAgL/Pzs4+l5aWvvj3d7/i4WE/jo0NP+Pi4j6Ylxe/ubi4PeDfXz+zsrI+wsFBv4KBAb/k42O/4N9fP+blZb/i4WG/09LSPujnZ7/S0VE/jo0NP4qJCT+JiIg98vFxP+3sbD64tzc/mJcXP/X0dL7CwUG/2tlZPw==",
-      "vectorSha256": "dc10b770b858226ed09831a47820740b398cd46903b6701eec6077bf4c9402fb",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "e2fc1305f945b9595d84dfae73351ab578fbaaa640e94d7691ce8f8915544aa3",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0901": {
-      "vector": "3dxcPpqZGb+hoKC81dRUvpaVFb+/vr4+wcBAvJSTEz+bmpo+qaiovaqpKb+5uLg9xMNDv4iHBz/39va+5ONjP7i3Nz+lpCQ+5uVlv9fW1r6Xlpa+rq0tP4eGhr6gnx+/3dxcPqqpKb+amRk/6ulpP/b1db+Ihwc/kZAQvauqqj7d3Fw+mpkZv6GgoLzV1FS+lpUVv7++vj7BwEC8lJMTP5uamj6pqKi9qqkpv7m4uD3Ew0O/iIcHP/f29r7k42M/uLc3P6WkJD7m5WW/19bWvpeWlr6urS0/h4aGvqCfH7/d3Fw+qqkpv5qZGT/q6Wk/9vV1v4iHBz+RkBC9q6qqPg==",
-      "vectorSha256": "0354ad007d2a6e5ae0b42746481084a869bf56efc5ea8c546e6d420e37bd490f",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "3be218d129eb25a716771ed541048c6b08195fb76d6fc80b82e65476f4c14f4d",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0902": {
-      "vector": "pqUlv//+/j65uLg9iYiIPYOCgj61tDS+lZQUPt7dXb+cmxu/+Pd3P6empr7f3t6+6+rqvs/Ozr67uro+xcREPru6uj68uzs/n56evvv6+j60szO/5ONjP9va2r7q6Wm/9fR0vtrZWT/BwEC8sbAwvby7O7/W1VW/vLs7P+7tbb+mpSW///7+Prm4uD2JiIg9g4KCPrW0NL6VlBQ+3t1dv5ybG7/493c/p6amvt/e3r7r6uq+z87Ovru6uj7FxEQ+u7q6Pry7Oz+fnp6++/r6PrSzM7/k42M/29ravurpab/19HS+2tlZP8HAQLyxsDC9vLs7v9bVVb+8uzs/7u1tvw==",
-      "vectorSha256": "b7e14594e151d7007c2366eacca22182cc51c0b8999692ac37f4230c4b562ec6",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "f7ccbc137aefe9e18e4d9a615bd68f5b938ea26822e9cd646dce5931daea7bd3",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0903": {
-      "vector": "2djYvfTzcz/My0u/tLMzP4KBAb+Ihwe/mZiYvd7dXT++vT0/rawsPuzraz+cmxs/3dxcvoKBAT/t7Gw+6ejovYKBAT+Lioq+/fx8vqyrK7+opyc/i4qKvqinJ7+VlBS+oqEhv5GQEL2Ihwe/09LSPs7NTT+8uzu/0dBQvf38fL7Z2Ni99PNzP8zLS7+0szM/goEBv4iHB7+ZmJi93t1dP769PT+trCw+7OtrP5ybGz/d3Fy+goEBP+3sbD7p6Oi9goEBP4uKir79/Hy+rKsrv6inJz+Lioq+qKcnv5WUFL6ioSG/kZAQvYiHB7/T0tI+zs1NP7y7O7/R0FC9/fx8vg==",
-      "vectorSha256": "c0543e1ea36b2039354c37286de531ea6c2b697d1cec495c0da7ab636b25ef33",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "56ef2a8edbbf042dee64f2943936b42b18f2d99315956531607c1689bc2a7143",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0904": {
-      "vector": "7OtrP7u6ur6opyc/hoUFv8fGxj7g31+/lZQUPvPy8j7z8vI+paQkvtLRUb/S0VG/o6KivpKREb/Qz08/8O9vv+XkZD6DgoK+4N9fP9LRUb+Pjo4+/Pt7v5uamr7Avz8/9PNzP97dXb+FhAQ+oaCgPI+Ojj7Ix0e/pKMjP5qZGT/s62s/u7q6vqinJz+GhQW/x8bGPuDfX7+VlBQ+8/LyPvPy8j6lpCS+0tFRv9LRUb+joqK+kpERv9DPTz/w72+/5eRkPoOCgr7g318/0tFRv4+Ojj78+3u/m5qavsC/Pz/083M/3t1dv4WEBD6hoKA8j46OPsjHR7+koyM/mpkZPw==",
-      "vectorSha256": "b2768fae06d4523674ed30ac7ac4cf9775238f9bfd3a58163af9efc4296a0970",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "30730e0f9308e06a1c417e6771a84bc2d096f174b21cad8e85055ab632ce3091",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0905": {
-      "vector": "6ejovbW0ND7FxEQ+5eRkvtTTU7/p6Og97exsvgAAgD+xsDC9AACAv5KRET+lpCQ+1dRUPu3sbL6Pjo6+k5KSvtLRUb/Lyso+kI8PP9jXVz+BgIA73t1dv6WkJL729XW/3dxcvqKhIb/T0tI+zMtLP/z7ez/t7Gw+wL8/v/LxcT/p6Oi9tbQ0PsXERD7l5GS+1NNTv+no6D3t7Gy+AACAP7GwML0AAIC/kpERP6WkJD7V1FQ+7exsvo+Ojr6TkpK+0tFRv8vKyj6Qjw8/2NdXP4GAgDve3V2/paQkvvb1db/d3Fy+oqEhv9PS0j7My0s//Pt7P+3sbD7Avz+/8vFxPw==",
-      "vectorSha256": "83b45fdab78f27cbde9b1c64c0326ecf64f36d0109476f56e7bd7ee41fd156d5",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "0fa70ac7d8a245fc4acd931fa7132926d735f9fb7dc8e9cfa7b34aea34ae5a5e",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0906": {
       "vector": "o6KiPpSTEz/l5GQ+nJsbP8XERL6RkBA9//7+vsfGxr7z8vI+5uVlv8/Ozj7My0u/+/r6vsC/P7+Ylxe/7exsvqKhIb+KiQm/wL8/P9rZWb/v7u4+1tVVP7u6uj6Qjw8/kpERP9TTUz/T0tK+7Otrv8jHR7/5+Pg9oaCgPLy7O7+joqI+lJMTP+XkZD6cmxs/xcREvpGQED3//v6+x8bGvvPy8j7m5WW/z87OPszLS7/7+vq+wL8/v5iXF7/t7Gy+oqEhv4qJCb/Avz8/2tlZv+/u7j7W1VU/u7q6PpCPDz+SkRE/1NNTP9PS0r7s62u/yMdHv/n4+D2hoKA8vLs7vw==",
       "vectorSha256": "53731860f00ec71aec198fe59997cce5a4ea7e1367032f47ae1d153c4df2a9d0",
@@ -7763,33 +7610,6 @@
       "provider": "cohere",
       "dimensions": 64,
       "textHash": "2878f0e16cf49e9b77bf83f3e39ae3272b0727e955e67d25e13f978151863d24",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0908": {
-      "vector": "rKsrP6WkJL6VlBS+zcxMvpOSkr7083M/3dxcPp6dHT+joqI++Pd3P7Oysr6opyc/l5aWPu/u7r7d3Fw+lZQUvru6ur6/vr6+7exsvp+enj6TkpI+6OdnP/n4+L2rqqq+4N9fP+fm5r6hoKA85+bmvvPy8j7Pzs6+x8bGPqmoqL2sqys/paQkvpWUFL7NzEy+k5KSvvTzcz/d3Fw+np0dP6Oioj7493c/s7KyvqinJz+XlpY+7+7uvt3cXD6VlBS+u7q6vr++vr7t7Gy+n56ePpOSkj7o52c/+fj4vauqqr7g318/5+bmvqGgoDzn5ua+8/LyPs/Ozr7HxsY+qaiovQ==",
-      "vectorSha256": "52d4679c9304cd4ef5205ca9a6ff3a3b0f27c4e5ac0246c65cba00e4c479d5e4",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "e88a064d41c86dab02877f07fdfc1a47d33837d7eaaf26f5201915e7355a55c5",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0909": {
-      "vector": "8fBwvZOSkr64tze/5eRkvtbVVT+xsDA9hoUFv5GQED3BwEA88O9vP/n4+L319HQ+pqUlP5ybGz+urS2/8vFxv9PS0j7NzEy+iIcHP+blZT/9/Hw+pqUlP5STE7+5uLi99/b2vouKij7T0tI+g4KCPsXERL6gnx8/hoUFv8vKyj7x8HC9k5KSvri3N7/l5GS+1tVVP7GwMD2GhQW/kZAQPcHAQDzw728/+fj4vfX0dD6mpSU/nJsbP66tLb/y8XG/09LSPs3MTL6Ihwc/5uVlP/38fD6mpSU/lJMTv7m4uL339va+i4qKPtPS0j6DgoI+xcREvqCfHz+GhQW/y8rKPg==",
-      "vectorSha256": "67e9a00b7d0401476b6b264cd36bf146fbeb9fa3bdb9b86e461423f68c9e5864",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "3b9b8606ac84d076fcdba0b22f95867b4d6962d2e7262b17d35c570f906b7cfa",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0910": {
-      "vector": "kZAQvezraz/X1ta+2tlZv+DfX7+sqys/3t1dv5iXF7/5+Pi9qqkpP4iHB7+6uTk/s7KyvpaVFb/e3V0//v19P4GAgLvDwsK+jYwMPtfW1j7Qz08/sbAwPa6tLT+qqSm/zs1NP8C/P7/c21s/g4KCvre2tr6urS2/5ONjv8vKyj6RkBC97OtrP9fW1r7a2Vm/4N9fv6yrKz/e3V2/mJcXv/n4+L2qqSk/iIcHv7q5OT+zsrK+lpUVv97dXT/+/X0/gYCAu8PCwr6NjAw+19bWPtDPTz+xsDA9rq0tP6qpKb/OzU0/wL8/v9zbWz+DgoK+t7a2vq6tLb/k42O/y8rKPg==",
-      "vectorSha256": "f30191b204bc6fa0f53b70816c19e552f0e24b89d2b2072ecf0431f52348f593",
-      "model": "embed-english-v3.0",
-      "provider": "cohere",
-      "dimensions": 64,
-      "textHash": "2cfd27682ded7fe6f2b9679ebf9f17f79b2a7996a1be368b18218b7e14f58926",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     }
   }

--- a/data/jokes-embeddings-openai.json
+++ b/data/jokes-embeddings-openai.json
@@ -3,8 +3,8 @@
     "provider": "openai",
     "model": "text-embedding-3-large",
     "dimensions": 64,
-    "generatedAt": "2025-09-22T23:16:21.852Z",
-    "recordCount": 865
+    "generatedAt": "2025-09-23T04:06:44.339Z",
+    "recordCount": 845
   },
   "records": {
     "j-0001": {
@@ -7594,159 +7594,6 @@
       "textHash": "3ff4a9952ca7f94b81d9d226e9735b5b6b39a36746999089b720350a26403e31",
       "updatedAt": "2025-09-21T23:10:32.417Z"
     },
-    "j-0889": {
-      "vector": "5ONjv+Pi4j61tDQ+o6KiPra1Nb/k42O/wcBAPLSzMz+ZmJg9+Pd3v7m4uD3f3t6+ycjIPYyLC7+ysTG/t7a2voyLC7+lpCS+z87Ovo+Ojj7s62s/19bWvquqqj7493c/gYCAO/Py8r6fnp4+o6Kivra1NT/HxsY+xsVFv5STEz/k42O/4+LiPrW0ND6joqI+trU1v+TjY7/BwEA8tLMzP5mYmD3493e/ubi4Pd/e3r7JyMg9jIsLv7KxMb+3tra+jIsLv6WkJL7Pzs6+j46OPuzraz/X1ta+q6qqPvj3dz+BgIA78/Lyvp+enj6joqK+trU1P8fGxj7GxUW/lJMTPw==",
-      "vectorSha256": "709f7eed750ac3f68ae514b0e385f75afe1b9dc19287c2ee0576b899ad024686",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "ed0c6b14de90e5500f3e34a022f9e9249f3bce248e56cbff50a5499c671330bb",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0890": {
-      "vector": "kZAQPe3sbD6gnx8/v76+PszLSz+Xlpa+1tVVv4GAgLv9/Hw+x8bGvs/Ozj6Xlpa+0dBQvZCPDz/Hxsa+iIcHv42MDD7U01O/nZwcvqKhIb/w728/2djYvfHwcL3p6Og9mpkZv+no6D3r6uq+g4KCPrOysr6dnBw+qKcnv9jXVz+RkBA97exsPqCfHz+/vr4+zMtLP5eWlr7W1VW/gYCAu/38fD7Hxsa+z87OPpeWlr7R0FC9kI8PP8fGxr6Ihwe/jYwMPtTTU7+dnBy+oqEhv/Dvbz/Z2Ni98fBwveno6D2amRm/6ejoPevq6r6DgoI+s7Kyvp2cHD6opye/2NdXPw==",
-      "vectorSha256": "66a7022f8ba1d0279a5503e167233caaf77c851f77bf8f0514f4753f23791ee2",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "f3acaeb1192888bca83350273cc3973662787ea5e9ba6e7cc7e54a58230f43de",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0891": {
-      "vector": "goEBP6Oioj7DwsI+mpkZP7a1NT/Y11c/iIcHv7Oysj6OjQ2/rq0tP6WkJD6JiIi9mJcXv/79fT/b2to+wcBAvIiHBz+WlRU/qKcnP+DfX7+UkxO/z87OvoqJCb+gnx+/9vV1P7a1Nb+urS0/9/b2vouKij7m5WU///7+vqSjIz+CgQE/o6KiPsPCwj6amRk/trU1P9jXVz+Ihwe/s7KyPo6NDb+urS0/paQkPomIiL2Ylxe//v19P9va2j7BwEC8iIcHP5aVFT+opyc/4N9fv5STE7/Pzs6+iokJv6CfH7/29XU/trU1v66tLT/39va+i4qKPublZT///v6+pKMjPw==",
-      "vectorSha256": "6c0adceaea88148ef5a9c0ac8899a93a5e5a2813623702c5cb8d974fbc7936f4",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "2aaaa0872eed160c5368df52edc15a4b5de0b8efd6caff259ade395b57b83975",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0892": {
-      "vector": "nJsbv7Oysr739va+ubi4vaSjI7/o52e/9PNzP6+urr7y8XG/g4KCPvv6+j7T0tK+yslJv9fW1j7V1FS+7+7uvszLSz/BwEA8+fj4PYaFBT+1tDQ+nJsbP5aVFb+joqI+1dRUvuLhYT/29XW/qqkpP9PS0j719HQ+hIMDP+blZb+cmxu/s7Kyvvf29r65uLi9pKMjv+jnZ7/083M/r66uvvLxcb+DgoI++/r6PtPS0r7KyUm/19bWPtXUVL7v7u6+zMtLP8HAQDz5+Pg9hoUFP7W0ND6cmxs/lpUVv6Oioj7V1FS+4uFhP/b1db+qqSk/09LSPvX0dD6EgwM/5uVlvw==",
-      "vectorSha256": "52885d32275b0285601cbe5180925e8992f92ad75678fe6b69c2e8e6a20a5018",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "944e85cc8930886dabcc4ff88ecd1391d96cad76c12667c4ba62caa7e81086ed",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0893": {
-      "vector": "19bWvp+enj6BgIC75ONjP+7tbb+Ihwc/kI8PP6inJz+koyO/tLMzP/z7e7+opyc/6+rqPqSjI7/d3Fy+zcxMPrSzMz+gnx8/1dRUvvz7ez+amRk/kI8Pv4+Ojr7z8vI+iokJP7y7Oz+9vDw+9fR0PqKhIb/u7W0/z87Ovqempr7X1ta+n56ePoGAgLvk42M/7u1tv4iHBz+Qjw8/qKcnP6SjI7+0szM//Pt7v6inJz/r6uo+pKMjv93cXL7NzEw+tLMzP6CfHz/V1FS+/Pt7P5qZGT+Qjw+/j46OvvPy8j6KiQk/vLs7P728PD719HQ+oqEhv+7tbT/Pzs6+p6amvg==",
-      "vectorSha256": "00bf23980ebb1ac46b1dcb0e7cedb52f737a2d8a039e326a084bc051a55a1899",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "325d0d21d09149336d25ebf4c8393e53feaf7fcd6aff27584bd298ea1431f2d9",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0894": {
-      "vector": "+fj4vZuamj7Y11e/19bWPuHg4Dz29XW/+fj4vYuKij7Ew0M/uLc3P9va2r7My0u/ubi4vZmYmD2Ihwc/rawsPvLxcT++vT2/0tFRv8jHR7+amRm/l5aWvs/Ozr7x8HC9ubi4vcjHR7/n5ua+5ONjP6empj6koyM/397evv79fT/5+Pi9m5qaPtjXV7/X1tY+4eDgPPb1db/5+Pi9i4qKPsTDQz+4tzc/29ravszLS7+5uLi9mZiYPYiHBz+trCw+8vFxP769Pb/S0VG/yMdHv5qZGb+Xlpa+z87OvvHwcL25uLi9yMdHv+fm5r7k42M/p6amPqSjIz/f3t6+/v19Pw==",
-      "vectorSha256": "6b063fa35504d87e0c2eb4e4776ed56341cec2a738c802a15f5e3b9fbbfedb7e",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "63baefc057555a513f82bf9f9280535517ab23c54ba48981c522eeec055b7450",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0895": {
-      "vector": "yMdHP+DfX7/t7Gw+jIsLP6empj7X1tY+vr09v4SDA7/q6Wk/vr09v7i3Nz+joqK+vbw8vvX0dD7t7Gw+urk5P728PL6dnBy+9/b2PvDvbz/FxEQ+lJMTv9/e3j7y8XG/m5qaPqCfHz/S0VE/urk5v/Py8r7Qz0+/7OtrP/X0dL7Ix0c/4N9fv+3sbD6Miws/p6amPtfW1j6+vT2/hIMDv+rpaT++vT2/uLc3P6Oior69vDy+9fR0Pu3sbD66uTk/vbw8vp2cHL739vY+8O9vP8XERD6UkxO/397ePvLxcb+bmpo+oJ8fP9LRUT+6uTm/8/LyvtDPT7/s62s/9fR0vg==",
-      "vectorSha256": "ecb79c8cce59dec8d8585674f66cb5a01be12a0f456e8d3a4f853383233ab19c",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "5d7e87eefbea85b91da89ab980a86eb4df3041fdeda829ad418dbd6149c317dc",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0896": {
-      "vector": "3t1dP/v6+r6WlRU/t7a2vsXERD6NjAy+u7q6PsXERL7b2to+hoUFv6yrK7+koyO/6+rqPqinJz+Pjo4+z87OvqKhIb/k42M//fx8vpGQEL3KyUk/g4KCvuDfX7/FxEQ+hoUFP4GAgLuGhQU/6ejovdDPTz+Lioq+9/b2Po2MDL7e3V0/+/r6vpaVFT+3tra+xcREPo2MDL67uro+xcREvtva2j6GhQW/rKsrv6SjI7/r6uo+qKcnP4+Ojj7Pzs6+oqEhv+TjYz/9/Hy+kZAQvcrJST+DgoK+4N9fv8XERD6GhQU/gYCAu4aFBT/p6Oi90M9PP4uKir739vY+jYwMvg==",
-      "vectorSha256": "f698bbbee46f72ff9861aefb8249f2abfbf3aeb93963571fde2c4315854a1567",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "1f90fb42f37f618d462544626772e504a548b26784a3a5a026e6b7ba2619d2a7",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0897": {
-      "vector": "1dRUvurpaT+0szM/ycjIvevq6j7Ew0O/wcBAPKGgoDz7+vo+jo0NP8XERL7u7W2/zMtLv5OSkr6/vr6+lZQUvsnIyD3S0VE/vbw8PtjXVz/c21u/zs1Nv6qpKT+zsrI+kpERPwAAgD/r6uq+//7+PgAAgL/Pzs6+rKsrv//+/r7V1FS+6ulpP7SzMz/JyMi96+rqPsTDQ7/BwEA8oaCgPPv6+j6OjQ0/xcREvu7tbb/My0u/k5KSvr++vr6VlBS+ycjIPdLRUT+9vDw+2NdXP9zbW7/OzU2/qqkpP7Oysj6SkRE/AACAP+vq6r7//v4+AACAv8/Ozr6sqyu///7+vg==",
-      "vectorSha256": "bd5e1fcec05ca4662c9aeacd0bc168f2b529f1e4939ae346595c0132300adc05",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "19cc1509257c4fc8dfa1367a8244e58f117ec82cd2adcdf8a476c2ac4d5851df",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0898": {
-      "vector": "1dRUPuTjY7/My0s/w8LCvs/Ozr6hoKA8oqEhv769Pb+Miwu/xcREPu3sbD6Miws/iIcHv+no6L3KyUm//Pt7v66tLT/m5WU/hIMDP+rpaT+zsrK+5+bmvtrZWb/n5ua+p6amPuTjY7/f3t6+3t1dv7a1NT+DgoK+/fx8PouKir7V1FQ+5ONjv8zLSz/DwsK+z87OvqGgoDyioSG/vr09v4yLC7/FxEQ+7exsPoyLCz+Ihwe/6ejovcrJSb/8+3u/rq0tP+blZT+EgwM/6ulpP7Oysr7n5ua+2tlZv+fm5r6npqY+5ONjv9/e3r7e3V2/trU1P4OCgr79/Hw+i4qKvg==",
-      "vectorSha256": "4c7be61c6f117c67a09c9a8b85309298a2c10c868935984a1498ec2bd0ae1a5c",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "230395adc8c2df2a31aee166e1f312d64d96583bbd76861699beea433f48f021",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0899": {
-      "vector": "6OdnP4aFBT+wry8/1tVVv/HwcD39/Hw+qaiovcTDQ7+OjQ0/gYCAO7SzMz+CgQG/xMNDv4iHB7/S0VE/0dBQPZKRET/l5GS+qaioPdXUVL7d3Fy+kZAQPZ6dHT+xsDA9m5qavoaFBT/l5GS+2tlZP6GgoDywry8/+/r6vtbVVT/o52c/hoUFP7CvLz/W1VW/8fBwPf38fD6pqKi9xMNDv46NDT+BgIA7tLMzP4KBAb/Ew0O/iIcHv9LRUT/R0FA9kpERP+XkZL6pqKg91dRUvt3cXL6RkBA9np0dP7GwMD2bmpq+hoUFP+XkZL7a2Vk/oaCgPLCvLz/7+vq+1tVVPw==",
-      "vectorSha256": "669a659fd71fe4b9857d0080e844945340709377aa599bb87f1bf570cab26bac",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "2f2bf3c6800b312dd0eff0f5cb952a72d82f7ba0206c588216a3276b6c499b29",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0900": {
-      "vector": "5eRkvuPi4j6Lioo+9fR0vu/u7j7Y11e/oJ8fv9XUVL6wry+///7+PtPS0r61tDQ++Pd3P6Oior6TkpI+paQkPpOSkj6opye/2tlZv6moqL2cmxs/kI8Pv6KhIT+xsDC919bWvuDfX7/Ix0e/gYCAO+3sbD78+3u/h4aGPublZT/l5GS+4+LiPouKij719HS+7+7uPtjXV7+gnx+/1dRUvrCvL7///v4+09LSvrW0ND7493c/o6KivpOSkj6lpCQ+k5KSPqinJ7/a2Vm/qaiovZybGz+Qjw+/oqEhP7GwML3X1ta+4N9fv8jHR7+BgIA77exsPvz7e7+HhoY+5uVlPw==",
-      "vectorSha256": "4a12b63831d30ca1dc04cc1d62a0945f2156db0a00d328a1d6c197c1a23de179",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "e2fc1305f945b9595d84dfae73351ab578fbaaa640e94d7691ce8f8915544aa3",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0901": {
-      "vector": "09LSvuPi4j7y8XE/+vl5P46NDb/6+Xk/t7a2vtLRUb+amRm/lpUVv+zra7+OjQ0/0M9Pv5WUFL7GxUW/hYQEvtnY2L3Ew0O/vbw8PqmoqD0AAIC/29ravoiHBz/d3Fy+5+bmvoaFBT/x8HA9z87Ovp+enj7My0s/7OtrP8rJST/T0tK+4+LiPvLxcT/6+Xk/jo0Nv/r5eT+3tra+0tFRv5qZGb+WlRW/7Otrv46NDT/Qz0+/lZQUvsbFRb+FhAS+2djYvcTDQ7+9vDw+qaioPQAAgL/b2tq+iIcHP93cXL7n5ua+hoUFP/HwcD3Pzs6+n56ePszLSz/s62s/yslJPw==",
-      "vectorSha256": "cfd1608674108986dd9371d59adb468f36d739f60f63212a635546e70daf0910",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "3be218d129eb25a716771ed541048c6b08195fb76d6fc80b82e65476f4c14f4d",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0902": {
-      "vector": "jYwMvoGAgLuOjQ2/xMNDP+DfX7/OzU2/xcREPp2cHL7p6Oi9rawsvqmoqL319HQ+3NtbP/HwcL2EgwM/1NNTv6qpKT/7+vo+3t1dv7q5OT/+/X2/sbAwPYaFBT/a2Vm/s7KyvsTDQ7/v7u4+hIMDv6inJz/6+Xk/mJcXv+Pi4j6NjAy+gYCAu46NDb/Ew0M/4N9fv87NTb/FxEQ+nZwcvuno6L2trCy+qaiovfX0dD7c21s/8fBwvYSDAz/U01O/qqkpP/v6+j7e3V2/urk5P/79fb+xsDA9hoUFP9rZWb+zsrK+xMNDv+/u7j6EgwO/qKcnP/r5eT+Ylxe/4+LiPg==",
-      "vectorSha256": "ab7af2a6d44d9faab00bc93cf4fbcfda5bca6448f7828c45502080aca1f57d08",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "f7ccbc137aefe9e18e4d9a615bd68f5b938ea26822e9cd646dce5931daea7bd3",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0903": {
-      "vector": "j46OPpKRET+enR0/sbAwPcnIyL3Y11c/vbw8vsrJST+joqK+n56evp2cHD79/Hw+tbQ0Pru6ur66uTk/vbw8PomIiL3HxsY+AACAP4KBAT/9/Hy+zcxMPtHQUD2mpSW/pqUlv5uamr6vrq4+p6amPrq5Ob/p6Og9mJcXP/v6+r6Pjo4+kpERP56dHT+xsDA9ycjIvdjXVz+9vDy+yslJP6Oior6fnp6+nZwcPv38fD61tDQ+u7q6vrq5OT+9vDw+iYiIvcfGxj4AAIA/goEBP/38fL7NzEw+0dBQPaalJb+mpSW/m5qavq+urj6npqY+urk5v+no6D2Ylxc/+/r6vg==",
-      "vectorSha256": "6336087bec5a93a70012aa34c44f53cd7d1b93ffacfd353669b66e5984050fbd",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "56ef2a8edbbf042dee64f2943936b42b18f2d99315956531607c1689bc2a7143",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0904": {
-      "vector": "iokJv6empj7Qz0+/vr09P/j3d7/5+Pi97u1tv/Dvbz+EgwO/6ejoPd/e3r6Miwu/xsVFP6yrKz/x8HA92tlZv+rpab+xsDC96ulpv/b1db8AAIA/sbAwveblZb+pqKi9y8rKvuDfX7/g31+/9fR0PrSzM7+9vDy+29raPvTzc7+KiQm/p6amPtDPT7++vT0/+Pd3v/n4+L3u7W2/8O9vP4SDA7/p6Og9397evoyLC7/GxUU/rKsrP/HwcD3a2Vm/6ulpv7GwML3q6Wm/9vV1vwAAgD+xsDC95uVlv6moqL3Lysq+4N9fv+DfX7/19HQ+tLMzv728PL7b2to+9PNzvw==",
-      "vectorSha256": "747101a0f7bb1e5fc7b34bb2bfc4f5573eb3fc6a192dd0cdd5e2a939a26665e0",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "30730e0f9308e06a1c417e6771a84bc2d096f174b21cad8e85055ab632ce3091",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0905": {
-      "vector": "wsFBv8zLSz+opye/zs1NP8HAQDzPzs4++fj4Pfr5eb+dnBy+wL8/P+LhYb/BwEC8zs1NP4uKir7e3V2/+vl5v5STEz8AAIC/2djYvdnY2L3z8vI+ycjIPZeWlr7+/X0/AACAv/z7ez/6+Xk/jYwMvoGAgLv9/Hy+mJcXv9TTUz/CwUG/zMtLP6inJ7/OzU0/wcBAPM/Ozj75+Pg9+vl5v52cHL7Avz8/4uFhv8HAQLzOzU0/i4qKvt7dXb/6+Xm/lJMTPwAAgL/Z2Ni92djYvfPy8j7JyMg9l5aWvv79fT8AAIC//Pt7P/r5eT+NjAy+gYCAu/38fL6Ylxe/1NNTPw==",
-      "vectorSha256": "df99c2b3d61f60356ec06e94d3fe41d5a463ca9b89a679a7e98ff91e8ab3892a",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "0fa70ac7d8a245fc4acd931fa7132926d735f9fb7dc8e9cfa7b34aea34ae5a5e",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0906": {
       "vector": "pKMjv/n4+D3T0tK+goEBv769Pb/7+vo+29ravqKhIb/p6Oi98O9vP7Oysr6CgQE/5ONjv7CvL7/z8vK+9PNzP9XUVD7Pzs6+/v19v4KBAb/R0FC94uFhv46NDT/b2tq+4+LiPvn4+L2FhAS+kpERv+Pi4r7S0VG/kI8PP5OSkr6koyO/+fj4PdPS0r6CgQG/vr09v/v6+j7b2tq+oqEhv+no6L3w728/s7KyvoKBAT/k42O/sK8vv/Py8r7083M/1dRUPs/Ozr7+/X2/goEBv9HQUL3i4WG/jo0NP9va2r7j4uI++fj4vYWEBL6SkRG/4+LivtLRUb+Qjw8/k5KSvg==",
       "vectorSha256": "a37f135764d222674b86dbfd5311a7f100c3b5e4b37284d311159b6575ace6dc",
@@ -7763,33 +7610,6 @@
       "provider": "openai",
       "dimensions": 64,
       "textHash": "2878f0e16cf49e9b77bf83f3e39ae3272b0727e955e67d25e13f978151863d24",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0908": {
-      "vector": "np0dP9PS0j6Ylxe/6OdnP5qZGT+JiIg9mZiYPfj3dz/f3t6+kZAQPfr5eT+GhQW/8/LyvtXUVL6joqI+9fR0PoKBAb8AAIC/qaioPYOCgj6amRm/goEBP6inJz+KiQm/v76+Puzraz/BwEC8//7+Po2MDL6EgwM/hoUFP+fm5r6enR0/09LSPpiXF7/o52c/mpkZP4mIiD2ZmJg9+Pd3P9/e3r6RkBA9+vl5P4aFBb/z8vK+1dRUvqOioj719HQ+goEBvwAAgL+pqKg9g4KCPpqZGb+CgQE/qKcnP4qJCb+/vr4+7OtrP8HAQLz//v4+jYwMvoSDAz+GhQU/5+bmvg==",
-      "vectorSha256": "3f7d308cf19df9ece5e4a67e33b61c6ea99643f4ee2bf1552999581144273fb2",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "e88a064d41c86dab02877f07fdfc1a47d33837d7eaaf26f5201915e7355a55c5",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0909": {
-      "vector": "k5KSvpGQEL3v7u6+qqkpv5qZGT/l5GQ+9/b2vuHg4Dywry+/7+7uvv/+/r68uzs/rawsPsXERD7r6uq+0tFRv5+enj7p6Oi9kI8Pv/j3d7/7+vq+1tVVP4aFBb+lpCQ++vl5v5mYmD3u7W2/09LSPv38fD7v7u6+6Odnv5aVFT+TkpK+kZAQve/u7r6qqSm/mpkZP+XkZD739va+4eDgPLCvL7/v7u6+//7+vry7Oz+trCw+xcREPuvq6r7S0VG/n56ePuno6L2Qjw+/+Pd3v/v6+r7W1VU/hoUFv6WkJD76+Xm/mZiYPe7tbb/T0tI+/fx8Pu/u7r7o52e/lpUVPw==",
-      "vectorSha256": "1e5c81d7995148365c9e552a11f4e0feeaef5baf1f8531bf9807d12a67c15b19",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "3b9b8606ac84d076fcdba0b22f95867b4d6962d2e7262b17d35c570f906b7cfa",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0910": {
-      "vector": "+fj4vf38fD7S0VE/7u1tP8bFRT+0szM/wcBAvJaVFb+FhAQ++/r6vpCPD7/Qz08/nZwcPqKhIT/d3Fw+g4KCPr++vj7FxES+oJ8fv9PS0j6OjQ0/8vFxP4KBAT/X1ta+m5qavsC/Pz/Ew0M/lpUVP9va2j7T0tK+xsVFv6+urr75+Pi9/fx8PtLRUT/u7W0/xsVFP7SzMz/BwEC8lpUVv4WEBD77+vq+kI8Pv9DPTz+dnBw+oqEhP93cXD6DgoI+v76+PsXERL6gnx+/09LSPo6NDT/y8XE/goEBP9fW1r6bmpq+wL8/P8TDQz+WlRU/29raPtPS0r7GxUW/r66uvg==",
-      "vectorSha256": "9e0e999ed083fdc5ae0a8b053297e8d400966c87f8c2c4ebd54186d59d79fcad",
-      "model": "text-embedding-3-large (second opinion)",
-      "provider": "openai",
-      "dimensions": 64,
-      "textHash": "2cfd27682ded7fe6f2b9679ebf9f17f79b2a7996a1be368b18218b7e14f58926",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     }
   }

--- a/data/jokes-embeddings.json
+++ b/data/jokes-embeddings.json
@@ -3,8 +3,8 @@
     "provider": "synthetic",
     "model": "synthetic-64",
     "dimensions": 64,
-    "generatedAt": "2025-09-23T01:02:19.484Z",
-    "recordCount": 870
+    "generatedAt": "2025-09-23T04:04:56.265Z",
+    "recordCount": 850
   },
   "records": {
     "j-0001": {
@@ -7594,159 +7594,6 @@
       "textHash": "3ff4a9952ca7f94b81d9d226e9735b5b6b39a36746999089b720350a26403e31",
       "updatedAt": "2025-09-21T03:21:38.309Z"
     },
-    "j-0889": {
-      "vector": "2djYPcvKyj6/vr6+iIcHv9fW1j60szM/k5KSvqKhIb+sqys/9vV1P9rZWT/b2to+yslJP7i3Nz/j4uK+9fR0PtPS0j6BgIC7y8rKPsXERD7s62u/9PNzP8LBQT+JiIi91tVVv9HQUL2zsrK+oJ8fP4yLCz+cmxu/trU1P+fm5j7Z2Ng9y8rKPr++vr6Ihwe/19bWPrSzMz+TkpK+oqEhv6yrKz/29XU/2tlZP9va2j7KyUk/uLc3P+Pi4r719HQ+09LSPoGAgLvLyso+xcREPuzra7/083M/wsFBP4mIiL3W1VW/0dBQvbOysr6gnx8/jIsLP5ybG7+2tTU/5+bmPg==",
-      "vectorSha256": "57c8d6f2ea3311bc8b08762e7990f7aba11e1b2ace143cfe819b1c3e93a61d34",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "ed0c6b14de90e5500f3e34a022f9e9249f3bce248e56cbff50a5499c671330bb",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0890": {
-      "vector": "1dRUvoyLCz/Z2Ni9v76+vpqZGb/a2Vk/lpUVP97dXT+NjAy+x8bGvr69Pb+enR0/2tlZP/Tzc7+GhQW/19bWPuno6L3Ix0c/q6qqvv38fD7X1tY+hIMDv/Dvb7+cmxs/397ePtrZWb/5+Pi9yslJv8vKyr60szO/wcBAPPPy8j7V1FS+jIsLP9nY2L2/vr6+mpkZv9rZWT+WlRU/3t1dP42MDL7Hxsa+vr09v56dHT/a2Vk/9PNzv4aFBb/X1tY+6ejovcjHRz+rqqq+/fx8PtfW1j6EgwO/8O9vv5ybGz/f3t4+2tlZv/n4+L3KyUm/y8rKvrSzM7/BwEA88/LyPg==",
-      "vectorSha256": "21174797ee82f15337e53c54028598a1d3c111b8fe397a5a372ba6169e623c99",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "f3acaeb1192888bca83350273cc3973662787ea5e9ba6e7cc7e54a58230f43de",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0891": {
-      "vector": "/fx8Pr28PL7JyMi9xMNDP56dHb+JiIg9g4KCPvX0dD7e3V0/h4aGvpaVFb/My0s/4uFhv+Hg4LyYlxc/jIsLP9va2r7t7Gw+AACAv4GAgLuNjAy+s7Kyvry7O7+JiIi9srExP+rpaT/Avz8/pqUlP5STEz+TkpI+xMNDv7GwMD39/Hw+vbw8vsnIyL3Ew0M/np0dv4mIiD2DgoI+9fR0Pt7dXT+Hhoa+lpUVv8zLSz/i4WG/4eDgvJiXFz+Miws/29ravu3sbD4AAIC/gYCAu42MDL6zsrK+vLs7v4mIiL2ysTE/6ulpP8C/Pz+mpSU/lJMTP5OSkj7Ew0O/sbAwPQ==",
-      "vectorSha256": "f36c635bcf2cc1595d1a9e91b90114a3d3030ede18682ca074fece9df7341070",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "2aaaa0872eed160c5368df52edc15a4b5de0b8efd6caff259ade395b57b83975",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0892": {
-      "vector": "7exsvrGwML2FhAQ+nJsbP6+urr7s62u/vLs7v4aFBb+OjQ0/5+bmvtjXV7+Miwu/v76+vqinJz/X1tY+2tlZv4uKir7Qz08/09LSPqalJb/083O/09LSPp6dHb/R0FC97OtrP5CPD7+qqSm/uLc3v9rZWb/h4OA8kZAQPcfGxr7t7Gy+sbAwvYWEBD6cmxs/r66uvuzra7+8uzu/hoUFv46NDT/n5ua+2NdXv4yLC7+/vr6+qKcnP9fW1j7a2Vm/i4qKvtDPTz/T0tI+pqUlv/Tzc7/T0tI+np0dv9HQUL3s62s/kI8Pv6qpKb+4tze/2tlZv+Hg4DyRkBA9x8bGvg==",
-      "vectorSha256": "083e78e1ba07bca84b995bf1d8e7f5e3c2c22bdf01b71482965059ee065dc004",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "944e85cc8930886dabcc4ff88ecd1391d96cad76c12667c4ba62caa7e81086ed",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0893": {
-      "vector": "k5KSvvHwcL3My0s/mpkZP9rZWb///v6++fj4PdLRUb/6+Xm/8vFxv728PL79/Hy+o6KiPru6ur7o52e/+fj4Pezra7/v7u4+1tVVP9zbWz+hoKA87+7uPpCPD7+Miws/sbAwvZGQEL2rqqq+paQkvsPCwr6OjQ2//v19P4OCgj6TkpK+8fBwvczLSz+amRk/2tlZv//+/r75+Pg90tFRv/r5eb/y8XG/vbw8vv38fL6joqI+u7q6vujnZ7/5+Pg97Otrv+/u7j7W1VU/3NtbP6GgoDzv7u4+kI8Pv4yLCz+xsDC9kZAQvauqqr6lpCS+w8LCvo6NDb/+/X0/g4KCPg==",
-      "vectorSha256": "c4c5eec91735f17cd6777dda81e3ce4d1d71739374bdbb6cf7f4afd16632ad8c",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "325d0d21d09149336d25ebf4c8393e53feaf7fcd6aff27584bd298ea1431f2d9",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0894": {
-      "vector": "zcxMPvn4+L39/Hw++/r6vvLxcb/Z2Ng9s7KyPs3MTD7JyMg9jIsLP5WUFD63trY+m5qaPu/u7r6gnx8/zcxMvpiXFz/U01O//fx8PtDPTz+Pjo6+/v19v7m4uL23tra+8O9vP5eWlj6EgwM/jIsLv9va2r6hoKC8xsVFP7u6ur7NzEw++fj4vf38fD77+vq+8vFxv9nY2D2zsrI+zcxMPsnIyD2Miws/lZQUPre2tj6bmpo+7+7uvqCfHz/NzEy+mJcXP9TTU7/9/Hw+0M9PP4+Ojr7+/X2/ubi4vbe2tr7w728/l5aWPoSDAz+Miwu/29ravqGgoLzGxUU/u7q6vg==",
-      "vectorSha256": "189cf325010bf609bd857b7fd660e1d1ec977accd22a9cdf88f1576a35c82a8c",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "63baefc057555a513f82bf9f9280535517ab23c54ba48981c522eeec055b7450",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0895": {
-      "vector": "g4KCPv38fD7+/X2/lJMTP8LBQb+opye/pqUlv/b1db/W1VW/t7a2vvHwcD3X1ta+9vV1v8TDQz+TkpI+pqUlv7e2tj69vDy+5+bmvublZb/6+Xm/xMNDv42MDD69vDw+rq0tv9va2r6UkxM/lpUVP9PS0r6KiQk/397ePsvKyr6DgoI+/fx8Pv79fb+UkxM/wsFBv6inJ7+mpSW/9vV1v9bVVb+3tra+8fBwPdfW1r729XW/xMNDP5OSkj6mpSW/t7a2Pr28PL7n5ua+5uVlv/r5eb/Ew0O/jYwMPr28PD6urS2/29ravpSTEz+WlRU/09LSvoqJCT/f3t4+y8rKvg==",
-      "vectorSha256": "91ad232463875d8f2b88864e9b5310f0734c21d9844e76974591e6f7ca04de26",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "5d7e87eefbea85b91da89ab980a86eb4df3041fdeda829ad418dbd6149c317dc",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0896": {
-      "vector": "pqUlv5mYmD2npqY+5eRkvsHAQLzr6uq+hIMDv66tLT/DwsI+jo0NP4aFBb/5+Pi99vV1P+jnZ7+DgoK+zMtLv8XERD75+Pg94uFhP5WUFL6ZmJi96ulpv+rpaT+dnBy+7Otrv6alJT+zsrK+k5KSPuPi4j78+3s/l5aWvvf29j6mpSW/mZiYPaempj7l5GS+wcBAvOvq6r6EgwO/rq0tP8PCwj6OjQ0/hoUFv/n4+L329XU/6Odnv4OCgr7My0u/xcREPvn4+D3i4WE/lZQUvpmYmL3q6Wm/6ulpP52cHL7s62u/pqUlP7Oysr6TkpI+4+LiPvz7ez+Xlpa+9/b2Pg==",
-      "vectorSha256": "f63d37d6823ddaea233196fb87ef4ca261821b41af8c70ebc2bc55846fbeab38",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "1f90fb42f37f618d462544626772e504a548b26784a3a5a026e6b7ba2619d2a7",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0897": {
-      "vector": "mJcXv/Tzcz/BwEC8nJsbv4KBAb/Lysq+yMdHv9nY2D3Hxsa+hoUFv8rJSb+xsDC9t7a2PublZT/083M/srExP4eGhr7BwEC8yslJv5+enj69vDw+qaiovYWEBL7e3V0/4uFhv728PD7Pzs4+3t1dP4eGhj6lpCS+qKcnv728PD6Ylxe/9PNzP8HAQLycmxu/goEBv8vKyr7Ix0e/2djYPcfGxr6GhQW/yslJv7GwML23trY+5uVlP/Tzcz+ysTE/h4aGvsHAQLzKyUm/n56ePr28PD6pqKi9hYQEvt7dXT/i4WG/vbw8Ps/Ozj7e3V0/h4aGPqWkJL6opye/vbw8Pg==",
-      "vectorSha256": "27b93e8f6d4dc7316b6e659018e304b47c01f9cb7025fa2bac1f84a6283b4176",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "19cc1509257c4fc8dfa1367a8244e58f117ec82cd2adcdf8a476c2ac4d5851df",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0898": {
-      "vector": "5+bmvsbFRT+amRk/09LSvtzbWz/X1tY+oaCgPKSjIz/e3V2/v76+vvf29j7i4WG/sK8vP+fm5r7u7W0/9vV1P9rZWT+lpCS+2NdXv/z7ez+HhoY+iIcHv52cHL6JiIg95eRkvqqpKb/CwUE/hoUFP9/e3j7JyMi9u7q6vq6tLb/n5ua+xsVFP5qZGT/T0tK+3NtbP9fW1j6hoKA8pKMjP97dXb+/vr6+9/b2PuLhYb+wry8/5+bmvu7tbT/29XU/2tlZP6WkJL7Y11e//Pt7P4eGhj6Ihwe/nZwcvomIiD3l5GS+qqkpv8LBQT+GhQU/397ePsnIyL27urq+rq0tvw==",
-      "vectorSha256": "b69681d9e54be388bad3b1286ec8643dd4938fc2c5a8728e8a1e2f1fd06025a9",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "230395adc8c2df2a31aee166e1f312d64d96583bbd76861699beea433f48f021",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0899": {
-      "vector": "oJ8fv+jnZ7+0szO/u7q6voeGhj6CgQE/8O9vv9bVVT+npqa+s7Kyvo+Ojj7T0tK+oJ8fP5CPDz/y8XE/yslJv6Oior6DgoI+k5KSPpKREb+gnx+/iIcHv//+/r7083O/7u1tv4GAgLvJyMg9jYwMPvDvbz+9vDy+o6KiPqSjIz+gnx+/6Odnv7SzM7+7urq+h4aGPoKBAT/w72+/1tVVP6empr6zsrK+j46OPtPS0r6gnx8/kI8PP/LxcT/KyUm/o6KivoOCgj6TkpI+kpERv6CfH7+Ihwe///7+vvTzc7/u7W2/gYCAu8nIyD2NjAw+8O9vP728PL6joqI+pKMjPw==",
-      "vectorSha256": "35a60b12de91dec276a2d39ebe198c09618c9b2c428e271a4d00e2b3e4c871f7",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "2f2bf3c6800b312dd0eff0f5cb952a72d82f7ba0206c588216a3276b6c499b29",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0900": {
-      "vector": "2NdXP87NTT+WlRW/8/Lyvu/u7r7i4WE/zMtLP6uqqj6KiQm/3t1dP8HAQLyUkxM/i4qKPsC/P7/Pzs6+AACAP5CPD7/Qz0+/6ulpv7a1Nb+trCw+xcREvt/e3j77+vo+oaCgvPr5eT+zsrI+jIsLv4SDAz+NjAy+yMdHP4GAgDvY11c/zs1NP5aVFb/z8vK+7+7uvuLhYT/My0s/q6qqPoqJCb/e3V0/wcBAvJSTEz+Lioo+wL8/v8/Ozr4AAIA/kI8Pv9DPT7/q6Wm/trU1v62sLD7FxES+397ePvv6+j6hoKC8+vl5P7Oysj6Miwu/hIMDP42MDL7Ix0c/gYCAOw==",
-      "vectorSha256": "7973c50507dd12c9e5e34b1e6c92360ffe1617cba20a396fcdb2850fc8baac67",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "e2fc1305f945b9595d84dfae73351ab578fbaaa640e94d7691ce8f8915544aa3",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0901": {
-      "vector": "v76+PpCPDz+cmxs/vLs7v5KREb/x8HC9pKMjv+3sbD6FhAS+paQkPuTjY7/GxUU/q6qqvqyrKz/CwUE/6Odnv/LxcT/X1ta+0tFRP/38fL6XlpY+xMNDv7CvLz/DwsK+5uVlv6SjIz+ioSG/np0dP8/Ozj7g318/7exsPsbFRT+/vr4+kI8PP5ybGz+8uzu/kpERv/HwcL2koyO/7exsPoWEBL6lpCQ+5ONjv8bFRT+rqqq+rKsrP8LBQT/o52e/8vFxP9fW1r7S0VE//fx8vpeWlj7Ew0O/sK8vP8PCwr7m5WW/pKMjP6KhIb+enR0/z87OPuDfXz/t7Gw+xsVFPw==",
-      "vectorSha256": "98ae0b1b4cda8727c5d745a25f6850cc1827356d369fef6068b708e031754d27",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "3be218d129eb25a716771ed541048c6b08195fb76d6fc80b82e65476f4c14f4d",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0902": {
-      "vector": "u7q6vvn4+D2mpSU/y8rKvq+urj6wry+/sbAwPdDPT7/h4OA8x8bGPtjXV7/39va+iYiIPauqqr7d3Fy+kpERv52cHL6Qjw8/jIsLP6qpKb+FhAQ+3dxcvtPS0r7a2Vm/xsVFv7GwML2hoKC8qaiovcrJSb/X1tY+0M9Pv8jHR7+7urq++fj4PaalJT/Lysq+r66uPrCvL7+xsDA90M9Pv+Hg4DzHxsY+2NdXv/f29r6JiIg9q6qqvt3cXL6SkRG/nZwcvpCPDz+Miws/qqkpv4WEBD7d3Fy+09LSvtrZWb/GxUW/sbAwvaGgoLypqKi9yslJv9fW1j7Qz0+/yMdHvw==",
-      "vectorSha256": "e8b9719686c43b64c4744698a06b0e155b2501c0d13ee394a51584f634cb1ba7",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "f7ccbc137aefe9e18e4d9a615bd68f5b938ea26822e9cd646dce5931daea7bd3",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0903": {
-      "vector": "goEBv66tLb+2tTU/hoUFv97dXb+JiIg9p6amvo2MDD7W1VW/jIsLv/79fb+dnBy+ubi4PbSzM7+Ihwe/6ulpv4aFBb/t7Gy+kI8PP7Oysj7CwUG/9vV1P9jXV7/h4OC8wcBAvO/u7r6OjQ2/r66uPri3N7/o52e/+vl5P+zra7+CgQG/rq0tv7a1NT+GhQW/3t1dv4mIiD2npqa+jYwMPtbVVb+Miwu//v19v52cHL65uLg9tLMzv4iHB7/q6Wm/hoUFv+3sbL6Qjw8/s7KyPsLBQb/29XU/2NdXv+Hg4LzBwEC87+7uvo6NDb+vrq4+uLc3v+jnZ7/6+Xk/7Otrvw==",
-      "vectorSha256": "b47d38e48001d82199942916d858ff18089e01ed1d8268a5951568b55772b0a9",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "56ef2a8edbbf042dee64f2943936b42b18f2d99315956531607c1689bc2a7143",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0904": {
-      "vector": "iokJP5ybGz+JiIg96+rqvpqZGb/W1VW//Pt7v769PT/Hxsa+8/LyvoeGhr6joqI+/v19P5GQED3o52c/8vFxv+blZb+KiQk/9PNzP6inJ7+6uTk/1NNTv+Pi4r7Y11c/tbQ0vszLSz+lpCQ+mpkZP9HQUL2ioSG/paQkvoGAgLuKiQk/nJsbP4mIiD3r6uq+mpkZv9bVVb/8+3u/vr09P8fGxr7z8vK+h4aGvqOioj7+/X0/kZAQPejnZz/y8XG/5uVlv4qJCT/083M/qKcnv7q5OT/U01O/4+LivtjXVz+1tDS+zMtLP6WkJD6amRk/0dBQvaKhIb+lpCS+gYCAuw==",
-      "vectorSha256": "0ddb22dcb7c0199e97b907d40ac517413d04036eabae4c9fee328809771d482f",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "30730e0f9308e06a1c417e6771a84bc2d096f174b21cad8e85055ab632ce3091",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0905": {
-      "vector": "mZiYPcHAQLy8uzu/np0dP7CvLz/Ix0e/yslJv/Dvbz/Avz+/q6qqPoeGhr7l5GQ+397ePru6uj7w72+/mpkZP+vq6j6hoKA8hIMDv4WEBL7m5WW/trU1P7i3N7+trCy+k5KSvomIiD37+vo+6+rqvrGwMD2FhAQ+sK8vv4SDAz+ZmJg9wcBAvLy7O7+enR0/sK8vP8jHR7/KyUm/8O9vP8C/P7+rqqo+h4aGvuXkZD7f3t4+u7q6PvDvb7+amRk/6+rqPqGgoDyEgwO/hYQEvublZb+2tTU/uLc3v62sLL6TkpK+iYiIPfv6+j7r6uq+sbAwPYWEBD6wry+/hIMDPw==",
-      "vectorSha256": "ede517f93ee7749ac7846f0e575fb4c14883eb8b7afc6d0f8d975bd659b357cf",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "0fa70ac7d8a245fc4acd931fa7132926d735f9fb7dc8e9cfa7b34aea34ae5a5e",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
     "j-0906": {
       "vector": "9PNzP/X0dD6mpSW/5+bmPoqJCT/u7W2/9PNzv8fGxj7j4uK++vl5P6qpKb+rqqq+rawsPuvq6j6GhQW/5+bmPsHAQDzIx0c/0M9Pv66tLb/HxsY+nJsbv8fGxj7Pzs4+yMdHv/Dvbz/083M/yMdHP5mYmD2NjAw+kZAQPbm4uL3083M/9fR0PqalJb/n5uY+iokJP+7tbb/083O/x8bGPuPi4r76+Xk/qqkpv6uqqr6trCw+6+rqPoaFBb/n5uY+wcBAPMjHRz/Qz0+/rq0tv8fGxj6cmxu/x8bGPs/Ozj7Ix0e/8O9vP/Tzcz/Ix0c/mZiYPY2MDD6RkBA9ubi4vQ==",
       "vectorSha256": "1c7ad0d1b898c3be0e3329869f24445e5298c1bb8441a02f64bf9d72e4bcc2ff",
@@ -7763,33 +7610,6 @@
       "provider": "synthetic",
       "dimensions": 64,
       "textHash": "2878f0e16cf49e9b77bf83f3e39ae3272b0727e955e67d25e13f978151863d24",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0908": {
-      "vector": "zs1Nv/n4+D329XW/sbAwPeHg4Dywry8/8vFxv+zra7+pqKg9kI8PP9LRUT/Lyso+5eRkvu/u7j6opyc/yMdHv8C/Pz+amRk/5uVlP87NTT+5uLi94eDgPLCvL7+2tTW/6Odnv5qZGb/e3V2/kZAQveXkZD7HxsY+r66uPre2tr7OzU2/+fj4Pfb1db+xsDA94eDgPLCvLz/y8XG/7Otrv6moqD2Qjw8/0tFRP8vKyj7l5GS+7+7uPqinJz/Ix0e/wL8/P5qZGT/m5WU/zs1NP7m4uL3h4OA8sK8vv7a1Nb/o52e/mpkZv97dXb+RkBC95eRkPsfGxj6vrq4+t7a2vg==",
-      "vectorSha256": "82a19cd6c44ab9a182c4411df1580220dc3312ecb706998432eaad550aab1db7",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "e88a064d41c86dab02877f07fdfc1a47d33837d7eaaf26f5201915e7355a55c5",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0909": {
-      "vector": "trU1v42MDL7GxUW/5+bmPtzbW7+fnp6+h4aGvpCPD7/9/Hy+jYwMPgAAgL///v6+3dxcPre2tj7V1FQ+zs1Nv6WkJD77+vq+lpUVP9XUVL79/Hw+iYiIPaalJT+EgwM/ycjIvYuKij69vDy+kpERv+jnZz/j4uK+3Ntbv+XkZD62tTW/jYwMvsbFRb/n5uY+3Ntbv5+enr6Hhoa+kI8Pv/38fL6NjAw+AACAv//+/r7d3Fw+t7a2PtXUVD7OzU2/paQkPvv6+r6WlRU/1dRUvv38fD6JiIg9pqUlP4SDAz/JyMi9i4qKPr28PL6SkRG/6OdnP+Pi4r7c21u/5eRkPg==",
-      "vectorSha256": "cb9ef8ee1475cbaa836b0bbf67c811054702724fcab037ce5d301d572dee7830",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "3b9b8606ac84d076fcdba0b22f95867b4d6962d2e7262b17d35c570f906b7cfa",
-      "updatedAt": "2025-09-22T01:50:07.859Z"
-    },
-    "j-0910": {
-      "vector": "z87OPru6uj6urS2/jIsLv8zLSz+koyO/7OtrP6qpKb+OjQ0/pKMjP5CPD7/S0VE/goEBP5OSkr7Ew0O/oqEhv+3sbL6Qjw8//v19P+7tbT/OzU0///7+PsHAQLz29XU/+vl5P8LBQb+enR2/oJ8fP8bFRT/FxES+j46Ovp2cHD7Pzs4+u7q6Pq6tLb+Miwu/zMtLP6SjI7/s62s/qqkpv46NDT+koyM/kI8Pv9LRUT+CgQE/k5KSvsTDQ7+ioSG/7exsvpCPDz/+/X0/7u1tP87NTT///v4+wcBAvPb1dT/6+Xk/wsFBv56dHb+gnx8/xsVFP8XERL6Pjo6+nZwcPg==",
-      "vectorSha256": "58a045ee8bb3d81bcf362529ea19cb6cefbcd32dc5e1ac78b63ec134b9777b09",
-      "model": "synthetic-64",
-      "provider": "synthetic",
-      "dimensions": 64,
-      "textHash": "2cfd27682ded7fe6f2b9679ebf9f17f79b2a7996a1be368b18218b7e14f58926",
       "updatedAt": "2025-09-22T01:50:07.859Z"
     },
     "j-0911": {

--- a/data/jokes-manifest.json
+++ b/data/jokes-manifest.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "generatedAt": "2025-09-22T23:16:21.809Z",
-    "total": 865,
+    "generatedAt": "2025-09-23T04:05:28.246Z",
+    "total": 850,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",
     "fields": [
@@ -25,10 +25,10 @@
         "sequence": 1
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "25b86de4c565923a74dad51665c058978d64569fc9756382cc64afe996a9145f",
-        "updatedAt": "2025-09-20T22:27:41.489Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0002": {
@@ -46,10 +46,10 @@
         "sequence": 2
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f9c3aaf90bda00a0ae4a59aa2c43a27be08bb8449dbd166db08076cb95f8f228",
-        "updatedAt": "2025-09-20T22:27:41.490Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0003": {
@@ -67,10 +67,10 @@
         "sequence": 3
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7f3b64634f4ec96d01bbbe924821a8bebbb3a11488788254ed95c732b8117ac5",
-        "updatedAt": "2025-09-20T22:27:41.490Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0004": {
@@ -88,10 +88,10 @@
         "sequence": 4
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cd4fe6d19b8e33e13821833a98624ba8d4cb0092237c044fa39ff0380dcef2ab",
-        "updatedAt": "2025-09-20T22:27:41.490Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0005": {
@@ -109,10 +109,10 @@
         "sequence": 5
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6e8db44805f0b978a4f10547988ead1ff28cfe70fd8452ef17caf041d52d4748",
-        "updatedAt": "2025-09-20T22:27:41.490Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0006": {
@@ -130,10 +130,10 @@
         "sequence": 6
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "bafcaadbb32c7dea8f5fe49fac318bac2a5802cadf566b1a1052b034c4a7f719",
-        "updatedAt": "2025-09-20T22:27:41.493Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0007": {
@@ -151,10 +151,10 @@
         "sequence": 7
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "eea9312a5b2d80911c5d3d75d86dbe8d1dee0a551e560da6afbc4667e609c8cc",
-        "updatedAt": "2025-09-20T22:27:41.493Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0008": {
@@ -172,10 +172,10 @@
         "sequence": 8
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a1b967b8a5fbe6b3e01203969edaf8480a22dbb2f921a2e42f4ceba36f9afca0",
-        "updatedAt": "2025-09-20T22:27:41.493Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0009": {
@@ -193,10 +193,10 @@
         "sequence": 9
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5532e4d3bf3901aa9142ca81bf0f752b0777f9684e50cc5a34033dc9be1a220d",
-        "updatedAt": "2025-09-20T22:27:41.494Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0010": {
@@ -214,10 +214,10 @@
         "sequence": 10
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "72394f7f2264a0c00ce5467d0bbf725ee60b520f353ba2953537b6b0eca98d4f",
-        "updatedAt": "2025-09-20T22:27:41.494Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0011": {
@@ -235,10 +235,10 @@
         "sequence": 11
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "328b69e0e2499f45ac6355895b299f77ef15044e8e31d48334e6615b6cfbde37",
-        "updatedAt": "2025-09-20T22:27:41.494Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0012": {
@@ -256,10 +256,10 @@
         "sequence": 12
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "83e2bb316bac6ee6509aa367d74049fd3697a0222e961c648690fcd224542e60",
-        "updatedAt": "2025-09-20T22:27:41.495Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0013": {
@@ -277,10 +277,10 @@
         "sequence": 13
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1e5f9cb43801a8f26454b402a02780d5b1ec029a0b2b2878b7491ac1afa6720e",
-        "updatedAt": "2025-09-20T22:27:41.495Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0014": {
@@ -298,10 +298,10 @@
         "sequence": 14
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f1874e031b502bd23dca64a09df15b68a75b6de8ce07e31a22b3182ccc019d28",
-        "updatedAt": "2025-09-20T22:27:41.495Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0015": {
@@ -319,10 +319,10 @@
         "sequence": 15
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "77f7b4a9a3a7f02d5456250fa0be4c868114193b4592af90a8f2909b9ac24f29",
-        "updatedAt": "2025-09-20T22:27:41.496Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0016": {
@@ -340,10 +340,10 @@
         "sequence": 16
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "33ba9c2c30bb60eefd519ccab01cdd1d3d00fec21c72e2026a4165634e1a1d59",
-        "updatedAt": "2025-09-20T22:27:41.496Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0017": {
@@ -361,10 +361,10 @@
         "sequence": 17
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d03339ea030c8973824102b563a3aa7f5b0663c4a2e0a7492b62c847de752523",
-        "updatedAt": "2025-09-20T22:27:41.497Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0018": {
@@ -382,10 +382,10 @@
         "sequence": 18
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "db4adc12e700bd2baedc029b5fa5a5ea2f6f4cdee72100226ee45e65640a2c99",
-        "updatedAt": "2025-09-20T22:27:41.497Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0019": {
@@ -403,10 +403,10 @@
         "sequence": 19
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "57f3255d209d39254da6626c4be04bc318d947f4b4ede6a9ea52edd8970c2993",
-        "updatedAt": "2025-09-20T22:27:41.497Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0020": {
@@ -424,10 +424,10 @@
         "sequence": 20
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "78199a06c9407eb98a56e13a1d37408ef45300916854034d58069ba0a6dd11a6",
-        "updatedAt": "2025-09-20T22:27:41.497Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0021": {
@@ -445,10 +445,10 @@
         "sequence": 21
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dcecebb6afb12ccd251fc6efbd40fff2621a83c4c701bc2b4567637a563b6225",
-        "updatedAt": "2025-09-20T22:27:41.497Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0022": {
@@ -466,10 +466,10 @@
         "sequence": 22
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cc29949b6702904605b95c56277282ab8feb98b9cf938ac6c36c002f14b14a73",
-        "updatedAt": "2025-09-20T22:27:41.497Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0023": {
@@ -487,10 +487,10 @@
         "sequence": 23
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "604b8a7c6f3a7ecc70e28aa544566edf57d1ab0fd0b8c2f698327f2cd9dc3fa8",
-        "updatedAt": "2025-09-20T22:27:41.498Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0024": {
@@ -508,10 +508,10 @@
         "sequence": 24
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8d3e180a373278bbb02c7f7988f159dc1d84e89247eed21e725d2e1e6a76c756",
-        "updatedAt": "2025-09-20T22:27:41.498Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0025": {
@@ -529,10 +529,10 @@
         "sequence": 25
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a02d87ac60d2d2430ee8a01cbb6309caf401ee34d247d0a59be61135f051e77e",
-        "updatedAt": "2025-09-20T22:27:41.498Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0026": {
@@ -550,10 +550,10 @@
         "sequence": 26
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8de9da55ff9b1b8210ec09d7f136a96a5f17c2ee116b114835fa5bb6bd564907",
-        "updatedAt": "2025-09-20T22:27:41.498Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0027": {
@@ -571,10 +571,10 @@
         "sequence": 27
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2f89efe3479b2d1b0a174c5d21fe0110b0917e70c11554a55a6c9e9aa4bafc0f",
-        "updatedAt": "2025-09-20T22:27:41.498Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0028": {
@@ -592,10 +592,10 @@
         "sequence": 28
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "87c7495f55b2b4de4d94a7957b2f7f080cd6e39d4f2a070e9e0a5c8a2553e9ee",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0029": {
@@ -613,10 +613,10 @@
         "sequence": 29
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5486edaf47edeada0c32b1c7fa477db40d3ad46d793e7ed5cb25330596cb20fb",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0030": {
@@ -634,10 +634,10 @@
         "sequence": 30
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8bf2b9f1ab8d26cfad3d03ddc3eb253036fe8d092ec0935be6aedb1a717f5264",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0031": {
@@ -655,10 +655,10 @@
         "sequence": 31
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8cb2dcb442ceb1df29a7ce0651a0dc24142c671c1e33ea7a722d6970dd8ccf19",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0032": {
@@ -676,10 +676,10 @@
         "sequence": 32
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ab6b630a2e174685c28fe9fa5fdcc5eba99020e4cb07ca27c0e38521f632562e",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0033": {
@@ -697,10 +697,10 @@
         "sequence": 33
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b477ebb1af6e0bfd929f8af2bac397e5e3ee163c905a3805af1388b247d010f2",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0034": {
@@ -718,10 +718,10 @@
         "sequence": 34
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1c75a59e9f7c9137cf59e2d6b27c47a18e7ca24ad42b06328c5d17a9e38e9435",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0035": {
@@ -739,10 +739,10 @@
         "sequence": 35
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2fb858b518802a3ef6f4f7727bc77e06506f3641692004f62a9f8f5e077a09f9",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0036": {
@@ -760,10 +760,10 @@
         "sequence": 36
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f8305ba0cfd05cdff565cdc9c94550d17fc2311161cdad16166428b766357412",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0037": {
@@ -781,10 +781,10 @@
         "sequence": 37
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d89d120b7208d377a322e7e04b8a5f4affebb78c53015f4cd4c3b936187fd03c",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0038": {
@@ -802,10 +802,10 @@
         "sequence": 38
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "79b94998ecf727786c1182b3ad0bc06bcd455f31f78d1fe48b4e8d5f7031991e",
-        "updatedAt": "2025-09-20T22:27:41.499Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0039": {
@@ -823,10 +823,10 @@
         "sequence": 39
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ee857bfd51b1abd54028408898dca3c54d1f93b07242cee3b790117a12905663",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0040": {
@@ -844,10 +844,10 @@
         "sequence": 40
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4b6fdfa9e6742943fdc46d4adfc0ae1fec9d415e835d291cc59b22b9167fd85b",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0041": {
@@ -865,10 +865,10 @@
         "sequence": 41
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "987fc45997e28cde266e7e7b74d4022636497193ddcf424029766091dbbe2a79",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0042": {
@@ -886,10 +886,10 @@
         "sequence": 42
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a43cc37deebb7e4340b308e811721a8e99e1946964acd9177758a44053994aeb",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0043": {
@@ -907,10 +907,10 @@
         "sequence": 43
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4ed1ee698a217b3244fcb5f3dff153c82ebecc76a5170d717b39bb817c55ab3d",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0044": {
@@ -928,10 +928,10 @@
         "sequence": 44
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a529dbe58783005b575b6c567a1776ab2342124a9c26c34e3494e8379a8b8c5e",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0045": {
@@ -949,10 +949,10 @@
         "sequence": 45
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "efb0846b3aaff20a546e8822194ef569294dce407210da5eda8d43b5853818e8",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0046": {
@@ -970,10 +970,10 @@
         "sequence": 46
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9120ce1d1ee284e487c9e4e25717767749c26e6a3e45e27cf71abf19febadda2",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0047": {
@@ -991,10 +991,10 @@
         "sequence": 47
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0d6e0f34d507116e7fa8be6e4a5b8ab8d1c6ec9d6e47c5fd3a3c40bf74cbdffd",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0048": {
@@ -1012,10 +1012,10 @@
         "sequence": 48
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3d1c290f214f2ba98728df04296e5c11fe66fff0bd7f6d4e23b3d0b879c6a5e8",
-        "updatedAt": "2025-09-20T22:27:41.500Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0049": {
@@ -1033,10 +1033,10 @@
         "sequence": 49
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5e27f04ebe5f331e861ccf684e731d762f0a8d9038498a1928711a3192093e16",
-        "updatedAt": "2025-09-20T22:27:41.501Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0050": {
@@ -1054,10 +1054,10 @@
         "sequence": 50
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "392521a85568e6979a29b10b06394dd65f25f9b1c4848bc7fec2b1d3ecf3a301",
-        "updatedAt": "2025-09-20T22:27:41.501Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0051": {
@@ -1075,10 +1075,10 @@
         "sequence": 51
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c1df035b526b8f19c0fdf628e80377345f404881e0142f11ff1e0599b3bec6f1",
-        "updatedAt": "2025-09-20T22:27:41.501Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0052": {
@@ -1096,10 +1096,10 @@
         "sequence": 52
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "567d7f6e0e2dd89e056caa837019e7e2d0a35b0bbc5db62ef878c171f241041d",
-        "updatedAt": "2025-09-20T22:27:41.501Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0053": {
@@ -1117,10 +1117,10 @@
         "sequence": 53
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "268dac40eca24aaf06a03ab2c8f8e96a301669c06bcdd911613d64a6fbb1c132",
-        "updatedAt": "2025-09-20T22:27:41.501Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0054": {
@@ -1138,10 +1138,10 @@
         "sequence": 54
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4f17d4f905d5b8bd6da85f9c2315ad6dafaaf43787d6a9f374380a49d495a04f",
-        "updatedAt": "2025-09-20T22:27:41.501Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0055": {
@@ -1159,10 +1159,10 @@
         "sequence": 55
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dcf4ceef2984a5bc22825596fea39c96a12f6a8b5a01fcd80e259841156f4512",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0056": {
@@ -1180,10 +1180,10 @@
         "sequence": 56
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "91aa1cab7507aae72ec32a004d42aa4bb15cbd69890fa71807007a9da16add4b",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0057": {
@@ -1201,10 +1201,10 @@
         "sequence": 57
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cd6d2c454197192f7d31ba481861da8c26108d70983fdd248e8e30027e7630ad",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0058": {
@@ -1222,10 +1222,10 @@
         "sequence": 58
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4116e31caab79ff5014ce09c9af5d7a5a68281ddc0d729055a785da823137cf9",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0059": {
@@ -1243,10 +1243,10 @@
         "sequence": 59
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4ccd6fb2b611054aab8ea4ffa7ec38707ff30a8532f47cb57a4b826a1a45c38f",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0060": {
@@ -1264,10 +1264,10 @@
         "sequence": 60
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7fd334733fd963c87ecc24803f1484daf786356c3f0b2d44df5745c8464b25cf",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0061": {
@@ -1285,10 +1285,10 @@
         "sequence": 61
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e72d9264f4cff287b0e41feb891eb1571a8182769b52ff432da80f6814d2deae",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0062": {
@@ -1306,10 +1306,10 @@
         "sequence": 62
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "94554a7484518d84094c9761036d3c78b4e4faf81595872f789ade42b0233eb7",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0063": {
@@ -1327,10 +1327,10 @@
         "sequence": 63
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "98953d64b91fb392abfe50288e22a4ede664a8b703469f9fc997a21303e9a40a",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0064": {
@@ -1348,10 +1348,10 @@
         "sequence": 64
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8fa5beb887b23d44310271cc3e358a6e06a5c5a93205753f76b570077d66de68",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0065": {
@@ -1369,10 +1369,10 @@
         "sequence": 65
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b12d378928f5972740dd29e9c753325281db532e22a984f1c705d6810de76718",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0066": {
@@ -1390,10 +1390,10 @@
         "sequence": 66
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a6e647b2bce12e2fcad9b80fe2ddd73ec65fdc87b40204f30f175b03bd946b0d",
-        "updatedAt": "2025-09-20T22:27:41.505Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0067": {
@@ -1411,10 +1411,10 @@
         "sequence": 67
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8ce368b4ab02fe5c00598c3968ddbcb82f5e9401251f98e28acc44c043875739",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0068": {
@@ -1432,10 +1432,10 @@
         "sequence": 68
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "60bc2fd0a609ef1d789244266d82f4015d69248f5e743a2cb2b0ddc946bdf3a1",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0069": {
@@ -1453,10 +1453,10 @@
         "sequence": 69
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3676a6c330b5c23db66ab67490143fbe55d5f3a53d105dfde26fe897f41014b8",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0070": {
@@ -1474,10 +1474,10 @@
         "sequence": 70
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ad9f1cc967c5def3df57569f0812c28fa3f03b13014408d3ece32ee5bab54761",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0071": {
@@ -1495,10 +1495,10 @@
         "sequence": 71
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2f30752ddf0839c10d5e998968a8175dd354010aec1dc875413b049d85d6caf7",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0072": {
@@ -1516,10 +1516,10 @@
         "sequence": 72
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fc8db06713846ca6e56854ec53b220a8ee7b4f016492a2db230dd7a8bdf1bf78",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0073": {
@@ -1537,10 +1537,10 @@
         "sequence": 73
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f5ac33a50154fbfb0fe774727c3d02ded46d0e13d2469715cc2a21324042cbb9",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0074": {
@@ -1558,10 +1558,10 @@
         "sequence": 74
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a4c95f70c90231f6ea783704048455fa78503fc2b1efc80363f20d95fd1f5817",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0075": {
@@ -1579,10 +1579,10 @@
         "sequence": 75
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3aeb71a62d2d36eaf6856e773eb824f836ee4401be0e5293980822892405dadb",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0076": {
@@ -1600,10 +1600,10 @@
         "sequence": 76
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a13d450a1f9a01c52c5bd5b9c22de570207fe0e7f0257e6069e1b2c6ec86b39d",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0077": {
@@ -1621,10 +1621,10 @@
         "sequence": 77
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4fa72edaffbd31421ece1a5dcd3f49302b0304683a9ece753d7c5df717160c61",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0078": {
@@ -1642,10 +1642,10 @@
         "sequence": 78
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d98d02da93896fd4404c2fe860329de198c9e62fdc6939cf2ebee69f97a77d5f",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0079": {
@@ -1663,10 +1663,10 @@
         "sequence": 79
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8bceb9acd92a9a8bf3dfa5bc20900513dbc57dfb4accf63c667f0f191cb15231",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0080": {
@@ -1684,10 +1684,10 @@
         "sequence": 80
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "13cdef955c1af5fefc54400ca013061cb7ebf3dc84c5033ea6fef89aae3f3a4a",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0081": {
@@ -1705,10 +1705,10 @@
         "sequence": 81
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ab90bbf2714e2fd502d2860793486acb6c574e246976102e197fe633ca1e79d4",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0082": {
@@ -1726,10 +1726,10 @@
         "sequence": 82
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0e7b8b2f7580dfa47cbf176116068b70f3b30ab6633c52fa0528c88ca42307f7",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0083": {
@@ -1747,10 +1747,10 @@
         "sequence": 83
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d123347d16191b3d4671a04eef84d20bf39124353ff7762c66b9b963890af75c",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0084": {
@@ -1768,10 +1768,10 @@
         "sequence": 84
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4d212e902a7030b32cbf560daf6c3de848fac1ccd71beffe8cefc8642500b75b",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0085": {
@@ -1789,10 +1789,10 @@
         "sequence": 85
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d6008d5ca25846e94bed479dd8a18ce7275f7f6f49e289eb1ee1b66309b0c5a1",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0086": {
@@ -1810,10 +1810,10 @@
         "sequence": 86
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "30fa0075ff602a349611cca07105ccba985db566ccdc8dd71bef815947f4d978",
-        "updatedAt": "2025-09-20T22:27:41.506Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0087": {
@@ -1831,10 +1831,10 @@
         "sequence": 87
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "04d854d135b398a657fccd631472cb4391c006dd51a4cbf4da70859bb524d678",
-        "updatedAt": "2025-09-20T22:27:41.507Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0088": {
@@ -1852,10 +1852,10 @@
         "sequence": 88
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2cd32aa6c746ea26ec4083b43547372b78a3aef35643d1fe2775e7e0aeb41318",
-        "updatedAt": "2025-09-20T22:27:41.507Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0089": {
@@ -1873,10 +1873,10 @@
         "sequence": 89
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e1da52d19ee7423d3b3cfb6d9cd9794a96c83cd1eb8a149d06d2988284f60977",
-        "updatedAt": "2025-09-20T22:27:41.507Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0090": {
@@ -1894,10 +1894,10 @@
         "sequence": 90
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a4a4768c94c06847f95067fb516b0bb428c095e4b747ed0b986ab832b48f54ab",
-        "updatedAt": "2025-09-20T22:27:41.507Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0091": {
@@ -1915,10 +1915,10 @@
         "sequence": 91
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2fb80b7be94d2c6fa9da5931e65c84681f18dfbc0807232c2bc1b588dae5bb3d",
-        "updatedAt": "2025-09-20T22:27:41.507Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0092": {
@@ -1936,10 +1936,10 @@
         "sequence": 92
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "206bde4edfbf2b37419f6b71fdaf2541fc0d60ebb2e8d6ab757c2018711493da",
-        "updatedAt": "2025-09-20T22:27:41.507Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0093": {
@@ -1957,10 +1957,10 @@
         "sequence": 93
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "85addfa4f9561b8fd6b85103f36f1842fb47da8b06575d20b5900362b8fb35eb",
-        "updatedAt": "2025-09-20T22:27:41.507Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0094": {
@@ -1978,10 +1978,10 @@
         "sequence": 94
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c785bb970e215e868863d363fb64df6e06fa7817e649c55f957a32b2b9176ba4",
-        "updatedAt": "2025-09-20T22:27:41.507Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0095": {
@@ -1999,10 +1999,10 @@
         "sequence": 95
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a02e04935743c147b5d5e867c63b1126c15708d4bcb2f1a180c245c25b4d342b",
-        "updatedAt": "2025-09-20T22:27:41.507Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0096": {
@@ -2020,10 +2020,10 @@
         "sequence": 96
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "450cc6b287b0c2ad3640abefcaedab112f43dfd73d524c6d46b5cf06f1b0f634",
-        "updatedAt": "2025-09-20T22:27:41.508Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0097": {
@@ -2041,10 +2041,10 @@
         "sequence": 97
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "72b4aaae731ce8257b19cb80aa3f9ca8e3111029e60e7b1f9d1af9350491ac05",
-        "updatedAt": "2025-09-20T22:27:41.508Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0098": {
@@ -2062,10 +2062,10 @@
         "sequence": 98
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "07e466f6acf01319fa49242ff1331a8c28c8c1d78746c86ad6d646d83a54086d",
-        "updatedAt": "2025-09-20T22:27:41.508Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0099": {
@@ -2083,10 +2083,10 @@
         "sequence": 99
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4b81d605a0af6395a0de792ce873196b6d28304937c18edf17851b6ad377feac",
-        "updatedAt": "2025-09-20T22:27:41.508Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0100": {
@@ -2104,10 +2104,10 @@
         "sequence": 100
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "47719b926e61007f0cbcdef3323fa003ffbc410b496adf51a02b8362f390b0dd",
-        "updatedAt": "2025-09-20T22:27:41.508Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0101": {
@@ -2125,10 +2125,10 @@
         "sequence": 101
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b5528e59e784f7f5ce79d8e285cb4b0eb02d2ec379d048ab0cdc91110a75c58b",
-        "updatedAt": "2025-09-20T22:27:41.508Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0102": {
@@ -2146,10 +2146,10 @@
         "sequence": 102
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1d9a7e9487b5631bb0ee88c1506e8329d6a958d82564f4710f997bdc7a506e7d",
-        "updatedAt": "2025-09-20T22:27:41.508Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0103": {
@@ -2167,10 +2167,10 @@
         "sequence": 103
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e75e8caad6a07e320486b581b7fba5f3d83dfe8e449788be3e3a36f493cedb46",
-        "updatedAt": "2025-09-20T22:27:41.508Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0104": {
@@ -2188,10 +2188,10 @@
         "sequence": 104
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "64b1bf031a5af11c0e1adcaa6a5c9c13855215b105176694d31f4364b8d5e3cf",
-        "updatedAt": "2025-09-20T22:27:41.508Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0105": {
@@ -2209,10 +2209,10 @@
         "sequence": 105
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d7cd59842677f0b8d18e36626baee0249341033462d0baa0581fcf405a447ff2",
-        "updatedAt": "2025-09-20T22:27:41.509Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0106": {
@@ -2230,10 +2230,10 @@
         "sequence": 106
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "129d0f0101731b671067e7aed575fba66fd194c3e6adb873d593fa6c8bf5adb7",
-        "updatedAt": "2025-09-20T22:27:41.509Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0107": {
@@ -2251,10 +2251,10 @@
         "sequence": 107
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "02e2cf317a751a093298311a7178e6e1b1c96351cfd01044bccc4a37d08132bb",
-        "updatedAt": "2025-09-20T22:27:41.509Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0108": {
@@ -2272,10 +2272,10 @@
         "sequence": 108
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "978b95b70bc4a3c67ffd27a9b99d3fda56250e6ecdabbd8e9e51ef12e8b0e985",
-        "updatedAt": "2025-09-20T22:27:41.509Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0109": {
@@ -2293,10 +2293,10 @@
         "sequence": 109
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "00b8295f99658088db5ec0f3308352809f8f7a5c81086ad1dd00b5c6ae586786",
-        "updatedAt": "2025-09-20T22:27:41.509Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0110": {
@@ -2314,10 +2314,10 @@
         "sequence": 110
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "eab65d0a2509d8e92453860a3fb27e92745ede3ec90b55c18e43c50a546a2a07",
-        "updatedAt": "2025-09-20T22:27:41.509Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0111": {
@@ -2335,10 +2335,10 @@
         "sequence": 111
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cbe4d9489824f7df6e7bedb575d36017601cbf01ed8c99884d7da34b698f0c7c",
-        "updatedAt": "2025-09-20T22:27:41.509Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0112": {
@@ -2356,10 +2356,10 @@
         "sequence": 112
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "498df164102e3d47b6c370726d92f3cec2bad4e9441f2fbb0c0f901fa2071045",
-        "updatedAt": "2025-09-20T22:27:41.509Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0113": {
@@ -2377,10 +2377,10 @@
         "sequence": 113
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4adba64bf1e423f80948cf51b172f5b22255c3943bd8a2868e895009fe10b3c1",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0114": {
@@ -2398,10 +2398,10 @@
         "sequence": 114
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5a5dd3b22ecd925c99dd84a891c01c3e8b91444a6212eb37cf24607d9e8c9807",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0115": {
@@ -2419,10 +2419,10 @@
         "sequence": 115
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "07986ba64ebf6dbdff37ac710abd5ee2b1598319a774e96f7162704a988d8acf",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0116": {
@@ -2440,10 +2440,10 @@
         "sequence": 116
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d607f235c0b277a9a60f328b297aa0a459dbb05c9b9c96a4ecab715954d95780",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0117": {
@@ -2461,10 +2461,10 @@
         "sequence": 117
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1406617e7b5e87212d0274427d3cdbced62315a2bc0ca97832946588a6f6138c",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0118": {
@@ -2482,10 +2482,10 @@
         "sequence": 118
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "896e62352bb3d3366587b1bfcd338726766bb7f18b1113cc75c7dc2e1cd64f45",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0119": {
@@ -2503,10 +2503,10 @@
         "sequence": 119
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6d9fa590fc7e73dbf2f0130857159ee6c167a13802970a7eb06dd654f6d22b94",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0120": {
@@ -2524,10 +2524,10 @@
         "sequence": 120
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4bdbaa493fed411608b05fc73143cb1d16c17f81e8a0c4461af88c41a554b3aa",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0121": {
@@ -2545,10 +2545,10 @@
         "sequence": 121
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fad623b119c4ba37ac34255b4fedc6628a2c88c7969d90e18d800c058bd4a158",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0122": {
@@ -2566,10 +2566,10 @@
         "sequence": 122
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "29cbcfd54c24035c94d31b7c1e480fd60ccfc6109cdf5d5ac23c809302236b0f",
-        "updatedAt": "2025-09-20T22:27:41.510Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0123": {
@@ -2587,10 +2587,10 @@
         "sequence": 123
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "500fc9c9c9e7fc9a0037308abc2ea4aaa7996c8a613c33c21819725077ef82a8",
-        "updatedAt": "2025-09-20T22:27:41.511Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0124": {
@@ -2608,10 +2608,10 @@
         "sequence": 124
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "aef6a4487cc107d4437b0672749cbae090329ae9b6c6cda94adae40f442cf59c",
-        "updatedAt": "2025-09-20T22:27:41.511Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0125": {
@@ -2629,10 +2629,10 @@
         "sequence": 125
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c87400e17957076b05defd9e2154122c4218971bdcdd535e220e5d027b3e2c5c",
-        "updatedAt": "2025-09-20T22:27:41.511Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0126": {
@@ -2650,10 +2650,10 @@
         "sequence": 126
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6104503f919ac6d741a6f41e18386c62efebef022bba2a9f24ec6369fbfbd2d9",
-        "updatedAt": "2025-09-20T22:27:41.511Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0127": {
@@ -2671,10 +2671,10 @@
         "sequence": 127
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c640d094e1e9fdda299b60a868e9ae9dfa95afcd711a4a9530cc74e4c6f89cae",
-        "updatedAt": "2025-09-20T22:27:41.511Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0128": {
@@ -2692,10 +2692,10 @@
         "sequence": 128
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "69fbc30843d82f028c063c4d4ba247e188ff15f1cebacf2d0c14f2a800045994",
-        "updatedAt": "2025-09-20T22:27:41.511Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0129": {
@@ -2713,10 +2713,10 @@
         "sequence": 129
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9d038ae4aaee02051de03bd614b0b38e3e53aa4052d7636d1611d8e5d9e581f3",
-        "updatedAt": "2025-09-20T22:27:41.511Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0130": {
@@ -2734,10 +2734,10 @@
         "sequence": 130
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "18beefc2537fd926dd912912573871c55cadeeb86ebc0604cb889b34c459d0ec",
-        "updatedAt": "2025-09-20T22:27:41.511Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0131": {
@@ -2755,10 +2755,10 @@
         "sequence": 131
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b93977b8f571b663b8e0179a709bfa16113a38d0fdd74c9224acc13ae511f7b2",
-        "updatedAt": "2025-09-20T22:27:41.511Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0132": {
@@ -2776,10 +2776,10 @@
         "sequence": 132
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "bb4ed5de24e451736046e0ea5bf6f61bb57a62ed8fa3070b64c2f78e1e2b8bec",
-        "updatedAt": "2025-09-20T22:27:41.512Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0133": {
@@ -2797,10 +2797,10 @@
         "sequence": 133
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ed8f23f9df2c00d8d0a9bc191028fa96c567c8c3f9539991ce7ce189d3c3d636",
-        "updatedAt": "2025-09-20T22:27:41.512Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0134": {
@@ -2818,10 +2818,10 @@
         "sequence": 134
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6e024bbeed0efb05fa3cfe524b311ac94872d565d779c7e76852f7406f382ca0",
-        "updatedAt": "2025-09-20T22:27:41.512Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0135": {
@@ -2839,10 +2839,10 @@
         "sequence": 135
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6594a2d4df224aadc21f8780c6ebb20f47bdf8fa11187909a8dfa89ab525589a",
-        "updatedAt": "2025-09-20T22:27:41.512Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0136": {
@@ -2860,10 +2860,10 @@
         "sequence": 136
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "82280c0dab48cf62dee2f9b37da679b7d1651485a659ceb0f09f81ceaabc190e",
-        "updatedAt": "2025-09-20T22:27:41.512Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0137": {
@@ -2881,10 +2881,10 @@
         "sequence": 137
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "32990bccda2eba7ca98f318a322c090865a47cd840962a456d4a1290459008f0",
-        "updatedAt": "2025-09-20T22:27:41.512Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0138": {
@@ -2902,10 +2902,10 @@
         "sequence": 138
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d15a1de51b6b3683ae5efd8902fbb497d89d35d82b4acd8bd1c8d39f7b745b17",
-        "updatedAt": "2025-09-20T22:27:41.512Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0139": {
@@ -2923,10 +2923,10 @@
         "sequence": 139
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "77b1cb3bc62c4a686be26e3d88ec692bde808f309904d2906bdbbac32ef34ad4",
-        "updatedAt": "2025-09-20T22:27:41.512Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0140": {
@@ -2944,10 +2944,10 @@
         "sequence": 140
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "799730b7d12c7fea580b92a7067b5f55171d86a3532d0e2681c35ff0b31a3560",
-        "updatedAt": "2025-09-20T22:27:41.512Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0141": {
@@ -2965,10 +2965,10 @@
         "sequence": 141
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a78ea491000d834a5b9eed17ec38ebe540b6594893ac43aaa11ca63162219d35",
-        "updatedAt": "2025-09-20T22:27:41.513Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0142": {
@@ -2986,10 +2986,10 @@
         "sequence": 142
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2dc5061de9f63a555199ac32ffcb118e4449218e8d818da899b549e108dd774b",
-        "updatedAt": "2025-09-20T22:27:41.513Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0143": {
@@ -3007,10 +3007,10 @@
         "sequence": 143
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "15992d49e557759d6567fe8731fba9260f0ff10db7d77bd0f2ca30f6537efa47",
-        "updatedAt": "2025-09-20T22:27:41.513Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0144": {
@@ -3028,10 +3028,10 @@
         "sequence": 144
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e53c35b1de538326faf349a446d40fac3ae8a2d58a5625d3be56fe74ac54fc54",
-        "updatedAt": "2025-09-20T22:27:41.513Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0145": {
@@ -3049,10 +3049,10 @@
         "sequence": 145
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3c666f0d5712cce59342146b031a83a06ddb1c3711138c515d7fa1ba7a89ae9a",
-        "updatedAt": "2025-09-20T22:27:41.513Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0146": {
@@ -3070,10 +3070,10 @@
         "sequence": 146
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ec9b74bdbe895f2c309adf066751b90f35f46e050ab471c8f4003070b9acc895",
-        "updatedAt": "2025-09-20T22:27:41.513Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0147": {
@@ -3091,10 +3091,10 @@
         "sequence": 147
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b28191525220ca5ac6baa142799521a6201bae68136e09632d49955e9d5ff12a",
-        "updatedAt": "2025-09-20T22:27:41.513Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0148": {
@@ -3112,10 +3112,10 @@
         "sequence": 148
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c82387d436b21da50cfdd1d775b1ab489795ed007e4641b1bd78beda23b91ecd",
-        "updatedAt": "2025-09-20T22:27:41.513Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0149": {
@@ -3133,10 +3133,10 @@
         "sequence": 149
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b5893363db4b87c1ce0fc4c37d3660c1dfb227abdb0b4c650f980ea9aca20415",
-        "updatedAt": "2025-09-20T22:27:41.514Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0150": {
@@ -3154,10 +3154,10 @@
         "sequence": 150
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c1d8888f9538f8026c166d4f0a32e22fb1cecb276e4088a96abac6f4280c4715",
-        "updatedAt": "2025-09-20T22:27:41.514Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0151": {
@@ -3175,10 +3175,10 @@
         "sequence": 151
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4b2aa0920b4339c20021653c2a3af7296f68cba7ceb3c2782aa3999a06b5b57e",
-        "updatedAt": "2025-09-20T22:27:41.514Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0152": {
@@ -3196,10 +3196,10 @@
         "sequence": 152
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d052eb5330aac4ededb629ab103ffe87eab99540b17732212deb7741abe7f41c",
-        "updatedAt": "2025-09-20T22:27:41.514Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0153": {
@@ -3217,10 +3217,10 @@
         "sequence": 153
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9ddbc19fdbe1cb8cdf728a69e4ac1dacd48a2700981e74c5e938e3298c9f2d41",
-        "updatedAt": "2025-09-20T22:27:41.514Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0154": {
@@ -3238,10 +3238,10 @@
         "sequence": 154
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e13e27cf989bc2e67d7daf720cfc0d11ac8768d81c1cc7d4aa98b1ebe98e660a",
-        "updatedAt": "2025-09-20T22:27:41.514Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0155": {
@@ -3259,10 +3259,10 @@
         "sequence": 155
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b00d65734732bb7a4c1308b83e43e36de4916bc5aa4bed703c95e9261717d576",
-        "updatedAt": "2025-09-20T22:27:41.514Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0156": {
@@ -3280,10 +3280,10 @@
         "sequence": 156
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "558c0f9f8b79927e9ae664dec52659250072f89f5f30aaa73f872467dd628889",
-        "updatedAt": "2025-09-20T22:27:41.514Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0157": {
@@ -3301,10 +3301,10 @@
         "sequence": 157
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "249a03671cab61b8cb9434f393f15d989a536356f8efb54bbbbc4da118055fd6",
-        "updatedAt": "2025-09-20T22:27:41.515Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0158": {
@@ -3322,10 +3322,10 @@
         "sequence": 158
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "10c1fe3e2038d825bd471ec90eca09be4308e531d15c7b5a12a43f9262ed9f74",
-        "updatedAt": "2025-09-20T22:27:41.515Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0159": {
@@ -3343,10 +3343,10 @@
         "sequence": 159
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "066a6e9b2df9ce5a43ee4154eec33991a01106de67b0ab95a4d50b5083d36ab1",
-        "updatedAt": "2025-09-20T22:27:41.515Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0160": {
@@ -3364,10 +3364,10 @@
         "sequence": 160
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "00b42caaef70380acb661b5bb254a96745211fcb667b12024e92a708debd4393",
-        "updatedAt": "2025-09-20T22:27:41.515Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0161": {
@@ -3385,10 +3385,10 @@
         "sequence": 161
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7f015a87c799b86208f1fb14da4c4b48f4e8566f7b45effac8f40e2162c52669",
-        "updatedAt": "2025-09-20T22:27:41.515Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0162": {
@@ -3406,10 +3406,10 @@
         "sequence": 162
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c41f90452f3b7303787e450dccbe107b434dffb79886a613766b556add61b92a",
-        "updatedAt": "2025-09-20T22:27:41.515Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0163": {
@@ -3427,10 +3427,10 @@
         "sequence": 163
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "774662625a6bc69884956afa4e90a281e4df54dfcbc52da23dff021d01ea65d5",
-        "updatedAt": "2025-09-20T22:27:41.515Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0164": {
@@ -3448,10 +3448,10 @@
         "sequence": 164
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "bdf849297967fb403d00b2e37252d3059fd65770a490065528d0b47a63c5ee96",
-        "updatedAt": "2025-09-20T22:27:41.515Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0165": {
@@ -3469,10 +3469,10 @@
         "sequence": 165
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9489d105b70dad7a9ef55c578953d0efc06682f4763a85d194770c9480bb02aa",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0166": {
@@ -3490,10 +3490,10 @@
         "sequence": 166
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e26d8467285c27d7db48802b40f2bdf3b30cd55f59417468bcfbd56d96cbd764",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0167": {
@@ -3511,10 +3511,10 @@
         "sequence": 167
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "019b2ca1dcfc39118fc9628222d5edc023ccb7bd9dc0cebd300ba68d56d796a2",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0168": {
@@ -3532,10 +3532,10 @@
         "sequence": 168
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "528f5a744bc7e9791db76b6b5ce8b82d6a71a29dd481fbfa91fb887c8e822843",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0169": {
@@ -3553,10 +3553,10 @@
         "sequence": 169
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "50648df09ac6bdec960b2d772cc34d6389f39abae457b0bec1bb5acd85ef95f4",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0170": {
@@ -3574,10 +3574,10 @@
         "sequence": 170
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6afb391c3496505992d2526786a963997622633265e3fdc5d75c951702c8b475",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0171": {
@@ -3595,10 +3595,10 @@
         "sequence": 171
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "80e6f68238e84b56b16f2e96977787e8e67b18deaaa489228bc64bf1ded94937",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0172": {
@@ -3616,10 +3616,10 @@
         "sequence": 172
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6e72c9cd6aac006106ec0069318c53f904547335cc00fc93931456273615b829",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0173": {
@@ -3637,10 +3637,10 @@
         "sequence": 173
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "737b9749589c85d061520151e85e561275f38d47927c357341a7a0220426e76c",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0174": {
@@ -3658,10 +3658,10 @@
         "sequence": 174
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c6b2ff04fe78d71716f6346cbe1d12ca75bdc2f0f153b5621d3770317320936d",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0175": {
@@ -3679,10 +3679,10 @@
         "sequence": 175
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e737eefa575ff5e6a2ce868f4e784f0c060bcb60cd6bf245ace6025703d11349",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0176": {
@@ -3700,10 +3700,10 @@
         "sequence": 176
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "842a579663af67d6bd91af534b1643f29e8afc51bde3089c64abf90569adb626",
-        "updatedAt": "2025-09-20T22:27:41.516Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0177": {
@@ -3721,10 +3721,10 @@
         "sequence": 177
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c7f2fc6ccfedfcb96370e482b8230c29528cbef850edb648b2fe6e98f20a7787",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0178": {
@@ -3742,10 +3742,10 @@
         "sequence": 178
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c4aab0a0570bc05203c81fa09581e210b4d5909f6ea44065730c097c6a886e9c",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0179": {
@@ -3763,10 +3763,10 @@
         "sequence": 179
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "330024435866cbf23a0b406167c8598dc3bed019ddce78cd34da1c47c502e9fd",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0180": {
@@ -3784,10 +3784,10 @@
         "sequence": 180
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9356ccea8715cbb7f59be519f785392ce3e7a9e19be4bb0dff6efaa501bc0d6d",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0181": {
@@ -3805,10 +3805,10 @@
         "sequence": 181
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5d4519b596b786f7930f7037eca062059cb91fd974ee5afc6b7d9475c7464cd6",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0182": {
@@ -3826,10 +3826,10 @@
         "sequence": 182
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "21830244646034cceafffa747e99f7dd8ef633a7926fbb719211c3a4d9fdc293",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0183": {
@@ -3847,10 +3847,10 @@
         "sequence": 183
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "628803ea70bf885d37875a0dd3d136814c5a1ec80f4df65e4ac7a9a77eb9e022",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0184": {
@@ -3868,10 +3868,10 @@
         "sequence": 184
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "754aef28d8e833f092d5d16bbb49de6187f9ba0601e96428c3deab017961fa12",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0185": {
@@ -3889,10 +3889,10 @@
         "sequence": 185
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e75557198f414a11c5ded6bd3e288f42a20287fd1008356947170808e426bae6",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0186": {
@@ -3910,10 +3910,10 @@
         "sequence": 186
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1999046c60aaa16eeec2bfa5acf355d65afd2e45b44c2cd4caaead4a4384e4b4",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0187": {
@@ -3931,10 +3931,10 @@
         "sequence": 187
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "19b9c1ddd5f583bbbec53b6a85ec46ead24875beac2f1e1cd373d049742aae03",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0188": {
@@ -3952,10 +3952,10 @@
         "sequence": 188
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "31923f00690c733440e43d241ddab26401abdbb95a3a2d1e22da2b1a75499f66",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0189": {
@@ -3973,10 +3973,10 @@
         "sequence": 189
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5d5168929af68ac56d71496f10a7a25fdd7a25a77e58f65be2f817ff81d0d835",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0190": {
@@ -3994,10 +3994,10 @@
         "sequence": 190
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f8ee9ab33c5cb9a40549dc0c6e31e1ef06f2da081fdc4e88b4474b3afd6259fb",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0191": {
@@ -4015,10 +4015,10 @@
         "sequence": 191
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9168315c89ff3f0be54d3eaaff64504ec7341a0b2bc2bd3e318e789b825679a1",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0192": {
@@ -4036,10 +4036,10 @@
         "sequence": 192
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "261a672930fffba0b8c7cfdb8adba02ce00bf7eda9b94c6baa99abba9101202c",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0193": {
@@ -4057,10 +4057,10 @@
         "sequence": 193
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2b0f8cdc6d0307ade4ca8438b7adb22360742e0633eade1f26efff62e0082a25",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0194": {
@@ -4078,10 +4078,10 @@
         "sequence": 194
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3ed777cfb4bde7cb5107e63af3bfc13b44c6e8392c57b3322bd1253695726f6e",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0195": {
@@ -4099,10 +4099,10 @@
         "sequence": 195
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ecefac56b628ff1b6010a36d68764e2b64e764ad4a4955771495b4f3df11f74c",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0196": {
@@ -4120,10 +4120,10 @@
         "sequence": 196
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1156cb5b3cde89c728953dbdd805eb5c0440a76f44be636bd20f560840167f95",
-        "updatedAt": "2025-09-20T22:27:41.517Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0197": {
@@ -4141,10 +4141,10 @@
         "sequence": 197
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8283bf2c260ed1915dc6aec3fe250a85d6f6bc3e45788d4082261ec37276a4a5",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0198": {
@@ -4162,10 +4162,10 @@
         "sequence": 198
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7179eae7b90143d0320566313532d2803913b778e81a46c0b1d1ed42f5c52196",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0199": {
@@ -4183,10 +4183,10 @@
         "sequence": 199
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ee046d39afa81d40a7cf650ff0933038b6f36ebfba2a46c3b5882a771ca44241",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0200": {
@@ -4204,10 +4204,10 @@
         "sequence": 200
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "42697eb341f548a77a5772f2a5f0bb0057d5a3cfe20d59d96737310e4a11ac0f",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0201": {
@@ -4225,10 +4225,10 @@
         "sequence": 201
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9b9f6f7ae6f8d062df1cae9179b925cc3b506bd239119d7df000e5e2271a1e5a",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0202": {
@@ -4246,10 +4246,10 @@
         "sequence": 202
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ee5577d5cbf1d01407b125d1b8e85dc873af841b6850d2d038681a26f1c611dd",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0203": {
@@ -4267,10 +4267,10 @@
         "sequence": 203
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e00aacc41283e4f2deb42b0d083cb08aa84929263fbe83e66b889b69b962c249",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0204": {
@@ -4288,10 +4288,10 @@
         "sequence": 204
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9d91026b102a13789df2126746c39ea4a804250233680dce7d8febcdfd430c9b",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0205": {
@@ -4309,10 +4309,10 @@
         "sequence": 205
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b0210bb1413d7c149bc47656f2aa407e8531a7351793b928b1db44816d831e66",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0206": {
@@ -4330,10 +4330,10 @@
         "sequence": 206
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4a9231ec4e07b866653d6f91a4bb33e81a8f1246795ca897b8aefee9661ea4d5",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0207": {
@@ -4351,10 +4351,10 @@
         "sequence": 207
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f7ffee549948c89cc240d9f3d05204595fe0ed7d17ee9b3edcecd6b5c5f28106",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0208": {
@@ -4372,10 +4372,10 @@
         "sequence": 208
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "91810c5eccdce523ed32e8e144a253f73a7231decd62139f3ea096b3c0d196f4",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0209": {
@@ -4393,10 +4393,10 @@
         "sequence": 209
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5d24acf468315fc1103444889f50509955053bb3cb9dfe98dd518df894b86b6c",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0210": {
@@ -4414,10 +4414,10 @@
         "sequence": 210
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "78e2b3ffc6caa466d5b730f78b381d077b3758d6db27fdd39a59a78fd9f67c56",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0211": {
@@ -4435,10 +4435,10 @@
         "sequence": 211
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f9196cf08dadd2ac10724ce18dc8aef7602aa0bfd96ccb62337322ebbd1d2d9d",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0212": {
@@ -4456,10 +4456,10 @@
         "sequence": 212
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "03e804fd6e9a124803d6b5d6fdfcf511583c9c4e579d87712e6e25a7148dab77",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0213": {
@@ -4477,10 +4477,10 @@
         "sequence": 213
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "84c16e0a4fb20a6312ed405fadbc7c2459a02f6ebd2d06f9ab009ff5fad56172",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0214": {
@@ -4498,10 +4498,10 @@
         "sequence": 214
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "af7a0ed70f25d31af15828e98b6b619c62c4e5c2ae36abea8115a228501ac56c",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0215": {
@@ -4519,10 +4519,10 @@
         "sequence": 215
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "162af39f4f5d7322a454e1211ccf34b6145d4b8425d0d89655c8d3bfeb165dc3",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0216": {
@@ -4540,10 +4540,10 @@
         "sequence": 216
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3e396efc45f378ffe7b14dd14d59a532ceff29e6d37b3df120cd3a506b157324",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0217": {
@@ -4561,10 +4561,10 @@
         "sequence": 217
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "934e448d731666a58d681eeb203e07d3410756d002b94b8d9f2ef5516c2ac3f7",
-        "updatedAt": "2025-09-20T22:27:41.518Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0218": {
@@ -4582,10 +4582,10 @@
         "sequence": 218
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "63016681ac971c039baa64a2c1331a3a091756c59163030664cd66fb8330e0ef",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0219": {
@@ -4603,10 +4603,10 @@
         "sequence": 219
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "253e0de364ecac36fd661fc292abb4acc2c8a4f30749c1b9ae2ab27ea85d79be",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0220": {
@@ -4624,10 +4624,10 @@
         "sequence": 220
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "20beeceae0ae8128559e207718853d0400aba0b6ce44f0a7134f68a75d2a1f0a",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0221": {
@@ -4645,10 +4645,10 @@
         "sequence": 221
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5b4107fd5266ba59719f2313c795909d44391e37a877611a81741ad4e5fb0c0c",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0222": {
@@ -4666,10 +4666,10 @@
         "sequence": 222
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "35041e57740033a91acd968e1643d472f2015f38c3656f065d335c6839d2070d",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0223": {
@@ -4687,10 +4687,10 @@
         "sequence": 223
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7a47e731400d13b4735aef7f252e381fb208380d131552f062de599a09f5ebae",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0224": {
@@ -4708,10 +4708,10 @@
         "sequence": 224
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "277e5966560d84ea64b50e3821ece34578a5d42db255efe38d0ce6436461d229",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0225": {
@@ -4729,10 +4729,10 @@
         "sequence": 225
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "62bb393e81ba5c9051fc0a6dd6a683a5387abb7f08ab98fea5b1f1175d7ee54b",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0226": {
@@ -4750,10 +4750,10 @@
         "sequence": 226
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fffaf54f5d1f6e6919ce9991935f78406414c3ebc1a964a8228e2084b64eae4a",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0227": {
@@ -4771,10 +4771,10 @@
         "sequence": 227
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "330e523ece7f3c48794f5c44e08619e6893fd4a83afb61025b02b290df857b45",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0228": {
@@ -4792,10 +4792,10 @@
         "sequence": 228
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "18ecbb4c1bcc82ec6d63200ebe7ceaebab5d27bcd0ac739080b0f5cdf5fb77a6",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0229": {
@@ -4813,10 +4813,10 @@
         "sequence": 229
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "10dcc84c3c7204e69f48b1313a1fcbc495d2e6c51011ac336336b364e1a28048",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0230": {
@@ -4834,10 +4834,10 @@
         "sequence": 230
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f794a2a4f19c882035794fba9ea639275d4fe1b5784dadb4d23743aa8f85f958",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0231": {
@@ -4855,10 +4855,10 @@
         "sequence": 231
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a70cb1c259d6e7572c6026ddb9e82be30744b664e4918a64a281a6aa116417ff",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0232": {
@@ -4876,10 +4876,10 @@
         "sequence": 232
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b735183da16492434cdbf1cb394faecf22d8fb09dd09796f17a73776dd4d270f",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0233": {
@@ -4897,10 +4897,10 @@
         "sequence": 233
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "28bd0559f45df7809b74a525aa6fe8d71f2415dfc9cecca6216202dc1da3293e",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0234": {
@@ -4918,10 +4918,10 @@
         "sequence": 234
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4995971bacbb9a452b5e6a6f1ec28b0af33bec1057a57cf1c6c4a0f6702aafbe",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0235": {
@@ -4939,10 +4939,10 @@
         "sequence": 235
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f8d97ab2a5a53e3f8b0f05bbf5a697172ca244bb065e03705169cd8c0e84a781",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0236": {
@@ -4960,10 +4960,10 @@
         "sequence": 236
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f733b29897d86bd092836565ce5187c078473ffc50a759a4d37061831ec91c80",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0237": {
@@ -4981,10 +4981,10 @@
         "sequence": 237
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "49b376eb2c4cf98f90cc3d0563a78b2f3a6f9fb80859f29834b7d5619bee5509",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0238": {
@@ -5002,10 +5002,10 @@
         "sequence": 238
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d743086a2a52693c8570a021f28a65b98b44a5945eb970517b75bf6713e2b519",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0239": {
@@ -5023,10 +5023,10 @@
         "sequence": 239
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8b6657ee9cf04a8ef977e819ab5da9560ce7f6040b5966d2047e2b4394018615",
-        "updatedAt": "2025-09-20T22:27:41.519Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0240": {
@@ -5044,10 +5044,10 @@
         "sequence": 240
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ef9536d3e4e580c55ebbd035f66941c5210ba134ff285b13f57a212a5c1d8f01",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0241": {
@@ -5065,10 +5065,10 @@
         "sequence": 241
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fcbf7e3e66a0635487b40e2d5351c8cb6997947832c7926db2ce2f9b6ab1a340",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0242": {
@@ -5086,10 +5086,10 @@
         "sequence": 242
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f244aeba1a5caa8b1186c9519c794f0cc9e35a6334b3e697a43f6124a389e00e",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0243": {
@@ -5107,10 +5107,10 @@
         "sequence": 243
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "72b01f66a5095d3fe9754182921dbdd0a91363d6a31f37e936924b3589c01622",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0244": {
@@ -5128,10 +5128,10 @@
         "sequence": 244
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a703431c9c98137df6b0326158eb95e1aa6884ef88b3988670ec5857708b5980",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0245": {
@@ -5149,10 +5149,10 @@
         "sequence": 245
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "748b58206eb5154cb527beb51a9bbe149c20c90c4d41f648d91846465e35f631",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0246": {
@@ -5170,10 +5170,10 @@
         "sequence": 246
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8b5dca7a7a8d3e559b942353f5e35409a7e7cd40502674248e3855d991da3633",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0247": {
@@ -5191,10 +5191,10 @@
         "sequence": 247
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "326af365a8ed18083b9f5280eca8f08a0a5e52f2ab687c682820a2b324ed5c26",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0248": {
@@ -5212,10 +5212,10 @@
         "sequence": 248
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a3f166498716371865e030802859b8132291840a04456c4a5504fc2a922bc151",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0249": {
@@ -5233,10 +5233,10 @@
         "sequence": 249
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7009b196608a6e33fb31e0736cee3d904baf5e10a6740f31482aa2f085bd1d5c",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0250": {
@@ -5254,10 +5254,10 @@
         "sequence": 250
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "eab6b7fa0ec2e3529eed0adb1ccc2335847c3b2744ceb7e1e94adfaa0acc9151",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0251": {
@@ -5275,10 +5275,10 @@
         "sequence": 251
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5fa783a6bcec93e52ecb1335e27a73bef6695add4a642d60cf6ffb42bf96ee7c",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0252": {
@@ -5296,10 +5296,10 @@
         "sequence": 252
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0da570d15e546124c8d40a1e408f49efc082a982fda93410d58a7dd179c5c7c9",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0253": {
@@ -5317,10 +5317,10 @@
         "sequence": 253
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3e761b3f18ec5fbac003c58f4888f6f81b38c589fc93f7ef1d2d05ac29f6f25e",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0254": {
@@ -5338,10 +5338,10 @@
         "sequence": 254
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "352102daaa07d9c68b67eaff980eb427f079534c0f7a033797a65be850ad4540",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0255": {
@@ -5359,10 +5359,10 @@
         "sequence": 255
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "94aea705b6681356044556866b250e19d2edd787960c0e6fcdcb7b9a6a1d8116",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0256": {
@@ -5380,10 +5380,10 @@
         "sequence": 256
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3a912a074df1d39202a03130b3b8c96d63bf59a27bcfcc9c2468420984eb2642",
-        "updatedAt": "2025-09-20T22:27:41.520Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0257": {
@@ -5401,10 +5401,10 @@
         "sequence": 257
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "11fdb3bf6e0aef82a059e56d7ece52555e93395719c3073a863c9abe8581e613",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0258": {
@@ -5422,10 +5422,10 @@
         "sequence": 258
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7bbc624f4c5eecd1c55498c829a1ad2bc63747a6956aba99034a53be71c4c2c4",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0259": {
@@ -5443,10 +5443,10 @@
         "sequence": 259
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "15a7afe91adb04906903f2cce8864e10ea6f93d6badda807750ade366c78c95a",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0260": {
@@ -5464,10 +5464,10 @@
         "sequence": 260
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "203f84554ba270355d49b440ba6b58b75ad3b6e27748eab4370411724bee0a6b",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0261": {
@@ -5485,10 +5485,10 @@
         "sequence": 261
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f0857c1665795ee4538d0f5c6032d4a890e7b2515f60c72b4955cb9dfae816e6",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0262": {
@@ -5506,10 +5506,10 @@
         "sequence": 262
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7deddc8c90755ad94a0878fc3f79f78abf7fb07b6a6747e44b43242d32cfbd00",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0263": {
@@ -5527,10 +5527,10 @@
         "sequence": 263
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a8fa09a146b9ac0d179da58e4c210e271645d5176e8abbd69f94c698754081dd",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0264": {
@@ -5548,10 +5548,10 @@
         "sequence": 264
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dd0766adc82dbedc6b51e03bd415123e41da0a3a06297a91f285e96ee2bb5d9b",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0265": {
@@ -5569,10 +5569,10 @@
         "sequence": 265
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e4a85b9b6bf667daa64ada84081835bc7e1448f0fdba4c5f1f94e2bb2d6152fe",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0266": {
@@ -5590,10 +5590,10 @@
         "sequence": 266
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f354457dcf0a3260df88d16bb50049b33220d576776be6a75ed7ee46f7bf5da1",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0267": {
@@ -5611,10 +5611,10 @@
         "sequence": 267
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c118dce47a177ce640a25d7640bd60405cdb2f92bb4351e415addd3070d676f9",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0268": {
@@ -5632,10 +5632,10 @@
         "sequence": 268
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d44c7ee253a909ebab499626b6a98dc12d35aed0188f5ee68158fc3f3298607a",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0269": {
@@ -5653,10 +5653,10 @@
         "sequence": 269
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dc9d10a3065eba899905b474bc2862b20cf5fe968d81a54c10865d9fecff1587",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0270": {
@@ -5674,10 +5674,10 @@
         "sequence": 270
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3dd65c6c1f8496cbe597450c02e3ca0b335e06585866652cdf5b3ead5882c4ca",
-        "updatedAt": "2025-09-20T22:27:41.521Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0271": {
@@ -5695,10 +5695,10 @@
         "sequence": 271
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4f70410ffb14a5a8a92611333a7ebf11481f57f6cec44688c6b80dcd30bffd44",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0272": {
@@ -5716,10 +5716,10 @@
         "sequence": 272
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fdba44555d4386ad08ed69765d3812c076792acabf1dd1011f7c38a544d9c346",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0273": {
@@ -5737,10 +5737,10 @@
         "sequence": 273
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8c7ce7e2da24f7627b96c4e274602c5b04434a24944de2e081a4ca30a0df849f",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0274": {
@@ -5758,10 +5758,10 @@
         "sequence": 274
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1849efdffd178a174735c6b3b2ec33597c470ff1b4f8d9d473b3c9262eb508a3",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0275": {
@@ -5779,10 +5779,10 @@
         "sequence": 275
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "93c3e75cd2501aa76282261bacc1b36746d5cc705860affe752e1dfd1f8239fd",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0276": {
@@ -5800,10 +5800,10 @@
         "sequence": 276
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4abf7eec256fa08a1f58108e09616252359faf48ad4aeeee3048cea361e2466a",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0277": {
@@ -5821,10 +5821,10 @@
         "sequence": 277
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "820d2b10e682fb1abb4ee4395ae0dbf030ef101400ab8130aeea1765a1552488",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0278": {
@@ -5842,10 +5842,10 @@
         "sequence": 278
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1b4a1b50e3d0d2e9f33bf032cbc057bcfe41c222a1b49c74fd37c83c68ed941a",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0279": {
@@ -5863,10 +5863,10 @@
         "sequence": 279
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "50f233a4d6d1a4ec1136c65787374e25bf6fb3f39adc0546abfaede6c4dc9c95",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0280": {
@@ -5884,10 +5884,10 @@
         "sequence": 280
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4039207ed9283837b5050ea8313f9bc4031f7869fe8e5b6bbdc2e6b20e18982a",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0281": {
@@ -5905,10 +5905,10 @@
         "sequence": 281
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "49a503b8254d6b1e23b425214f7257ce84e370da5aa59c0b8fb16de483927ee7",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0282": {
@@ -5926,10 +5926,10 @@
         "sequence": 282
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b45fc870a7dd14a0a2ba194fc5ffdba98ab630f83b85bc25c7a949746f25ad60",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0283": {
@@ -5947,10 +5947,10 @@
         "sequence": 283
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2c1e92de5a350b140c8ad5b386beba86ea5c11cdc752cc1afbb436969688c17d",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0284": {
@@ -5968,10 +5968,10 @@
         "sequence": 284
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1183115e2c5e555c54125c72ba1ad9e2098e51bb9fa9f5a9480fe3db30c57d04",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0285": {
@@ -5989,10 +5989,10 @@
         "sequence": 285
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d66b55e233d8bb3362bfc438da26e44a15207384b2a27f69d567f36986debf98",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0286": {
@@ -6010,10 +6010,10 @@
         "sequence": 286
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d58e3404b1ac36f3283ea8485e1da98e3680363b90f7c744c87151aafd46a825",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0287": {
@@ -6031,10 +6031,10 @@
         "sequence": 287
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1cae1c78723dc11067756e1de945c11f7387bacb24f0ce2f82b099c866d63890",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0288": {
@@ -6052,10 +6052,10 @@
         "sequence": 288
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fd43b77d6ba2e41d9308e621eaa0c5e8fb8061f310a96e81ec6f710708c13c08",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0289": {
@@ -6073,10 +6073,10 @@
         "sequence": 289
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d13eb80252681a98d22148b4775af34fba907167d5f1f50448c4f7182d6977ed",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0290": {
@@ -6094,10 +6094,10 @@
         "sequence": 290
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e0846cf7c9ed17c4279c43cbf5a7380e6847c3ab9be8d1f87155e90f8736c7de",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0291": {
@@ -6115,10 +6115,10 @@
         "sequence": 291
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c4cae21aa2ce737859bcb7735ab610c2b5ae5cc966c4c5ce17597c401c123274",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0292": {
@@ -6136,10 +6136,10 @@
         "sequence": 292
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3d8aa5531aeb06d184761468645bc4eede4ebd892fb3fdf734168b3349a62d3e",
-        "updatedAt": "2025-09-20T22:27:41.522Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0293": {
@@ -6157,10 +6157,10 @@
         "sequence": 293
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fb2c0dec8e4fda9788a61388a98ff23717de5055224fe6a16e7998c5a34873ab",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0294": {
@@ -6178,10 +6178,10 @@
         "sequence": 294
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5e878c6381e802e70193236f9456e13286b0c47140dcb1aeb15b5aa14bced900",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0295": {
@@ -6199,10 +6199,10 @@
         "sequence": 295
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "250cf913598f312db191c8430ebe8109eafe2bafe4bf4955942f91ebe871c58e",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0296": {
@@ -6220,10 +6220,10 @@
         "sequence": 296
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fdbb6adf8358abd6d41bad1fd57f4d9d656c6438ef973400b641c0d2aa4c5e42",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0297": {
@@ -6241,10 +6241,10 @@
         "sequence": 297
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e488a08fd3485f0386b26d9b9caa30cb31b76a471a13d2b2f0264360ae541f91",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0298": {
@@ -6262,10 +6262,10 @@
         "sequence": 298
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d5e1df1fc4694e52b246df86bb3f0ab9c042ed46494262912c0c7e01f7334215",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0299": {
@@ -6283,10 +6283,10 @@
         "sequence": 299
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8eaeffe71f70a975018df9cb44a8c05f7e936f7114ed79970b895452dde4d4a2",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0300": {
@@ -6304,10 +6304,10 @@
         "sequence": 300
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2a99ea58b47a3f047f03b96f702c66f99c29097c9214d38d3f13c55b00fd2992",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0301": {
@@ -6325,10 +6325,10 @@
         "sequence": 301
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "bdffae2316667ddc7641cd1a575616be2c62df41f73636648583f4248b1175e5",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0302": {
@@ -6346,10 +6346,10 @@
         "sequence": 302
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dfdf0a1165621ba1a2f6e53dd1ebcde83fa7c5f742830b330887d7d6024ca7e6",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0303": {
@@ -6367,10 +6367,10 @@
         "sequence": 303
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ba8a75e3c4132a0fa2039448522bb0c8d78bf02f96860db064f940cba0e9ca85",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0304": {
@@ -6388,10 +6388,10 @@
         "sequence": 304
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1b2c134b32d9d8ca42a0c0e8132786f1810346696dab7db82ae02bd4c0d42ab9",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0305": {
@@ -6409,10 +6409,10 @@
         "sequence": 305
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "18dc55fb145dbd89248a9023b26155dc3f9d49a2cdf14cad472b06fdc8561a98",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0306": {
@@ -6430,10 +6430,10 @@
         "sequence": 306
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "716908c6a7fd515a60146cbf823a8da2d720fab301e06150a85d1cdde5915254",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0307": {
@@ -6451,10 +6451,10 @@
         "sequence": 307
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4ca0c4968d9213d4f6b544185ad34052ddecc364af457e2950d8de37798e90cc",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0308": {
@@ -6472,10 +6472,10 @@
         "sequence": 308
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "54b304f219827bf896902775f3196d312dd6b4555c101b73038f9681bf21032f",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0309": {
@@ -6493,10 +6493,10 @@
         "sequence": 309
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f1e13cda2d4c0be9ef62a18209e2ee4b2c48e9d93797de27740a58be69088b92",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0310": {
@@ -6514,10 +6514,10 @@
         "sequence": 310
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "150ef8fe51ce08bdb3b5fbfde2796679e73bfb60814844957d20e169f06c0861",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0311": {
@@ -6535,10 +6535,10 @@
         "sequence": 311
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d2530b3c68c64b3ba1e1306e73d5d46696cb8d8d1ce3c28a8911c35853f87d53",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0312": {
@@ -6556,10 +6556,10 @@
         "sequence": 312
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "47f48d18f699501be81b02d3112fd401ad636142197ae9a4c40e14fe80ccbe41",
-        "updatedAt": "2025-09-20T22:27:41.523Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0313": {
@@ -6577,10 +6577,10 @@
         "sequence": 313
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b32c4001ab08a6b979b40c8f40eca41784aea030800d66c2b9425ebc870e1955",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0314": {
@@ -6598,10 +6598,10 @@
         "sequence": 314
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "298f12547050c7e2a462859fa83bf0029b768b3e2da5af7f8a4b677866931aef",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0315": {
@@ -6619,10 +6619,10 @@
         "sequence": 315
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9d4c6fb748091186ccb06bc005c0e9934ca92b6b5d77ab855c15ad34c9ae9d36",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0316": {
@@ -6640,10 +6640,10 @@
         "sequence": 316
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f33f2c736771776332be3a95941b313cef7ae5c2255fc852294ab50aca1ef678",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0318": {
@@ -6658,13 +6658,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 318
+        "sequence": 317
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "73aecf9575100e174f07f570ca2f995b3e2ecf63e8a30a512ee0ea9a45c1e4e7",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0319": {
@@ -6679,13 +6679,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 319
+        "sequence": 318
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "44c70f301400221012f4171f0e1d7fec286f96a437f33b990ed7ef26f8027cb4",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0320": {
@@ -6700,13 +6700,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 320
+        "sequence": 319
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "faedfcd3b6a92fbb1eb10757befb865a0cabef97de00efae84c99c5197af23b8",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0321": {
@@ -6721,13 +6721,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 321
+        "sequence": 320
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "304c72c2f74866ecd4c1743fb947495b186547f140c705d97d46de6f1fe516ba",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0322": {
@@ -6742,13 +6742,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 322
+        "sequence": 321
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8b45898f7eb338b4a0166f094a6d5e9e90268b9463bc9678b5a16083a5c68350",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0323": {
@@ -6763,13 +6763,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 323
+        "sequence": 322
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "40963a47f0c1966fc31945c5dda12b9cb5b52f8ddfdffa04e0679e7884685132",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0324": {
@@ -6784,13 +6784,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 324
+        "sequence": 323
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0e23129219a5b74c81d3dfd6bde7085c097a8222601698c527c408d87f2d2b2c",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0325": {
@@ -6805,13 +6805,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 325
+        "sequence": 324
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e67c6a8c74784d69a116a7b443dee6a2115b5d7ef08dc363dede6630ce50d706",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0326": {
@@ -6826,13 +6826,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 326
+        "sequence": 325
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "902866244b4dfe7da1e7d6851049eb0bbb86f466812eec7b87f394199dcaaccb",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0327": {
@@ -6847,13 +6847,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 327
+        "sequence": 326
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3c6df1e3a920b320eba10e333bae4a67e1ff919bc9c26f18d4ad7eed173427ed",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0328": {
@@ -6868,13 +6868,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 328
+        "sequence": 327
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ad51ad8525f2f8fc80d4b319809a931806e63f79d8ebd96bac302cff4568ef72",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0329": {
@@ -6889,13 +6889,13 @@
         "punchline": 49
       },
       "source": {
-        "sequence": 329
+        "sequence": 328
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d54b3ff6d03d4f781840296ff53d79dff42a817125e84031f44c481433f8fdee",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0330": {
@@ -6910,13 +6910,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 330
+        "sequence": 329
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8bb8e232732e72b2d6ee4d794f7c234116948e945aff99055aee3321ae1e0d0f",
-        "updatedAt": "2025-09-20T22:27:41.524Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0331": {
@@ -6931,13 +6931,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 331
+        "sequence": 330
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "70301e938556d3cc3cc5e5f5f8dae4328c26787100595774823ec59cb5da8a43",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0332": {
@@ -6952,13 +6952,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 332
+        "sequence": 331
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d8e0f968aa3362382edb627b52dcf953608ede73d51d7faa87bdfe04e64fa4bf",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0333": {
@@ -6973,13 +6973,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 333
+        "sequence": 332
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0ce8117276000f75de64799f14d423975959a6e738d8094c3c80e1fe07caaa38",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0334": {
@@ -6994,13 +6994,13 @@
         "punchline": 49
       },
       "source": {
-        "sequence": 334
+        "sequence": 333
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "46522b9d273e85603418e5db604f4d2c5c526d517a1c0e72b6758a5afcbc870e",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0335": {
@@ -7015,13 +7015,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 335
+        "sequence": 334
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b12bef7c2f6324366911a368e9395c25b6b2d74b16ab48bab9d1fdd5e468f4fe",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0336": {
@@ -7036,13 +7036,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 336
+        "sequence": 335
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "92b64ea33894e6ab6918ca823961d932ef9b84777d5e199f9b7aa14b029faba5",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0337": {
@@ -7057,13 +7057,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 337
+        "sequence": 336
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "faf1c9e1ccd53568bb08a94a1415af95a7a7fe581ca2b42e8219ae3fe7360b64",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0338": {
@@ -7078,13 +7078,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 338
+        "sequence": 337
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a3d949099848ae07c6e06488281f6f8ab645f7cfeaa27d972eb06f15993675b1",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0339": {
@@ -7099,13 +7099,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 339
+        "sequence": 338
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3ac0fb17f11826b4afc62634953011c9b097da8a4678a214c8389079be7a9f35",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0340": {
@@ -7120,13 +7120,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 340
+        "sequence": 339
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c23a20ecf9d19bd57641e5df90c1967b6e06f068da00e3d514b13be0b12430a0",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0341": {
@@ -7141,13 +7141,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 341
+        "sequence": 340
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a70d756bc4220004a9b99752e4973b0bb24bfe07cc17c9c8df73b76ba9365846",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0342": {
@@ -7162,13 +7162,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 342
+        "sequence": 341
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7db1bdc71db5ae5a10f6899d43466a793c1435429560c93269fae55eb23370dc",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0343": {
@@ -7183,13 +7183,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 343
+        "sequence": 342
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d645c7311237cf7b93d20269ffef0b35e6d0fef2259a68ddf771fcbf68336d4a",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0344": {
@@ -7204,13 +7204,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 344
+        "sequence": 343
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3c18229c93bdcc7756c7dff8cf48b4be7fed7cc0e16e0d5243d536666089a39f",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0345": {
@@ -7225,13 +7225,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 345
+        "sequence": 344
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a9db79282efbafee640819bee96015a813b90629dbf9f9bca2d99a8540f5fa70",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0346": {
@@ -7246,13 +7246,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 346
+        "sequence": 345
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2a0e428da8168b27abeb480782f050e6664f31829288f62ed0661c6f6ea08a22",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0347": {
@@ -7267,13 +7267,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 347
+        "sequence": 346
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3ebd0a10bc378ba527f03bd37823197dc0473ff8a62ab83a9e59a871c2b0913c",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0348": {
@@ -7288,13 +7288,13 @@
         "punchline": 58
       },
       "source": {
-        "sequence": 348
+        "sequence": 347
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a9c36c0d6593374aeb4719c0ca61dd3db3c75c6eee3885cd68cbb4d226b4a2f0",
-        "updatedAt": "2025-09-20T22:27:41.525Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0349": {
@@ -7309,13 +7309,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 349
+        "sequence": 348
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e10f96e04590016dab305bba6f2a7d70746a33b33e55f9d003433a78becef677",
-        "updatedAt": "2025-09-20T22:27:41.526Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0350": {
@@ -7330,13 +7330,13 @@
         "punchline": 46
       },
       "source": {
-        "sequence": 350
+        "sequence": 349
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c576601f02b5b579b7f6448d739df07fdc35d3da60425c604b8162e60b6e4f49",
-        "updatedAt": "2025-09-20T22:27:41.526Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0351": {
@@ -7351,13 +7351,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 351
+        "sequence": 350
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "496768aab5bdf4075ef9ad098436f1bbdfe6046076bc99f8c86324e2c60be461",
-        "updatedAt": "2025-09-20T22:27:41.526Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0352": {
@@ -7372,13 +7372,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 352
+        "sequence": 351
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "227070e66a04d1a3e3520cbb66d69cfb254fafff00f26bd6577974fb2b188092",
-        "updatedAt": "2025-09-20T22:27:41.526Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0353": {
@@ -7393,13 +7393,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 353
+        "sequence": 352
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "aa4567e40b0d4031474b15de33693bcedc3ebff508f100e897ade38fd0e956fe",
-        "updatedAt": "2025-09-20T22:27:41.526Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0354": {
@@ -7414,13 +7414,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 354
+        "sequence": 353
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "bee90f672aea03e1cab90c6d45387887ea3ec67e663d8abe295d3f52b8023989",
-        "updatedAt": "2025-09-20T22:27:41.526Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0355": {
@@ -7435,13 +7435,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 355
+        "sequence": 354
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "33bbd814f2c7f0bb727a6d00d4c1af7c9f9022439d75853a8eb2bdd193b7256e",
-        "updatedAt": "2025-09-20T22:27:41.526Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0356": {
@@ -7456,13 +7456,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 356
+        "sequence": 355
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4b2312c3bcdd90207d0ed8e520fc1e671c6cc8bf306b49491812b2681089716f",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0357": {
@@ -7477,13 +7477,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 357
+        "sequence": 356
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1ece131c42610c5d46535e31de1075027fe9b53deca56904cabee48856f9a08f",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0358": {
@@ -7498,13 +7498,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 358
+        "sequence": 357
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7077a120004b5595ea638e6414597995e27d9c3a9317e57f350f28bc42f3feb1",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0359": {
@@ -7519,13 +7519,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 359
+        "sequence": 358
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f4d2abdc291cc44f8b68fb0fc87b86a78d61bb18b740e25662e58eacd0b76289",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0360": {
@@ -7540,13 +7540,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 360
+        "sequence": 359
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e7d17277ba2aaef982816c1cad3276f339ef5f80ef1ef976ce4dee1dd5db4c04",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0361": {
@@ -7561,13 +7561,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 361
+        "sequence": 360
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "857466795affbc37f70c13604c7a1c09eee992599db9c9e21b9aeb60291b53fc",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0362": {
@@ -7582,13 +7582,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 362
+        "sequence": 361
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "140dc5daf80f1cca2c564ed7640aa3e07c3d0e35091e076d36f7eb2898445d2b",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0363": {
@@ -7603,13 +7603,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 363
+        "sequence": 362
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b080a928311017aacb488d65416a87893232a7f5c323cd91405038ab4299a5cb",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0364": {
@@ -7624,13 +7624,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 364
+        "sequence": 363
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "907065b86e27a8a37792bae0fd5f00c6cdc7a4aa727d82b9bda4fc7f3a38b51a",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0365": {
@@ -7645,13 +7645,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 365
+        "sequence": 364
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2b6fcf7e6c8775255d0c4c1b6dc34e612e7ac01b397c25bd44d0c31c2d57a28d",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0366": {
@@ -7666,13 +7666,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 366
+        "sequence": 365
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5dc80f55650c8873a7b00a024e4b7d68bec12bf109b99f11d1a659d39d30abd5",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0367": {
@@ -7687,13 +7687,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 367
+        "sequence": 366
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fa53097efb242b2301c5702c044a829526dd733892a0c4342b0fe7dcf79c32c0",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0368": {
@@ -7708,13 +7708,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 368
+        "sequence": 367
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c9c46ccc2cb323f19f400d7cfa2e39f4a2d3371ae471a1e2c860f9409e63f074",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0369": {
@@ -7729,13 +7729,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 369
+        "sequence": 368
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7538b4f1aa663a84ec1c4af62af7930248d9d2daf7278d44b71f233d3ddf6536",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0370": {
@@ -7750,13 +7750,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 370
+        "sequence": 369
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fc40b8c20bd13b12b3a557d22a99392748387ab2ef46434103e6ead2ec6459c1",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0371": {
@@ -7771,13 +7771,13 @@
         "punchline": 7
       },
       "source": {
-        "sequence": 371
+        "sequence": 370
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2cd62a0aac2d8ae673cce46a49be102b054efffa77072a22b158cec3250f4ae5",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0372": {
@@ -7792,13 +7792,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 372
+        "sequence": 371
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "92f8c640e4b198cf6a9439e5cb4af1766655aac427376c994887ddd9ff0cebf9",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0373": {
@@ -7813,13 +7813,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 373
+        "sequence": 372
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "369929f9377402ed80aa0af6a5c9d22cde7336f67a7a0a59e01a4f9a5362e59d",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0374": {
@@ -7834,13 +7834,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 374
+        "sequence": 373
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "451a60bed5eaff6ab7f29f6e4973ea8d0f82f85fdbe87b949f89ee4390200938",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0375": {
@@ -7855,13 +7855,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 375
+        "sequence": 374
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "db873768747a89788687526e1ddb6d5dd69507f149a2acc7de926f71579b6407",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0376": {
@@ -7876,13 +7876,13 @@
         "punchline": 53
       },
       "source": {
-        "sequence": 376
+        "sequence": 375
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d265307f081d70671d49448abc22eef78eb46e9a34ac61904ed75db1e5662193",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0377": {
@@ -7897,13 +7897,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 377
+        "sequence": 376
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "88ac7232d2e6c841d5daa1ffe1316e82edc5c962ac5ee232f6317033fba4b117",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0378": {
@@ -7918,13 +7918,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 378
+        "sequence": 377
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1a33a2d41b8daf3b398bd653e674340aff74a935e3f944e43b07c17eca8792df",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0379": {
@@ -7939,13 +7939,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 379
+        "sequence": 378
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "06d4ae06d72a1777852d8fe24cd99ef56e2068594f4b7f5972d6ff216b985bce",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0380": {
@@ -7960,13 +7960,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 380
+        "sequence": 379
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6bc82c070e580d036504386a01858e496f56b8994bd9637e9b504949b21e55e8",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0381": {
@@ -7981,13 +7981,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 381
+        "sequence": 380
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "03eb9ff27e28a4dda12d98b36371e7579eb51dc679a5978e1b6000e609a4294e",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0382": {
@@ -8002,13 +8002,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 382
+        "sequence": 381
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "51c3ea7806c7caf0350562b12bc931c5a62b39c53036199aa980812028aa13eb",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0383": {
@@ -8023,13 +8023,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 383
+        "sequence": 382
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "250d8d96a9196dd6ec83e6b22db7e4d333866f4e4765d3a3cce3a26a9ea0b0ed",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0384": {
@@ -8044,13 +8044,13 @@
         "punchline": 39
       },
       "source": {
-        "sequence": 384
+        "sequence": 383
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d489435fe0baec2f043d71128ac486e344249518452e39ac77d91f65a49a9776",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0385": {
@@ -8065,13 +8065,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 385
+        "sequence": 384
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b0a5305acbf7c0dcd815f6881fd5c17a85f57beb73c46517482e2c6ca72d9fe5",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0386": {
@@ -8086,13 +8086,13 @@
         "punchline": 39
       },
       "source": {
-        "sequence": 386
+        "sequence": 385
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3d80b2ff75ff8b81f9eaba6c9eb249d1bc5f07a8d41591c97d6c80f28fcada47",
-        "updatedAt": "2025-09-20T22:27:41.532Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0387": {
@@ -8107,13 +8107,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 387
+        "sequence": 386
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1e19535d81c1a288d52617c344ae02398e7ff254ba9e370af3a7644c02a5257a",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0388": {
@@ -8128,13 +8128,13 @@
         "punchline": 45
       },
       "source": {
-        "sequence": 388
+        "sequence": 387
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "971f11c8cde4975538e6cb9d987a83f9b52237e73f996692c65e59a1ce50e35a",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0389": {
@@ -8149,13 +8149,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 389
+        "sequence": 388
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f37f9b2f0204e2f301e563d2ec11078a387c95764e42a8aad3c0fef7bab15440",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0390": {
@@ -8170,13 +8170,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 390
+        "sequence": 389
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1f2cb8760d9658434c788ffb7a9daac39749cbde73a8c7c4711c7cae3b3f2936",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0391": {
@@ -8191,13 +8191,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 391
+        "sequence": 390
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e7d4a68edbb8601acc4697505d7dfa89e7f9a47cab90a80184d9a44fccc5e041",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0392": {
@@ -8212,13 +8212,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 392
+        "sequence": 391
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1476023c938168f7db841166631c21e5378205b638eccb8cb99669688c000b04",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0393": {
@@ -8233,13 +8233,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 393
+        "sequence": 392
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dc8c4b02e5557fed44cfa520f9a3a396df76afd3e07d4d037b7ad0e41dd14ff7",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0394": {
@@ -8254,13 +8254,13 @@
         "punchline": 86
       },
       "source": {
-        "sequence": 394
+        "sequence": 393
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "71d60b7a3aae49a016b41e5ea57400402e3b647539af9cedcf72ca08a92b8e21",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0395": {
@@ -8275,13 +8275,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 395
+        "sequence": 394
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d6c1092c229908676e96aeebc116b728cb3f3e34df9639b46f0e6e370bd326ca",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0396": {
@@ -8296,13 +8296,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 396
+        "sequence": 395
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "91e5e14e625d2cee175f6478a13a88ed2660581b61b7f2b642aa0e30fcd498bc",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0397": {
@@ -8317,13 +8317,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 397
+        "sequence": 396
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6e48c58f3bcdd864284b182260cd2070210a8d2862e0d8139cfed9bc2df9a30f",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0398": {
@@ -8338,13 +8338,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 398
+        "sequence": 397
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "92a8350a3241b377c46f7647d733d64f3bfa3cc1a8522b5cf9360406f9769ece",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0399": {
@@ -8359,13 +8359,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 399
+        "sequence": 398
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b69de227fe4268491b36ddd81e0f2b46e8f4ef15c1945ac374e77d7c4c1bc154",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0400": {
@@ -8380,13 +8380,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 400
+        "sequence": 399
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5af76e6d1f60a88cc3bfc7a1ca215502af9058330558f809ec4e9956479868b3",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0401": {
@@ -8401,13 +8401,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 401
+        "sequence": 400
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f810e7da92501ad3cd11945b5192eb66e6826190314543a9200d4314c1848c77",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0402": {
@@ -8422,13 +8422,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 402
+        "sequence": 401
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0672ec70eaa349d802d5d320616a08abd6984761b0b0641f1c486ae7e2e7cac6",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0403": {
@@ -8443,13 +8443,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 403
+        "sequence": 402
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "892a36bff48954143220ad8e10bebdf283db85493537f4bb257a769deb93a91a",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0404": {
@@ -8464,13 +8464,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 404
+        "sequence": 403
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0ab26c58c04c986d0d2cdfce2a3a3b73b957b2c5f827a2707744f67416df610a",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0405": {
@@ -8485,13 +8485,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 405
+        "sequence": 404
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e973bde9a504b44fc3795387ef7a7b5f0d62b7fc551fcbff3e0c00f7ebd9e7a0",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0406": {
@@ -8506,13 +8506,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 406
+        "sequence": 405
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "39633b343b6d06dc9748aa96dd6ef7e63b912f52f1d58959694c333f5d197d84",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0407": {
@@ -8527,13 +8527,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 407
+        "sequence": 406
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4392f3087e06e11d578dbf88cf46d4320fe6af24c223dd94f19d0cf4cdeecc30",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0408": {
@@ -8548,13 +8548,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 408
+        "sequence": 407
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "db6731d229918dba986924c2c2af96545d60a5ad447e6b226b24da85d6f3336b",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0409": {
@@ -8569,13 +8569,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 409
+        "sequence": 408
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "45288f6f3616e3911bf2251f65e9c61771af83914d0389b5a29435f87582ac27",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0410": {
@@ -8590,13 +8590,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 410
+        "sequence": 409
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b2f4dc14373ba3e4d2358ecf37a459fb54ab1f9bff933f528070a2b6d883480c",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0411": {
@@ -8611,13 +8611,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 411
+        "sequence": 410
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c302104940abc8ec2bb2bc025a3ffba0554e2974a3b90f3b68271b0ea87421f2",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0412": {
@@ -8632,13 +8632,13 @@
         "punchline": 65
       },
       "source": {
-        "sequence": 412
+        "sequence": 411
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fc609929b6afeb1155947bb2f284a2cb0dfe8edc09fb0dfe1eea5271c04a6bcd",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0413": {
@@ -8653,13 +8653,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 413
+        "sequence": 412
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3d21a19e46d6f52df9ab09edf47f818fe0be8d58f0d72e1f3999d3f699e87d4c",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0414": {
@@ -8674,13 +8674,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 414
+        "sequence": 413
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "867633e4462993b5e1c23ae5f34db40a08b8d986020c50e758d9d5e4083a64b5",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0415": {
@@ -8695,13 +8695,13 @@
         "punchline": 41
       },
       "source": {
-        "sequence": 415
+        "sequence": 414
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a38104351020e674b29b8068d7611dbc2bd75ab115fe6a3314f04ab26fa97b83",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0416": {
@@ -8716,13 +8716,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 416
+        "sequence": 415
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0d6a9e5dbd05fed343413658f5f8e1cb39d70c77bbff653a87a657962144abf7",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0417": {
@@ -8737,13 +8737,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 417
+        "sequence": 416
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "55f626a01242f406f033703dff079d33742c883e662de433e8389e6276e55cf9",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0418": {
@@ -8758,13 +8758,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 418
+        "sequence": 417
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3f70f58b63c6c352a6996ca13da66a6f1deb45b3616bbf25ccbf49f2867af6e7",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0419": {
@@ -8779,13 +8779,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 419
+        "sequence": 418
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ff90870b1f1a832fc1ed8684267ec333330668279a80990995e0a1ba432cc421",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0420": {
@@ -8800,13 +8800,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 420
+        "sequence": 419
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "193bdc00787caf45e9b51ab41413ab976903f293bb1bea573ef407819e4c492d",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0421": {
@@ -8821,13 +8821,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 421
+        "sequence": 420
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "94108dc82e6a307f8c882e8de8e4aba041a83b368756e7f8cbf75dad792a455e",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0422": {
@@ -8842,13 +8842,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 422
+        "sequence": 421
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f6c73a7b791e1a0773988438503cef254d0d6234bb72a676e1659371b448a4d8",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0423": {
@@ -8863,13 +8863,13 @@
         "punchline": 45
       },
       "source": {
-        "sequence": 423
+        "sequence": 422
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c7badbd8b8abdd4556b41f3e0d353cdf1e109765e08bf335444511e7200eb8e4",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0424": {
@@ -8884,13 +8884,13 @@
         "punchline": 88
       },
       "source": {
-        "sequence": 424
+        "sequence": 423
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6b267221b5dd109433607dadd4cdc0102be0d2efa7d8a086af7b0ab6aad70031",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0425": {
@@ -8905,13 +8905,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 425
+        "sequence": 424
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "583342d77b4c8fdd99f7d14fb56b7f652752888f98258b84fc145a50fd6f05b9",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0426": {
@@ -8926,13 +8926,13 @@
         "punchline": 3
       },
       "source": {
-        "sequence": 426
+        "sequence": 425
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "28e942f20fa8965c29078d9cb8321bd9b2ad03d8e662e48e75efdee71345466a",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0427": {
@@ -8947,13 +8947,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 427
+        "sequence": 426
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1aa50401b9791107b98ffcfba1c8552e4985f05c6938c4ac72002c9c6cf428ac",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0429": {
@@ -8968,13 +8968,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 429
+        "sequence": 427
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "76c44066ecc4a2cd402b40bbaeb9b441bf72ebe50ed40605f3ab8705efaca4c6",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0430": {
@@ -8989,13 +8989,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 430
+        "sequence": 428
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "98985419a2569b28f5643f3e684480bfc0c942dc66e2c7489bb9ff2beb6e9b86",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0431": {
@@ -9010,13 +9010,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 431
+        "sequence": 429
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f8007f143387a9d50152c1e47d7bb9a0b65ae869280f101ae1e16f7cc14bd863",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0432": {
@@ -9031,13 +9031,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 432
+        "sequence": 430
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "93039a45b2b4d6749a90479896c93e906ec85ba09222cd4f25051368d312eb87",
-        "updatedAt": "2025-09-20T22:27:41.533Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0433": {
@@ -9052,13 +9052,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 433
+        "sequence": 431
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "296f468883fb1dad4d5cfe95a16e22724a7d475cfe306d37a5595c8b85e6f050",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0434": {
@@ -9073,13 +9073,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 434
+        "sequence": 432
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b55db9be9bd8fa083321ac7335eee557223e27a759a043faa6a7e0f9c8166c54",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0435": {
@@ -9094,13 +9094,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 435
+        "sequence": 433
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "de429233363075193ee6eefaef70a7a421b01460c62100818bc1d88357f8d366",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0436": {
@@ -9115,13 +9115,13 @@
         "punchline": 5
       },
       "source": {
-        "sequence": 436
+        "sequence": 434
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6924e5c52975cfa942e6e8f32d66f6b5316f2bfe8d8ed83e66b3d8f5fbabdacf",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0437": {
@@ -9136,13 +9136,13 @@
         "punchline": 55
       },
       "source": {
-        "sequence": 437
+        "sequence": 435
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7ba9cd8475a37ec92c0fddd1ffec4ad9acbbe43534ba575bb315dcd370ae7cc0",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0438": {
@@ -9157,13 +9157,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 438
+        "sequence": 436
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7047b642f8f84b8c853a5687cbba9f0f941b1ef3815d7f3fd0909d9b4e738d5e",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0439": {
@@ -9178,13 +9178,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 439
+        "sequence": 437
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5bfdc63cb52ab3764343cc31a9f23651666bf8d3ff4367a22c2989e605a34744",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0440": {
@@ -9199,13 +9199,13 @@
         "punchline": 59
       },
       "source": {
-        "sequence": 440
+        "sequence": 438
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1c69dd419277f68b52cda4768bde4b5dceb65fc48b0779d5e6eea84f7c01671f",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0441": {
@@ -9220,13 +9220,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 441
+        "sequence": 439
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3bf27f0f54086f17c348145c12e926f6e4bb52e94492458d61a9164fd4613f8b",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0442": {
@@ -9241,13 +9241,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 442
+        "sequence": 440
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "52e292bdb42598b74b89c5d19908bf312f885a424268580fc54121c813817970",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0443": {
@@ -9262,13 +9262,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 443
+        "sequence": 441
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "84def8d587bbb32916e6b412cbda0f8698d5643a9037fad7a2fb4a97bdf5f22e",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0444": {
@@ -9283,13 +9283,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 444
+        "sequence": 442
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4054b6e67d1fc1c6582b77c3d1c001abd07401c6851f974d6a921d39c3aee844",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0445": {
@@ -9304,13 +9304,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 445
+        "sequence": 443
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "605521f37804d29c6ea21ef00eaac300a4507047d8cb5baaaf286c7bc7fe7622",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0446": {
@@ -9325,13 +9325,13 @@
         "punchline": 87
       },
       "source": {
-        "sequence": 446
+        "sequence": 444
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f9909bc51afa6d2caffedadb521f836e625237873edc60894dea912d2c823208",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0447": {
@@ -9346,13 +9346,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 447
+        "sequence": 445
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "856f1e7526711838d2812ca6694e639b80aaec4f118017d84eb931e00deb14a1",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0448": {
@@ -9367,13 +9367,13 @@
         "punchline": 48
       },
       "source": {
-        "sequence": 448
+        "sequence": 446
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5706b956daea7641e2975e6b9c6aa3f3280dc2f898028e01dd5459f1eb0197bd",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0449": {
@@ -9388,13 +9388,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 449
+        "sequence": 447
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8209a724ff484f3cf0d18b0702d233034bca83d1caa5cc6329f4d02a808bd8a9",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0450": {
@@ -9409,13 +9409,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 450
+        "sequence": 448
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "651a6f5eec1444bee956f4f96ae742aa93f5a9bd40f27d94338544ccb2d068f9",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0451": {
@@ -9430,13 +9430,13 @@
         "punchline": 5
       },
       "source": {
-        "sequence": 451
+        "sequence": 449
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c450182194b158beed55161c2cff696c85315720d1a80644112cdddb3b86154e",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0452": {
@@ -9451,13 +9451,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 452
+        "sequence": 450
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cdef324eba084291dca2ba3304792f9c74232e0eabe218758aaab95252a94360",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0453": {
@@ -9472,13 +9472,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 453
+        "sequence": 451
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8ce1bb21a4f294b39bb8ca355891e2233305bd8d20a2b5f27e935a0980355416",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0454": {
@@ -9493,13 +9493,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 454
+        "sequence": 452
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9f2556dcfd9ee7817f36f5087f878b63840908fb869f6c631426a9b42bf05d9f",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0455": {
@@ -9514,13 +9514,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 455
+        "sequence": 453
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6bdb8b29aa893ad722784d5dce5bbbcc285679d834b406b415c26d46f21bdca8",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0456": {
@@ -9535,13 +9535,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 456
+        "sequence": 454
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dd3847d65464e38175940b700695fe80f50ec302c50bc535cb267f0cf054634e",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0457": {
@@ -9556,13 +9556,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 457
+        "sequence": 455
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "84c6ab6864ffd022502b8284ca100acd9dc83a68c59d9fa66b9b8ce57d3cfee1",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0458": {
@@ -9577,13 +9577,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 458
+        "sequence": 456
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b0e7595fe4c998ddd2cc85a0969de540bd128b304e758fac26ba06043b1928d3",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0459": {
@@ -9598,13 +9598,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 459
+        "sequence": 457
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1346807a5fdcb691a5b8581b03cd2585ab8432a59dd8337077983ecc7232eb7b",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0460": {
@@ -9619,13 +9619,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 460
+        "sequence": 458
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e73857e55df3a3ce4344553166008f0acd4761ff1a4688fcdb4c9e624cb334f5",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0461": {
@@ -9640,13 +9640,13 @@
         "punchline": 60
       },
       "source": {
-        "sequence": 461
+        "sequence": 459
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "265dae54f39c41d9eb9de31c02ffcd6e7fe36041eb57e8b8ec4474ff497141d1",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0462": {
@@ -9661,13 +9661,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 462
+        "sequence": 460
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ad831831bcf05543eaff18a2224107200cceb9d10f7ed231721ceabd7c68279c",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0463": {
@@ -9682,13 +9682,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 463
+        "sequence": 461
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "41a5b49cef532a25e87a8d6e0c50b0fda47dbd8f6e259da1ba89d12a68eb8ec4",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0464": {
@@ -9703,13 +9703,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 464
+        "sequence": 462
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "82e52e893b04444af09061e4921e5657c687c4b51c96692378f3f4d3ba97d2ca",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0466": {
@@ -9724,13 +9724,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 465
+        "sequence": 463
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "59d6949e02fdb8abcd8de649b5b249c20d3a00b904fbd823cf280ce403170369",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0467": {
@@ -9745,13 +9745,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 466
+        "sequence": 464
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6fa13087ccb2375879128b3beb5f2692f6f90266dc1f42b3649c290cbfae30a0",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0468": {
@@ -9766,13 +9766,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 467
+        "sequence": 465
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "51eba6add50437907c74eb20e32bb0f50918ba24ae6b9075796195d62dc41410",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0469": {
@@ -9787,13 +9787,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 468
+        "sequence": 466
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5080cb365947cf74ade88d1fe82bd2659bccf70df298217bd7d7a03b5bf93fea",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0470": {
@@ -9808,13 +9808,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 469
+        "sequence": 467
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "947916c557ff099ec8dbe896c13ed78be2a7d7da5d510fc28c1315bda25bc5f2",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0471": {
@@ -9829,13 +9829,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 470
+        "sequence": 468
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f85add8b3f939dc1ec30e6a16d5367bc627d1609566c3e81a9b187154f906c76",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0472": {
@@ -9850,13 +9850,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 471
+        "sequence": 469
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9308151032af0543d4750450523f0aab058e827844f9f4de7a1f69b91bfbf08a",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0473": {
@@ -9871,13 +9871,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 472
+        "sequence": 470
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dd41830da0b674fd51c57f80da27b7c74f6ebbd2e72b46eb94d33652528dcc55",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0474": {
@@ -9892,13 +9892,13 @@
         "punchline": 44
       },
       "source": {
-        "sequence": 473
+        "sequence": 471
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "03f5444a246a58d4fe7521af1c9b5ab24956520e60b34317d6ae637db93cea1a",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0475": {
@@ -9913,13 +9913,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 474
+        "sequence": 472
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f243f75cd1091dcd7309fe3203c78c83366626bb278b70417bfe220cb0f5be7a",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0476": {
@@ -9934,13 +9934,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 475
+        "sequence": 473
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7d3ba5dd12946d2096146ac347c5eed0029a6801a7f7cb81d1c8164e8618683d",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0477": {
@@ -9955,13 +9955,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 476
+        "sequence": 474
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "34bd1d7733b59b3487b4edd7cfcc6102739d9a6bc5b6f18182c93a859ab6b107",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0478": {
@@ -9976,13 +9976,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 477
+        "sequence": 475
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "77b668bb95f2fdbde237e8b7a1ee7d61802ab4d7c603251d5438b4fad570e6ea",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0479": {
@@ -9997,13 +9997,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 478
+        "sequence": 476
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2cae5b479aebbb62e15f13f6ec86cfa384ec1fb6de3e8a2f61aa1006dc00897e",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0480": {
@@ -10018,13 +10018,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 479
+        "sequence": 477
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "388f32006825fbf9b346f75871b6bda05c5da1b86f1df65ecaeb48aacc261f74",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0481": {
@@ -10039,13 +10039,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 480
+        "sequence": 478
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b86e8a4acd469688ee1e96abe36ef2eb5606cebbaf981892af327554ba10fc23",
-        "updatedAt": "2025-09-20T22:27:41.534Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0482": {
@@ -10060,13 +10060,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 481
+        "sequence": 479
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "09ec0e7df206aca281bf9bbdb1279f172c59a6e1fdae0efb602a1538f2a9db98",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0483": {
@@ -10081,13 +10081,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 482
+        "sequence": 480
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "364869b9b28f07949709548e2a13fc2d4991ebd31c5fe6577cc0d6039a1c466d",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0484": {
@@ -10102,13 +10102,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 483
+        "sequence": 481
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fbea6fd1effb99a1f1cc28357de3f5e85cd57edb232bc7050fbe3b2b974bd18f",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0485": {
@@ -10123,13 +10123,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 484
+        "sequence": 482
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fda7c3bcdfa1cbe0a233480a9af95bb0b473b66093b23da5a9c19a4257d16b5f",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0486": {
@@ -10144,13 +10144,13 @@
         "punchline": 44
       },
       "source": {
-        "sequence": 485
+        "sequence": 483
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "69257f8b0e05cc64d462aa8eb76794a5558cc233a3f1953490c509df1375112f",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0487": {
@@ -10165,13 +10165,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 486
+        "sequence": 484
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4e6d3ba76ca9851f523882224371beca99e092ea6b3eff5f623a0030d5b5173d",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0488": {
@@ -10186,13 +10186,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 487
+        "sequence": 485
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e8f74c945411d119c185611d0e6beab11c78c5ed9ebb31496530c661e28e7698",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0489": {
@@ -10207,13 +10207,13 @@
         "punchline": 45
       },
       "source": {
-        "sequence": 488
+        "sequence": 486
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b0418b1172aafd9ccd7c838306ea33c9977ddcb79940f391f3a0fd793f8af9c1",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0490": {
@@ -10228,13 +10228,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 489
+        "sequence": 487
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f2d6d7a24e234c82de43b588c9a3d4a1cf07ae367b5356bc0fb7584cd8f4cb8f",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0491": {
@@ -10249,13 +10249,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 490
+        "sequence": 488
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4961ff480be412f656efd01f38e9fb3451a805f97e66826b3e26ccdb70f284ed",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0492": {
@@ -10270,13 +10270,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 491
+        "sequence": 489
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "325c3d75aa974f88d7cc83fe8bb49e6992c289986b8700095992a573abef5bbf",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0493": {
@@ -10291,13 +10291,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 492
+        "sequence": 490
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4c544c0a170fa5cfdbe6fd97bd5bc838e33db603f7bb8f4a7ae8dfd6ef7c6cf3",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0494": {
@@ -10312,13 +10312,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 493
+        "sequence": 491
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cb0bcc8ab20e4d4b91f0ffb06942617632df50cb435d14aa2fbee2f5402f4e27",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0495": {
@@ -10333,13 +10333,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 494
+        "sequence": 492
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5d6275080a76c4688f6fd51917d21274c1dc8015923b9156660df7d909a32267",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0496": {
@@ -10354,13 +10354,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 495
+        "sequence": 493
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "26728b1a9005ee9dbe8b5d0c94b62c3b76c3daf6e3890795c5dd39207f9b63fc",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0497": {
@@ -10375,13 +10375,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 496
+        "sequence": 494
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "66a89a0c4387034b2edfbc691f612cb12235cf7bf9061aa52383ace6e6640eaf",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0498": {
@@ -10396,13 +10396,13 @@
         "punchline": 56
       },
       "source": {
-        "sequence": 497
+        "sequence": 495
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f07626f8eedb0024324c872b2edafc2a436025e8d1b0595f9f246dea919ae054",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0499": {
@@ -10417,13 +10417,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 498
+        "sequence": 496
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6bdbf2d25f7b30c7c3af4a750a6b75be078da255ab245d6b497199c381e32350",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0500": {
@@ -10438,13 +10438,13 @@
         "punchline": 5
       },
       "source": {
-        "sequence": 499
+        "sequence": 497
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "200cdd6430d12865dcf233599b36d5c12a52f512c3f2966e440fa7e01c203bba",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0501": {
@@ -10459,13 +10459,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 500
+        "sequence": 498
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7753f5f2b1c659bbc3cfdc837d3ec7f685cf1c0aefba4775cb0c6e7305144e9f",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0502": {
@@ -10480,13 +10480,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 501
+        "sequence": 499
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "da90f8ca8084b299eea611628e893aae638ff4efaa9dd327ea0ff24e44196a0c",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0503": {
@@ -10501,13 +10501,13 @@
         "punchline": 5
       },
       "source": {
-        "sequence": 502
+        "sequence": 500
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "678ecf885bee5ca1be038b1d8d1cba5b6e3268d6550e8d68f818be0c2215cb85",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0504": {
@@ -10522,13 +10522,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 503
+        "sequence": 501
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6734306cc99f54e29237f7d284b9b7136e065e88ba235c96c24ee70ca8a4ecc8",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0505": {
@@ -10543,13 +10543,13 @@
         "punchline": 50
       },
       "source": {
-        "sequence": 504
+        "sequence": 502
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e6290accbcd053b17e565a75f1ef749d8e5ad6ad827192ccc631f475628cf39d",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0506": {
@@ -10564,13 +10564,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 505
+        "sequence": 503
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "05103aefca06a98f35b2586257e7d66cff7f56f43a66e40aefa79eec7b1ddfd8",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0507": {
@@ -10585,13 +10585,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 506
+        "sequence": 504
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6591d1e011af414d5016b10ff0761061f803de9fddc0ab14a4d0024241ee190e",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0508": {
@@ -10606,13 +10606,13 @@
         "punchline": 66
       },
       "source": {
-        "sequence": 507
+        "sequence": 505
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fc904074ce1cd9b136f1d9acfcce6855a4003d39b68633e047fc0e9d71060863",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0509": {
@@ -10627,13 +10627,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 508
+        "sequence": 506
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cca3f375b0b41b7a3de2c3e68523abbd5b06b4770ddf2f83680e5904bc74d91e",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0510": {
@@ -10648,13 +10648,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 509
+        "sequence": 507
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a60812aa4713c32be3f78fa78de92d0b08eb7d279c068967de1099478e35052d",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0511": {
@@ -10669,13 +10669,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 510
+        "sequence": 508
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e4b2b5811bf95e2e8cc35c7ec284bae74792dbc92bbb3bcedf5964dae92f0c49",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0512": {
@@ -10690,13 +10690,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 511
+        "sequence": 509
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a385e729a03200230eab48733e17a86a3f71331164581394337a899c1f558aba",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0513": {
@@ -10711,13 +10711,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 512
+        "sequence": 510
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dfe6cdf2290229f244abf8b94ab6b7aaf5583672b8808ffec770d8e57347af69",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0514": {
@@ -10732,13 +10732,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 513
+        "sequence": 511
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "21a217337904dcf2785d236c82a99b3ef376551af81fc249fdbecadbe4e219ac",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0515": {
@@ -10753,13 +10753,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 514
+        "sequence": 512
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9bf8654a9508c9769efeeee8f17c954109088f1377ae2156fd4bf3cb3c9fcf58",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0516": {
@@ -10774,13 +10774,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 515
+        "sequence": 513
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0077f1122c28601e00481564bf9f0a89639f5904d5e3806a2226dfaf68cca690",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0517": {
@@ -10795,13 +10795,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 516
+        "sequence": 514
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "563f0b228aaa9e0aaea1cf023799b0caa91042b534f7afcd6ecfd00d623bba15",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0518": {
@@ -10816,13 +10816,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 517
+        "sequence": 515
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "87d94379e78c312c83c156214a0e74d52b4b7cd4187c917081860e48d100bd0f",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0519": {
@@ -10837,13 +10837,13 @@
         "punchline": 55
       },
       "source": {
-        "sequence": 518
+        "sequence": 516
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3e09a8c7f3c090c1be9ebac25dad9baad0c0976a4330a9425916aea3a5f4ebed",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0520": {
@@ -10858,13 +10858,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 519
+        "sequence": 517
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0493995de949b2c0de6ca255fbd53459b925500ce395fd5e6c25037a642d404c",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0522": {
@@ -10879,13 +10879,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 521
+        "sequence": 518
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b14aaa15e4bef272c17eadbfdc3948934803fe5bffdeb16f018f038033e74f78",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0523": {
@@ -10900,13 +10900,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 522
+        "sequence": 519
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "33c901842926e41639a7a42779bfc31aeca8a39ffac595bee9f10f2932f324a3",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0524": {
@@ -10921,13 +10921,13 @@
         "punchline": 52
       },
       "source": {
-        "sequence": 523
+        "sequence": 520
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "962cb9ab825f78588814440fd4e748fa62b32de9f67834d77fa98799b328d233",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0525": {
@@ -10942,13 +10942,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 524
+        "sequence": 521
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8f0676c3b705cd9959e7aebec5f81d73800c2b49483ad2cfc448191783f8f924",
-        "updatedAt": "2025-09-20T22:27:41.535Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0526": {
@@ -10963,13 +10963,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 525
+        "sequence": 522
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "10957be9f188e5fba2dc85d1535ea0f530c9f47488865c6ff0bd886b9d923db9",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0527": {
@@ -10984,13 +10984,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 526
+        "sequence": 523
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "109e6a7c038f7b19693a1d04ec90da4c5e4036bd555fb4992f0afc808104d3f7",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0528": {
@@ -11005,13 +11005,13 @@
         "punchline": 7
       },
       "source": {
-        "sequence": 527
+        "sequence": 524
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f9c651c5f2d92c6405e6ec3b245c63d4e2aed80d901dd4761f67c56297a91706",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0529": {
@@ -11026,13 +11026,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 528
+        "sequence": 525
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ef7ace5325b76b8124ebdb059d8cbbef161c7181a71cadfcb736aef441067caa",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0530": {
@@ -11047,13 +11047,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 529
+        "sequence": 526
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cf118ea1341489c325690bfb9fd389687c7ef81cc20058fe1b612cefee808894",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0531": {
@@ -11068,13 +11068,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 530
+        "sequence": 527
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5b47509e2c4284cdd8c7ca62a0ee03c4a6fd928a8348c557ba9fef85b9d2e74a",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0532": {
@@ -11089,13 +11089,13 @@
         "punchline": 41
       },
       "source": {
-        "sequence": 531
+        "sequence": 528
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "134d23be81fcca22709a12d2465b08a72b7ed6761fffa418e055d65a24a9dfb1",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0533": {
@@ -11110,13 +11110,13 @@
         "punchline": 81
       },
       "source": {
-        "sequence": 532
+        "sequence": 529
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9479f75898471ee0562bd6af24bb63781b532e9f6084cd32fd7bc8606ceebb11",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0534": {
@@ -11131,13 +11131,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 533
+        "sequence": 530
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "afadfdd4819ca2c82f7820ee4fd474b603c9ae2b41e83d4d530cf946350576d9",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0535": {
@@ -11152,13 +11152,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 534
+        "sequence": 531
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9392e78bcc01bbd00d4b8004910815d1dc23530858880dda3a69fa6384f6f54b",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0536": {
@@ -11173,13 +11173,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 535
+        "sequence": 532
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7d4ce5e1022f6b07dd4f9efa87f0296c28793d110ee31647448b35230cb2a41c",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0537": {
@@ -11194,13 +11194,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 536
+        "sequence": 533
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9b7638ed4f58b0f2c40a429eeb612212083c149fb79430fff6bf820ac60b99c9",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0538": {
@@ -11215,13 +11215,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 537
+        "sequence": 534
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "477b29e4a048667d88d3a8b7acd5ef88ceef61e6e86ead31fd7100efd0c0fa58",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0539": {
@@ -11236,13 +11236,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 538
+        "sequence": 535
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f593984334b49d093d2be82027ae10c0a3f35a62dd6aacb5239082b1621b5b68",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0540": {
@@ -11257,13 +11257,13 @@
         "punchline": 7
       },
       "source": {
-        "sequence": 539
+        "sequence": 536
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3842bbcc71d79331c2e874cf8cbf5f773b7080b120fdce18dc16dccf9152d431",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0541": {
@@ -11278,13 +11278,13 @@
         "punchline": 37
       },
       "source": {
-        "sequence": 540
+        "sequence": 537
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ee676d94d047ba59cb015db4a23ed1ee37bff02f627c22cdfff7f17271f9684b",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0542": {
@@ -11299,13 +11299,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 541
+        "sequence": 538
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "74f4a9cb804a1b381143e238c36504a06c5b47063da0bfd348e9f7aa04dd9ac4",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0543": {
@@ -11320,13 +11320,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 542
+        "sequence": 539
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0fba0e39a9afc49e56e77a40d61b1a123981d2dd6b7fb3377c01d28639b2238e",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0544": {
@@ -11341,13 +11341,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 543
+        "sequence": 540
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8fadb3fbd085b17d223e0db96468e15a23cea928a4e1de86e9955bf108245ee0",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0545": {
@@ -11362,13 +11362,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 544
+        "sequence": 541
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d91599cdcfa4585d5c22158027c9d47b39e4424b19330115b3d6630a41841b85",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0546": {
@@ -11383,13 +11383,13 @@
         "punchline": 78
       },
       "source": {
-        "sequence": 545
+        "sequence": 542
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7fcbfd4a475e4bab0af9abb4a7840e10f0681227a129a8126378e2756bebb834",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0547": {
@@ -11404,13 +11404,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 546
+        "sequence": 543
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a375aa7ddaa838b2164b59d36d9baab443489bd725cfd0337bf6af8e39e23fdb",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0548": {
@@ -11425,13 +11425,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 547
+        "sequence": 544
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fece6cb87d93541093317b60fdb9ff69494ce59b20a8bf528fe7c137f1ab08b5",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0549": {
@@ -11446,13 +11446,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 548
+        "sequence": 545
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "bf5b8a1e48de76e22be88b9635fff9766735e3da1440b39b13fd64a2252ca91d",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0550": {
@@ -11467,13 +11467,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 549
+        "sequence": 546
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "509e40d41f31a381a6e91d91b23c2648ca035fa0f99cdbfdfc10747b836a0748",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0551": {
@@ -11488,13 +11488,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 550
+        "sequence": 547
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2eb23e7741541871b8fe3096ebff9b6bf2e361e54faa2443980a51c400cff187",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0552": {
@@ -11509,13 +11509,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 551
+        "sequence": 548
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "03630ed0b3752c49135e3b6ae03cfab1ebed1bb576748a36c32308a0dd8edebb",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0553": {
@@ -11530,13 +11530,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 552
+        "sequence": 549
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "992dbebd5d385d6cef23eb0c79eeb2791e03c23a5bc28e03ae46051d02cc8e79",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0554": {
@@ -11551,13 +11551,13 @@
         "punchline": 37
       },
       "source": {
-        "sequence": 553
+        "sequence": 550
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "526159a42d41106b8c71595f9ba557aead81ea6788cba5eb511ea5549b5a381f",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0555": {
@@ -11572,13 +11572,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 554
+        "sequence": 551
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "93f689ff574a985ff9f0aebf8ea3e177d94cf944bfa05db5e0803ad3cb555838",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0556": {
@@ -11593,13 +11593,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 555
+        "sequence": 552
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "38c483ec3301640126580210ce79db0b9ee3a8c25b0d8160ee06a47561954c67",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0557": {
@@ -11614,13 +11614,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 556
+        "sequence": 553
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c622f635c1538364d705687363e1e6a829296b05a43b1d528523d2b5bbeff1a3",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0558": {
@@ -11635,13 +11635,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 557
+        "sequence": 554
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b92891851486e8247373c0503764d866d608cfdb7777e98d6b4bcdec96a80e0a",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0559": {
@@ -11656,13 +11656,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 558
+        "sequence": 555
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "175892bc1d2920a7d1d34995f64980d9004112bd298456ab98f404501cfa283a",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0560": {
@@ -11677,13 +11677,13 @@
         "punchline": 58
       },
       "source": {
-        "sequence": 559
+        "sequence": 556
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "605057cccbc3134860c204dc1dda64c844df3f4789c80d3669757b7b90b603e5",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0561": {
@@ -11698,13 +11698,13 @@
         "punchline": 46
       },
       "source": {
-        "sequence": 560
+        "sequence": 557
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6074286975d8ffd157558a56ff40c87a967bc3315422c7185d0cf9b04cdd0092",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0562": {
@@ -11719,13 +11719,13 @@
         "punchline": 61
       },
       "source": {
-        "sequence": 561
+        "sequence": 558
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b624952ac7a7da3f30072159491c9b96457fdc1f7b5f28f2c72d95723460b610",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0563": {
@@ -11740,13 +11740,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 562
+        "sequence": 559
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "68d1c327c09dd302a7f3b1bab53ca08695bdcd1ce10f5a2b5b3232308e4d8a35",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0564": {
@@ -11761,13 +11761,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 563
+        "sequence": 560
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "23ff2bfe6654d177ab04024a17a90ae1fa69c073224e4d869725e77c8438b22f",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0565": {
@@ -11782,13 +11782,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 564
+        "sequence": 561
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a5cb422bd9a48984e7492b749c638bbacbf97d245a1f5d2ed9a0b47efab1926c",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0566": {
@@ -11803,13 +11803,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 565
+        "sequence": 562
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ca413477cc101dcb07adc344a60019a634b5d64c11adc56e66cac697c29bd037",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0567": {
@@ -11824,13 +11824,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 566
+        "sequence": 563
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0c07c53dafcb33d1f0bcdc4dd0dbd02017d947524a9efb37a5f7fe1bc7328971",
-        "updatedAt": "2025-09-20T22:27:41.536Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0568": {
@@ -11845,13 +11845,13 @@
         "punchline": 74
       },
       "source": {
-        "sequence": 567
+        "sequence": 564
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cc4514a1a9f2ce159fb5dd56dbd1aade3fc8f1bee223f861e32b8d0c7ce31dff",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0569": {
@@ -11866,13 +11866,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 568
+        "sequence": 565
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ddf7b8540001bff60104abee6b05d4d2f1de47890bac0a64717c5d40a522d931",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0570": {
@@ -11887,13 +11887,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 569
+        "sequence": 566
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7060e628d75395de5ca23bb8b5f15e839ba3bfba92095dc1a63d80e1c017d8c1",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0571": {
@@ -11908,13 +11908,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 570
+        "sequence": 567
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5be619328f587ed26f2b701a257eee2a71a6787a32321fd68d9fbbff2596eb3f",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0572": {
@@ -11929,13 +11929,13 @@
         "punchline": 44
       },
       "source": {
-        "sequence": 571
+        "sequence": 568
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "44939da514c933efd5a347a1e4490b92d0e615a71246839fcbc3dddf97605669",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0573": {
@@ -11950,13 +11950,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 572
+        "sequence": 569
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d8c9191c739bb19ad8198f38ee2a03e7856c779563264e4d4e3b2facee7f65db",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0574": {
@@ -11971,13 +11971,13 @@
         "punchline": 51
       },
       "source": {
-        "sequence": 573
+        "sequence": 570
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a6a80f351cf15fde2d7b5d00fade7db52b2badab49acd82a9b15cad6624c55a9",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0575": {
@@ -11992,13 +11992,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 574
+        "sequence": 571
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ba54705a50cc9cd39951a0c58e3a1e6bae76f5bd8e6ca4aeca09157e80ce5ade",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0576": {
@@ -12013,13 +12013,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 575
+        "sequence": 572
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "06e440905516f8ea5a606432ddf3eb8f1015fc2bf2d1b2fdb9154a447a5363cf",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0577": {
@@ -12034,13 +12034,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 576
+        "sequence": 573
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "611c19001f8d2c55f131e9a4791ea4152a620b781612ca7ece68c91dafc113e1",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0578": {
@@ -12055,13 +12055,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 577
+        "sequence": 574
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9a91542646df9ee510f1671fa35a43df7b06152d1386584c81a71ffc4a22650d",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0579": {
@@ -12076,13 +12076,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 578
+        "sequence": 575
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c17520105809842d9884c23c186908909f60f016511fcd2dd0fd5d651e5326af",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0580": {
@@ -12097,13 +12097,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 579
+        "sequence": 576
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0e0e820dd404ea2331294b3093647f8516455110379b30d5f9c56191b85f2a50",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0581": {
@@ -12118,13 +12118,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 580
+        "sequence": 577
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "673bd5e9cdfcf90a9addef36fb984ec5e1258eeaed9dab6ae6557b40c532539d",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0582": {
@@ -12139,13 +12139,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 581
+        "sequence": 578
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c4ae0ce3882e40d1266e2d10e10e56bdb6e4a1da685bc95bc7c6592595d45afe",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0583": {
@@ -12160,13 +12160,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 582
+        "sequence": 579
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8dfcca57a9e5f0d95e79240128c5e79f578e631f0e69508676644de0211558d1",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0584": {
@@ -12181,13 +12181,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 583
+        "sequence": 580
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "477cf45d3fff8254f6d6b1e9f6ede0274f51c8184bce04bde971b6fcf938237f",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0585": {
@@ -12202,13 +12202,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 584
+        "sequence": 581
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "035d88c2eae7f22d86ee6d38a608b03aac6ae37b7d05870a0304f523e7f1c73f",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0586": {
@@ -12223,13 +12223,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 585
+        "sequence": 582
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "090d6d2bdc407eb5251305623bd3fd175e865ec7f71f3cc84046d5c399b7d567",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0587": {
@@ -12244,13 +12244,13 @@
         "punchline": 4
       },
       "source": {
-        "sequence": 586
+        "sequence": 583
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8e6b563080a9770a1d772052f80cb61bbd52f10199c589b5721ac069c9adbc8c",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0588": {
@@ -12265,13 +12265,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 587
+        "sequence": 584
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a580a49fff2fb676f2062642b278c3a50ebbabf1b0d5463afaa2478ae3460550",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0589": {
@@ -12286,13 +12286,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 588
+        "sequence": 585
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "49b6f1994c80cd3a8c33573791284228fc26e27972033a3e9e3ce7fb94d7ce83",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0590": {
@@ -12307,13 +12307,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 589
+        "sequence": 586
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4b1daacc937332845e6a84c1bbe5d414e85eee2c3648fe375d9f83c7bca38399",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0591": {
@@ -12328,13 +12328,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 590
+        "sequence": 587
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "086bfa923690c68af9031a690c21a500dc575d7dbf3f4e0323b7ffe7142f66ae",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0592": {
@@ -12349,13 +12349,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 591
+        "sequence": 588
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f1452b12992abbc6d85a3d5cbb3e3da69356d9384abcd461bad40a741d68a36b",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0593": {
@@ -12370,13 +12370,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 592
+        "sequence": 589
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "998b5b0d6baaaeaad0b4785395ddf89072b21db9011db59d13b1a6e6c3a7bab2",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0594": {
@@ -12391,13 +12391,13 @@
         "punchline": 58
       },
       "source": {
-        "sequence": 593
+        "sequence": 590
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d583c13201f6a0f08c5be61d36b0fd455406f3b30daa432cab1b7939fa9c1dfa",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0595": {
@@ -12412,13 +12412,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 594
+        "sequence": 591
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6ac8028d91bc27dd1897d1aece4809bd1c51df0c6a2d8304aa5900eec37f2325",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0596": {
@@ -12433,13 +12433,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 595
+        "sequence": 592
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7f50b82101e6989fe3b6fe27cd483c77b6b717e3e68a6db5113bea8a6bb7ada5",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0597": {
@@ -12454,13 +12454,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 596
+        "sequence": 593
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "752248561cc0943e1d6372f7cb53c5c4a98a187591b095c6098c44bb5f38e486",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0598": {
@@ -12475,13 +12475,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 597
+        "sequence": 594
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f17db82ba7513d488172846d9dbbd36324ac19c3ef539a4264f6abaea12d6701",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0599": {
@@ -12496,13 +12496,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 598
+        "sequence": 595
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6d7e625c3ea2c5e29202867df01a53dfd53a0e67fe560f62800f1f037aa4d9d5",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0600": {
@@ -12517,13 +12517,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 599
+        "sequence": 596
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "32e9e15eedbf6cdb7e176441f913d55602f18991fba96808865a17f969f2be9a",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0601": {
@@ -12538,13 +12538,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 600
+        "sequence": 597
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "33c94b64d13c36de493345089b998cb9ac2a79a846d47069e9e2f6bf03d4a59f",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0602": {
@@ -12559,13 +12559,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 601
+        "sequence": 598
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "96fe4bd2575cd83eec8382708875ebe72be73f59968c908163ab024d1c627a57",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0603": {
@@ -12580,13 +12580,13 @@
         "punchline": 58
       },
       "source": {
-        "sequence": 602
+        "sequence": 599
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ed1ad13a8156b020abb0d9be8c3d4d9949a5c254c12d484400704203517686db",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0604": {
@@ -12601,13 +12601,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 603
+        "sequence": 600
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "584562f8e6f0bbd607d611830c02fb1721e6cd1f3d62ab7e6e270ee0082a5164",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0605": {
@@ -12622,13 +12622,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 604
+        "sequence": 601
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "bf8fe47effa0734daeb5906cac33d2e82edb305e9d4668f6748c1240b223149a",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0606": {
@@ -12643,13 +12643,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 605
+        "sequence": 602
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "766384139d44ebef4a378414516ca2aa3393e1efa4ab7e334cc7010aac090030",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0607": {
@@ -12664,13 +12664,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 606
+        "sequence": 603
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6f17d5c00b3ef681f1b7b359056ab7ba5ff608f0a5d0aff979c9c421f48bd7ce",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0608": {
@@ -12685,13 +12685,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 607
+        "sequence": 604
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "376d398ddf3e6f7a156aefc024b178c11ff385f7072edc099608fe403692d993",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0609": {
@@ -12706,13 +12706,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 608
+        "sequence": 605
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dabb9515a934a4c2000bbaf23cf8129fd88bc66e5b0b1162b309e894b78b4721",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0610": {
@@ -12727,13 +12727,13 @@
         "punchline": 45
       },
       "source": {
-        "sequence": 609
+        "sequence": 606
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6e84077c3576d3681a9bf7ec2260ceea95b0fe9e25ce05283ddccd894f9a0550",
-        "updatedAt": "2025-09-20T22:27:41.537Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0611": {
@@ -12748,13 +12748,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 610
+        "sequence": 607
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ff55d9c2757ddc08d06909aa172e693fa03d7062b30fad1543629da3ad4d62b8",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0612": {
@@ -12769,13 +12769,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 611
+        "sequence": 608
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f0b3a5ae0c13796609ad20d9232f73e138ad9cd205651e9e9e1159247f761075",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0613": {
@@ -12790,13 +12790,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 612
+        "sequence": 609
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "540592c9144117cd0891f81df1e51c8cb32e6366f0e1e4126243c03db77b3173",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0614": {
@@ -12811,13 +12811,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 613
+        "sequence": 610
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c6ce2a9e5bce13840673f46dbfba5104cc4af29f1a10d11627b11651614b5349",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0615": {
@@ -12832,13 +12832,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 614
+        "sequence": 611
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fecf95a71aefda5d8f6eab0c01f54d08d5ab06700c05c72a5d4d127c296a3297",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0616": {
@@ -12853,13 +12853,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 615
+        "sequence": 612
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2453a4d7c4d752dacaf051ff6ad83ae14c61700864e2649d6c8be7e9ec44ade7",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0617": {
@@ -12874,13 +12874,13 @@
         "punchline": 66
       },
       "source": {
-        "sequence": 616
+        "sequence": 613
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "368f5fb7ab7432b13bcc0df29ad1646ada62cc217e8ea5a5b9c24c45a2bfa1d3",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0618": {
@@ -12895,13 +12895,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 617
+        "sequence": 614
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b0a7a78db464b704fa7c403e072ba260dc1bf958934d8371168527beec003a2a",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0619": {
@@ -12916,13 +12916,13 @@
         "punchline": 54
       },
       "source": {
-        "sequence": 618
+        "sequence": 615
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "393e4c3457a5c6e926ccad60a6e316a90b18916ab9c8005f6aacfbf5a17a59b4",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0620": {
@@ -12937,13 +12937,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 619
+        "sequence": 616
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f6367cc347282692413ce5723765946e0d08c61427b38f6c7cc9722143f20a79",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0621": {
@@ -12958,13 +12958,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 620
+        "sequence": 617
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e60a956c7250c89b7f747b2a59f685ff6b7cbc47d321f6da251b9071cd7e6436",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0622": {
@@ -12979,13 +12979,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 621
+        "sequence": 618
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9720846710c1b6cf57aa93ac4632f7ad91a340fc8e251998a6436c42c813edf4",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0623": {
@@ -13000,13 +13000,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 622
+        "sequence": 619
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e9524ab0466a600c204728d8829b365159aac83ab13465e45764d180722057e2",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0624": {
@@ -13021,13 +13021,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 623
+        "sequence": 620
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6f0b575810b6d978099ab9c7bc58763c5f2f37e6612f9f2fa8cc2705116bfb40",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0625": {
@@ -13042,13 +13042,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 624
+        "sequence": 621
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4368eec9aa12a37447b114b418dd0fb33fe0e614b39a8fdc4a89456e978af3bb",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0626": {
@@ -13063,13 +13063,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 625
+        "sequence": 622
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "968828b2538adaefd03f35a49ca93903fbb09a239f606f6d43d97f820931a124",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0627": {
@@ -13084,13 +13084,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 626
+        "sequence": 623
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c2517ccfdc4210b22bc2a137d3fb1dc722f7c0e06e857ab3250971e81eb59b75",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0628": {
@@ -13105,13 +13105,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 627
+        "sequence": 624
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d782bb35a870da609b52b5675fe9ba47085212f8abc90203aab4613b8b5a898f",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0629": {
@@ -13126,13 +13126,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 628
+        "sequence": 625
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "185944da2d0f1b3d899c775b5d64fcbcb0c90577db3578a028afb33a3863ff65",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0630": {
@@ -13147,13 +13147,13 @@
         "punchline": 44
       },
       "source": {
-        "sequence": 629
+        "sequence": 626
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1d51b605f9261a789ea470c717811165e7bab724abf047dfe7a268ba5607e9a5",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0631": {
@@ -13168,13 +13168,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 630
+        "sequence": 627
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "457d9097a0eb3ee39868861ebb19acea027bd8be186bde4011b33eaa95f888c3",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0632": {
@@ -13189,13 +13189,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 631
+        "sequence": 628
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9cefa36ce838aba21e4ed360b7ffc87a1f1e13ef961fb3a36a593bd3045b1e18",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0633": {
@@ -13210,13 +13210,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 632
+        "sequence": 629
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "af18485fb293c3d19334f03242e625593e5b289cb36a67253b1cd65a27209c59",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0634": {
@@ -13231,13 +13231,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 633
+        "sequence": 630
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "294f7f78a215ffa2ca9f0da44d40d710dd566fff7b00773253d62435e9532d53",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0635": {
@@ -13252,13 +13252,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 634
+        "sequence": 631
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c89c54f7b3c13eab18bfd977bf3c8682517e089268287d99a31dc77e58a084f4",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0636": {
@@ -13273,13 +13273,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 635
+        "sequence": 632
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "983e706241cc499fa64f8e3e0da2e0e4364ceb884397c6f98e70107fb46c14c5",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0637": {
@@ -13294,13 +13294,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 636
+        "sequence": 633
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9ab90421acaf15f5cff2c1980b90362694172f7b5d25b8bbd357093f418c12aa",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0638": {
@@ -13315,13 +13315,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 637
+        "sequence": 634
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "970cba365d63c5ede4d53f1859529d890214c49ba6b6a8679ae8bf88996723a1",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0639": {
@@ -13336,13 +13336,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 638
+        "sequence": 635
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c6a3f64a07da7c2bdcf8be5a3e6fefa5ae422fa7189a9bcf40da0eef77588bcc",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0640": {
@@ -13357,13 +13357,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 639
+        "sequence": 636
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e6283b92a390fa35e0d06a0b5be54c41ead50f47fe7d4f9903c8eca350acf79f",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0641": {
@@ -13378,13 +13378,13 @@
         "punchline": 65
       },
       "source": {
-        "sequence": 640
+        "sequence": 637
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8b823d30c993d24341e33ccbfc4a4ae23caf7914fc01e6d8741e0bb6c2442651",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0642": {
@@ -13399,13 +13399,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 641
+        "sequence": 638
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f5a41cd5c2b797f553839653cd1d5e3484e415aa9fa2d41b404219c6f8decefc",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0643": {
@@ -13420,13 +13420,13 @@
         "punchline": 46
       },
       "source": {
-        "sequence": 642
+        "sequence": 639
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "033439a22e3d5c513b7b6bad2548ad2bf108b23c96ca5f51ddbb2621e2546ea1",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0644": {
@@ -13441,13 +13441,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 643
+        "sequence": 640
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d791f6dc7f1b7e22f6abac0b2edaf6efd08f5a9e53e4c3da3bce431a71a13462",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0645": {
@@ -13462,13 +13462,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 644
+        "sequence": 641
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "62c47195e74fbf1486fc67809beb03645b3cf842a62799d9af5d96bd52002baa",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0646": {
@@ -13483,13 +13483,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 645
+        "sequence": 642
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d5b00aa741bc49934d7d94db5b105238fccec61a39955e5aac660bedf7b42d0f",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0647": {
@@ -13504,13 +13504,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 646
+        "sequence": 643
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0436ba22ff21a54052d2d93951121c720b2217f878b368b26858f66f719d5c87",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0648": {
@@ -13525,13 +13525,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 647
+        "sequence": 644
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dd4448abdf0aedf28c124cd30a1d56aeae7862201a59bcc37be7482c04f9ffb9",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0649": {
@@ -13546,13 +13546,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 648
+        "sequence": 645
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2915d6e519f11cfd9aaed01e7c483d9135c67b76070ea87e8b230e62bd78025d",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0650": {
@@ -13567,13 +13567,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 649
+        "sequence": 646
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0539744a0372d241b7f6a90ecad140a05aa3479d372577cd87b4510413d87370",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0651": {
@@ -13588,13 +13588,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 650
+        "sequence": 647
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "59a3b83451dd606a6ace322eca9cb5add34c982b1af5842ffd50cc23139fdc42",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0652": {
@@ -13609,13 +13609,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 651
+        "sequence": 648
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e484cacfaa7b2b92331d44d8bd5d0f5e7d6edc51d495bd4a9680c267ce70063a",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0653": {
@@ -13630,13 +13630,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 652
+        "sequence": 649
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fe33fb6b20a5ef4c9293801c9ccc9773ee81ebe7c8ee40d0ef549776fcd11edc",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0654": {
@@ -13651,13 +13651,13 @@
         "punchline": 50
       },
       "source": {
-        "sequence": 653
+        "sequence": 650
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "44ad2c9aa9c46601c624eb543fbe6f76c66ea99b173e6b50f2b6d1037e5a87e1",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0655": {
@@ -13672,13 +13672,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 654
+        "sequence": 651
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4558f437ebabbbb228d51d671e7dc2b2f20c9f98055d2ff818b89878d8fe1bb2",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0656": {
@@ -13693,13 +13693,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 655
+        "sequence": 652
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "46c37e6d873326ff1af3840ce763610de740ad63a3ec9aaa47c0923f6806ec42",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0657": {
@@ -13714,13 +13714,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 656
+        "sequence": 653
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b67cdc0b3f531768733288d3613f5c394ea6091cadc70681d0fa33afc37b8534",
-        "updatedAt": "2025-09-20T22:27:41.538Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0658": {
@@ -13735,13 +13735,13 @@
         "punchline": 38
       },
       "source": {
-        "sequence": 657
+        "sequence": 654
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3b95a2a7a95a07c979165862ae7f80bb7d9518040e282e86bd9933e72f9ba826",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0659": {
@@ -13756,13 +13756,13 @@
         "punchline": 49
       },
       "source": {
-        "sequence": 658
+        "sequence": 655
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "615d6b89a436f9b4d725386636324b530b7d1322f94601d3fd1c8b7e4149c2d3",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0660": {
@@ -13777,13 +13777,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 659
+        "sequence": 656
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "79a34c3c25adc10cb876419418bf519eb67466eba0005d09c173d4286cdca90e",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0661": {
@@ -13798,13 +13798,13 @@
         "punchline": 7
       },
       "source": {
-        "sequence": 660
+        "sequence": 657
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "37a7d6ed824b85b30537541e992bfbe4d7ecad940a79a6adafb6829a49afd677",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0662": {
@@ -13819,13 +13819,13 @@
         "punchline": 57
       },
       "source": {
-        "sequence": 661
+        "sequence": 658
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "41aba9743f5c9981705a5781c0f3462f3312f9f7e172c6cd24600869f91040bc",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0663": {
@@ -13840,13 +13840,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 662
+        "sequence": 659
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9ed7d3e75ac8aa9e0b7bca20c91ac3d9d74404ff33da9b4d2b2619443f117969",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0664": {
@@ -13861,13 +13861,13 @@
         "punchline": 42
       },
       "source": {
-        "sequence": 663
+        "sequence": 660
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fe78761a454cd185aa617728015df535359941d7a71cb18584eb803b167593eb",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0665": {
@@ -13882,13 +13882,13 @@
         "punchline": 5
       },
       "source": {
-        "sequence": 664
+        "sequence": 661
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "818eed9c28cc16f42aa327f8856e0f1deb3e68030139a2b3399cfa3c89ef53e0",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0666": {
@@ -13903,13 +13903,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 665
+        "sequence": 662
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ad04b454062dbee096de800ee2319b727e8459bf288921d60c4323353f8ae63e",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0667": {
@@ -13924,13 +13924,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 666
+        "sequence": 663
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f84eaf1f5dbe3b0221082a5eb47b92ea5b0163bd4b2eef36bf0af800266971df",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0668": {
@@ -13945,13 +13945,13 @@
         "punchline": 39
       },
       "source": {
-        "sequence": 667
+        "sequence": 664
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "24122ec57a8846449c08dfa83008878ceaa5ad02ed55ce9d0674057386a4ed36",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0669": {
@@ -13966,13 +13966,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 668
+        "sequence": 665
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "96616afeb447bf4395bb76a8f9764d727029d64b0c965ce6d2e50d2357579e75",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0671": {
@@ -13987,13 +13987,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 669
+        "sequence": 666
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1e7f837e06b13b600b84deeb8530cf9a52ba410bbf93d02c1441294f9b508b1d",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0672": {
@@ -14008,13 +14008,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 670
+        "sequence": 667
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "960ec5cd87c943a2d3cea17221705a32d4a2a2cc38762929be90ba78c2d08f02",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0673": {
@@ -14029,13 +14029,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 671
+        "sequence": 668
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5bd34f2d519a1cced202000ae0cea1f5f657b71f124e7a34fd5c46dcf43c0f64",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0675": {
@@ -14050,13 +14050,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 672
+        "sequence": 669
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c78887789cfa03d7d4bcb98cb7ab9f4375e0345259c850d46ff0106d4a39778c",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0676": {
@@ -14071,13 +14071,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 673
+        "sequence": 670
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "27198bae1fddfb77437f193a3d9052035a0acd5504b3ae405045588e711cfe3e",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0677": {
@@ -14092,13 +14092,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 674
+        "sequence": 671
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "78d5ec9bf0f33b6d5c06135054713e88f666406b19da1814af747022217cc84e",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0678": {
@@ -14113,13 +14113,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 675
+        "sequence": 672
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "206921a33a8ae8e378d695e360a712a4c8f1718107bfbfbf9698d461177c85bc",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0679": {
@@ -14134,13 +14134,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 676
+        "sequence": 673
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2c1be0b80967dd4e216875ee319762adebbc543a863c3c485423bc3a5383e67a",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0680": {
@@ -14155,13 +14155,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 677
+        "sequence": 674
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f3af3eb9262b9d0df31ac5a54dcfbffefd1717210eeaab16eb0489361e6bb11c",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0681": {
@@ -14176,13 +14176,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 678
+        "sequence": 675
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f225ca2e044b267aa125476a3f160b9e12823fe6e0a69a989b0033bb27be0874",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0682": {
@@ -14197,13 +14197,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 679
+        "sequence": 676
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f3ae73628c55f474baf86791965799bc69ddf180cc804c950ea89e3c25f5148e",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0683": {
@@ -14218,13 +14218,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 680
+        "sequence": 677
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fee92f731e0c9c56d0dfb669e55f3c3d3f04d58ccdd4a10b7480bef38258b4d2",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0684": {
@@ -14239,13 +14239,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 681
+        "sequence": 678
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ccd7c9f4f6fab7698f26a620bb25e81111731f2bed8ef7c0177091dc084125e3",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0685": {
@@ -14260,13 +14260,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 682
+        "sequence": 679
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f64ad0fd54074d4b1ef6d4f3b8199bd18db62423688d689a5a22c73954c784ba",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0686": {
@@ -14281,13 +14281,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 683
+        "sequence": 680
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8a694b825ffbfe5578c6240abc0f52185c9626b20ead4edcb5e43dd0a055e290",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0687": {
@@ -14302,13 +14302,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 684
+        "sequence": 681
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "afeb9981e762426c597fda96372136b84fa0a69f4c960c261277c588c4ba683a",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0689": {
@@ -14323,13 +14323,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 686
+        "sequence": 682
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a079381fb55474c0def999023f569c12dc4eedf316f6b9e16d5dcb1e87980916",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0690": {
@@ -14344,13 +14344,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 687
+        "sequence": 683
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "16400df9d408970176d1460de588a63be874f131b98ee501a4a30cca9d49c8b1",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0691": {
@@ -14365,13 +14365,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 688
+        "sequence": 684
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3f4a180775f52eb33cc772208bc657e94810a54ac96df77eb7315cce2fea5c37",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0692": {
@@ -14386,13 +14386,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 689
+        "sequence": 685
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "06e065af012d19e13b97c9e6a84ba70828b0969b75e5140a9e9b7122ae697b7e",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0693": {
@@ -14407,13 +14407,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 690
+        "sequence": 686
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "89bbaa4a694fc637e43a2ef46cd5247b2140cbe6c2279443c08f176de90c3567",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0694": {
@@ -14428,13 +14428,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 691
+        "sequence": 687
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6ca5c315e2ee5a4543d450db965e5441655025ba675ef53a9b712d6e3cc63ed0",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0695": {
@@ -14449,13 +14449,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 692
+        "sequence": 688
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1d4bf88f30ee969a330cd44daff3b9ae70cadd95e8d75ca7a7aed3102f0a7961",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0696": {
@@ -14470,13 +14470,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 693
+        "sequence": 689
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "867fddfea668fee59b27ea25d81d5212deec8612d2442353aac6e80481faa229",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0697": {
@@ -14491,13 +14491,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 694
+        "sequence": 690
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8a215b3ee63996ddab2a32ee01dc2b98582e8b5354bea9673b8f9edbd5b97c9e",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0698": {
@@ -14512,13 +14512,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 695
+        "sequence": 691
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d72a6640f4967051839194179082c4e285e190797d71a1b48e0fd213bbaccaf9",
-        "updatedAt": "2025-09-20T22:27:41.539Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0701": {
@@ -14533,13 +14533,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 697
+        "sequence": 692
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "625b57da04ccdd9e0a618206ac276c4d915bcc94b15466055ca83dd129959ea5",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0702": {
@@ -14554,13 +14554,13 @@
         "punchline": 60
       },
       "source": {
-        "sequence": 698
+        "sequence": 693
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6028e16ad4ac474b8c3339a03c5b7a1d167a52dd387800ed4b8d827638126be1",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0703": {
@@ -14575,13 +14575,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 699
+        "sequence": 694
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "79f2b002f15692045c94f186152d462fda8ae0080e6311d3bf8d325cd7ca7470",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0704": {
@@ -14596,13 +14596,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 700
+        "sequence": 695
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "26ac40f89d2aa93b8a6201d5596ad3ca74508aa8c7262d85dcc3e203ad1e5998",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0705": {
@@ -14617,13 +14617,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 701
+        "sequence": 696
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c7920ca23923709b3b41a892075c984e0b385d5bd4855945a4e9b6c98964b999",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0707": {
@@ -14638,13 +14638,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 703
+        "sequence": 697
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "40b213540a85e3022107155ee8315ace74be726d82e656343c89ff205f5ecc20",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0708": {
@@ -14659,13 +14659,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 704
+        "sequence": 698
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d5463ae65694985206f490ec34b44e0f19707c35b81a93142bc6b00133aca09a",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0709": {
@@ -14680,13 +14680,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 705
+        "sequence": 699
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "067eaeadadf540dbeceb68d0d71aad10eb65f037b1f015cb1e9e342a5c03d3ea",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0710": {
@@ -14701,13 +14701,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 706
+        "sequence": 700
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "71cc883cd21a52f15abe4eb4f049df3da8a8eaffd9d85ae4b269fba78c53459a",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0711": {
@@ -14722,13 +14722,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 707
+        "sequence": 701
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "019d52fd7f6a2d1c40c00252577ac21977af68e011f86fe9f2fad1f856be44a9",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0712": {
@@ -14743,13 +14743,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 708
+        "sequence": 702
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6ee6f598116c983946549c66bb2a310d480b8df91f0ec59ef6234feba4a82948",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0713": {
@@ -14764,13 +14764,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 709
+        "sequence": 703
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ce22a74f7de009212a6012f832203e1d15d57616f4f3207023e900c4268eff1b",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0714": {
@@ -14785,13 +14785,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 710
+        "sequence": 704
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1cbe540f86f963a496b71ca0e41e1e1f62603fbcaae66bbabebd0fc0858cece8",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0717": {
@@ -14806,13 +14806,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 711
+        "sequence": 705
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "11b62431a07341bf42249771a70dc5b0eab5bb341cc9e9a1ac7d340348459dd7",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0719": {
@@ -14827,13 +14827,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 713
+        "sequence": 706
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5edccd434030b9979ad618c8651e99de17ad5db6e228216839a3d5ec9539def1",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0720": {
@@ -14848,13 +14848,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 714
+        "sequence": 707
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1d2d685a23d8dea217e1c6c4761f0996a1e90f876e9f76c28d4e220ba9aaddd7",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0721": {
@@ -14869,13 +14869,13 @@
         "punchline": 56
       },
       "source": {
-        "sequence": 715
+        "sequence": 708
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "40473571bbf4b9bc89abfd64dc1f0d2a6c566caa45fff717cdc3f828cc7cd77b",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0722": {
@@ -14890,13 +14890,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 716
+        "sequence": 709
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8a8c1a5fdbc40e9293bd5bf054b9f299775ba14051b5d4733cbe1e772798b22d",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0723": {
@@ -14911,13 +14911,13 @@
         "punchline": 51
       },
       "source": {
-        "sequence": 717
+        "sequence": 710
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "68bbe4ab1c903d14dc7e549440c57c9d324a85cb5c0d87586b80a0ce6668c98a",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0724": {
@@ -14932,13 +14932,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 718
+        "sequence": 711
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8651fec03f67d6a6fa90f7240a34d9c3e7b970807babd2b24ba0f979b1e8adbd",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0725": {
@@ -14953,13 +14953,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 719
+        "sequence": 712
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "88884e420ec9079f7de8bc7cfe3a71cffa6452ffb94bbd6ce3c713890f3b4f4a",
-        "updatedAt": "2025-09-20T22:27:41.540Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0726": {
@@ -14974,13 +14974,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 720
+        "sequence": 713
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e00189d1f4cee50635f7e0e1c89db7725e93653d247a44056e156986edf29a36",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0727": {
@@ -14995,13 +14995,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 721
+        "sequence": 714
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9adc57a849d8927c57fd4d07bd3cdced7c38d1aefaa73ab6f085855b6dc9d886",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0728": {
@@ -15016,13 +15016,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 722
+        "sequence": 715
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "41dc96a592d541859970c6f013e46167a15535935231fd71f349841808ee5c43",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0730": {
@@ -15037,13 +15037,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 724
+        "sequence": 716
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3cf329c80d7426686731b91b610461f5447cec7ae235380b0014a742d2cda381",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0731": {
@@ -15058,13 +15058,13 @@
         "punchline": 37
       },
       "source": {
-        "sequence": 725
+        "sequence": 717
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ce454efa75ca3a5d96ad78f79340e5f9dc192116c55c96a0d535a73e6ac2490d",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0732": {
@@ -15079,13 +15079,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 726
+        "sequence": 718
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "152b204902d495079dd346b6cc6a1cb54b74df001d3759f6c13b418c96488c0f",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0733": {
@@ -15100,13 +15100,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 727
+        "sequence": 719
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "baacb9bbc2ff861af9ed7e92f66d4d1f35a77bce393fa9ce194cd436dba8ebc4",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0735": {
@@ -15121,13 +15121,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 729
+        "sequence": 720
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ee458728223954badbe8e4987c702d393cef50e790117386069d3b4822d44811",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0736": {
@@ -15142,13 +15142,13 @@
         "punchline": 39
       },
       "source": {
-        "sequence": 730
+        "sequence": 721
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "717bd5a138ed05c63c4aec70b3e25302bdbfa7051bda19a4317fc568072dd877",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0737": {
@@ -15163,13 +15163,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 731
+        "sequence": 722
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "45de56d1fcbe9575d1ac9872c732f220c13b21e80e769dcd87ac57c3c47c4d9e",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0741": {
@@ -15184,13 +15184,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 733
+        "sequence": 723
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fc08dcf9c4255f861c4176ae5a7c6a5f3d56aefd3bddfcafc6be51dfba77028c",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0742": {
@@ -15205,13 +15205,13 @@
         "punchline": 14
       },
       "source": {
-        "sequence": 734
+        "sequence": 724
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "426d408ec300c6f9b6a867b159e5b69fdb0bd4bd1c6e37e57085e6f556caf46b",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0744": {
@@ -15226,13 +15226,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 735
+        "sequence": 725
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1e0d4ccfb65da4f49a599f2c0b4b6f8c664dec5d7586d96f44b739136e484f6e",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0746": {
@@ -15247,13 +15247,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 736
+        "sequence": 726
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9f5706e7884758d97b891f28a526c8e468312cbc3199464507d86df80dd9ea19",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0747": {
@@ -15268,13 +15268,13 @@
         "punchline": 46
       },
       "source": {
-        "sequence": 737
+        "sequence": 727
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "63817c89cbe242a464fa4519bef3073be2c8b8ec595ea19d2ccbb001a4e1401c",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0748": {
@@ -15289,13 +15289,13 @@
         "punchline": 74
       },
       "source": {
-        "sequence": 738
+        "sequence": 728
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "71d0f21761f927ebcfabc0be57551f18fe6c4986be10910826ea2545185cac4e",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0749": {
@@ -15310,13 +15310,13 @@
         "punchline": 78
       },
       "source": {
-        "sequence": 739
+        "sequence": 729
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1b194a306cf5d30b4b3cb00bff365833421f276d10c0e078147d585dd67db333",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0750": {
@@ -15331,13 +15331,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 740
+        "sequence": 730
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a5c28b9b810f31b3a2ab2079486d1ca5c90545e17f9d02744cd7b095583666c1",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0751": {
@@ -15352,13 +15352,13 @@
         "punchline": 16
       },
       "source": {
-        "sequence": 741
+        "sequence": 731
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dcd17e5c1b70b94156a2f1396fa9ae6568c9a62042d9c2c65fa8cde69c89b9e1",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0752": {
@@ -15373,13 +15373,13 @@
         "punchline": 59
       },
       "source": {
-        "sequence": 742
+        "sequence": 732
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e91754f5a92e99f5fb1cab3d73bde1250d409f0971227038eea68e9bc85f7a87",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0753": {
@@ -15394,13 +15394,13 @@
         "punchline": 27
       },
       "source": {
-        "sequence": 743
+        "sequence": 733
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c2c729a08cac7d71441c86edc7537dae724841040826c82da195954f617769ec",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0754": {
@@ -15415,13 +15415,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 744
+        "sequence": 734
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2f8f64d5d81344da3250df2120b636d954f86d0eff62a6c35141ac8edeb41cbc",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0755": {
@@ -15436,13 +15436,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 745
+        "sequence": 735
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9f44ebbb4a7df429f40630bebb0e054990593227b7e449accfb16e9f5eee5419",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0756": {
@@ -15457,13 +15457,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 746
+        "sequence": 736
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b3e2cd858ed47899b76400ea22d428531a435f4602d3958c5d1898d7ba7a61ce",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0757": {
@@ -15478,13 +15478,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 747
+        "sequence": 737
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "72b0b40757dba10bc62f7577a98151ec121d90b41325e3c143e9dc1c21552591",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0758": {
@@ -15499,13 +15499,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 748
+        "sequence": 738
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e9808823ef5750330cc12b0e4cc3a285b7c9ae0df911a654caf5b1d29d02d1ba",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0759": {
@@ -15520,13 +15520,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 749
+        "sequence": 739
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "75243deea0336711e7faf4d59f658b4b8fde3dd71802cad0538aa2659c2ca6e4",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0760": {
@@ -15541,13 +15541,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 750
+        "sequence": 740
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "369b03ad6df7fe0462e807f587a36f57187fd771cc4ea53a38f9da4c0ec6bf54",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0761": {
@@ -15562,13 +15562,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 751
+        "sequence": 741
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "92cea857f776627c5d4180f6927763a4860b978c2632eb56317e8ba1bebf4ac8",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0762": {
@@ -15583,13 +15583,13 @@
         "punchline": 4
       },
       "source": {
-        "sequence": 752
+        "sequence": 742
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "04d42033488ef59cdb876c49317921b51b49dc041bfbaa582dee621ad5bfeb13",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0763": {
@@ -15604,13 +15604,13 @@
         "punchline": 20
       },
       "source": {
-        "sequence": 753
+        "sequence": 743
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a6e05807e0bb9300f6dac494e0b46304346f866ecef9544ae86df87c50653fb8",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0764": {
@@ -15625,13 +15625,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 754
+        "sequence": 744
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "320ee9de96c90e96c52cf79c0733fa63e08a39312bbe039349f0d8b48693e434",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0765": {
@@ -15646,13 +15646,13 @@
         "punchline": 23
       },
       "source": {
-        "sequence": 755
+        "sequence": 745
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4ad4c466c85146c7f1df6a96842cb250552ecd94e2ff3268fe6480aa720f6628",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0766": {
@@ -15667,13 +15667,13 @@
         "punchline": 4
       },
       "source": {
-        "sequence": 756
+        "sequence": 746
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2cbc1802d26ca10582cdd585ef1de96b1f37b8e9fdf1afa6aa85103395bb49e1",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0769": {
@@ -15688,13 +15688,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 759
+        "sequence": 747
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f1c33caaf47a81e69a2a621e11008dca86ddcef6e42305a69e852033163b0143",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0770": {
@@ -15709,13 +15709,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 760
+        "sequence": 748
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9491bed5afbaf7854de146c23e10bce1dccbfed858337ffe35d7582b6b5e49ea",
-        "updatedAt": "2025-09-20T22:27:41.541Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0772": {
@@ -15730,13 +15730,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 762
+        "sequence": 749
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "47b321685e259837408acf6877f8a7db513556ae73d7202847511b6989aac56f",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0773": {
@@ -15751,13 +15751,13 @@
         "punchline": 50
       },
       "source": {
-        "sequence": 763
+        "sequence": 750
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1fcf4cb189849b935d580ade4beff244a9cff8eb91cec6d18054977ffc384ede",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0774": {
@@ -15772,13 +15772,13 @@
         "punchline": 18
       },
       "source": {
-        "sequence": 764
+        "sequence": 751
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8dc30dea2fa889b00d41eab2bd41e1c6ecd58240b23b4f0c428d122d8e93e28a",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0775": {
@@ -15793,13 +15793,13 @@
         "punchline": 10
       },
       "source": {
-        "sequence": 765
+        "sequence": 752
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1d80fcb7ca3bd49679022c67812e4d6a15ef460d4893649f2c0074975d8c03ca",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0776": {
@@ -15814,13 +15814,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 766
+        "sequence": 753
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e458299b0fe81176fd1e0a2953da736703756a4a61667de59785995dae5f68d5",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0777": {
@@ -15835,13 +15835,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 767
+        "sequence": 754
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d39130d5b340e2d626d7356f5aa988a549b279af6c668fc6c949fdd4c636cd9e",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0778": {
@@ -15856,13 +15856,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 768
+        "sequence": 755
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4333a9f81b691ae5934e9bfd51bc161165bc4811065a2b2f13ab3f405e08915e",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0780": {
@@ -15877,13 +15877,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 770
+        "sequence": 756
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "faa64b2a2b9f2f57921de54b9f9efd42ff713ed9580fce2d32a7d0aa545a86ea",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0783": {
@@ -15898,13 +15898,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 773
+        "sequence": 757
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "71bedaa4e1965bba667b583a184d77f5994134366fc9c93699b383a1f43cb787",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0784": {
@@ -15919,13 +15919,13 @@
         "punchline": 62
       },
       "source": {
-        "sequence": 774
+        "sequence": 758
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b924468ff10d0a2c6423093ea54b0770f87d1d0c9e20917246faadaed268e8e3",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0785": {
@@ -15940,13 +15940,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 775
+        "sequence": 759
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "142d39012a1b7f1b677af3f3f2fd413bf208563387e06a0004fc237d93e23256",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0786": {
@@ -15961,13 +15961,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 776
+        "sequence": 760
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e1586eb478619044815cd3e80c46523d9bca6e0a8484e01381bb62937d727ae9",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0787": {
@@ -15982,13 +15982,13 @@
         "punchline": 57
       },
       "source": {
-        "sequence": 777
+        "sequence": 761
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2772c6f875062dc2128cd7f3cf817a806e221e459aa89b7b59fa69718c4eb5ef",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0788": {
@@ -16003,13 +16003,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 778
+        "sequence": 762
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f760e25a494ffbd0a6f10bc83e38befa8300ee3a3c74ddbebb12cc854fd54e05",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0789": {
@@ -16024,13 +16024,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 779
+        "sequence": 763
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b15a277c1b875f3a15b29be18ca4d564e1f3d80a468d67b24bfce7569db342f1",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0791": {
@@ -16045,13 +16045,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 780
+        "sequence": 764
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a6d3b8499ec29be37a3cfb3d0320fd4d5b548d59ac0e266e7a04c82faddbd06c",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0792": {
@@ -16066,13 +16066,13 @@
         "punchline": 28
       },
       "source": {
-        "sequence": 781
+        "sequence": 765
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "789e91590cd86447de0f2e75cb3cba6b45962d2ba32190576cae8a4171991e3f",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0793": {
@@ -16087,13 +16087,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 782
+        "sequence": 766
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3d2812c391f4e00e97299f864dc8326231affde97cd5483184f45e8ac062c24c",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0794": {
@@ -16108,13 +16108,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 783
+        "sequence": 767
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b6534d298abaee0013896ddac08c9e8650dec091c9972f7dadbb504fda1086d1",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0795": {
@@ -16129,13 +16129,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 784
+        "sequence": 768
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "850a522f453c50ed5d027cda7e134658719ed172aab5aa4cee49878a117a6a8c",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0796": {
@@ -16150,13 +16150,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 785
+        "sequence": 769
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c78486e5bc34962b8c776c3ba8e5812996c9cb685749c7b30d5c3bad4b140ac9",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0797": {
@@ -16171,13 +16171,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 786
+        "sequence": 770
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b20d7e2b4d0be1d51546b771f25d0ab290ddb33a6db032883c6c16f58b32911d",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0798": {
@@ -16192,13 +16192,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 787
+        "sequence": 771
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "451313fa9f54bb6aaf1ed4e16932bbc846692b12fc155ce06298aed5f8d9a146",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0800": {
@@ -16213,13 +16213,13 @@
         "punchline": 22
       },
       "source": {
-        "sequence": 788
+        "sequence": 772
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "bc5fdc7e898bf28c4fb746859150b5344a902fddb6af15bf59925a9c61350b3a",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0801": {
@@ -16234,13 +16234,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 789
+        "sequence": 773
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "640ac1d6c175d1a0775ec909e31211449976799ae5e7d955303f199775ee0ada",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0803": {
@@ -16255,13 +16255,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 791
+        "sequence": 774
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3eaf37500fbdb517835349ad5f67d866d9930853b9e9fb21d9fa809fb1005d17",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0804": {
@@ -16276,13 +16276,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 792
+        "sequence": 775
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3b41bfc6a56a26eb6e828a7e49736d35f03305a3cbf40bd56bddf2e07cad4724",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0805": {
@@ -16297,13 +16297,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 793
+        "sequence": 776
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "43414da1c258ce9f9d935940ad5063268d9b52033c73ec4026057ca40749c21a",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0808": {
@@ -16318,13 +16318,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 795
+        "sequence": 777
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c4d9d18f9c9e258c4197ffceb53b15de28101ce32bb12f678af48c51a1f0d83c",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0813": {
@@ -16339,13 +16339,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 798
+        "sequence": 778
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4e17727065e2ac6eaeefd6dd06be65aff46f8c18208e530f11ffdccf74349bb4",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0814": {
@@ -16360,13 +16360,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 799
+        "sequence": 779
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "bf2f7302c429257e99ca7ff6195006509dd1fdb3c3fa6f37479d3e925faa13f8",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0817": {
@@ -16381,13 +16381,13 @@
         "punchline": 49
       },
       "source": {
-        "sequence": 801
+        "sequence": 780
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "972021b10551f0b4a82800cc5d5a43189e4c551144b39d86e2a9073a22593b0c",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0819": {
@@ -16402,13 +16402,13 @@
         "punchline": 62
       },
       "source": {
-        "sequence": 802
+        "sequence": 781
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "268caeee53df9bd4fed8a5e306812113ff3f62f7e75757eead2e12bcdd182c55",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0820": {
@@ -16423,13 +16423,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 803
+        "sequence": 782
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "20aea8c4aab0571c71fe228ac52e0dc3a7bee8e7e03f85cf1589584a5a40842e",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0821": {
@@ -16444,13 +16444,13 @@
         "punchline": 19
       },
       "source": {
-        "sequence": 804
+        "sequence": 783
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7f7cd2ffb9285564ea6c51633b2f1f24ea1701327fe1c3dcf7a036ee3c9c78e5",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0822": {
@@ -16465,13 +16465,13 @@
         "punchline": 36
       },
       "source": {
-        "sequence": 805
+        "sequence": 784
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "17c3437a53fbb6bcba5436824ea71d9d4d476d64fbbb95f8638bd29e52d77313",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0823": {
@@ -16486,13 +16486,13 @@
         "punchline": 46
       },
       "source": {
-        "sequence": 806
+        "sequence": 785
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ca4265a089ed46de8d04c9a4c7c8457baedec069afba07a5ff98d50db00082e6",
-        "updatedAt": "2025-09-20T22:27:41.542Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0824": {
@@ -16507,13 +16507,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 807
+        "sequence": 786
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6064ac780d3080ec5e6d56a929f805aec2846b62fcebc1123ab35c188cef1c3a",
-        "updatedAt": "2025-09-20T22:27:41.543Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0825": {
@@ -16528,13 +16528,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 808
+        "sequence": 787
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4606a8ddcb4bc27254be1dae8b12745ddfc5106b47c10bfaaf50212a3a19f2fe",
-        "updatedAt": "2025-09-20T22:27:41.543Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0826": {
@@ -16549,13 +16549,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 809
+        "sequence": 788
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1cfb177a38b1c952e11f5b436309c2e9dd40a60ca073a8e6d5195531ce47321d",
-        "updatedAt": "2025-09-20T22:27:41.543Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0827": {
@@ -16570,13 +16570,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 810
+        "sequence": 789
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9c8d45c3600b988dfe00e0445a3238fc0f91bd914e457061fdc3988ff4d58caa",
-        "updatedAt": "2025-09-20T22:27:41.543Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0828": {
@@ -16591,13 +16591,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 811
+        "sequence": 790
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "150330a049a39ed7dff8a137e0c2e547c08ae4b59107a816b0ae618e492be986",
-        "updatedAt": "2025-09-20T22:27:41.543Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0829": {
@@ -16612,13 +16612,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 812
+        "sequence": 791
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b883bbee276581208cae3136f1d7d90374898e38adb3397124c0304843dfb681",
-        "updatedAt": "2025-09-20T22:27:41.543Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0830": {
@@ -16633,13 +16633,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 813
+        "sequence": 792
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "115d2c7fb6f57ce5b03b7a7f9d77e7bb26490653c085b2106227d7d203938838",
-        "updatedAt": "2025-09-21T03:21:38.300Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0831": {
@@ -16654,13 +16654,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 814
+        "sequence": 793
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "abcde1a6d01de46b0c6a7799e09c0ff91a8dbc35e60eec680eea23d2d54f9ecf",
-        "updatedAt": "2025-09-21T03:21:38.301Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0832": {
@@ -16675,13 +16675,13 @@
         "punchline": 59
       },
       "source": {
-        "sequence": 815
+        "sequence": 794
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d25c91cc7e86521865d3035cc40c8c4d71b2d8287f7755d7efcc12e9ed6431dd",
-        "updatedAt": "2025-09-21T03:21:38.301Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0833": {
@@ -16696,13 +16696,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 816
+        "sequence": 795
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2f37d465d47dff60e715e685366220cd249f0ea1a5764117648dfc36f47c1375",
-        "updatedAt": "2025-09-21T03:21:38.301Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0834": {
@@ -16717,13 +16717,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 817
+        "sequence": 796
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "dae17bba40524d5d0d3a07097616c20d9a79da333783f20a0b2ff66943ae9808",
-        "updatedAt": "2025-09-21T03:21:38.302Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0835": {
@@ -16738,13 +16738,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 818
+        "sequence": 797
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "9de7f81586067edfaf84d9367673bfc6551192846fc007fa80617148e80413bb",
-        "updatedAt": "2025-09-21T03:21:38.303Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0836": {
@@ -16759,13 +16759,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 819
+        "sequence": 798
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "96a13b9c8f12389e99bad1d8c1a01bb885df5a062bac77e745f14c324231c737",
-        "updatedAt": "2025-09-21T03:21:38.303Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0838": {
@@ -16780,13 +16780,13 @@
         "punchline": 43
       },
       "source": {
-        "sequence": 821
+        "sequence": 799
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "888b67be7dac9fe4e2f69fb9f4c2f589f74cb54151bafe060cad5fbeb35ebda2",
-        "updatedAt": "2025-09-21T03:21:38.303Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0839": {
@@ -16801,13 +16801,13 @@
         "punchline": 30
       },
       "source": {
-        "sequence": 822
+        "sequence": 800
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "8ffb9415fc2d391c9ddafdb2926fd309c3a310f2b30082a835771a7d56aa2ddf",
-        "updatedAt": "2025-09-21T03:21:38.303Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0840": {
@@ -16822,13 +16822,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 823
+        "sequence": 801
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "74517fbe3b2a7753042b5609c9b2b017ed9e06a1e667bc10ea3380cfd6e30a05",
-        "updatedAt": "2025-09-21T03:21:38.303Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0841": {
@@ -16843,13 +16843,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 824
+        "sequence": 802
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "18c01d755f5d4401eee9728694a55d4cbc25d51cf75f1c2dba15cd52165beba5",
-        "updatedAt": "2025-09-21T03:21:38.303Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0842": {
@@ -16864,13 +16864,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 825
+        "sequence": 803
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3026cb748bab4c61eb9ba6ecac7ed0bdb608ff4445143d48eecbf71f480182a4",
-        "updatedAt": "2025-09-21T03:21:38.303Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0843": {
@@ -16885,13 +16885,13 @@
         "punchline": 45
       },
       "source": {
-        "sequence": 826
+        "sequence": 804
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ba7e9b81658e990aabb1ab559ebc06a3c4fd29c59b55c9020f1dafa73e88e0ef",
-        "updatedAt": "2025-09-21T03:21:38.304Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0844": {
@@ -16906,13 +16906,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 827
+        "sequence": 805
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3e3e58001b8ae4d6afb8aab2c3b02e49e89f5d9b39eba9b9b205840e915ff396",
-        "updatedAt": "2025-09-21T03:21:38.304Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0845": {
@@ -16927,13 +16927,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 828
+        "sequence": 806
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e892ee87b232444da8ef72be20883ef16fbbd5ccaf5d1d3ba6de645a1a4fa5b1",
-        "updatedAt": "2025-09-21T03:21:38.304Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0846": {
@@ -16948,13 +16948,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 829
+        "sequence": 807
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4f44606953c9060ee01db30b4e400bf6d240d5f2b11f5aa7276ba669c1110c2a",
-        "updatedAt": "2025-09-21T03:21:38.304Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0847": {
@@ -16969,13 +16969,13 @@
         "punchline": 41
       },
       "source": {
-        "sequence": 830
+        "sequence": 808
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "be1deaf49c6ae4e65ca34823068be80ecf52dc74e0b97f6f1a98f938a5aaffcc",
-        "updatedAt": "2025-09-21T03:21:38.304Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0848": {
@@ -16990,13 +16990,13 @@
         "punchline": 35
       },
       "source": {
-        "sequence": 831
+        "sequence": 809
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "692e9368a4d6447f52249365ad785a4cc0a62358bcef8074d723028adc24576d",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0849": {
@@ -17011,13 +17011,13 @@
         "punchline": 52
       },
       "source": {
-        "sequence": 832
+        "sequence": 810
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7bb16508c1eb60c5950c96532b82adf66886a6a85ae3f492acc1ff6d89e5605c",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0850": {
@@ -17032,13 +17032,13 @@
         "punchline": 39
       },
       "source": {
-        "sequence": 833
+        "sequence": 811
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "feee4288de4f044dc88693f2ec06955104f170f5a7ed400d9f94a5eca2096704",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0851": {
@@ -17053,13 +17053,13 @@
         "punchline": 61
       },
       "source": {
-        "sequence": 834
+        "sequence": 812
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5dcbe3e41d493d50786fcfe68408015b7b3c7cc5219ccf3920b21069e671aa2e",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0852": {
@@ -17074,13 +17074,13 @@
         "punchline": 47
       },
       "source": {
-        "sequence": 835
+        "sequence": 813
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3ce12eea7c4bcf1ab498f3da395092b89c2dea4c4711e9eda8397d9b989ee9c6",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0854": {
@@ -17095,13 +17095,13 @@
         "punchline": 49
       },
       "source": {
-        "sequence": 836
+        "sequence": 814
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a6b1d9520b1fda4f87041178a3af3f2a767d181c0978f6fe2960d4dabba05c40",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0855": {
@@ -17116,13 +17116,13 @@
         "punchline": 25
       },
       "source": {
-        "sequence": 837
+        "sequence": 815
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "43bde12404731f59e7d126fed3c01f602a0aaff87f2b601872c78c3615b04413",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0856": {
@@ -17137,13 +17137,13 @@
         "punchline": 59
       },
       "source": {
-        "sequence": 838
+        "sequence": 816
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "865a79b7ea56ac59a66cbb7fb00c0c8f4bef87b9067c5e31b9c0c0db522e9a69",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0857": {
@@ -17158,13 +17158,13 @@
         "punchline": 6
       },
       "source": {
-        "sequence": 839
+        "sequence": 817
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "30b198dd153bc6034bdb69ddd651d08d5ce68e33651a3a5120f409bf2505a6a8",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0858": {
@@ -17179,13 +17179,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 840
+        "sequence": 818
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3c48ab46714b805d82b8a6cfc6c96d73c01c63509f5011b0c622c951f0818f68",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0859": {
@@ -17200,13 +17200,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 841
+        "sequence": 819
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "a8488f178d28c2d1f13ad030bb62363de3124ee27fdaa9f367274c012aad4984",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0861": {
@@ -17221,13 +17221,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 843
+        "sequence": 820
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "d8b9cb8cc7323e97dbcb12c917410598b241a2ad4fe7683a937e89d3474c9b69",
-        "updatedAt": "2025-09-21T03:21:38.305Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0863": {
@@ -17242,13 +17242,13 @@
         "punchline": 31
       },
       "source": {
-        "sequence": 844
+        "sequence": 821
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7564c63c294ef17a78812b3952b54a7253980817c01e219f330420a3776a1c17",
-        "updatedAt": "2025-09-21T03:21:38.306Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0864": {
@@ -17263,13 +17263,13 @@
         "punchline": 33
       },
       "source": {
-        "sequence": 845
+        "sequence": 822
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2f99095517a5a02a77b9eb1b0f28ae9d19080618bfebfbd8b2eea59c14239b49",
-        "updatedAt": "2025-09-21T03:21:38.306Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0865": {
@@ -17284,13 +17284,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 846
+        "sequence": 823
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "336dbcbd60b3c1d9b58bad868545f3192be0ae0089b9b476556b41cc96dc0ef3",
-        "updatedAt": "2025-09-21T03:21:38.306Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0867": {
@@ -17305,13 +17305,13 @@
         "punchline": 29
       },
       "source": {
-        "sequence": 847
+        "sequence": 824
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "fbadbd46116d967d030d668f8f1148bce013ec5b9d8b59fb75f27655dfedb05a",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0868": {
@@ -17326,13 +17326,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 848
+        "sequence": 825
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7b4c51f1f62ed8d55de303ce7386659c4f33a995e9794e720bfd135ae43b1f34",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0870": {
@@ -17347,13 +17347,13 @@
         "punchline": 40
       },
       "source": {
-        "sequence": 849
+        "sequence": 826
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "2f1655ab6aba4de43b7c5b9057b4850c6e01cf8e4b488cfc398c8919a414bfa3",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0871": {
@@ -17368,13 +17368,13 @@
         "punchline": 9
       },
       "source": {
-        "sequence": 850
+        "sequence": 827
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "6e0deffdfea98b5bdadf129e556f2792c9b1fa8aee09dbbedd95fcf5f51d41c5",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0872": {
@@ -17389,13 +17389,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 851
+        "sequence": 828
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "77069c9ff2849d164dcf81cea194cdebf70d68b3c23fd8529b0aa77d9239714a",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0873": {
@@ -17410,13 +17410,13 @@
         "punchline": 11
       },
       "source": {
-        "sequence": 852
+        "sequence": 829
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "50eba4f83622c08b343115cc827320e2d1acc2d313942e5ac7f0f0a3e8d7206d",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0874": {
@@ -17431,13 +17431,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 853
+        "sequence": 830
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ce6a158bed7e563741c150f15149c9bb38e5da73a4e8276dcfb41c17fe8ef894",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0875": {
@@ -17452,13 +17452,13 @@
         "punchline": 32
       },
       "source": {
-        "sequence": 854
+        "sequence": 831
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "06cae9a06880d842efc70184ae565b7479769d3d95a6ece4d263b85eca3184d6",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0876": {
@@ -17473,13 +17473,13 @@
         "punchline": 98
       },
       "source": {
-        "sequence": 855
+        "sequence": 832
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5980086b601feb5a14fdfb9ff15eec32b8991ab3e998bf7d8a6d63c3ec848405",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0877": {
@@ -17494,13 +17494,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 856
+        "sequence": 833
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "011ebbf3611864bb1c7501afef8f59a3e21a1291355703f881033e6d9f728bf4",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0879": {
@@ -17515,13 +17515,13 @@
         "punchline": 13
       },
       "source": {
-        "sequence": 857
+        "sequence": 834
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ed84f0eac3fed17cf9c3a27d603c079679e7c0f25700af51553ec9618954d8c9",
-        "updatedAt": "2025-09-21T03:21:38.308Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0880": {
@@ -17536,13 +17536,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 858
+        "sequence": 835
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "29d5bf6eccf12b72c0a7cf720c90a73a276c68f766582631a0037fa0c530cbe1",
-        "updatedAt": "2025-09-21T03:21:38.309Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0881": {
@@ -17557,13 +17557,13 @@
         "punchline": 5
       },
       "source": {
-        "sequence": 859
+        "sequence": 836
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "de0be36cb76d2c84e00a6b2aaa9c6d2cd55b647b2c18544b02c0cde039262d69",
-        "updatedAt": "2025-09-21T03:21:38.309Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0882": {
@@ -17578,13 +17578,13 @@
         "punchline": 17
       },
       "source": {
-        "sequence": 860
+        "sequence": 837
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5d37fa8d64e87c4c635cb44313f7481d79cab782e1121d1d830d0ef3d2e7c09e",
-        "updatedAt": "2025-09-21T03:21:38.309Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0883": {
@@ -17599,13 +17599,13 @@
         "punchline": 8
       },
       "source": {
-        "sequence": 861
+        "sequence": 838
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e31f09cde6c3e707d0e7c61136d6b4777ce7265d8e0128cc67e83e5654b8fa9c",
-        "updatedAt": "2025-09-21T03:21:38.309Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0884": {
@@ -17620,13 +17620,13 @@
         "punchline": 15
       },
       "source": {
-        "sequence": 862
+        "sequence": 839
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b53806dc249d6c9e18548b16d4c518f78c6e99b8affcbdce5bab4afa281793d0",
-        "updatedAt": "2025-09-21T03:21:38.309Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0885": {
@@ -17641,13 +17641,13 @@
         "punchline": 34
       },
       "source": {
-        "sequence": 863
+        "sequence": 840
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "3d26498014d56989a91a872d21e6686b3fd091d6956dd97fab0ac2e341a7cb8a",
-        "updatedAt": "2025-09-21T03:21:38.309Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0886": {
@@ -17662,13 +17662,13 @@
         "punchline": 21
       },
       "source": {
-        "sequence": 864
+        "sequence": 841
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0d6c2fddfc2f19d0472f292ef680ea4dbe102e2ab0117d2a38a63f9ad5462b2e",
-        "updatedAt": "2025-09-21T03:21:38.309Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0887": {
@@ -17683,13 +17683,13 @@
         "punchline": 24
       },
       "source": {
-        "sequence": 865
+        "sequence": 842
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "46797df025bc292843000dc4afcba67d9dd6c75fbbcb7e478d32bfc6bfe362f4",
-        "updatedAt": "2025-09-21T03:21:38.309Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0888": {
@@ -17704,370 +17704,13 @@
         "punchline": 12
       },
       "source": {
-        "sequence": 866
+        "sequence": 843
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "5d17b1090c12d0c39e75511db1c16af2b9c6a3a6afa5ae1ae84fada6a58db7ac",
-        "updatedAt": "2025-09-21T03:21:38.309Z"
-      }
-    },
-    "j-0889": {
-      "hashes": {
-        "setup": "16e71b4f91b12483fbe4bb5b6c62263505b178aad59c7a55a14ec6813eb1db88",
-        "punchline": "e044264e0b72ed7fcb001254832b6e83ce0ba6e8c55b203415758d4ca27fccf3",
-        "combined": "2310c095e156e69b169457634ab0b377f07ae09dbb1660a461b686f6fc21f5d7",
-        "tokenSignature": "a-apparently-fired-florist-from-got-i-leaves-many-too-took"
-      },
-      "lengths": {
-        "joke": 26,
-        "punchline": 34
-      },
-      "source": {
-        "sequence": 867
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "57c8d6f2ea3311bc8b08762e7990f7aba11e1b2ace143cfe819b1c3e93a61d34",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0890": {
-      "hashes": {
-        "setup": "2c47158659cfe64f88f31943ed7b79590cb575f5812006a264b12ccd8b90da95",
-        "punchline": "84077336f1a1ecdee358fd20167476a8e1831807a042953eca41c13223c38650",
-        "combined": "a8e366863afaf6f6e4ba04f4752b03715381189a3724458895285b9ab7c397a7",
-        "tokenSignature": "dam-did-fish-hit-it-say-the-wall-what-when"
-      },
-      "lengths": {
-        "joke": 43,
-        "punchline": 4
-      },
-      "source": {
-        "sequence": 868
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "21174797ee82f15337e53c54028598a1d3c111b8fe397a5a372ba6169e623c99",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0891": {
-      "hashes": {
-        "setup": "9f7ed7386e8be80e3c691ca64f8178534d4077c44a70829b964ea5a3d4d48f73",
-        "punchline": "a7d44042a78f9b5c2c0a2d5f3d8c54dd304db4c5c63e4853d5c5750819960665",
-        "combined": "82ed69a5ec7c6412e59c7b207b8dd860c1b6dee5b92a554dc86e9f6e60c2038c",
-        "tokenSignature": "are-bicycles-can-on-own-stand-t-their-they-tired-two-why"
-      },
-      "lengths": {
-        "joke": 38,
-        "punchline": 18
-      },
-      "source": {
-        "sequence": 869
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f36c635bcf2cc1595d1a9e91b90114a3d3030ede18682ca074fece9df7341070",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0892": {
-      "hashes": {
-        "setup": "53c66a41c47250b36d8df590e96f75b0335a84b7782eea83909452d7808a7c22",
-        "punchline": "698dfd38e87e2d9da1982a390956720b42e20fa029a2d9f27e6b7b20b043e6a3",
-        "combined": "d66003ee34450abb848d39aa2bfbcb939320677a8eac89a7ec5f860666144910",
-        "tokenSignature": "a-away-breaks-car-down-frog-gets-happens-it-s-to-toad-what-when"
-      },
-      "lengths": {
-        "joke": 49,
-        "punchline": 17
-      },
-      "source": {
-        "sequence": 870
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "083e78e1ba07bca84b995bf1d8e7f5e3c2c22bdf01b71482965059ee065dc004",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0893": {
-      "hashes": {
-        "setup": "aa68f6c8701566c8b53d9675c08051550d561287dfc8e44b575cec408c78ce88",
-        "punchline": "fba1d8e92e7d6f157cd549b2e9f577ff26f3b7cfd4f64b50456fd54a5f95e623",
-        "combined": "a8dfacf77c43bcf3076bdc57d9214ccc0520a077c77db5d7862d88611cfc6396",
-        "tokenSignature": "a-all-bought-but-day-dealer-don-drug-from-he-i-know-laced-shoes-some-t-them-tripping-was-what-with"
-      },
-      "lengths": {
-        "joke": 39,
-        "punchline": 65
-      },
-      "source": {
-        "sequence": 871
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "c4c5eec91735f17cd6777dda81e3ce4d1d71739374bdbb6cf7f4afd16632ad8c",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0894": {
-      "hashes": {
-        "setup": "086e660440f2ba2a13821b75569e0fc0bced448071f0c92f6251eaba6745c4b9",
-        "punchline": "25cf8bb4440d026605a5132c7140d5e0c19310c5702d3d70c78fc0f6734bdff9",
-        "combined": "c1c1a7d67209d52bcbc6d586270260798aa78d2f9667c534da07c0d601b1acb3",
-        "tokenSignature": "be-because-chicken-coops-do-doors-four-had-have-if-only-sedans-they-two-why-would"
-      },
-      "lengths": {
-        "joke": 41,
-        "punchline": 54
-      },
-      "source": {
-        "sequence": 872
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "189cf325010bf609bd857b7fd660e1d1ec977accd22a9cdf88f1576a35c82a8c",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0895": {
-      "hashes": {
-        "setup": "b7eac12ae658f93eec3775ba768563dc7c509bf24ba0535e3fd67233e07416f1",
-        "punchline": "bd99bc161256dc536445680e7fdd2787e36591eaf2699291e917a168ddf84d7e",
-        "combined": "f69c5ef86ff426ee2d25b9507c2f9bcfc65f7822761660e0e05ff7a4f7f04882",
-        "tokenSignature": "a-do-give-in-lemon-lemonaid-need-to-what-you"
-      },
-      "lengths": {
-        "joke": 36,
-        "punchline": 9
-      },
-      "source": {
-        "sequence": 873
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "91ad232463875d8f2b88864e9b5310f0734c21d9844e76974591e6f7ca04de26",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0896": {
-      "hashes": {
-        "setup": "78c1d25b1f17d3e06196ec0a03a2856e7a5d86e4db6c4c390f53f656633bfa03",
-        "punchline": "5b3678ae92852dfffe45ffef1c2151fa6fb245705a078987143535de23b8ed69",
-        "combined": "cbd7f5aa3f56e0a0dc9d0dbc1391d4aeb7ed6b2d04a55b79058e49abe90f93f4",
-        "tokenSignature": "a-all-cut-dad-did-get-got-haircut-hey-i-no-them-you"
-      },
-      "lengths": {
-        "joke": 32,
-        "punchline": 23
-      },
-      "source": {
-        "sequence": 874
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "f63d37d6823ddaea233196fb87ef4ca261821b41af8c70ebc2bc55846fbeab38",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0897": {
-      "hashes": {
-        "setup": "482bbb9128050f734a2e44f15c0bb1066848c6b18444a90c771061c030ff2534",
-        "punchline": "aa44ee7a384ad6ac2f1c7a55848a47277de6b8c6ce182f47e4218a8754bfab3d",
-        "combined": "8bd07c895b5f196d383084c4ff74e309f294cb472f9c7e8e04135593f2a58a63",
-        "tokenSignature": "changing-don-i-is-it-keeps-know-t-time-what"
-      },
-      "lengths": {
-        "joke": 16,
-        "punchline": 34
-      },
-      "source": {
-        "sequence": 875
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "27b93e8f6d4dc7316b6e659018e304b47c01f9cb7025fa2bac1f84a6283b4176",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0898": {
-      "hashes": {
-        "setup": "83a8b79ef6835590540053947891310ba6c8bcbbbee70bfdc304ea6b2c6bf82b",
-        "punchline": "19163dc794fce3b492497e109ff9471464022c2d32a994cb5c2242bb23f4e2f6",
-        "combined": "096eaa425183d54949d9b932bfcb0ea97fb143926c741f8aec73b661e8542884",
-        "tokenSignature": "a-bar-bartender-before-can-for-get-goes-i-into-never-pop-says-served-the-ve-walks-weasel-what-wow-you"
-      },
-      "lengths": {
-        "joke": 112,
-        "punchline": 20
-      },
-      "source": {
-        "sequence": 876
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b69681d9e54be388bad3b1286ec8643dd4938fc2c5a8728e8a1e2f1fd06025a9",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0899": {
-      "hashes": {
-        "setup": "973098166a2dfdf36c62bd35adc35483637ce0c5853d8eabfec31504ffa83fba",
-        "punchline": "14699d1816ac5808fe9b1b7d4aca37b11f90d430bb808bd459f5bcca487ec9ea",
-        "combined": "b86c67c8e05eabd952f29aa7f64bf04fb6b46b7fa96df926b064fa37c9d5b8fa",
-        "tokenSignature": "1-2-a-bulb-change-does-how-it-light-many-optometrists-or-take-to"
-      },
-      "lengths": {
-        "joke": 58,
-        "punchline": 18
-      },
-      "source": {
-        "sequence": 877
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "35a60b12de91dec276a2d39ebe198c09618c9b2c428e271a4d00e2b3e4c871f7",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0900": {
-      "hashes": {
-        "setup": "87f800db89cd5ba3f352f901911d8f04349a07385ce93d3d60c1a89767dfa027",
-        "punchline": "6eb05ff604740d43879b47dd71910a4f3e2b63a5e8e5effbb20ecd8b8881ff9b",
-        "combined": "5eb8faa76d4bee55041b51c810620759572241f914a961478b012b80f2bb3a97",
-        "tokenSignature": "12-2nd-a-april-are-etc-february-how-in-january-many-march-seconds-year"
-      },
-      "lengths": {
-        "joke": 31,
-        "punchline": 59
-      },
-      "source": {
-        "sequence": 878
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "7973c50507dd12c9e5e34b1e6c92360ffe1617cba20a396fcdb2850fc8baac67",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0901": {
-      "hashes": {
-        "setup": "c520a3a2614940fa03fade473ac722218aaa5404160d12711d0ecb520d9c17dc",
-        "punchline": "b9c0a5ed32fb85762b4448713d2ea063d4f11852b530e0ddd108477c6f285674",
-        "combined": "3099fceccdf5ad55097fe978ae839f400aab0e1c8117119708b671ac305bf758",
-        "tokenSignature": "baby-did-la-other-pasta-say-spaghetti-the-to-vista-what"
-      },
-      "lengths": {
-        "joke": 50,
-        "punchline": 21
-      },
-      "source": {
-        "sequence": 879
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "98ae0b1b4cda8727c5d745a25f6850cc1827356d369fef6068b708e031754d27",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0902": {
-      "hashes": {
-        "setup": "b22c1df822ae72976f690540f29d1014d7d9919b663be4470b09a9aaebb354bc",
-        "punchline": "d6acce58810d89e5a423471d83cbb0ed7c85ad9dd1080e35af7a384ce01ca140",
-        "combined": "989c17ec5220c771f8a14d6a3f903c699ad9a5dbf0887f95a4db55572fc8615b",
-        "tokenSignature": "anywhere-been-bin-haven-i-s-t-the-where"
-      },
-      "lengths": {
-        "joke": 16,
-        "punchline": 24
-      },
-      "source": {
-        "sequence": 880
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "e8b9719686c43b64c4744698a06b0e155b2501c0d13ee394a51584f634cb1ba7",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0903": {
-      "hashes": {
-        "setup": "c227f141cbf6028f4ee4c5c34b7ae22cef0c118efe99e55a8d8df558a49107aa",
-        "punchline": "4f3dc2cfd1ad0bab8cc7648eb3fa85b633922714c0652a3cda36e085f1948099",
-        "combined": "893c567afbb79c75e512e2abcad2a59acaf2934331f9a609534a93202526b22d",
-        "tokenSignature": "arrays-because-developer-did-didn-get-he-his-job-quit-t-the-why"
-      },
-      "lengths": {
-        "joke": 35,
-        "punchline": 29
-      },
-      "source": {
-        "sequence": 881
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "b47d38e48001d82199942916d858ff18089e01ed1d8268a5951568b55772b0a9",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0904": {
-      "hashes": {
-        "setup": "482a56fefd39cff71ecdcbd3db58c39067b7fdc9b1c3d5b21dad82ab770eaf2c",
-        "punchline": "9926ac340b2c372c68bbef10d88ca697e87d3b47cc8d55cb7abbe802375f8029",
-        "combined": "305f821151eb9119c242f91bf23da9c9742cf9a4b71feaf1c74d5ed28a6b9184",
-        "tokenSignature": "25-31-always-and-because-christmas-dec-did-equals-halloween-mix-oct-programmer-the-up-why"
-      },
-      "lengths": {
-        "joke": 61,
-        "punchline": 29
-      },
-      "source": {
-        "sequence": 882
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "0ddb22dcb7c0199e97b907d40ac517413d04036eabae4c9fee328809771d482f",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
-      }
-    },
-    "j-0905": {
-      "hashes": {
-        "setup": "bfc2e27a170ca98453df9459bb8b44ac7c57be5c46831ae5d8b773e690af2501",
-        "punchline": "62fea14ac493eab395ef489be0d1a7a636c9134c88d96ed3e998e7359f4cfb97",
-        "combined": "0cc36d87fdd06a21ab2cc0f9ece3decc28c1b15d90c2b91c76687257b5230d41",
-        "tokenSignature": "did-just-nothing-ocean-one-other-say-the-they-to-waved-what"
-      },
-      "lengths": {
-        "joke": 42,
-        "punchline": 25
-      },
-      "source": {
-        "sequence": 883
-      },
-      "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "ede517f93ee7749ac7846f0e575fb4c14883eb8b7afc6d0f8d975bd659b357cf",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0906": {
@@ -18082,13 +17725,13 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 884
+        "sequence": 844
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "1c7ad0d1b898c3be0e3329869f24445e5298c1bb8441a02f64bf9d72e4bcc2ff",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
     "j-0907": {
@@ -18103,76 +17746,118 @@
         "punchline": 26
       },
       "source": {
-        "sequence": 885
+        "sequence": 845
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "4587526c81f5b052cd26bddbed4531f81060966da62ccf42b714b71faf9aca6c",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
-    "j-0908": {
+    "j-0911": {
       "hashes": {
-        "setup": "80641917e368db452b67ee0694a68e018fab2b38601acfe52b2bf3319632d7f3",
-        "punchline": "62e89142b93a11403e1242cebabeaf6eacda1538f6d75e9408518910948d7c03",
-        "combined": "e4ff33071c64474531bc4e12ca2fdc89077f16441e59bd0174f449af2c850ba4",
-        "tokenSignature": "a-case-did-golfer-got-he-hole-in-of-one-pairs-pants-the-two-wear-why"
+        "setup": "61faba0c177d3067b19739cbc9114ff7c01f0ef6e876a9fd4036d6f531289040",
+        "punchline": "e9faaed9e1720fdec02f86e0ebcc732c3183d57c242aecf6872ea741f4c9b6cb",
+        "combined": "574707b76c564f448b94d9f96cf01bc2513a50d1f8712558245a63c7afca949e",
+        "tokenSignature": "always-calm-could-during-escape-hit-it-keyboard-meetings-the-was-why"
       },
       "lengths": {
-        "joke": 43,
-        "punchline": 29
+        "joke": 49,
+        "punchline": 27
       },
       "source": {
-        "sequence": 886
+        "sequence": 846
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "82a19cd6c44ab9a182c4411df1580220dc3312ecb706998432eaad550aab1db7",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
-    "j-0909": {
+    "j-0912": {
       "hashes": {
-        "setup": "257fd70e76bb2c1f989a1bbf027eae391bfb6e1ca7bb5e20b4c5235eddf25d2d",
-        "punchline": "7ca8ffd20a8f6197e189329d688c8e573bfbaedc21dc3c703bdc3f4c8e0d72b9",
-        "combined": "1c170a1fcd6b262a438f06020bf39c2f41212f0deb173c7607bfc08a08d11996",
-        "tokenSignature": "arrays-did-didn-get-job-programmer-quit-t-the-their-they-why"
+        "setup": "9c03e254f5ef3926f9e6fc2b1047877b29f465e4e4855de70356deb7814865df",
+        "punchline": "61c65a0891b3a8caa6649783061d76b6157dfbb62cf725360c1f1f01e46d689c",
+        "combined": "265102a6dfaa341baebced38df5a3806dad4e34f356a0629e3b55e1fe4e8ff55",
+        "tokenSignature": "a-book-did-figures-improve-it-its-math-routine-start-the-to-wanted-why-workout"
       },
       "lengths": {
-        "joke": 38,
+        "joke": 46,
+        "punchline": 33
+      },
+      "source": {
+        "sequence": 847
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0913": {
+      "hashes": {
+        "setup": "20e479544f11f48a9df506dee9cb610a63dc3e03c124c2952111c43b942d1078",
+        "punchline": "17f698a30788fd2e857e6f0680582ea4c77e1c166985b26efbcbc080a9d43803",
+        "combined": "1ca1e23378616dd21b6b2d6eba080e3e15d5c28fe6e867d272b9e45bece760fd",
+        "tokenSignature": "baker-did-every-get-how-invited-it-knew-party-roll-the-they-to-why-with"
+      },
+      "lengths": {
+        "joke": 45,
+        "punchline": 30
+      },
+      "source": {
+        "sequence": 848
+      },
+      "embedding": {
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
+      }
+    },
+    "j-0914": {
+      "hashes": {
+        "setup": "b223624781d11d4a1b8e34c5da5726df296b4faa820ed45722c3e15ee48a13d9",
+        "punchline": "63dd79d1290f0fb4579365a6e538518f4e431278226ab178c8c6e24b2da84f3a",
+        "combined": "9c930c6ea46d2734374bc6f313d8ca18b7918236a3d5aa1ee515378a373fdb40",
+        "tokenSignature": "calendar-days-did-get-its-nervous-numbered-the-were-why"
+      },
+      "lengths": {
+        "joke": 33,
         "punchline": 23
       },
       "source": {
-        "sequence": 887
+        "sequence": 849
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "cb9ef8ee1475cbaa836b0bbf67c811054702724fcab037ce5d301d572dee7830",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     },
-    "j-0910": {
+    "j-0915": {
       "hashes": {
-        "setup": "c9482a8c6b434cdfa54143911e785f574ac189f67359199d952e3dfb274e0d26",
-        "punchline": "849a9707e3c60b2373cd5e19076d2dd664dc6edc4dd1c02c0c6f1b7db78df3fd",
-        "combined": "5563de1b687cc4815956da3641caa253a42231cd60f30c7040c5f0135ae8889d",
-        "tokenSignature": "bugs-don-like-many-nature-programmers-t-too-why"
+        "setup": "1c40aaa60a3283b1ab1651094190ddaf16df00ff91a102f0e24bff914a2e3d2d",
+        "punchline": "c33d8d8a654cacbb8aedb429b0164735be225caed7b66cc3add0e3759be8ee3c",
+        "combined": "a1af25060ef4d27414bd7b48152737c5ee8cba6648f3fa511755e92bfb580cb5",
+        "tokenSignature": "a-bring-case-contents-did-dinner-in-notebook-of-scientist-table-the-there-to-was-why"
       },
       "lengths": {
-        "joke": 34,
-        "punchline": 14
+        "joke": 49,
+        "punchline": 38
       },
       "source": {
-        "sequence": 888
+        "sequence": 850
       },
       "embedding": {
-        "status": "ready",
-        "model": "synthetic-64",
-        "vectorSha256": "58a045ee8bb3d81bcf362529ea19cb6cefbcd32dc5e1ac78b63ec134b9777b09",
-        "updatedAt": "2025-09-22T01:50:07.859Z"
+        "status": "pending",
+        "model": null,
+        "vectorSha256": null,
+        "updatedAt": null
       }
     }
   }

--- a/data/similarity-overrides.json
+++ b/data/similarity-overrides.json
@@ -1,11 +1,28 @@
 {
   "meta": {
     "description": "Manual overrides for cosine similarity reports. Pairs listed here were reviewed and should not be treated as duplicates.",
-    "updatedAt": "2025-09-22T23:16:21.950Z"
+    "updatedAt": "2025-09-23T04:01:55.055Z"
   },
   "datasets": {
     "jokes": {
-      "protectedPairs": []
+      "protectedPairs": [
+        {
+          "ids": [
+            "j-0018",
+            "j-0906"
+          ],
+          "label": "Keep both",
+          "reason": "Kid and chicken setups share the slide punchline but land differently when told back-to-back."
+        },
+        {
+          "ids": [
+            "j-0502",
+            "j-0907"
+          ],
+          "label": "Keep both",
+          "reason": "Crab and oyster versions both hinge on shellfish wordplay with different sea creatures."
+        }
+      ]
     },
     "quotes": {
       "protectedPairs": [

--- a/data/similarity-report-jokes.json
+++ b/data/similarity-report-jokes.json
@@ -1,157 +1,10 @@
 {
   "dataset": "jokes",
   "threshold": 0.5,
-  "generatedAt": "2025-09-23T01:03:32.987Z",
+  "generatedAt": "2025-09-23T04:03:02.199Z",
   "provider": "hfspace",
   "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
   "matches": [
-    {
-      "idA": "j-0429",
-      "idB": "j-0899",
-      "similarity": 0.9987134296946547,
-      "previewA": "How many optometrists does it take to change a light bulb? 1 or 2? • 1... or 2?",
-      "previewB": "How many optometrists does it take to change a light bulb? • 1 or 2? 1... or 2?"
-    },
-    {
-      "idA": "j-0800",
-      "idB": "j-0910",
-      "similarity": 0.9942716816336866,
-      "previewA": "Why don't programmers like nature? • There's too many bugs.",
-      "previewB": "Why don't programmers like nature? • Too many bugs."
-    },
-    {
-      "idA": "j-0426",
-      "idB": "j-0900",
-      "similarity": 0.9899130422112801,
-      "previewA": "How many seconds are in a year? 12. January 2nd, February 2nd, March 2nd, April 2nd.... • etc",
-      "previewB": "How many seconds are in a year? • 12. January 2nd, February 2nd, March 2nd, April 2nd.... etc"
-    },
-    {
-      "idA": "j-0170",
-      "idB": "j-0889",
-      "similarity": 0.9888571043627349,
-      "previewA": "I just got fired from a florist • apparently I took too many leaves.",
-      "previewB": "I got fired from a florist • apparently I took too many leaves."
-    },
-    {
-      "idA": "j-0290",
-      "idB": "j-0898",
-      "similarity": 0.9869892198217917,
-      "previewA": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before. • What can I get for you?\" \"Pop,",
-      "previewB": "A weasel walks into a bar. The bartender says, \"Wow, I've never served a weasel before. What can I get for you?\" • Pop,g"
-    },
-    {
-      "idA": "j-0258",
-      "idB": "j-0894",
-      "similarity": 0.9777018734794799,
-      "previewA": "Why does a chicken coop only have two doors? • Because if it had four doors it would be a chicken sedan.",
-      "previewB": "Why do chicken coops only have two doors? • Because if they had four, they would be chicken sedans"
-    },
-    {
-      "idA": "j-0808",
-      "idB": "j-0908",
-      "similarity": 0.9765614224635286,
-      "previewA": "Why did the golfer bring two pairs of pants? • In case he got a hole in one.",
-      "previewB": "Why did the golfer wear two pairs of pants? • In case he got a hole in one."
-    },
-    {
-      "idA": "j-0687",
-      "idB": "j-0909",
-      "similarity": 0.9765537811504814,
-      "previewA": "Why did the programmer quit his job? • Because he didn't get arrays.",
-      "previewB": "Why did the programmer quit their job? • They didn't get arrays."
-    },
-    {
-      "idA": "j-0412",
-      "idB": "j-0893",
-      "similarity": 0.976474716588536,
-      "previewA": "I bought shoes from a drug dealer once. • I don't know what he laced them with, but I was tripping all day.",
-      "previewB": "I bought some shoes from a drug dealer. • I don't know what he laced them with, but I was tripping all day!"
-    },
-    {
-      "idA": "j-0306",
-      "idB": "j-0892",
-      "similarity": 0.972301723422015,
-      "previewA": "What happens to a frog's car when it breaks down? • It gets toad.",
-      "previewB": "What happens to a frog's car when it breaks down? • It gets toad away"
-    },
-    {
-      "idA": "j-0765",
-      "idB": "j-0904",
-      "similarity": 0.9518423232769507,
-      "previewA": "Why do programmers always get Christmas and Halloween mixed up? • Because DEC 25 = OCT 31",
-      "previewB": "Why did the programmer always mix up Halloween and Christmas? • Because Oct 31 equals Dec 25."
-    },
-    {
-      "idA": "j-0404",
-      "idB": "j-0901",
-      "similarity": 0.9492391618899723,
-      "previewA": "Q: What did the spaghetti say to the other spaghetti? • A: Pasta la vista, baby!",
-      "previewB": "What did the spaghetti say to the other spaghetti? • Pasta la vista, baby!"
-    },
-    {
-      "idA": "j-0687",
-      "idB": "j-0903",
-      "similarity": 0.9359708607201127,
-      "previewA": "Why did the programmer quit his job? • Because he didn't get arrays.",
-      "previewB": "Why did the developer quit his job? • Because he didn't get arrays."
-    },
-    {
-      "idA": "j-0342",
-      "idB": "j-0891",
-      "similarity": 0.921786475423563,
-      "previewA": "Why can't a bicycle stand on its own? • It's two-tired.",
-      "previewB": "Why can't bicycles stand on their own? • They are two tired"
-    },
-    {
-      "idA": "j-0903",
-      "idB": "j-0909",
-      "similarity": 0.9204315525155635,
-      "previewA": "Why did the developer quit his job? • Because he didn't get arrays.",
-      "previewB": "Why did the programmer quit their job? • They didn't get arrays."
-    },
-    {
-      "idA": "j-0132",
-      "idB": "j-0902",
-      "similarity": 0.8830924360322465,
-      "previewA": "Where’s the bin? • Dad: I haven’t been anywhere!",
-      "previewB": "Where’s the bin? • I haven’t been anywhere!"
-    },
-    {
-      "idA": "j-0167",
-      "idB": "j-0895",
-      "similarity": 0.8789559937066833,
-      "previewA": "What do you give a sick lemon? • Lemonaid.",
-      "previewB": "What do you give to a lemon in need? • Lemonaid."
-    },
-    {
-      "idA": "j-0542",
-      "idB": "j-0905",
-      "similarity": 0.876686037658057,
-      "previewA": "What did the ocean say to the shore? • Nothing, it just waved.",
-      "previewB": "What did one ocean say to the other ocean? • Nothing, they just waved."
-    },
-    {
-      "idA": "j-0451",
-      "idB": "j-0890",
-      "similarity": 0.8746644499437756,
-      "previewA": "What did the fish say when it swam into a wall? • Damn!",
-      "previewB": "What did the fish say when it hit the wall? • Dam."
-    },
-    {
-      "idA": "j-0569",
-      "idB": "j-0897",
-      "similarity": 0.8489520167198789,
-      "previewA": "\"What time is it?\" I don't know... • it keeps changing.",
-      "previewB": "What time is it? • I don't know... it keeps changing."
-    },
-    {
-      "idA": "j-0606",
-      "idB": "j-0896",
-      "similarity": 0.8404811348567082,
-      "previewA": "\"Hey, dad, did you get a haircut?\" \"No • I got them all cut.\"",
-      "previewB": "Hey, dad, did you get a haircut? • No, I got them all cut."
-    },
     {
       "idA": "j-0502",
       "idB": "j-0907",
@@ -258,13 +111,6 @@
       "previewB": "What's the best time to go to the dentist? • Tooth hurty."
     },
     {
-      "idA": "j-0296",
-      "idB": "j-0905",
-      "similarity": 0.6987150309024556,
-      "previewA": "What did the ocean say to the beach? • Thanks for all the sediment.",
-      "previewB": "What did one ocean say to the other ocean? • Nothing, they just waved."
-    },
-    {
       "idA": "j-0211",
       "idB": "j-0241",
       "similarity": 0.6875025752301489,
@@ -354,13 +200,6 @@
       "similarity": 0.6456497206522479,
       "previewA": "Why don't skeletons ride roller coasters? • They don't have the stomach for it.",
       "previewB": "Why don’t skeletons ever go trick or treating? • Because they have nobody to go with."
-    },
-    {
-      "idA": "j-0277",
-      "idB": "j-0905",
-      "similarity": 0.6423135819800875,
-      "previewA": "What did the sea say to the sand? • \"We have to stop meeting like this.\"",
-      "previewB": "What did one ocean say to the other ocean? • Nothing, they just waved."
     },
     {
       "idA": "j-0043",
@@ -498,7 +337,7 @@
     {
       "idA": "j-0881",
       "idB": "j-0887",
-      "similarity": 0.5790203966184697,
+      "similarity": 0.5790204395026527,
       "previewA": "What's Santa's favourite type of music? • Wrap!",
       "previewB": "What says Oh Oh Oh? • Santa walking backwards!"
     },
@@ -519,7 +358,7 @@
     {
       "idA": "j-0880",
       "idB": "j-0886",
-      "similarity": 0.5671674268519845,
+      "similarity": 0.5671673159028517,
       "previewA": "Why does Santa have three gardens? • So he can 'ho ho ho'!",
       "previewB": "Why does Santa go down the chimney? • Because it soots him!"
     },
@@ -592,13 +431,6 @@
       "similarity": 0.5532895680226011,
       "previewA": "Why is no one friends with Dracula? • Because he's a pain in the neck.",
       "previewB": "What's it like to be kissed by a vampire? • It's a pain in the neck."
-    },
-    {
-      "idA": "j-0796",
-      "idB": "j-0909",
-      "similarity": 0.5522187673420884,
-      "previewA": "Why did the programmer's wife leave him? • He didn't know how to commit.",
-      "previewB": "Why did the programmer quit their job? • They didn't get arrays."
     },
     {
       "idA": "j-0358",
@@ -678,13 +510,6 @@
       "previewB": "Where do bees go to the bathroom? • The BP station."
     },
     {
-      "idA": "j-0824",
-      "idB": "j-0909",
-      "similarity": 0.536343763476834,
-      "previewA": "Why did the programmer bring a broom to work? • To clean up all the bugs.",
-      "previewB": "Why did the programmer quit their job? • They didn't get arrays."
-    },
-    {
       "idA": "j-0687",
       "idB": "j-0824",
       "similarity": 0.5356864832194758,
@@ -748,13 +573,6 @@
       "previewB": "Why do you never see elephants hiding in trees? • Because they're so good at it."
     },
     {
-      "idA": "j-0406",
-      "idB": "j-0905",
-      "similarity": 0.5224431503274164,
-      "previewA": "Why is the ocean always blue? • Because the shore never waves back.",
-      "previewB": "What did one ocean say to the other ocean? • Nothing, they just waved."
-    },
-    {
       "idA": "j-0310",
       "idB": "j-0906",
       "similarity": 0.5210259657834401,
@@ -767,13 +585,6 @@
       "similarity": 0.5200077259778232,
       "previewA": "What do you call a fish with no eyes? • A fsh.",
       "previewB": "What do you call a pig with three eyes? • Piiig"
-    },
-    {
-      "idA": "j-0824",
-      "idB": "j-0903",
-      "similarity": 0.5198571735512049,
-      "previewA": "Why did the programmer bring a broom to work? • To clean up all the bugs.",
-      "previewB": "Why did the developer quit his job? • Because he didn't get arrays."
     },
     {
       "idA": "j-0121",
@@ -860,13 +671,6 @@
       "previewB": "Where do you learn to make banana splits? • At sundae school."
     },
     {
-      "idA": "j-0796",
-      "idB": "j-0903",
-      "similarity": 0.5060160268239098,
-      "previewA": "Why did the programmer's wife leave him? • He didn't know how to commit.",
-      "previewB": "Why did the developer quit his job? • Because he didn't get arrays."
-    },
-    {
       "idA": "j-0090",
       "idB": "j-0479",
       "similarity": 0.5055998423990044,
@@ -874,32 +678,11 @@
       "previewB": "I thought about going on an all-almond diet. • But that's just nuts."
     },
     {
-      "idA": "j-0243",
-      "idB": "j-0899",
-      "similarity": 0.5052839721013682,
-      "previewA": "How many kids with ADD does it take to change a lightbulb? • Let's go ride bikes!",
-      "previewB": "How many optometrists does it take to change a light bulb? • 1 or 2? 1... or 2?"
-    },
-    {
-      "idA": "j-0335",
-      "idB": "j-0908",
-      "similarity": 0.5049958119526822,
-      "previewA": "Why did the fireman wear red, white, and blue suspenders? • To hold his pants up.",
-      "previewB": "Why did the golfer wear two pairs of pants? • In case he got a hole in one."
-    },
-    {
       "idA": "j-0066",
       "idB": "j-0203",
       "similarity": 0.5045177834753811,
       "previewA": "What do you get when you cross a pig and a pineapple? • A porky pine",
       "previewB": "what happens when you cross a sheep with a kangaroo? • A woolly jumper!"
-    },
-    {
-      "idA": "j-0834",
-      "idB": "j-0903",
-      "similarity": 0.504514928062778,
-      "previewA": "Why did the JavaScript heap close shop? • It ran out of memory.",
-      "previewB": "Why did the developer quit his job? • Because he didn't get arrays."
     },
     {
       "idA": "j-0027",


### PR DESCRIPTION
## Summary
- remove the recent duplicate joke records so the deck only keeps one wording for each gag
- add overrides protecting the kid/chicken slide joke and shellfish charity joke as intentional near-duplicates
- regenerate the jokes manifest, embeddings stores, and similarity report to reflect the slimmed deck

## Testing
- node --check apps/jokes/jokes.js
- node -e "global.window = {}; require('./apps/jokes/jokes.js'); console.log(Array.isArray(window.jokes), window.jokes.length);"
- node tools/review-content-similarity.js --dataset=jokes --provider=synthetic --write --update-manifest
- node tools/review-content-similarity.js --dataset=jokes --provider=hfspace --model=bienkieu/sentence-embedding --batch-size=8 --force --threshold-jokes=0.5 --report=data/similarity-report-jokes.json

------
https://chatgpt.com/codex/tasks/task_e_68d21a9a3e508328bee075a00e8f3a38