### PR TITLE
Limit slang categories to Gen Alpha and Gen Z

### DIFF
--- a/apps/slang/all-slang.html
+++ b/apps/slang/all-slang.html
@@ -336,12 +336,12 @@
       </a>
     </nav>
     <h1>All Slang</h1>
-    <p>Browse every term, filter by category, and jump into shuffle mode when you want to drill the definitions.</p>
+    <p>Browse every term, filter by generation, and jump into shuffle mode when you want to drill the definitions.</p>
     <p class="count">Showing <span data-count>0</span> of <span data-total>0</span> terms</p>
     <div class="filters">
       <label class="category-picker" for="category-select">
-        <span class="visually-hidden">Select slang category</span>
-        <select id="category-select" aria-label="Slang category" data-category-select></select>
+        <span class="visually-hidden">Select slang generation</span>
+        <select id="category-select" aria-label="Slang generation" data-category-select></select>
       </label>
       <form class="filter" data-filter-form>
         <label for="slang-filter">Filter slang terms</label>

--- a/apps/slang/index.html
+++ b/apps/slang/index.html
@@ -392,12 +392,12 @@
     </nav>
     <header class="app-header">
       <h1>Slang</h1>
-      <p>Shuffle through Gen Z slang, switch categories, and reveal the meaning, a usage example, and a hint for when to drop it.</p>
+      <p>Shuffle through Gen Alpha and Gen Z slang, switch between generations, and reveal the meaning, a usage example, and a hint for when to drop it.</p>
     </header>
     <div class="filters">
       <label class="category-picker" for="category-select">
-        <span class="visually-hidden">Select slang category</span>
-        <select id="category-select" aria-label="Slang category"></select>
+        <span class="visually-hidden">Select slang generation</span>
+        <select id="category-select" aria-label="Slang generation"></select>
       </label>
     </div>
     <article class="card" aria-live="polite">

--- a/apps/slang/slang.js
+++ b/apps/slang/slang.js
@@ -7,360 +7,360 @@ window.slangEntries = [
             "definition": "Effortless charisma that makes flirting or connecting feel natural.",
             "example": "Jaden walked into the study group with so much rizz that everyone scooted over to make room.",
             "hint": "Use it to hype someone whose charm wins people over without trying.",
-            "category": "Compliments & Hype",
-            "categoryId": "hype"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0002",
             "term": "slay",
             "definition": "To execute something flawlessly and with undeniable style.",
             "example": "You slay every time you present, so the team asked you to intro the client call.",
             "hint": "Use it when someone completely nails the assignment with flair.",
-            "category": "Compliments & Hype",
-            "categoryId": "hype"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0003",
             "term": "ate",
             "definition": "Delivered such a strong performance that there’s nothing left to add.",
             "example": "Maya ate that choreography and still had the energy to teach it to the rest of us.",
             "hint": "Use it when someone’s effort was so good there are no notes to give.",
-            "category": "Compliments & Hype",
-            "categoryId": "hype"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0004",
             "term": "goated",
             "definition": "Locked-in greatest of all time status for a skill or achievement.",
             "example": "Our goalie is goated after blocking every shot in overtime.",
             "hint": "Use it to crown someone the undeniable best at what they do.",
-            "category": "Compliments & Hype",
-            "categoryId": "hype"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0005",
             "term": "bussin",
             "definition": "So good that you can’t help reacting out loud, usually about food or an experience.",
             "example": "This late-night ramen is bussin, so I’m definitely ordering another bowl.",
             "hint": "Use it when something tastes or feels unbelievably good.",
-            "category": "Compliments & Hype",
-            "categoryId": "hype"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0006",
             "term": "pop off",
             "definition": "To start performing amazingly or to go off with contagious energy.",
             "example": "The DJ told the crowd to pop off and the dance floor instantly filled up.",
             "hint": "Use it when someone or something erupts in the best possible way.",
-            "category": "Compliments & Hype",
-            "categoryId": "hype"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0007",
             "term": "valid",
             "definition": "Genuinely good, trustworthy, or worth cosigning without hesitation.",
             "example": "Your playlist is valid, I’m adding half these tracks to my rotation.",
             "hint": "Use it when an idea, outfit, or opinion is absolutely on point.",
-            "category": "Compliments & Hype",
-            "categoryId": "hype"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0008",
             "term": "delulu",
             "definition": "Playfully calling out someone for unrealistic optimism or fantasy thinking.",
             "example": "I’m delulu for believing the professor will cancel tomorrow’s quiz.",
             "hint": "Use it when a friend’s daydream needs a gentle reality check.",
-            "category": "Callouts & Reactions",
-            "categoryId": "callouts"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0009",
             "term": "no cap",
             "definition": "A promise that what you’re saying is straight facts with zero exaggeration.",
             "example": "The finale had me tearing up, no cap.",
             "hint": "Use it to underline that you’re being completely honest.",
-            "category": "Callouts & Reactions",
-            "categoryId": "callouts"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0010",
             "term": "mid",
             "definition": "Totally average and not worth the hype or the backlash.",
             "example": "That highly rated brunch spot was mid, so we bounced after one plate.",
             "hint": "Use it to call something aggressively okay and nothing more.",
-            "category": "Callouts & Reactions",
-            "categoryId": "callouts"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0011",
             "term": "sus",
             "definition": "Short for suspicious; signals that something feels off.",
             "example": "That last-minute invite sounded sus, so we double-checked the details.",
             "hint": "Use it when a situation has weird energy and needs investigation.",
-            "category": "Callouts & Reactions",
-            "categoryId": "callouts"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0012",
             "term": "ratio",
             "definition": "When replies or quote posts outnumber the original likes and steal the spotlight.",
             "example": "Her clapback post ratioed the original thread in five minutes.",
             "hint": "Use it when a response completely outperforms the original post.",
-            "category": "Callouts & Reactions",
-            "categoryId": "callouts"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0013",
             "term": "receipts",
             "definition": "Screenshots or proof that confirm what you’re claiming online or IRL.",
             "example": "Drop the receipts if you’re going to say he bailed on the project.",
             "hint": "Use it when you demand evidence before believing the tea.",
-            "category": "Callouts & Reactions",
-            "categoryId": "callouts"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0014",
             "term": "pressed",
             "definition": "Seriously bothered or stressed about something small.",
             "example": "She’s still pressed about losing in Mario Kart last weekend.",
             "hint": "Use it when someone can’t let a minor inconvenience go.",
-            "category": "Callouts & Reactions",
-            "categoryId": "callouts"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0015",
             "term": "big yikes",
             "definition": "A dramatic cringe reaction to an awkward or messy situation.",
             "example": "Forgetting his name on the livestream was a big yikes moment.",
             "hint": "Use it when secondhand embarrassment is off the charts.",
-            "category": "Callouts & Reactions",
-            "categoryId": "callouts"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0016",
             "term": "skibidi",
             "definition": "Pure nonsense meme energy used when something feels chaotic and absurd.",
             "example": "That skibidi dance break during homeroom had the teacher speechless.",
             "hint": "Use it when a moment turns into full meme chaos for no reason.",
-            "category": "Internet Culture",
-            "categoryId": "internet"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0017",
             "term": "doomscroll",
             "definition": "To keep scrolling through bad news long after you should stop.",
             "example": "I stayed up doomscrolling wildfire updates until my phone died.",
             "hint": "Use it when someone can’t put the feed down even though it’s stressing them out.",
-            "category": "Internet Culture",
-            "categoryId": "internet"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0018",
             "term": "touch grass",
             "definition": "A reminder to log off and rejoin reality for a bit.",
             "example": "You’ve been fighting in the comments for hours—go touch grass.",
             "hint": "Use it when someone needs a break from being extremely online.",
-            "category": "Internet Culture",
-            "categoryId": "internet"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0019",
             "term": "NPC",
             "definition": "Someone acting robotic, scripted, or out of touch with the moment.",
             "example": "The cashier repeating the same line at every customer felt like a total NPC move.",
             "hint": "Use it when a person seems to be on autopilot without real vibes.",
-            "category": "Internet Culture",
-            "categoryId": "internet"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0020",
             "term": "canon event",
             "definition": "A major life moment that shapes your personal story arc.",
             "example": "Missing that train turned into a canon event because I met my future roommate on the platform.",
             "hint": "Use it when a chaotic moment becomes part of your origin story.",
-            "category": "Internet Culture",
-            "categoryId": "internet"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0021",
             "term": "chronically online",
             "definition": "So deep in internet culture that real-life context gets forgotten.",
             "example": "Calling every inconvenience a villain era is peak chronically online behavior.",
             "hint": "Use it when someone’s takes clearly never left the timeline.",
-            "category": "Internet Culture",
-            "categoryId": "internet"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0022",
             "term": "brainrot",
             "definition": "When a show, song, or meme consumes every conversation you have.",
             "example": "We’ve got K-pop brainrot because the new album is literally all we play.",
             "hint": "Use it when one obsession has taken over your thoughts.",
-            "category": "Internet Culture",
-            "categoryId": "internet"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0023",
             "term": "viral",
             "definition": "Blowing up online fast enough that everyone sees it within hours.",
             "example": "Her DIY ring tutorial went viral before lunch and crashed her shop.",
             "hint": "Use it when content explodes across timelines at light speed.",
-            "category": "Internet Culture",
-            "categoryId": "internet"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0024",
             "term": "fanum tax",
             "definition": "Claiming a bite of your friend’s food just because you can.",
             "example": "Pay the fanum tax and hand over a fry before I raid the whole basket.",
             "hint": "Use it when you jokingly demand snacks from the squad.",
-            "category": "Daily Life & Relationships",
-            "categoryId": "relationships"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0025",
             "term": "situationship",
             "definition": "A romantic vibe that’s more than friends but not fully defined.",
             "example": "We’ve been in a situationship for months—movie nights, no labels.",
             "hint": "Use it when a relationship feels official but hasn’t been labeled.",
-            "category": "Daily Life & Relationships",
-            "categoryId": "relationships"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0026",
             "term": "soft launch",
             "definition": "Teasing a new relationship or project with subtle hints instead of a reveal.",
             "example": "She soft launched her partner with a story of two coffee cups and no tags.",
             "hint": "Use it when someone is warming up the feed before a full announcement.",
-            "category": "Daily Life & Relationships",
-            "categoryId": "relationships"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0027",
             "term": "hard launch",
             "definition": "The official reveal—photos, tags, and a caption that leaves no questions.",
             "example": "Their vacation carousel was a hard launch after months of mystery.",
             "hint": "Use it when the teasing ends and the reveal is unmistakable.",
-            "category": "Daily Life & Relationships",
-            "categoryId": "relationships"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0028",
             "term": "side quest",
             "definition": "A random task or adventure that detours from the main plan.",
             "example": "We were grocery shopping but took a side quest to hunt for limited-edition sneakers.",
             "hint": "Use it when a spontaneous detour becomes the highlight of the day.",
-            "category": "Daily Life & Relationships",
-            "categoryId": "relationships"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0029",
             "term": "girl dinner",
             "definition": "A snack-style meal assembled from whatever looks good in the kitchen.",
             "example": "My girl dinner tonight is crackers, strawberries, and three types of cheese.",
             "hint": "Use it when you cobble together a cozy snack plate instead of cooking.",
-            "category": "Daily Life & Relationships",
-            "categoryId": "relationships"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0030",
             "term": "bestie",
             "definition": "A go-to term of endearment for your closest friend or online fave.",
             "example": "Bestie, send me the link to that jacket before it sells out.",
             "hint": "Use it when you’re hyping someone in your inner circle.",
-            "category": "Daily Life & Relationships",
-            "categoryId": "relationships"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0031",
             "term": "adulting",
             "definition": "Handling grown-up responsibilities even when you’d rather not.",
             "example": "Catching up on emails and folding laundry all Sunday felt like peak adulting.",
             "hint": "Use it when you’re tackling chores or paperwork like a responsible human.",
-            "category": "Daily Life & Relationships",
-            "categoryId": "relationships"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0032",
             "term": "drip",
             "definition": "A seriously stylish outfit or accessory game.",
             "example": "His festival drip had photographers chasing him for street-style shots.",
             "hint": "Use it when someone’s look is effortlessly fashionable.",
-            "category": "Style & Aesthetic",
-            "categoryId": "style"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0033",
             "term": "fit check",
             "definition": "A quick showcase or rating of someone’s outfit from head to toe.",
             "example": "Drop your fit check in the group chat before we leave so we don’t twin by accident.",
             "hint": "Use it when you want the squad to show or rate their outfits.",
-            "category": "Style & Aesthetic",
-            "categoryId": "style"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0034",
             "term": "clean girl",
             "definition": "A minimal, polished aesthetic with slick hair, dewy skin, and neutral tones.",
             "example": "She pulled up in full clean girl mode—slick bun, gold hoops, and a monochrome fit.",
             "hint": "Use it when someone’s look is fresh, simple, and ultra put-together.",
-            "category": "Style & Aesthetic",
-            "categoryId": "style"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0035",
             "term": "snatched",
             "definition": "Looking sculpted, cinched, or perfectly styled, often after glam prep.",
             "example": "Her prom dress had her waist snatched and the photos went crazy.",
             "hint": "Use it when a look is sharply tailored or makeup is on point.",
-            "category": "Style & Aesthetic",
-            "categoryId": "style"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0036",
             "term": "thrift haul",
             "definition": "A reveal of secondhand finds scored from thrifting.",
             "example": "He posted a thrift haul full of vintage tees and everyone begged for the store name.",
             "hint": "Use it when you show off the gems you found while thrifting.",
-            "category": "Style & Aesthetic",
-            "categoryId": "style"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0037",
             "term": "glow up",
             "definition": "A major improvement in style, confidence, or overall vibe.",
             "example": "Her glow up this year included a new job, new hair, and unstoppable confidence.",
             "hint": "Use it when someone’s transformation deserves a spotlight.",
-            "category": "Style & Aesthetic",
-            "categoryId": "style"
+            "category": "Gen Alpha",
+            "categoryId": "gen-alpha"
         }, {
             "id": "sl-0038",
             "term": "vibe check",
             "definition": "A quick read on the room’s energy before making a move.",
             "example": "We did a vibe check before inviting the whole class to the afterparty.",
             "hint": "Use it when you’re gauging the mood before jumping in.",
-            "category": "Vibes & Feelings",
-            "categoryId": "vibes"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0039",
             "term": "it’s giving",
             "definition": "A way to compare someone’s vibe to a specific aesthetic or idea.",
             "example": "The new decor is giving cozy bookstore mixed with game night lounge.",
             "hint": "Use it when a look or moment nails a particular energy.",
-            "category": "Vibes & Feelings",
-            "categoryId": "vibes"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0040",
             "term": "low-key",
             "definition": "Subtle, quiet, or secretly true without wanting a big scene.",
             "example": "I’m low-key excited for the presentation even though I keep playing it cool.",
             "hint": "Use it when you want to admit something softly without the spotlight.",
-            "category": "Vibes & Feelings",
-            "categoryId": "vibes"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0041",
             "term": "high-key",
             "definition": "Very obvious, loud, or impossible to hide.",
             "example": "I high-key want to drop everything and book that weekend trip.",
             "hint": "Use it when you’re not afraid to be blatant about what you feel.",
-            "category": "Vibes & Feelings",
-            "categoryId": "vibes"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0042",
             "term": "main character",
             "definition": "Someone acting like life is their movie and all eyes are on them.",
             "example": "She walked through campus in slow motion like the main character after acing her exam.",
             "hint": "Use it when someone owns the spotlight and knows it.",
-            "category": "Vibes & Feelings",
-            "categoryId": "vibes"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0043",
             "term": "big mood",
             "definition": "A feeling or situation that feels extremely relatable.",
             "example": "Crawling back into bed after brunch is a big mood right now.",
             "hint": "Use it when something perfectly matches how you feel.",
-            "category": "Vibes & Feelings",
-            "categoryId": "vibes"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0044",
             "term": "locked in",
             "definition": "Completely focused with zero distractions allowed.",
             "example": "We’re locked in for finals week, so game nights are on pause.",
             "hint": "Use it when someone is in full concentration mode.",
-            "category": "Vibes & Feelings",
-            "categoryId": "vibes"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }, {
             "id": "sl-0045",
             "term": "for the plot",
             "definition": "Doing something mainly because it will make a great story later.",
             "example": "We booked the last-minute road trip purely for the plot.",
             "hint": "Use it when you take a risk just to keep life interesting.",
-            "category": "Vibes & Feelings",
-            "categoryId": "vibes"
+            "category": "Gen Z",
+            "categoryId": "gen-z"
         }
     ];
 

--- a/data/slang-manifest.json
+++ b/data/slang-manifest.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "generatedAt": "2025-09-23T13:32:46.596Z",
+    "generatedAt": "2025-09-23T17:36:50.059Z",
     "total": 45,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",
@@ -19,20 +19,20 @@
         "definition": "35d1a7288e3cde1a3c55e248f12dccba969fd2a317e72dff737abf1a665db6b4",
         "example": "5f3c242556f31fbc33173b3459e747b6b6034667cd8cb1f746de1c1af3b53f8c",
         "hint": "408b9738d607203d25bc3f65df1591eac5fcf88c8765ec6e678e874afb923064",
-        "category": "df520f8e79613e49e7934858773ef11a70cec548c7e9654753dbd694bd998c33",
-        "combined": "d0885c9ab4bfcacac0b30ca002f8e382dd6c63c900366fbe1ec0a9536389ed6b",
-        "tokenSignature": "charisma-charm-compliments-connecting-effortless-everyone-feel-flirting-group-hype-into-it-jaden-make-makes-much-natural-or-over-people-rizz-room-scooted-so-someone-study-that-the-to-trying-use-walked-whose-wins-with-without"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "dcd4dcf40b569fd9f630e96700c9c32a8d5097bef0b74c489849aee286a8165d",
+        "tokenSignature": "alpha-charisma-charm-connecting-effortless-everyone-feel-flirting-gen-group-hype-into-it-jaden-make-makes-much-natural-or-over-people-rizz-room-scooted-so-someone-study-that-the-to-trying-use-walked-whose-wins-with-without"
       },
       "lengths": {
         "term": 4,
         "definition": 67,
         "example": 92,
         "hint": 67,
-        "category": 18
+        "category": 9
       },
       "source": {
         "sequence": 1,
-        "categoryId": "hype"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -47,20 +47,20 @@
         "definition": "9e428e81ba5334a6cf04d4342a1e3a77d46c9607c3633c295ed0ea93549d9429",
         "example": "b1eedd3246d3a999efeeac040ed8d2145aa30cf578a22f131967b5f4b4f61dd4",
         "hint": "57fdb1df370e8cf6174b31d39f21e545ad6d5766fe72064dacd91bc869396cc5",
-        "category": "df520f8e79613e49e7934858773ef11a70cec548c7e9654753dbd694bd998c33",
-        "combined": "c809597bc8853f59f8780b39fef0f4fbdbf68003f09cff4619ecf7743298083a",
-        "tokenSignature": "and-asked-assignment-call-client-completely-compliments-every-execute-flair-flawlessly-hype-intro-it-nails-present-slay-so-someone-something-style-team-the-time-to-undeniable-use-when-with-you"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "7c908ff1172c8e981292a7ded519f0c2238d10ad2aa72490c3bf5209f22cc6da",
+        "tokenSignature": "alpha-and-asked-assignment-call-client-completely-every-execute-flair-flawlessly-gen-intro-it-nails-present-slay-so-someone-something-style-team-the-time-to-undeniable-use-when-with-you"
       },
       "lengths": {
         "term": 4,
         "definition": 58,
         "example": 80,
         "hint": 63,
-        "category": 18
+        "category": 9
       },
       "source": {
         "sequence": 2,
-        "categoryId": "hype"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -75,20 +75,20 @@
         "definition": "0c881ee87cffb571f7f8682897dc250de552317d49a9515e2fac737ebfecece5",
         "example": "ec64525a5ebea60ca4d82b4e0b4e1baa4b8ecac6e15ab20fcfe7d618aed9c93a",
         "hint": "466c33a3ec2aa1e9f5e784883e9f9408bc6ad3408913a114ef5d3561b9e114b3",
-        "category": "df520f8e79613e49e7934858773ef11a70cec548c7e9654753dbd694bd998c33",
-        "combined": "8b65600efdd5e63852b7c4e8e1b25f8ac0ecdec04c281a1bc48ae2c57950759e",
-        "tokenSignature": "a-add-and-are-ate-choreography-compliments-delivered-effort-energy-give-good-had-hype-it-left-maya-no-notes-nothing-of-performance-rest-s-so-someone-still-strong-such-teach-that-the-there-to-us-use-was-when"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "9939779ade5b0618391606cd298492dfcf9d7cd28ad778eeaf6b2874b0416302",
+        "tokenSignature": "a-add-alpha-and-are-ate-choreography-delivered-effort-energy-gen-give-good-had-it-left-maya-no-notes-nothing-of-performance-rest-s-so-someone-still-strong-such-teach-that-the-there-to-us-use-was-when"
       },
       "lengths": {
         "term": 3,
         "definition": 69,
         "example": 82,
         "hint": 68,
-        "category": 18
+        "category": 9
       },
       "source": {
         "sequence": 3,
-        "categoryId": "hype"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -103,20 +103,20 @@
         "definition": "0a7ce80d8b773e6b1203321eb8701fcd3b2861ce34957e382b13de98103dffa2",
         "example": "863a1aaee6275221b54d258fe8006186e0b92da8c8be268da2256bbf05617353",
         "hint": "5e6da8594c0764aae1e18132ff75cb70cfb756435b6c5b0ce6d373c6e9287954",
-        "category": "df520f8e79613e49e7934858773ef11a70cec548c7e9654753dbd694bd998c33",
-        "combined": "8b2df7575e29c81552cabb1721afa796bd475640b0e605f02b251e341357c478",
-        "tokenSignature": "a-achievement-after-all-at-best-blocking-compliments-crown-do-every-for-goalie-goated-greatest-hype-in-is-it-locked-of-or-our-overtime-shot-skill-someone-status-the-they-time-to-undeniable-use-what"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "6a6b9d878a442c6846e707f2d1c0e953cfb5908008df49b01fa765033948a4e0",
+        "tokenSignature": "a-achievement-after-all-alpha-at-best-blocking-crown-do-every-for-gen-goalie-goated-greatest-in-is-it-locked-of-or-our-overtime-shot-skill-someone-status-the-they-time-to-undeniable-use-what"
       },
       "lengths": {
         "term": 6,
         "definition": 65,
         "example": 59,
         "hint": 60,
-        "category": 18
+        "category": 9
       },
       "source": {
         "sequence": 4,
-        "categoryId": "hype"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -131,20 +131,20 @@
         "definition": "62bb33c05da25d5a134c0104b88b2d87c2767b1ec24972ef4e3791f7442c46d7",
         "example": "41d6c8adb3b27517f81575c7bbb5c4fdab65be7dc319844c9083f91b120cc301",
         "hint": "f1bf871782389e35bdcae1a9a71c42cf547fb7710695e2c17b1ff25e69cec70f",
-        "category": "df520f8e79613e49e7934858773ef11a70cec548c7e9654753dbd694bd998c33",
-        "combined": "d425ce4b8ceb4e5dfa7873acbff60fb1979e4d98c04a388d67344cf84066bb1a",
-        "tokenSignature": "about-an-another-bowl-bussin-can-compliments-definitely-experience-feels-food-good-help-hype-i-is-it-late-loud-m-night-or-ordering-out-ramen-reacting-so-something-t-tastes-that-this-unbelievably-use-usually-when-you"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "bdfa5076937e8d12d66c462fb6bd7350be913639e3fc7ba69c67d9b5da8fd2ac",
+        "tokenSignature": "about-alpha-an-another-bowl-bussin-can-definitely-experience-feels-food-gen-good-help-i-is-it-late-loud-m-night-or-ordering-out-ramen-reacting-so-something-t-tastes-that-this-unbelievably-use-usually-when-you"
       },
       "lengths": {
         "term": 6,
         "definition": 83,
         "example": 73,
         "hint": 56,
-        "category": 18
+        "category": 9
       },
       "source": {
         "sequence": 5,
-        "categoryId": "hype"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -159,20 +159,20 @@
         "definition": "00e72a335bb857dd122d2a229a9909be7dfe291d46d6df5db86212c4129f7a7e",
         "example": "2366ebd75695fec11d0d0fab2fb09cf10f39b85256b090366d1e41e484086939",
         "hint": "515c810c77d27fd8fd5b8acf3c35f52689f0633c52dc6f239c10354af5e9e68c",
-        "category": "df520f8e79613e49e7934858773ef11a70cec548c7e9654753dbd694bd998c33",
-        "combined": "45d87227fffad517ad6ef87765094b5171de809e307ebd5f79423321d572be16",
-        "tokenSignature": "amazingly-and-best-compliments-contagious-crowd-dance-dj-energy-erupts-filled-floor-go-hype-in-instantly-it-off-or-performing-pop-possible-someone-something-start-the-to-told-up-use-way-when-with"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "40a84ced246a537becd4508d88f1ae54c4d8856c1e75b179d558fddf72ee2698",
+        "tokenSignature": "alpha-amazingly-and-best-contagious-crowd-dance-dj-energy-erupts-filled-floor-gen-go-in-instantly-it-off-or-performing-pop-possible-someone-something-start-the-to-told-up-use-way-when-with"
       },
       "lengths": {
         "term": 7,
         "definition": 66,
         "example": 73,
         "hint": 65,
-        "category": 18
+        "category": 9
       },
       "source": {
         "sequence": 6,
-        "categoryId": "hype"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -187,20 +187,20 @@
         "definition": "cd1dad6e11a5e284dc50b5cab3ed20ee1db98ade3b05236673a9c9b028b41a46",
         "example": "28b7d78d6f85572ab623653e55bd50028f24ae1498164e4017cfc7f24e27d041",
         "hint": "c967e7b4893c3ece8dd104eb087c242372507e0d49a0de00a8c6cf891941d249",
-        "category": "df520f8e79613e49e7934858773ef11a70cec548c7e9654753dbd694bd998c33",
-        "combined": "5577f9884e5f3380065ee9cec891a61ae41fa171c40a9daae533d85de0eaf7cb",
-        "tokenSignature": "absolutely-adding-an-compliments-cosigning-genuinely-good-half-hesitation-hype-i-idea-is-it-m-my-on-opinion-or-outfit-playlist-point-rotation-these-to-tracks-trustworthy-use-valid-when-without-worth-your"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "a1edb1a11503a1517666398d3bb80e7f1e857ebd7cd5f0e713f7d476c8dc36a5",
+        "tokenSignature": "absolutely-adding-alpha-an-cosigning-gen-genuinely-good-half-hesitation-i-idea-is-it-m-my-on-opinion-or-outfit-playlist-point-rotation-these-to-tracks-trustworthy-use-valid-when-without-worth-your"
       },
       "lengths": {
         "term": 5,
         "definition": 67,
         "example": 68,
         "hint": 63,
-        "category": 18
+        "category": 9
       },
       "source": {
         "sequence": 7,
-        "categoryId": "hype"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -215,20 +215,20 @@
         "definition": "6005d39355a28588697c548d98012817da10ebe7b1cf1ffeba7dee9e5dc44e2a",
         "example": "e99a10ed5bf16325338663959d40f2c513d38d2fe0941d2fac5c2c4f7b038115",
         "hint": "d21687b3c78e87417e0204c99282f73294388da9399a9439e57f8883613ae319",
-        "category": "d738f50a29548006ede144fd55572c65ace4b50c4688682e8b96b1941ee07a2f",
-        "combined": "e9a68636185b1a4812f77eeb7e6209d071020efca92a1863ec893c89b9f1c035",
-        "tokenSignature": "a-believing-calling-callouts-cancel-check-daydream-delulu-fantasy-for-friend-gentle-i-it-m-needs-optimism-or-out-playfully-professor-quiz-reactions-reality-s-someone-the-thinking-tomorrow-unrealistic-use-when-will"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "7adc7cb48369c725474a006459110f6050c67910468205e1441507c8a6dbdb19",
+        "tokenSignature": "a-believing-calling-cancel-check-daydream-delulu-fantasy-for-friend-gen-gentle-i-it-m-needs-optimism-or-out-playfully-professor-quiz-reality-s-someone-the-thinking-tomorrow-unrealistic-use-when-will-z"
       },
       "lengths": {
         "term": 6,
         "definition": 75,
         "example": 67,
         "hint": 61,
-        "category": 20
+        "category": 5
       },
       "source": {
         "sequence": 8,
-        "categoryId": "callouts"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -243,20 +243,20 @@
         "definition": "27e0dca023606c19f991b8e714ad39bd36d97e5f8efb44e2051acf8c1303b8e9",
         "example": "32b62d96fd923c4625dbbf224aa7500c128385fdd64baadbcaab888af3f10591",
         "hint": "636eea61ba8a7d04183757d5ae036daa31c41a91b78a56638db24c03e2921973",
-        "category": "d738f50a29548006ede144fd55572c65ace4b50c4688682e8b96b1941ee07a2f",
-        "combined": "4a61c99b00929644211fb381295b4af523b1a15792d0a3ded2db36f140d1bd3e",
-        "tokenSignature": "a-being-callouts-cap-completely-exaggeration-facts-finale-had-honest-is-it-me-no-promise-re-reactions-saying-straight-tearing-that-the-to-underline-up-use-what-with-you-zero"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "f17233859c40173d080ee08ac2505c87b3a62d639ec0e06998f2e9d651c6934e",
+        "tokenSignature": "a-being-cap-completely-exaggeration-facts-finale-gen-had-honest-is-it-me-no-promise-re-saying-straight-tearing-that-the-to-underline-up-use-what-with-you-z-zero"
       },
       "lengths": {
         "term": 6,
         "definition": 75,
         "example": 37,
         "hint": 56,
-        "category": 20
+        "category": 5
       },
       "source": {
         "sequence": 9,
-        "categoryId": "callouts"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -271,20 +271,20 @@
         "definition": "ecb580ee574086625c0e2de9d497de5ceaa60c46f51194db25b399d7766dc6d5",
         "example": "8f60102f205ef351429acebc341ab42c118bb4b631b61d6a90138b88ab87deb0",
         "hint": "dd7eb4b8002513e9f7ef4ce6586fd7e15b808db5ff20ff576646f4c7f98cc22c",
-        "category": "d738f50a29548006ede144fd55572c65ace4b50c4688682e8b96b1941ee07a2f",
-        "combined": "f8ad6d8bab39a63b609f15ebbeb100f6477af067f2d8004618281f23acf750c5",
-        "tokenSignature": "after-aggressively-and-average-backlash-bounced-brunch-call-callouts-highly-hype-it-mid-more-not-nothing-okay-one-or-plate-rated-reactions-so-something-spot-that-the-to-totally-use-was-we-worth"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "2ba9ec64ee6dbfc789b9e0ec8475fa401d58b5a6a1fe63459bfa836428c7c243",
+        "tokenSignature": "after-aggressively-and-average-backlash-bounced-brunch-call-gen-highly-hype-it-mid-more-not-nothing-okay-one-or-plate-rated-so-something-spot-that-the-to-totally-use-was-we-worth-z"
       },
       "lengths": {
         "term": 3,
         "definition": 55,
         "example": 69,
         "hint": 60,
-        "category": 20
+        "category": 5
       },
       "source": {
         "sequence": 10,
-        "categoryId": "callouts"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -299,20 +299,20 @@
         "definition": "90a1dcdf08d47c1975fba39065ed7a3c60707df78c8e256282410f482538dada",
         "example": "dc09876f21fddbcace962046abb49928e49167a01aa23b2c3b421c76bbf73c59",
         "hint": "3b11eb5d2ecc9596b00111aa7190f43c3627eef2d8df6990561763a71b448024",
-        "category": "d738f50a29548006ede144fd55572c65ace4b50c4688682e8b96b1941ee07a2f",
-        "combined": "1aeff976030309799884a19b2d64afc3d0ad9ebae76a443fdbad28625755d2d4",
-        "tokenSignature": "a-and-callouts-checked-details-double-energy-feels-for-has-investigation-invite-it-last-minute-needs-off-reactions-short-signals-situation-so-something-sounded-sus-suspicious-that-the-use-we-weird-when"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "42d9e87d32831cbeacdac6129551957867fb77aada2ed3c512382f5762adbb86",
+        "tokenSignature": "a-and-checked-details-double-energy-feels-for-gen-has-investigation-invite-it-last-minute-needs-off-short-signals-situation-so-something-sounded-sus-suspicious-that-the-use-we-weird-when-z"
       },
       "lengths": {
         "term": 3,
         "definition": 55,
         "example": 70,
         "hint": 65,
-        "category": 20
+        "category": 5
       },
       "source": {
         "sequence": 11,
-        "categoryId": "callouts"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -327,20 +327,20 @@
         "definition": "e8c522029cc08c83152e722ff3359f0c744dc90fd6807e509537f9d2d4d90399",
         "example": "fe56208c9e4c131c0046010bdb26eb4579f723ae65f6c9273dbc4b25a6d1088f",
         "hint": "9fde5b811c160c14fc62955dffd14ac467f51a316f7a2787b007f05d2a7e37ec",
-        "category": "d738f50a29548006ede144fd55572c65ace4b50c4688682e8b96b1941ee07a2f",
-        "combined": "059ed9fdfb2efe2df23dc78741d173eda7191afe5318322a74e3a01519a23cfd",
-        "tokenSignature": "a-and-callouts-clapback-completely-five-her-in-it-likes-minutes-or-original-outnumber-outperforms-post-posts-quote-ratio-ratioed-reactions-replies-response-spotlight-steal-the-thread-use-when"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "edd4a07dbdab3dc26d3cc53dee6225960e446d04ae753c7fff4b3a0881855515",
+        "tokenSignature": "a-and-clapback-completely-five-gen-her-in-it-likes-minutes-or-original-outnumber-outperforms-post-posts-quote-ratio-ratioed-replies-response-spotlight-steal-the-thread-use-when-z"
       },
       "lengths": {
         "term": 5,
         "definition": 81,
         "example": 62,
         "hint": 64,
-        "category": 20
+        "category": 5
       },
       "source": {
         "sequence": 12,
-        "categoryId": "callouts"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -355,20 +355,20 @@
         "definition": "44b6503e7f4e9eccf0ba1ca5a95e865af38c366ece1071cc4bdf952cbc0bc43b",
         "example": "a40d9d85f5c0c372fbf53ca2d21790256344ea5e06e9077c14b3391f39e0601e",
         "hint": "9fb37671cf168820430edf0c4790d4c6fc65f14e7376003751c9bff0a1d04b0a",
-        "category": "d738f50a29548006ede144fd55572c65ace4b50c4688682e8b96b1941ee07a2f",
-        "combined": "07aa9a908373d290d5cd007a04d96a8ab863c6ec6af48d824608566afc3c32a5",
-        "tokenSignature": "bailed-before-believing-callouts-claiming-confirm-demand-drop-evidence-going-he-if-irl-it-on-online-or-project-proof-re-reactions-receipts-say-screenshots-tea-that-the-to-use-what-when-you"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "815d1836950e70e62d43b921373e882c4b304c458bb9d7bfe700a4d492b60064",
+        "tokenSignature": "bailed-before-believing-claiming-confirm-demand-drop-evidence-gen-going-he-if-irl-it-on-online-or-project-proof-re-receipts-say-screenshots-tea-that-the-to-use-what-when-you-z"
       },
       "lengths": {
         "term": 8,
         "definition": 69,
         "example": 66,
         "hint": 57,
-        "category": 20
+        "category": 5
       },
       "source": {
         "sequence": 13,
-        "categoryId": "callouts"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -383,20 +383,20 @@
         "definition": "7474db25d33cf74fdb2de62bb91133b90df9ec004c3d24cc44d5dd41541e4f13",
         "example": "54c5525eb49a4fb4372c07515025d11dc8346e210dbb58b6587087539bf61fb5",
         "hint": "9702ced1be27017c7dcd80bb5ca662d3f48d037d288512ce95c45766840a476c",
-        "category": "d738f50a29548006ede144fd55572c65ace4b50c4688682e8b96b1941ee07a2f",
-        "combined": "cc598cb135541ef9eca41351cc8f2501d30730377ea3669097b9996261df6ff2",
-        "tokenSignature": "a-about-bothered-callouts-can-go-in-inconvenience-it-kart-last-let-losing-mario-minor-or-pressed-reactions-s-seriously-she-small-someone-something-still-stressed-t-use-weekend-when"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "9779f9652e1bc5f2419500d95ddc81876f45f0679d4bdb26a6be519baa645328",
+        "tokenSignature": "a-about-bothered-can-gen-go-in-inconvenience-it-kart-last-let-losing-mario-minor-or-pressed-s-seriously-she-small-someone-something-still-stressed-t-use-weekend-when-z"
       },
       "lengths": {
         "term": 7,
         "definition": 53,
         "example": 60,
         "hint": 55,
-        "category": 20
+        "category": 5
       },
       "source": {
         "sequence": 14,
-        "categoryId": "callouts"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -411,20 +411,20 @@
         "definition": "237c9aab7c93a946e61451a06754a1583b892c211724a2dcf0aa9ac65cb3d5f3",
         "example": "3772c519dfbcc478ac6199cbb25392499884297ceb69fe9b9158bbd234ef3f6c",
         "hint": "c7e8f54105e556b8c6da5c0a60ae25a33caf5d7362ee63a0a12d98bff108359c",
-        "category": "d738f50a29548006ede144fd55572c65ace4b50c4688682e8b96b1941ee07a2f",
-        "combined": "bec39fa89418652abf6da2e0ce3c747baf4f4afcf4293d73e10bc509f84d78d1",
-        "tokenSignature": "a-an-awkward-big-callouts-charts-cringe-dramatic-embarrassment-forgetting-his-is-it-livestream-messy-moment-name-off-on-or-reaction-reactions-secondhand-situation-the-to-use-was-when-yikes"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "cb37b3e13b85dec445e2e97b2e0bab29e095582b84e4c673f2c16d7e52331ff1",
+        "tokenSignature": "a-an-awkward-big-charts-cringe-dramatic-embarrassment-forgetting-gen-his-is-it-livestream-messy-moment-name-off-on-or-reaction-secondhand-situation-the-to-use-was-when-yikes-z"
       },
       "lengths": {
         "term": 9,
         "definition": 60,
         "example": 61,
         "hint": 55,
-        "category": 20
+        "category": 5
       },
       "source": {
         "sequence": 15,
-        "categoryId": "callouts"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -439,20 +439,20 @@
         "definition": "40bab8099aba068dbf90b24acf8fa81a819f9e36f41bc3700b07c4728b1def33",
         "example": "559ea58526a511911793e2ce2b171153995c0f39b31c5e61f35436759c1482b6",
         "hint": "19d2af05f51882b3892b24a870f0881683c22d1faae30bd2a4019cc1e14a7bd5",
-        "category": "65a9c93bbc405f7148ab8e9311a7c8dd6b58b311ffb85a4e5e2fe90cd431877b",
-        "combined": "e79de20eeab9a9ba57d41659ee5a9300a44db635eade5c527fe851297748cf39",
-        "tokenSignature": "a-absurd-and-break-chaos-chaotic-culture-dance-during-energy-feels-for-full-had-homeroom-internet-into-it-meme-moment-no-nonsense-pure-reason-skibidi-something-speechless-teacher-that-the-turns-use-used-when"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "38cb2c4013405b662feef7ead23f1b1e26828df16637d7626f16d1e75881831e",
+        "tokenSignature": "a-absurd-alpha-and-break-chaos-chaotic-dance-during-energy-feels-for-full-gen-had-homeroom-into-it-meme-moment-no-nonsense-pure-reason-skibidi-something-speechless-teacher-that-the-turns-use-used-when"
       },
       "lengths": {
         "term": 7,
         "definition": 71,
         "example": 68,
         "hint": 62,
-        "category": 16
+        "category": 9
       },
       "source": {
         "sequence": 16,
-        "categoryId": "internet"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -467,20 +467,20 @@
         "definition": "56d2cb4c053d3d00980ad42c849a3e2923c183bd44d56ff96cb22f8ef08c822c",
         "example": "675819d2dacc5a8639a9b2d5a8631f3d40de48e7dfac2a91520cfa5cccb9e122",
         "hint": "7cfb7b57bb203af06fdbed2264df04afb3c7eb4baf84b240179522c0036554ad",
-        "category": "65a9c93bbc405f7148ab8e9311a7c8dd6b58b311ffb85a4e5e2fe90cd431877b",
-        "combined": "5c8fe3336a05474f9aefc833ff50ce6d6da29e11020c9f68ce00c7225ada72ac",
-        "tokenSignature": "after-bad-can-culture-died-doomscroll-doomscrolling-down-even-feed-i-internet-it-keep-long-my-news-out-phone-put-s-scrolling-should-someone-stayed-stop-stressing-t-the-them-though-through-to-until-up-updates-use-when-wildfire-you"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "423ed4e8d90de7fe3123d932b6a04711a3c8bfe9d34257dd3280c974773e22d6",
+        "tokenSignature": "after-alpha-bad-can-died-doomscroll-doomscrolling-down-even-feed-gen-i-it-keep-long-my-news-out-phone-put-s-scrolling-should-someone-stayed-stop-stressing-t-the-them-though-through-to-until-up-updates-use-when-wildfire-you"
       },
       "lengths": {
         "term": 10,
         "definition": 62,
         "example": 63,
         "hint": 80,
-        "category": 16
+        "category": 9
       },
       "source": {
         "sequence": 17,
-        "categoryId": "internet"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -495,20 +495,20 @@
         "definition": "bb00d7214912ad61ced1c21a5f6ce4b5f851de8806b18e5d4e3e12482fd29516",
         "example": "0169fcfaa9c09e7e5ae15605698ddc249d1ac69ed935f0476309d42758a275a3",
         "hint": "a30f509e954b1dcc02444d26efef355fa7156f279e60de6dada744557c617c26",
-        "category": "65a9c93bbc405f7148ab8e9311a7c8dd6b58b311ffb85a4e5e2fe90cd431877b",
-        "combined": "941be7595276dd404c0d22b81d22fe4b7a931e2190724c8aafcc3cb67af01e47",
-        "tokenSignature": "a-and-been-being-bit-break-comments-culture-extremely-fighting-for-from-go-grass-hours-in-internet-it-log-needs-off-online-reality-rejoin-reminder-someone-the-to-touch-use-ve-when-you"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "a1de2fe3812491ae21189a1169d01022685c7c08137f4f83286ba36899a6004a",
+        "tokenSignature": "a-alpha-and-been-being-bit-break-comments-extremely-fighting-for-from-gen-go-grass-hours-in-it-log-needs-off-online-reality-rejoin-reminder-someone-the-to-touch-use-ve-when-you"
       },
       "lengths": {
         "term": 11,
         "definition": 51,
         "example": 62,
         "hint": 62,
-        "category": 16
+        "category": 9
       },
       "source": {
         "sequence": 18,
-        "categoryId": "internet"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -523,20 +523,20 @@
         "definition": "a27d10bba6d95ee2eeb4c96007797ce18c15219980c9c86a39a4a9a2311fd705",
         "example": "f5ef994f725debf442aebcca04b8cc0acc8a46da9ad70105ff6f8ca6ab2e519d",
         "hint": "e1d24e3afd4d0717e06fb2cc2e5edbf76a38505854086af6e76ec1fe382f7769",
-        "category": "65a9c93bbc405f7148ab8e9311a7c8dd6b58b311ffb85a4e5e2fe90cd431877b",
-        "combined": "f54be22e3a0f75d2ec0f7fee16343455e339677e73cea2ee7d97797efd59999e",
-        "tokenSignature": "a-acting-at-autopilot-be-cashier-culture-customer-every-felt-internet-it-like-line-moment-move-npc-of-on-or-out-person-real-repeating-robotic-same-scripted-seems-someone-the-to-total-touch-use-vibes-when-with-without"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "9a5a1fe9dc6322db586ffa5b35882a68a38c92cea48a02c50a0d62dabdab112e",
+        "tokenSignature": "a-acting-alpha-at-autopilot-be-cashier-customer-every-felt-gen-it-like-line-moment-move-npc-of-on-or-out-person-real-repeating-robotic-same-scripted-seems-someone-the-to-total-touch-use-vibes-when-with-without"
       },
       "lengths": {
         "term": 3,
         "definition": 66,
         "example": 81,
         "hint": 65,
-        "category": 16
+        "category": 9
       },
       "source": {
         "sequence": 19,
-        "categoryId": "internet"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -551,20 +551,20 @@
         "definition": "1b2f9579685311b2f16cf79c71eb2453e050881e5ebc0d2f85268879c03b6d36",
         "example": "c4fb2b5f1e3ee6623f0ac78ff86eb3132d20549b0fc6c31d90c0c7e8c14da282",
         "hint": "de27276f8ed600dc8775f3a6234699af7265b377e09524b47cf14f78cc9881e4",
-        "category": "65a9c93bbc405f7148ab8e9311a7c8dd6b58b311ffb85a4e5e2fe90cd431877b",
-        "combined": "5462fbf5ed86a14189656d1d5642c724fdf70e0d239bb043b2f89f8df2b7f077",
-        "tokenSignature": "a-arc-because-becomes-canon-chaotic-culture-event-future-i-internet-into-it-life-major-met-missing-moment-my-of-on-origin-part-personal-platform-roommate-shapes-story-that-the-train-turned-use-when-your"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "0f8618a4f8d65cdcc018c8994b7417843e73848b3c26ca39680da575ef5136fb",
+        "tokenSignature": "a-alpha-arc-because-becomes-canon-chaotic-event-future-gen-i-into-it-life-major-met-missing-moment-my-of-on-origin-part-personal-platform-roommate-shapes-story-that-the-train-turned-use-when-your"
       },
       "lengths": {
         "term": 11,
         "definition": 56,
         "example": 94,
         "hint": 63,
-        "category": 16
+        "category": 9
       },
       "source": {
         "sequence": 20,
-        "categoryId": "internet"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -579,20 +579,20 @@
         "definition": "8226ba240648ef01b13b9f4c85b86c4437e0400a9252cf40c8616cda016dec8d",
         "example": "e303cf6ed616049b0c4f35b6819c92170ee32fb414919c25180ecb9dbabf3d34",
         "hint": "ac453d765e576b589f6462496d473472187134f88f4edf8f80ec1d9955f366f9",
-        "category": "65a9c93bbc405f7148ab8e9311a7c8dd6b58b311ffb85a4e5e2fe90cd431877b",
-        "combined": "17ac51ab1846bf1176edef6e00e09f34e4321b789767f29098ecb82b46799988",
-        "tokenSignature": "a-behavior-calling-chronically-clearly-context-culture-deep-era-every-forgotten-gets-in-inconvenience-internet-is-it-left-life-never-online-peak-real-s-so-someone-takes-that-the-timeline-use-villain-when"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "a2d0932bbc581c4739b0f71de92af78589dfa3879f702508e2ff3d52350283f1",
+        "tokenSignature": "a-alpha-behavior-calling-chronically-clearly-context-culture-deep-era-every-forgotten-gen-gets-in-inconvenience-internet-is-it-left-life-never-online-peak-real-s-so-someone-takes-that-the-timeline-use-villain-when"
       },
       "lengths": {
         "term": 18,
         "definition": 66,
         "example": 78,
         "hint": 60,
-        "category": 16
+        "category": 9
       },
       "source": {
         "sequence": 21,
-        "categoryId": "internet"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -607,20 +607,20 @@
         "definition": "14cec629e77851e246385e76f1155adaa70bf1898ed54332978e8740a560e6a7",
         "example": "9568249f958af6d11ad739db5f628da499a0f823d9b35af06eefee695cc3a400",
         "hint": "5fd21594cf02ae4468baaf6c6cb71a1eab50afcb4f98eb70071d96117addcbbc",
-        "category": "65a9c93bbc405f7148ab8e9311a7c8dd6b58b311ffb85a4e5e2fe90cd431877b",
-        "combined": "4f8c0997479ba726911d9e1d4117428214fe3b9abfbd4d2ee96c7861c7abef78",
-        "tokenSignature": "a-album-all-because-brainrot-consumes-conversation-culture-every-got-has-have-internet-is-it-k-literally-meme-new-obsession-one-or-over-play-pop-show-song-taken-the-thoughts-use-ve-we-when-you-your"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "bcd620cf51a989a510e6f3ed9ed7ccf7341b1da621886c1879e862c5398562c6",
+        "tokenSignature": "a-album-all-alpha-because-brainrot-consumes-conversation-every-gen-got-has-have-is-it-k-literally-meme-new-obsession-one-or-over-play-pop-show-song-taken-the-thoughts-use-ve-we-when-you-your"
       },
       "lengths": {
         "term": 8,
         "definition": 64,
         "example": 72,
         "hint": 55,
-        "category": 16
+        "category": 9
       },
       "source": {
         "sequence": 22,
-        "categoryId": "internet"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -635,20 +635,20 @@
         "definition": "19ac16100ccca78f898f6d21265e476cb744a89fc75ff388a0b2514c26aa2954",
         "example": "305148be301538cb2a4c76ef3c1e8bc7b99707a40674577fae156ec0d40ade9b",
         "hint": "02d9b3a7855a80fab713780029575b1f1033a0fee53cc86d3cabc47fba63561b",
-        "category": "65a9c93bbc405f7148ab8e9311a7c8dd6b58b311ffb85a4e5e2fe90cd431877b",
-        "combined": "c9e98aa2895661d48beb349d55529f3e6a7da3c8fa7014f121da5cf9260c9686",
-        "tokenSignature": "across-and-at-before-blowing-content-crashed-culture-diy-enough-everyone-explodes-fast-her-hours-internet-it-light-lunch-online-ring-sees-shop-speed-that-timelines-tutorial-up-use-viral-went-when-within"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "f250e4706601e09093f00fca823b40f9f2f03bbafa56cc026c864032a7e97683",
+        "tokenSignature": "across-alpha-and-at-before-blowing-content-crashed-diy-enough-everyone-explodes-fast-gen-her-hours-it-light-lunch-online-ring-sees-shop-speed-that-timelines-tutorial-up-use-viral-went-when-within"
       },
       "lengths": {
         "term": 5,
         "definition": 65,
         "example": 67,
         "hint": 61,
-        "category": 16
+        "category": 9
       },
       "source": {
         "sequence": 23,
-        "categoryId": "internet"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -663,20 +663,20 @@
         "definition": "fd6bb3a7637d12fb3bb1ec77996758f824132620247238e16c8a25302a44e1b2",
         "example": "791225591effe585f12f7d0b4feeff9813bbc2f1d2f869fe08531afc5e81dfa0",
         "hint": "108f1f0c743c6f1219306baa2a4fd35ad14910a700c28b1858c9bf05c1fcd933",
-        "category": "fc31d6a2796e8e103ddb394c31b1d72415f776d882faaf2b0fe77a6c3645a76e",
-        "combined": "ee6255150250d7546ce617187278a5f147773c8462e77dc93d98273e2c2ce8f6",
-        "tokenSignature": "a-and-basket-because-before-bite-can-claiming-daily-demand-fanum-food-friend-from-fry-hand-i-it-jokingly-just-life-of-over-pay-raid-relationships-s-snacks-squad-tax-the-use-when-whole-you-your"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "301d69a2bf0e025b073cde8f4336476620bfb5e0ed09b898359ea56cc54de25d",
+        "tokenSignature": "a-and-basket-because-before-bite-can-claiming-demand-fanum-food-friend-from-fry-gen-hand-i-it-jokingly-just-of-over-pay-raid-s-snacks-squad-tax-the-use-when-whole-you-your-z"
       },
       "lengths": {
         "term": 9,
         "definition": 59,
         "example": 69,
         "hint": 54,
-        "category": 26
+        "category": 5
       },
       "source": {
         "sequence": 24,
-        "categoryId": "relationships"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -691,20 +691,20 @@
         "definition": "542c4508ed4d7cab304996aa1bd3cbcb3b9316f65a4e6dc7d13f557dadfd47f3",
         "example": "7340bc165fdd614af74e4a12532e01a043823c9a6a559a5adb51ed1bde0c3a83",
         "hint": "b5eba26be8048a76bbec612fa789d77108b9ee554af0858cdfa7572d614df309",
-        "category": "fc31d6a2796e8e103ddb394c31b1d72415f776d882faaf2b0fe77a6c3645a76e",
-        "combined": "eb01b0a714d6a47b5eafa7564553555e75944c23c0ab237519cd33e59888e645",
-        "tokenSignature": "a-been-but-daily-defined-feels-for-friends-fully-hasn-in-it-labeled-labels-life-months-more-movie-nights-no-not-official-relationship-relationships-romantic-s-situationship-t-than-that-use-ve-vibe-we-when"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "fac5df5a70f0f8311a914639cf6237e56dcfb1c615820f66844bbf65f4393a56",
+        "tokenSignature": "a-been-but-defined-feels-for-friends-fully-gen-hasn-in-it-labeled-labels-months-more-movie-nights-no-not-official-relationship-romantic-s-situationship-t-than-that-use-ve-vibe-we-when-z"
       },
       "lengths": {
         "term": 13,
         "definition": 63,
         "example": 65,
         "hint": 66,
-        "category": 26
+        "category": 5
       },
       "source": {
         "sequence": 25,
-        "categoryId": "relationships"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -719,20 +719,20 @@
         "definition": "6092c472b1eb8b11d089a7908b2d8e5066dc6e2aa188c481c2a46502c881eec8",
         "example": "3795dc92894dcb8fbfb0061e46ec50e55806180920fc45e3dfde46406c6c2642",
         "hint": "58b8de61be727bd362edba45ea45ff4fb13c27c0989d6324bf8a4d85f51e750b",
-        "category": "fc31d6a2796e8e103ddb394c31b1d72415f776d882faaf2b0fe77a6c3645a76e",
-        "combined": "35bcc3f136aad4db2b7d7b51c9828cde12dab95d824dac3ad2eae99a4cba055e",
-        "tokenSignature": "a-and-announcement-before-coffee-cups-daily-feed-full-her-hints-instead-is-it-launch-launched-life-new-no-of-or-partner-project-relationship-relationships-reveal-she-soft-someone-story-subtle-tags-teasing-the-two-up-use-warming-when-with"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "3ce8d1087a871f03882af78857a07fe8c4da6c65289c4159e78b140e7ff10e1f",
+        "tokenSignature": "a-and-announcement-before-coffee-cups-feed-full-gen-her-hints-instead-is-it-launch-launched-new-no-of-or-partner-project-relationship-reveal-she-soft-someone-story-subtle-tags-teasing-the-two-up-use-warming-when-with-z"
       },
       "lengths": {
         "term": 11,
         "definition": 76,
         "example": 74,
         "hint": 70,
-        "category": 26
+        "category": 5
       },
       "source": {
         "sequence": 26,
-        "categoryId": "relationships"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -747,20 +747,20 @@
         "definition": "cfec34d270dba00fb4c350e03f1d8efb31cbc0e019c9eb00ee3983a1f7a4a2bf",
         "example": "4b736cad0db5cea37b09048998138fc0d4e640663bd0de7cd78fb73658ff4b99",
         "hint": "8fb8e8eb5805ba46c65eb32587ae6ab2231a98f4df797dcc0a7a94256ac4cccd",
-        "category": "fc31d6a2796e8e103ddb394c31b1d72415f776d882faaf2b0fe77a6c3645a76e",
-        "combined": "69799eec8dcdcdf8221656481a600f0f9b2f0ed61bb0349aba1dc04f5b244a71",
-        "tokenSignature": "a-after-and-caption-carousel-daily-ends-hard-is-it-launch-leaves-life-months-mystery-no-of-official-photos-questions-relationships-reveal-tags-teasing-that-the-their-unmistakable-use-vacation-was-when"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "207dfe494a1211ef945d40a5c9fcbe5f217345e08485407783c547b5d5a59146",
+        "tokenSignature": "a-after-and-caption-carousel-ends-gen-hard-is-it-launch-leaves-months-mystery-no-of-official-photos-questions-reveal-tags-teasing-that-the-their-unmistakable-use-vacation-was-when-z"
       },
       "lengths": {
         "term": 11,
         "definition": 73,
         "example": 66,
         "hint": 60,
-        "category": 26
+        "category": 5
       },
       "source": {
         "sequence": 27,
-        "categoryId": "relationships"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -775,20 +775,20 @@
         "definition": "706bf828a6d1d08517508bd1ac643dcbd1835efe1cb088d25f9b537894a42ade",
         "example": "91daae1a24258d0237120b7772cd71e3e1ee3b038496a1980aedaa67c220e989",
         "hint": "5ff6b004265e2b7c37086ace8c172baf5a062f7aae8234b530bae62a9331bf7b",
-        "category": "fc31d6a2796e8e103ddb394c31b1d72415f776d882faaf2b0fe77a6c3645a76e",
-        "combined": "33e621ca083850d38fda2b0b72ee48eb3afd4c66e80babb07418a2013fdd23b8",
-        "tokenSignature": "a-adventure-becomes-but-daily-day-detour-detours-edition-for-from-grocery-highlight-hunt-it-life-limited-main-of-or-plan-quest-random-relationships-shopping-side-sneakers-spontaneous-task-that-the-to-took-use-we-were-when"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "f510796468f8b59811884c9579cf7740b117f322ad9f0bfe31e77ae5d4c69099",
+        "tokenSignature": "a-adventure-becomes-but-day-detour-detours-edition-for-from-gen-grocery-highlight-hunt-it-limited-main-of-or-plan-quest-random-shopping-side-sneakers-spontaneous-task-that-the-to-took-use-we-were-when-z"
       },
       "lengths": {
         "term": 10,
         "definition": 59,
         "example": 84,
         "hint": 66,
-        "category": 26
+        "category": 5
       },
       "source": {
         "sequence": 28,
-        "categoryId": "relationships"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -803,20 +803,20 @@
         "definition": "fa63b8120c92e2c5464e03a004f9d6f9c4af7771947f547a445beaa591807ea2",
         "example": "6403fa87f2c53e709f62955e705825c4c74237c55afdb35f2f2fca952fee483f",
         "hint": "6a87477963f9248fe4b3d9788b760ab2fa488a9b42a9bca7d9959a0c8b8e9fa9",
-        "category": "fc31d6a2796e8e103ddb394c31b1d72415f776d882faaf2b0fe77a6c3645a76e",
-        "combined": "19f68eeacd2be29d736c8151a38560c751781cce3cbfdedfcd2526c8469d4bc2",
-        "tokenSignature": "a-and-assembled-cheese-cobble-cooking-cozy-crackers-daily-dinner-from-girl-good-in-instead-is-it-kitchen-life-looks-meal-my-of-plate-relationships-snack-strawberries-style-the-three-together-tonight-types-use-whatever-when-you"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "3926387dfa38376fbc87cfe1364a16a224c144e392679e8f9a89af1667fa5c42",
+        "tokenSignature": "a-and-assembled-cheese-cobble-cooking-cozy-crackers-dinner-from-gen-girl-good-in-instead-is-it-kitchen-looks-meal-my-of-plate-snack-strawberries-style-the-three-together-tonight-types-use-whatever-when-you-z"
       },
       "lengths": {
         "term": 11,
         "definition": 69,
         "example": 76,
         "hint": 70,
-        "category": 26
+        "category": 5
       },
       "source": {
         "sequence": 29,
-        "categoryId": "relationships"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -831,20 +831,20 @@
         "definition": "8e438d92bd54803352b40f6d674bac0df80df1ad62acdfa1addfdeced897ece8",
         "example": "3c198d4de6ffa08dd3d32e4f5de7362b30848f873500353cc4bc08a95fa61daf",
         "hint": "636bcaff2dc4b5e766f90cab7c5f82a8cfa665954a5201dac82fa24baed3f977",
-        "category": "fc31d6a2796e8e103ddb394c31b1d72415f776d882faaf2b0fe77a6c3645a76e",
-        "combined": "851df143d49d330b6fcf63a73d6ae49da792d89fcbc121bfee9f58287814ef41",
-        "tokenSignature": "a-before-bestie-circle-closest-daily-endearment-fave-for-friend-go-hyping-in-inner-it-jacket-life-link-me-of-online-or-out-re-relationships-sells-send-someone-term-that-the-to-use-when-you-your"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "16a62f474688e38e5f85a65d7f7ff732746c287563f839617d5d049556e303a6",
+        "tokenSignature": "a-before-bestie-circle-closest-endearment-fave-for-friend-gen-go-hyping-in-inner-it-jacket-link-me-of-online-or-out-re-sells-send-someone-term-that-the-to-use-when-you-your-z"
       },
       "lengths": {
         "term": 6,
         "definition": 66,
         "example": 60,
         "hint": 55,
-        "category": 26
+        "category": 5
       },
       "source": {
         "sequence": 30,
-        "categoryId": "relationships"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -859,20 +859,20 @@
         "definition": "504a389f421157c246a37c1a6ba90a0f3bee5aae63f7f24352bc2f3ca72f7c2c",
         "example": "1164a2602369c414ec5d9f9f6dc6bd7271f472c985189fb1b31facd287277f60",
         "hint": "440aa18fd97b69c521aae1bbf2400a54e02ef4d71f7875d34df62a487046c9f2",
-        "category": "fc31d6a2796e8e103ddb394c31b1d72415f776d882faaf2b0fe77a6c3645a76e",
-        "combined": "73410a5757a739278dc37e781e4840b85a30d857c8d46474d83eedb866c796b5",
-        "tokenSignature": "a-adulting-all-and-catching-chores-d-daily-emails-even-felt-folding-grown-handling-human-it-laundry-life-like-not-on-or-paperwork-peak-rather-re-relationships-responsibilities-responsible-sunday-tackling-up-use-when-you"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "c5d8569c001e8f0b39c3f5d3765f7b6357c7094eb25f65049c611b0dfc0989dc",
+        "tokenSignature": "a-adulting-all-and-catching-chores-d-emails-even-felt-folding-gen-grown-handling-human-it-laundry-like-not-on-or-paperwork-peak-rather-re-responsibilities-responsible-sunday-tackling-up-use-when-you-z"
       },
       "lengths": {
         "term": 8,
         "definition": 62,
         "example": 77,
         "hint": 73,
-        "category": 26
+        "category": 5
       },
       "source": {
         "sequence": 31,
-        "categoryId": "relationships"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -887,20 +887,20 @@
         "definition": "352ca04b03319f3b86fbc193f993e0e10d7c31fe45c429cf0b8a05b5efb841b7",
         "example": "665a2f20cba7fea8072ae8c2d2690aaa7e0dc042d2680d99801e1b7486f4199d",
         "hint": "512afd51d8d22ce499e25514f013e7a4c7e5a9ee232b2e5f50fff99b0a3e99e8",
-        "category": "00190eb0145de0d0b5e6b986dab2becdead79c3a3935186a64528e87dde29bf1",
-        "combined": "1bae71d6e3988d352550e5bf72c3bf7f8694c98897d979d85f3a1bbae0ead1c0",
-        "tokenSignature": "a-accessory-aesthetic-chasing-drip-effortlessly-fashionable-festival-for-game-had-him-his-is-it-look-or-outfit-photographers-s-seriously-shots-someone-street-style-stylish-use-when"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "28626f5da5509c60f4ae2523c8887989c0e8032f6c7bf5f6263f249aa6d7e802",
+        "tokenSignature": "a-accessory-alpha-chasing-drip-effortlessly-fashionable-festival-for-game-gen-had-him-his-is-it-look-or-outfit-photographers-s-seriously-shots-someone-street-style-stylish-use-when"
       },
       "lengths": {
         "term": 4,
         "definition": 45,
         "example": 71,
         "hint": 55,
-        "category": 17
+        "category": 9
       },
       "source": {
         "sequence": 32,
-        "categoryId": "style"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -915,20 +915,20 @@
         "definition": "ab560d29dfabe41ccdfb9ecdf2a42b029263d5c495f26d3ebe6b5733ca05218e",
         "example": "fa0bbaf5f9751f6581458e553295358616462868262c5fb1058d36b5ea1eb0f0",
         "hint": "70a88606a45f7b6e4782f37ba7b9e648de8c4e315f5a725d95ba4f2c8dce456c",
-        "category": "00190eb0145de0d0b5e6b986dab2becdead79c3a3935186a64528e87dde29bf1",
-        "combined": "6a5fc1e71f8c19a933a6e2f696a6c1096832c498316498c9674865f06b5f7fe3",
-        "tokenSignature": "a-accident-aesthetic-before-by-chat-check-don-drop-fit-from-group-head-in-it-leave-of-or-outfit-outfits-quick-rate-rating-s-show-showcase-so-someone-squad-style-t-the-their-to-toe-twin-use-want-we-when-you-your"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "8e959f4548529ea2207374bd3ba320118e96e6e5828c0512e47c0bc11eab28ae",
+        "tokenSignature": "a-accident-alpha-before-by-chat-check-don-drop-fit-from-gen-group-head-in-it-leave-of-or-outfit-outfits-quick-rate-rating-s-show-showcase-so-someone-squad-t-the-their-to-toe-twin-use-want-we-when-you-your"
       },
       "lengths": {
         "term": 9,
         "definition": 64,
         "example": 83,
         "hint": 61,
-        "category": 17
+        "category": 9
       },
       "source": {
         "sequence": 33,
-        "categoryId": "style"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -943,20 +943,20 @@
         "definition": "b39f931207420a636104195441b507f856412c78f45ae4b9d6dddb437def314a",
         "example": "3b71d50c171c5b5b6a7a2f648e36368e6db4b051b3d977848287ac15d56bba05",
         "hint": "90353e6a7eb4018e65f16a9da4d19b5d67d376f15ddd184d484c4543ccb9fa91",
-        "category": "00190eb0145de0d0b5e6b986dab2becdead79c3a3935186a64528e87dde29bf1",
-        "combined": "2c38aa2cc70d82fcb1789a544167fab57afc56fa8b20f05fd3df35d69d4119ac",
-        "tokenSignature": "a-aesthetic-and-bun-clean-dewy-fit-fresh-full-girl-gold-hair-hoops-in-is-it-look-minimal-mode-monochrome-neutral-polished-pulled-put-s-she-simple-skin-slick-someone-style-together-tones-ultra-up-use-when-with"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "6ce9b14d736f807580216eaf238eb03eb23ba574d6c7a81efd22e5a9fbc4d20a",
+        "tokenSignature": "a-aesthetic-alpha-and-bun-clean-dewy-fit-fresh-full-gen-girl-gold-hair-hoops-in-is-it-look-minimal-mode-monochrome-neutral-polished-pulled-put-s-she-simple-skin-slick-someone-together-tones-ultra-up-use-when-with"
       },
       "lengths": {
         "term": 10,
         "definition": 76,
         "example": 82,
         "hint": 68,
-        "category": 17
+        "category": 9
       },
       "source": {
         "sequence": 34,
-        "categoryId": "style"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -971,20 +971,20 @@
         "definition": "5f959e2c1bef32dba8f4aa4015290328560f3fa61776fc022eef6ae6174b252c",
         "example": "6d6cbef35437a6997f786ab36b437239da77fefc424c0960dbbd1f9d0470e85f",
         "hint": "51c16e47cd08da583b6354d63a290bbcff54ec8937fbef3bca8d28708458c53b",
-        "category": "00190eb0145de0d0b5e6b986dab2becdead79c3a3935186a64528e87dde29bf1",
-        "combined": "5a0b92f4e234c856e85c93fbfd8573b9d2020b137d425237986afcbce976ee34",
-        "tokenSignature": "a-aesthetic-after-and-cinched-crazy-dress-glam-had-her-is-it-look-looking-makeup-often-on-or-perfectly-photos-point-prep-prom-sculpted-sharply-snatched-style-styled-tailored-the-use-waist-went-when"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "ce3d1004f7fc2431c5d8b3c7c34c16bbc54f307ab37ef94b19a5fc5e65592148",
+        "tokenSignature": "a-after-alpha-and-cinched-crazy-dress-gen-glam-had-her-is-it-look-looking-makeup-often-on-or-perfectly-photos-point-prep-prom-sculpted-sharply-snatched-styled-tailored-the-use-waist-went-when"
       },
       "lengths": {
         "term": 8,
         "definition": 70,
         "example": 64,
         "hint": 61,
-        "category": 17
+        "category": 9
       },
       "source": {
         "sequence": 35,
-        "categoryId": "style"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -999,20 +999,20 @@
         "definition": "dbf9ffb12117a890fde5dc571a68690d1d0a392d79f196c309854185f7247596",
         "example": "e7537b9dae590a4c3a87691be2c952bd322068a7581cc5933ff507623b6327ad",
         "hint": "1868dbf1eb0da7cb5cd90d0ec23a10f6db3c37fc3f5941aab038dde8bc1c2063",
-        "category": "00190eb0145de0d0b5e6b986dab2becdead79c3a3935186a64528e87dde29bf1",
-        "combined": "c7e875eabb3711363a3e17af9dc49bb0023b03afed41db2914c1b4ea355bdadd",
-        "tokenSignature": "a-aesthetic-and-begged-everyone-finds-for-found-from-full-gems-haul-he-it-name-of-off-posted-reveal-scored-secondhand-show-store-style-tees-the-thrift-thrifting-use-vintage-when-while-you"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "f24bfd5345c7e32bb43406fba3dfa5053b41bc9aafb8040ee7512adecfb37893",
+        "tokenSignature": "a-alpha-and-begged-everyone-finds-for-found-from-full-gems-gen-haul-he-it-name-of-off-posted-reveal-scored-secondhand-show-store-tees-the-thrift-thrifting-use-vintage-when-while-you"
       },
       "lengths": {
         "term": 11,
         "definition": 51,
         "example": 84,
         "hint": 60,
-        "category": 17
+        "category": 9
       },
       "source": {
         "sequence": 36,
-        "categoryId": "style"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -1027,20 +1027,20 @@
         "definition": "e5ffaf392d75ba9eb42fe1196aafe23f4bb4f8ca91748602ebad3aa196883c62",
         "example": "79a6dabf995bd51a99b7271c9379ea69c7a271fbbe3a62bcea1c2a9d95ae2b2f",
         "hint": "e1e03306b561ce7e809d562df1d7e3d3b42bd9c6c4c216e416f341a00368548a",
-        "category": "00190eb0145de0d0b5e6b986dab2becdead79c3a3935186a64528e87dde29bf1",
-        "combined": "9a6bcc020ecfcfbbe333aa906f8a4f3c383e23c97721199895e0ccb040cd87d6",
-        "tokenSignature": "a-aesthetic-and-confidence-deserves-glow-hair-her-improvement-in-included-it-job-major-new-or-overall-s-someone-spotlight-style-this-transformation-unstoppable-up-use-vibe-when-year"
+        "category": "51d1d02d6d86fed8b6b050bb731018a7a9e552944894995ad463c35fb9df163a",
+        "combined": "b676b81a144890323afd4388762b328ed793eb1a4084090d406b78cade600a34",
+        "tokenSignature": "a-alpha-and-confidence-deserves-gen-glow-hair-her-improvement-in-included-it-job-major-new-or-overall-s-someone-spotlight-style-this-transformation-unstoppable-up-use-vibe-when-year"
       },
       "lengths": {
         "term": 7,
         "definition": 58,
         "example": 79,
         "hint": 58,
-        "category": 17
+        "category": 9
       },
       "source": {
         "sequence": 37,
-        "categoryId": "style"
+        "categoryId": "gen-alpha"
       },
       "embedding": {
         "status": "pending",
@@ -1055,20 +1055,20 @@
         "definition": "df6e55138cbcda70432d23e4984fc05837b8ada72d84cf0f0fb843e291c4172d",
         "example": "38da859d40d3b7916faa0e27edf94909d94b0d656cbcb7540f1f532d03f5fe2a",
         "hint": "1fbf37ac8307883c2a1ff7ed5f7e2a07085c7e512404955209e9a9dab9fe3a5e",
-        "category": "2964224f9c24740bc17a90cc7d5bc9dc2abd27b383b5eaee701d87408ec6e490",
-        "combined": "618be1cc69e36e120e535fa93a46a37a19249c96a77fa56df2ad31745950f7d5",
-        "tokenSignature": "a-afterparty-before-check-class-did-energy-feelings-gauging-in-inviting-it-jumping-making-mood-move-on-quick-re-read-room-s-the-to-use-vibe-vibes-we-when-whole-you"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "330e17616a64bc3eafa77b37c6b1ca02545ffad98519495f4d18a01e12c67b01",
+        "tokenSignature": "a-afterparty-before-check-class-did-energy-gauging-gen-in-inviting-it-jumping-making-mood-move-on-quick-re-read-room-s-the-to-use-vibe-we-when-whole-you-z"
       },
       "lengths": {
         "term": 10,
         "definition": 55,
         "example": 70,
         "hint": 54,
-        "category": 16
+        "category": 5
       },
       "source": {
         "sequence": 38,
-        "categoryId": "vibes"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -1083,20 +1083,20 @@
         "definition": "ef9b3101258f7afdae2fdb8a9f5e85bc1af5e328fef5d8db9ed266da36e25bae",
         "example": "940dee7635e38f77a68be0a6885722fb584b5c174ff11e8b471594cfc3d904dd",
         "hint": "98308ae417510ff70ca7e40f34b840ce1e053f128b8b093a57c97a34ce15d54a",
-        "category": "2964224f9c24740bc17a90cc7d5bc9dc2abd27b383b5eaee701d87408ec6e490",
-        "combined": "99e2724ba83f0006c56dadbae66e2646663ede9ff3ec5c35fe14b39bf4d23622",
-        "tokenSignature": "a-aesthetic-bookstore-compare-cozy-decor-energy-feelings-game-giving-idea-is-it-look-lounge-mixed-moment-nails-new-night-or-particular-s-someone-specific-the-to-use-vibe-vibes-way-when-with"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "6603d9262f6ad5c9eb7750abfa3c61cfaeb97c38ff7180bd0751ba0c4d7216e4",
+        "tokenSignature": "a-aesthetic-bookstore-compare-cozy-decor-energy-game-gen-giving-idea-is-it-look-lounge-mixed-moment-nails-new-night-or-particular-s-someone-specific-the-to-use-vibe-way-when-with-z"
       },
       "lengths": {
         "term": 11,
         "definition": 64,
         "example": 68,
         "hint": 55,
-        "category": 16
+        "category": 5
       },
       "source": {
         "sequence": 39,
-        "categoryId": "vibes"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -1111,20 +1111,20 @@
         "definition": "e2f4d521039038895949bf7c22c41f2f362593a8e73d2e22dd85f5b45e177a6f",
         "example": "f20dc565e9d001f2c4d3eb634c38caa8c2a4258a16b53f626549a107b7d65152",
         "hint": "4c1655cc1b8901ca00b2a985418682b10396ae0ddc70d01b344d114bfc845a38",
-        "category": "2964224f9c24740bc17a90cc7d5bc9dc2abd27b383b5eaee701d87408ec6e490",
-        "combined": "a5829c0cca519bb7f1a5ec555d4290703c2d77733ee674e31304f226749b1458",
-        "tokenSignature": "a-admit-big-cool-even-excited-feelings-for-i-it-keep-key-low-m-or-playing-presentation-quiet-scene-secretly-softly-something-spotlight-subtle-the-though-to-true-use-vibes-want-wanting-when-without-you"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "a5d5c93398e45c3043f28fec73bb5211b98136eb2b941c2603ac2bb0bc72aacd",
+        "tokenSignature": "a-admit-big-cool-even-excited-for-gen-i-it-keep-key-low-m-or-playing-presentation-quiet-scene-secretly-softly-something-spotlight-subtle-the-though-to-true-use-want-wanting-when-without-you-z"
       },
       "lengths": {
         "term": 7,
         "definition": 60,
         "example": 76,
         "hint": 69,
-        "category": 16
+        "category": 5
       },
       "source": {
         "sequence": 40,
-        "categoryId": "vibes"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -1139,20 +1139,20 @@
         "definition": "65f98d667dd85f282a7460360eafdcd56811a6b4de6e29901c8aa69791f5fdbe",
         "example": "719a3239e5d962d499945b43d612e73d3187c7745e25743a5a26d20288a4be10",
         "hint": "350799351cf74133e229af0594675ce1569c85588c7bdd4fd1f527481651ea7b",
-        "category": "2964224f9c24740bc17a90cc7d5bc9dc2abd27b383b5eaee701d87408ec6e490",
-        "combined": "e558306642219eb2bf34ec056dd406d4802b8fe8a4ccea69f479baac29250d9d",
-        "tokenSignature": "about-afraid-and-be-blatant-book-drop-everything-feel-feelings-hide-high-i-impossible-it-key-loud-not-obvious-or-re-that-to-trip-use-very-vibes-want-weekend-what-when-you"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "e5a582538025717e537de3b1a8ac07544e04a9f8f4f3b84cf9f3fed82416e456",
+        "tokenSignature": "about-afraid-and-be-blatant-book-drop-everything-feel-gen-hide-high-i-impossible-it-key-loud-not-obvious-or-re-that-to-trip-use-very-want-weekend-what-when-you-z"
       },
       "lengths": {
         "term": 8,
         "definition": 42,
         "example": 62,
         "hint": 64,
-        "category": 16
+        "category": 5
       },
       "source": {
         "sequence": 41,
-        "categoryId": "vibes"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -1167,20 +1167,20 @@
         "definition": "9206a06253e5e0502f80b5329872f1765ef808ef76c5b61a75d067d3c97c7e9d",
         "example": "f28b27c3d40475fc1b680ebf4f4928e9fba3af0a72cf0ac42c102f4b373ffd2a",
         "hint": "086cec1f2b7c0eac4641ac98929dfa6d3decc7bd291adf751b375cf60d11da5a",
-        "category": "2964224f9c24740bc17a90cc7d5bc9dc2abd27b383b5eaee701d87408ec6e490",
-        "combined": "c5e46b0757a38a183c2263bf3df9ec586ba21ea7b3017f696cc5de3615bcfa5a",
-        "tokenSignature": "acing-acting-after-all-and-are-campus-character-exam-eyes-feelings-her-in-is-it-knows-life-like-main-motion-movie-on-owns-she-slow-someone-spotlight-the-their-them-through-use-vibes-walked-when"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "eb2c002ba885486c65e088ef68e690dd4c3caf628051b6876cc89bd378b9107b",
+        "tokenSignature": "acing-acting-after-all-and-are-campus-character-exam-eyes-gen-her-in-is-it-knows-life-like-main-motion-movie-on-owns-she-slow-someone-spotlight-the-their-them-through-use-walked-when-z"
       },
       "lengths": {
         "term": 14,
         "definition": 65,
         "example": 86,
         "hint": 52,
-        "category": 16
+        "category": 5
       },
       "source": {
         "sequence": 42,
-        "categoryId": "vibes"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -1195,20 +1195,20 @@
         "definition": "8633fa9c9026a15978c7913bddc46c2cb7dcb92f58f20ce36a3dba9d8eea1b58",
         "example": "ac2e54f09beb4a1b168e26141c28ae8c58b7f34c6c61e00770da4e5d0d01961d",
         "hint": "23c780c63b0881580ee0e0944d435392bd1543cb49e8d669afa9bcf708132fc9",
-        "category": "2964224f9c24740bc17a90cc7d5bc9dc2abd27b383b5eaee701d87408ec6e490",
-        "combined": "6272aaf226a5a79878fdc5ec1d351cce9a03388a5dce08bf0e91ca0b515f1efe",
-        "tokenSignature": "a-after-back-bed-big-brunch-crawling-extremely-feel-feeling-feelings-feels-how-into-is-it-matches-mood-now-or-perfectly-relatable-right-situation-something-that-use-vibes-when-you"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "dda30e9e413011764bbf5e9f11d2da04fb864a4f9db8fa21114deb26c0d8a3d2",
+        "tokenSignature": "a-after-back-bed-big-brunch-crawling-extremely-feel-feeling-feels-gen-how-into-is-it-matches-mood-now-or-perfectly-relatable-right-situation-something-that-use-when-you-z"
       },
       "lengths": {
         "term": 8,
         "definition": 54,
         "example": 60,
         "hint": 53,
-        "category": 16
+        "category": 5
       },
       "source": {
         "sequence": 43,
-        "categoryId": "vibes"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -1223,20 +1223,20 @@
         "definition": "04a3794a857eae60d10235bc619c8fe66ccb5dd1d4b36e6aa6b01ac527c16189",
         "example": "0a872308d2baba99980898acc84e7e7a261663105fb0b3fd4f85d3fb4134187d",
         "hint": "33708c22c74ea91821a50ffb9cb1aff58a3238417eba7376690aea2d0b745e48",
-        "category": "2964224f9c24740bc17a90cc7d5bc9dc2abd27b383b5eaee701d87408ec6e490",
-        "combined": "be99a92632ed43280056454b298b2da2e3dd422c7c55f9654dbf5bf31772027c",
-        "tokenSignature": "allowed-are-completely-concentration-distractions-feelings-finals-focused-for-full-game-in-is-it-locked-mode-nights-on-pause-re-so-someone-use-vibes-we-week-when-with-zero"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "4f8f7e3b9dbfd7a9cfb6197adafd9c942a03ea295ccc696a579a22eef056ead8",
+        "tokenSignature": "allowed-are-completely-concentration-distractions-finals-focused-for-full-game-gen-in-is-it-locked-mode-nights-on-pause-re-so-someone-use-we-week-when-with-z-zero"
       },
       "lengths": {
         "term": 9,
         "definition": 50,
         "example": 61,
         "hint": 50,
-        "category": 16
+        "category": 5
       },
       "source": {
         "sequence": 44,
-        "categoryId": "vibes"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",
@@ -1251,20 +1251,20 @@
         "definition": "418d96c456ef698a3395d8024d4749052c1daf8f126e10fb667d7ad573eee782",
         "example": "8233067e6ae4e125cbbd6bce2b6cbbbffddb4677ed9522a3d31e9665ff85905e",
         "hint": "e2d4e0d84a873e82f6cea97df56ca2ee7fae22339513aa194a3a36c1b0385603",
-        "category": "2964224f9c24740bc17a90cc7d5bc9dc2abd27b383b5eaee701d87408ec6e490",
-        "combined": "6c6b4b507756543565c9b3d4a3c97904cb5a4c4e6ab02aeadec55ad15a6334ad",
-        "tokenSignature": "a-because-booked-doing-feelings-for-great-interesting-it-just-keep-last-later-life-mainly-make-minute-plot-purely-risk-road-something-story-take-the-to-trip-use-vibes-we-when-will-you"
+        "category": "6c3b9eb90037aebba64f9aa14af6509442fc9b2e41f43bb47bb76b6b45c76a27",
+        "combined": "154323375ce7b5714df10c7924685d1619048fdd73cd30804453fcdfca2c7511",
+        "tokenSignature": "a-because-booked-doing-for-gen-great-interesting-it-just-keep-last-later-life-mainly-make-minute-plot-purely-risk-road-something-story-take-the-to-trip-use-we-when-will-you-z"
       },
       "lengths": {
         "term": 12,
         "definition": 64,
         "example": 56,
         "hint": 58,
-        "category": 16
+        "category": 5
       },
       "source": {
         "sequence": 45,
-        "categoryId": "vibes"
+        "categoryId": "gen-z"
       },
       "embedding": {
         "status": "pending",


### PR DESCRIPTION
## Summary
- remap every slang entry so only the Gen Alpha and Gen Z categories remain in the deck metadata
- refresh the slang navigator and all-slang pages to talk about generational filtering and keep the labels accurate

## Testing
- node --check apps/slang/slang.js
- node -e "global.window = {}; require('./apps/slang/slang.js'); console.log(Array.isArray(window.slangEntries), window.slangEntries.length);"
- node tools/update-content-metadata.js --dataset=slang
- npx playwright test tests/slang-app.spec.js
- npx playwright test tests/home-navigation.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d2d9e1f730832884e6696301ffac45