### PR TITLE
Add home navigation to all Slang view and extend checks

### DIFF
--- a/apps/slang/all-slang.html
+++ b/apps/slang/all-slang.html
@@ -69,11 +69,63 @@
         border-color: rgba(158, 166, 255, 0.35);
         color: rgba(226, 232, 255, 0.95);
       }
+
+      .home-link {
+        color: rgba(226, 232, 255, 0.95);
+        border-color: rgba(158, 166, 255, 0.35);
+        background: rgba(158, 166, 255, 0.12);
+      }
+
+      .home-link:hover {
+        background: rgba(158, 166, 255, 0.18);
+        box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+      }
+
+      .home-link:focus-visible {
+        outline: 2px solid rgba(181, 187, 255, 0.7);
+        box-shadow: 0 0 0 3px rgba(158, 166, 255, 0.2);
+      }
     }
 
     main {
       max-width: 960px;
       margin: 0 auto;
+    }
+
+    .home-nav {
+      display: flex;
+      justify-content: flex-start;
+      margin-bottom: 1.5rem;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid rgba(109, 97, 255, 0.32);
+      text-decoration: none;
+      color: inherit;
+      font-weight: 600;
+      background: rgba(109, 97, 255, 0.1);
+      transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    }
+
+    .home-link span[aria-hidden="true"] {
+      font-size: 1.2rem;
+    }
+
+    .home-link:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(109, 97, 255, 0.22);
+      background: rgba(109, 97, 255, 0.16);
+    }
+
+    .home-link:focus-visible {
+      outline: 2px solid rgba(109, 97, 255, 0.45);
+      outline-offset: 3px;
+      box-shadow: 0 0 0 3px rgba(109, 97, 255, 0.2);
     }
 
     h1 {
@@ -277,6 +329,12 @@
 </head>
 <body>
   <main>
+    <nav class="home-nav" aria-label="Home navigation">
+      <a class="home-link" href="../../">
+        <span aria-hidden="true">←</span>
+        <span>Home</span>
+      </a>
+    </nav>
     <h1>All Slang</h1>
     <p>Browse every term, filter by category, and jump into shuffle mode when you want to drill the definitions.</p>
     <p class="count">Showing <span data-count>0</span> of <span data-total>0</span> terms</p>

--- a/data/slang-manifest.json
+++ b/data/slang-manifest.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "generatedAt": "2025-09-23T13:00:35.800Z",
+    "generatedAt": "2025-09-23T13:32:46.596Z",
     "total": 45,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",

--- a/tests/home-navigation.spec.js
+++ b/tests/home-navigation.spec.js
@@ -2,8 +2,12 @@ const { test, expect } = require('@playwright/test');
 
 const appPages = [
   { name: 'Dad Jokes', path: '/apps/jokes/' },
+  { name: 'Dad Jokes (All jokes)', path: '/apps/jokes/all-jokes.html' },
+  { name: 'Dad Jokes (Compact view)', path: '/apps/jokes/all-jokes-compact.html' },
   { name: 'Quotes', path: '/apps/quotes/' },
+  { name: 'Quotes (All quotes)', path: '/apps/quotes/all-quotes.html' },
   { name: 'Slang', path: '/apps/slang/' },
+  { name: 'Slang (All slang)', path: '/apps/slang/all-slang.html' },
   { name: 'Cosine Similarity Lab', path: '/apps/similarity-report/' },
   { name: 'Value Formatter', path: '/apps/value-formatter/' },
   { name: 'Asset Observatory', path: '/apps/asset-observatory/' },


### PR DESCRIPTION
## Summary
- add a styled Home button to the All Slang table view to align with other apps
- broaden the navigation regression to cover every jokes, quotes, and slang page
- refresh the slang content manifest via the maintenance script

## Testing
- node --check apps/slang/slang.js
- node -e "global.window = {}; require('./apps/slang/slang.js'); console.log(Array.isArray(window.slangEntries), window.slangEntries.length);"
- node tools/update-content-metadata.js --dataset=slang
- npx playwright test tests/slang-app.spec.js
- npx playwright test tests/home-navigation.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d2a0c6fcbc8328aec377cf39cbdb3d