### PR TITLE
Fix hidden state for slang usage hint

### DIFF
--- a/apps/slang/app.js
+++ b/apps/slang/app.js
@@ -137,6 +137,7 @@
 
     if (hintWrapper) {
       const shouldShowHint = visible && hasHint;
+      hintWrapper.classList.toggle('is-visible', shouldShowHint);
       hintWrapper.hidden = !shouldShowHint;
       hintWrapper.setAttribute('aria-hidden', shouldShowHint ? 'false' : 'true');
       if (hintText) {

--- a/apps/slang/index.html
+++ b/apps/slang/index.html
@@ -265,9 +265,13 @@
 
     .card__hint {
       margin: 0;
-      display: grid;
+      display: none;
       gap: 6px;
       color: var(--meaning-color);
+    }
+
+    .card__hint.is-visible {
+      display: grid;
     }
 
     .card__hint-label {

--- a/data/slang-manifest.json
+++ b/data/slang-manifest.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "generatedAt": "2025-09-23T17:59:48.748Z",
+    "generatedAt": "2025-09-23T23:01:13.905Z",
     "total": 45,
     "hashAlgorithm": "sha256",
     "tokenSignature": "unique-words-v1",

--- a/tests/slang-app.spec.js
+++ b/tests/slang-app.spec.js
@@ -49,6 +49,7 @@ test.describe('Slang app', () => {
     await expect(exampleWrapper).not.toHaveClass(/is-visible/);
     await expect(exampleWrapper).toHaveAttribute('aria-hidden', 'true');
     await expect(hintWrapper).toHaveAttribute('aria-hidden', 'true');
+    await expect(hintWrapper).toBeHidden();
     await expect(revealButton).toHaveAttribute('aria-pressed', 'false');
     await expect(revealButton).toBeEnabled();
     await expect(nextButton).toBeEnabled();
@@ -71,6 +72,7 @@ test.describe('Slang app', () => {
     const exampleText = ((await example.textContent()) || '').trim();
     expect(exampleText.length).toBeGreaterThan(0);
     await expect(hintWrapper).toHaveAttribute('aria-hidden', 'false');
+    await expect(hintWrapper).toBeVisible();
     const hintText = ((await hint.textContent()) || '').trim();
     expect(hintText.length).toBeGreaterThan(0);
 
@@ -81,6 +83,7 @@ test.describe('Slang app', () => {
     await expect(revealButton).toHaveAttribute('aria-pressed', 'false');
     await expect(exampleWrapper).not.toHaveClass(/is-visible/);
     await expect(hintWrapper).toHaveAttribute('aria-hidden', 'true');
+    await expect(hintWrapper).toBeHidden();
 
     const secondTerm = ((await term.textContent()) || '').trim();
     expect(secondTerm.length).toBeGreaterThan(0);
@@ -112,5 +115,6 @@ test.describe('Slang app', () => {
     await expect(revealButton).toHaveAttribute('aria-pressed', 'true');
     await expect(meaning).toHaveClass(/is-visible/);
     await expect(exampleWrapper).toHaveClass(/is-visible/);
+    await expect(hintWrapper).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- toggle an explicit `is-visible` class on the slang usage hint wrapper so the label stays hidden until reveal
- hide the hint container by default in CSS to match the new class toggle
- extend the slang Playwright spec to assert hint visibility and refresh the dataset manifest metadata

## Testing
- node --check apps/slang/slang.js
- node -e "global.window = {}; require('./apps/slang/slang.js'); console.log(Array.isArray(window.slangEntries), window.slangEntries.length);"
- node tools/update-content-metadata.js --dataset=slang
- npx playwright test tests/slang-app.spec.js


------
https://chatgpt.com/codex/tasks/task_e_68d324e2c83c8328b94a939683592355