### PR TITLE
Add offline caching service worker and manifest generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ node tools/generate-asset-report.js
 
 The script inspects every deck’s dataset, manifest, embedding store, similarity report, and upstream source file. It then writes an updated `apps/asset-observatory/asset-data.js` snapshot that the dashboard consumes to render charts and tables. Commit the refreshed file alongside your changes.
 
+## Offline bundle
+
+Load the homepage once while you have a connection to download the entire toolbox. A new service worker caches every HTML, JavaScript, and JSON asset referenced by `offline-manifest.json`, and the landing page shows a progress indicator while the larger embedding stores stream in. On iPhone, tap the Share icon in Safari and pick **Add to Home Screen** after the download finishes to launch the toolbox like an installed app.
+
+### Updating the cache manifest
+
+Any change to files under `apps/` or `data/` (or to `index.html` itself) requires a manifest refresh so the service worker can invalidate old caches. Regenerate the manifest and bump the cache version automatically with:
+
+```bash
+npm run build:offline
+```
+
+The script walks every HTML, JSON, and JavaScript file we ship, computes their sizes and a combined SHA-256 digest, and writes an updated `offline-manifest.json`. Commit the refreshed manifest together with your changes so clients pick up the new bundle the next time they load the homepage.
+
 ## Data maintenance
 
 - Run `node tools/update-content-metadata.js` after refreshing the jokes, quotes, or slang datasets to assign

--- a/index.html
+++ b/index.html
@@ -199,6 +199,91 @@
       margin: 0;
     }
 
+    .offline-card {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: clamp(16px, 2vw + 10px, 22px);
+      border-radius: 18px;
+      background: var(--row-background);
+      border: 1px solid var(--row-border);
+      box-shadow: var(--row-shadow);
+    }
+
+    .offline-card h2 {
+      margin: 0;
+      font-size: clamp(1.1rem, 0.5vw + 1rem, 1.35rem);
+    }
+
+    .offline-card__status {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.98rem;
+    }
+
+    .offline-card__meta {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    .offline-progress {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .offline-progress__bar {
+      position: relative;
+      width: 100%;
+      height: 12px;
+      border-radius: 999px;
+      background: rgba(74, 99, 255, 0.18);
+      overflow: hidden;
+    }
+
+    .offline-progress__fill {
+      position: absolute;
+      inset: 0;
+      background: var(--button-primary-background);
+      transform-origin: left;
+      transform: scaleX(0);
+      transition: transform 0.2s ease;
+    }
+
+    .offline-progress__detail {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--text-secondary);
+    }
+
+    .offline-card__hint {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--text-secondary);
+    }
+
+    .offline-card__steps {
+      margin: 0;
+    }
+
+    .offline-card__steps summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+
+    .offline-card__steps ol {
+      margin: 12px 0 0;
+      padding-left: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .offline-card__steps strong {
+      font-weight: 600;
+    }
+
     a.app-button--wide {
       width: 100%;
       justify-content: flex-start;
@@ -229,6 +314,28 @@
     <header class="site-header">
       <h1>Toolbox</h1>
     </header>
+    <section class="offline-card" data-offline-card aria-labelledby="offline-title">
+      <h2 id="offline-title">Offline bundle</h2>
+      <p class="offline-card__status" data-offline-status aria-live="polite">Loading offline manifest…</p>
+      <p class="offline-card__meta" data-offline-meta hidden></p>
+      <div class="offline-progress" data-offline-progress hidden>
+        <div class="offline-progress__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" data-offline-progress-bar>
+          <span class="offline-progress__fill" data-offline-progress-fill></span>
+        </div>
+        <p class="offline-progress__detail" data-offline-progress-detail></p>
+      </div>
+      <p class="offline-card__hint">
+        On iPhone, open Safari’s Share menu and choose <strong>Add to Home Screen</strong> after the download completes to launch the toolbox like an app.
+      </p>
+      <details class="offline-card__steps">
+        <summary>Step-by-step install</summary>
+        <ol>
+          <li>Load this page with a connection so the offline bundle can download.</li>
+          <li>Tap the Share icon <span aria-hidden="true">⬆️</span> in Safari.</li>
+          <li>Select <strong>Add to Home Screen</strong>, then confirm the shortcut name.</li>
+        </ol>
+      </details>
+    </section>
     <section class="app-groups" aria-labelledby="deck-section">
       <h2 id="deck-section" class="section-title">Deck collections</h2>
       <ul class="app-groups__list">
@@ -291,5 +398,163 @@
       </ul>
     </section>
   </main>
+  <script>
+    (function () {
+      const offlineCard = document.querySelector('[data-offline-card]');
+      if (!offlineCard) {
+        return;
+      }
+
+      const statusEl = offlineCard.querySelector('[data-offline-status]');
+      const metaEl = offlineCard.querySelector('[data-offline-meta]');
+      const progressWrapper = offlineCard.querySelector('[data-offline-progress]');
+      const progressBar = offlineCard.querySelector('[data-offline-progress-bar]');
+      const progressFill = offlineCard.querySelector('[data-offline-progress-fill]');
+      const progressDetail = offlineCard.querySelector('[data-offline-progress-detail]');
+
+      if (!statusEl || !progressWrapper || !progressBar || !progressFill || !progressDetail) {
+        return;
+      }
+
+      const formatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 });
+      const state = {
+        manifest: null
+      };
+
+      function setStatus(message) {
+        statusEl.textContent = message;
+      }
+
+      function updateMeta(text) {
+        if (!metaEl) {
+          return;
+        }
+
+        if (text) {
+          metaEl.hidden = false;
+          metaEl.textContent = text;
+        } else {
+          metaEl.hidden = true;
+          metaEl.textContent = '';
+        }
+      }
+
+      function formatBytes(bytes) {
+        if (!Number.isFinite(bytes) || bytes <= 0) {
+          return '0 B';
+        }
+
+        const units = ['B', 'KB', 'MB', 'GB'];
+        let value = bytes;
+        let unitIndex = 0;
+
+        while (value >= 1024 && unitIndex < units.length - 1) {
+          value /= 1024;
+          unitIndex += 1;
+        }
+
+        const fractionDigits = value >= 10 || unitIndex === 0 ? 0 : 1;
+        return `${formatter.format(Number(value.toFixed(fractionDigits)))} ${units[unitIndex]}`;
+      }
+
+      function setProgress(value) {
+        const clamped = Math.min(100, Math.max(0, value));
+        progressBar.setAttribute('aria-valuenow', String(Math.round(clamped)));
+        progressFill.style.transform = `scaleX(${clamped / 100})`;
+      }
+
+      function handleMessage(event) {
+        const payload = event.data;
+        if (!payload || payload.type !== 'offline-cache') {
+          return;
+        }
+
+        const detail = payload.detail || {};
+        const totalAssets = typeof detail.totalAssets === 'number' ? detail.totalAssets : 0;
+        const totalBytes = typeof detail.totalBytes === 'number' ? detail.totalBytes : 0;
+        const bundleSummary = totalAssets > 0 ? `Bundle v${detail.version || (state.manifest && state.manifest.version) || ''} · ${formatBytes(totalBytes)} across ${totalAssets} files` : '';
+
+        if (payload.state === 'start') {
+          progressWrapper.hidden = false;
+          setProgress(0);
+          progressDetail.textContent = `Downloading ${formatBytes(totalBytes)} of data…`;
+          setStatus('Caching offline bundle…');
+        } else if (payload.state === 'progress') {
+          const completed = typeof detail.completed === 'number' ? detail.completed : 0;
+          const loadedBytes = typeof detail.loadedBytes === 'number' ? detail.loadedBytes : 0;
+          const assetPath = detail.asset && detail.asset.path ? detail.asset.path : '';
+          const percent = totalBytes > 0 ? (loadedBytes / Math.max(totalBytes, 1)) * 100 : (completed / Math.max(totalAssets, 1)) * 100;
+
+          progressWrapper.hidden = false;
+          setProgress(percent);
+          progressDetail.textContent = [
+            `Cached ${completed} of ${totalAssets} files`,
+            `${formatBytes(loadedBytes)} / ${formatBytes(totalBytes)}`,
+            assetPath ? assetPath : null
+          ].filter(Boolean).join(' • ');
+          setStatus('Caching offline bundle…');
+        } else if (payload.state === 'complete') {
+          progressWrapper.hidden = true;
+          setProgress(100);
+          const readyText = detail.alreadyCached ? 'Offline bundle is up to date.' : 'Offline bundle ready for offline use.';
+          setStatus(readyText);
+          updateMeta(bundleSummary);
+        } else if (payload.state === 'error') {
+          progressWrapper.hidden = true;
+          setStatus('Offline caching failed. Refresh when you have a connection.');
+        }
+      }
+
+      function requestCaching(registration) {
+        if (!state.manifest || !registration || !registration.active) {
+          return;
+        }
+
+        registration.active.postMessage({
+          type: 'apply-manifest',
+          manifest: state.manifest
+        });
+      }
+
+      async function setup() {
+        if (!('serviceWorker' in navigator) || !('caches' in window)) {
+          setStatus('Offline caching is not available in this browser.');
+          return;
+        }
+
+        try {
+          const response = await fetch('offline-manifest.json', { cache: 'no-store' });
+          if (!response.ok) {
+            throw new Error(`Manifest request failed with status ${response.status}`);
+          }
+
+          const manifest = await response.json();
+          state.manifest = manifest;
+          const assets = Array.isArray(manifest.assets) ? manifest.assets : [];
+          const totalBytes = Number.isFinite(manifest.totalBytes) ? manifest.totalBytes : assets.reduce((total, asset) => total + (Number(asset.bytes) || 0), 0);
+          const summary = assets.length ? `Bundle v${manifest.version} · ${formatBytes(totalBytes)} across ${assets.length} files` : '';
+          updateMeta(summary);
+          setStatus('Offline bundle ready to download.');
+        } catch (error) {
+          console.error('Failed to load offline manifest', error);
+          setStatus('Unable to load the offline manifest. Refresh when you are back online.');
+          return;
+        }
+
+        try {
+          const registration = await navigator.serviceWorker.register('service-worker.js');
+          navigator.serviceWorker.addEventListener('message', handleMessage);
+
+          const readyRegistration = await navigator.serviceWorker.ready;
+          requestCaching(readyRegistration);
+        } catch (error) {
+          console.error('Service worker registration failed', error);
+          setStatus('Unable to register the offline service worker.');
+        }
+      }
+
+      setup();
+    })();
+  </script>
 </body>
 </html>

--- a/offline-manifest.json
+++ b/offline-manifest.json
@@ -1,0 +1,216 @@
+{
+  "version": "20250923-3a6ea8d9e669",
+  "generatedAt": "2025-09-23T23:13:33.557Z",
+  "totalAssets": 52,
+  "totalBytes": 5505782,
+  "assets": [
+    {
+      "path": "apps/asset-observatory/app.js",
+      "bytes": 21252
+    },
+    {
+      "path": "apps/asset-observatory/asset-data.js",
+      "bytes": 9553
+    },
+    {
+      "path": "apps/asset-observatory/index.html",
+      "bytes": 14530
+    },
+    {
+      "path": "apps/jokes/all-jokes-compact.html",
+      "bytes": 7825
+    },
+    {
+      "path": "apps/jokes/all-jokes.html",
+      "bytes": 4707
+    },
+    {
+      "path": "apps/jokes/app.js",
+      "bytes": 3228
+    },
+    {
+      "path": "apps/jokes/index.html",
+      "bytes": 6342
+    },
+    {
+      "path": "apps/jokes/jokes.js",
+      "bytes": 141344
+    },
+    {
+      "path": "apps/jokes/render-all.js",
+      "bytes": 4533
+    },
+    {
+      "path": "apps/quotes/all-quotes.html",
+      "bytes": 6908
+    },
+    {
+      "path": "apps/quotes/app.js",
+      "bytes": 4233
+    },
+    {
+      "path": "apps/quotes/index.html",
+      "bytes": 6093
+    },
+    {
+      "path": "apps/quotes/quotes-data.js",
+      "bytes": 121995
+    },
+    {
+      "path": "apps/quotes/render-all.js",
+      "bytes": 6081
+    },
+    {
+      "path": "apps/similarity-report/index.html",
+      "bytes": 118039
+    },
+    {
+      "path": "apps/slang/all-slang.html",
+      "bytes": 8592
+    },
+    {
+      "path": "apps/slang/app.js",
+      "bytes": 7649
+    },
+    {
+      "path": "apps/slang/index.html",
+      "bytes": 11360
+    },
+    {
+      "path": "apps/slang/render-all.js",
+      "bytes": 7325
+    },
+    {
+      "path": "apps/slang/slang.js",
+      "bytes": 19170
+    },
+    {
+      "path": "apps/value-formatter/index.html",
+      "bytes": 2832
+    },
+    {
+      "path": "data/curated-quotes.json",
+      "bytes": 22094
+    },
+    {
+      "path": "data/icanhazdadjokes-split.json",
+      "bytes": 123300
+    },
+    {
+      "path": "data/jokes-embeddings-cohere.json",
+      "bytes": 590002
+    },
+    {
+      "path": "data/jokes-embeddings-openai.json",
+      "bytes": 607564
+    },
+    {
+      "path": "data/jokes-embeddings.json",
+      "bytes": 590939
+    },
+    {
+      "path": "data/jokes-manifest.json",
+      "bytes": 567558
+    },
+    {
+      "path": "data/official-jokes-index.json",
+      "bytes": 61751
+    },
+    {
+      "path": "data/quotes-embeddings-cohere.json",
+      "bytes": 42311
+    },
+    {
+      "path": "data/quotes-embeddings-openai.json",
+      "bytes": 471956
+    },
+    {
+      "path": "data/quotes-embeddings.json",
+      "bytes": 456583
+    },
+    {
+      "path": "data/quotes-manifest.json",
+      "bytes": 478829
+    },
+    {
+      "path": "data/similarity-overrides.json",
+      "bytes": 1305
+    },
+    {
+      "path": "data/similarity-report-cross-deck-cohere.json",
+      "bytes": 5053
+    },
+    {
+      "path": "data/similarity-report-cross-deck-openai.json",
+      "bytes": 12391
+    },
+    {
+      "path": "data/similarity-report-cross-deck.json",
+      "bytes": 3322
+    },
+    {
+      "path": "data/similarity-report-jokes-cohere.json",
+      "bytes": 103093
+    },
+    {
+      "path": "data/similarity-report-jokes-openai.json",
+      "bytes": 41841
+    },
+    {
+      "path": "data/similarity-report-jokes.json",
+      "bytes": 30044
+    },
+    {
+      "path": "data/similarity-report-quotes-cohere.json",
+      "bytes": 466479
+    },
+    {
+      "path": "data/similarity-report-quotes-openai.json",
+      "bytes": 13485
+    },
+    {
+      "path": "data/similarity-report-quotes.json",
+      "bytes": 3233
+    },
+    {
+      "path": "data/similarity-report-slang-hfspace.json",
+      "bytes": 206
+    },
+    {
+      "path": "data/similarity-report-slang-s128.json",
+      "bytes": 163
+    },
+    {
+      "path": "data/similarity-report-slang.json",
+      "bytes": 162
+    },
+    {
+      "path": "data/slang-embeddings-hfspace.json",
+      "bytes": 110258
+    },
+    {
+      "path": "data/slang-embeddings-synthetic128.json",
+      "bytes": 46900
+    },
+    {
+      "path": "data/slang-embeddings.json",
+      "bytes": 31508
+    },
+    {
+      "path": "data/slang-manifest.json",
+      "bytes": 51910
+    },
+    {
+      "path": "data/test-runs/latest.json",
+      "bytes": 10622
+    },
+    {
+      "path": "index.html",
+      "bytes": 18681
+    },
+    {
+      "path": "service-worker.js",
+      "bytes": 8648
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A collection of lightweight browser apps served from a single landing page. Each mini-app focuses on quick interactions, from shuffling curated decks to formatting lists for development workflows.",
   "main": "index.js",
   "scripts": {
+    "build:offline": "node tools/generate-offline-manifest.js",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
     "test:record": "node tools/record-playwright-log.js"

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,355 @@
+const CACHE_PREFIX = 'toolbox-offline-v';
+const METADATA_CACHE = 'toolbox-offline-metadata';
+const METADATA_REQUEST = new Request(new URL('__toolbox-offline-manifest__', self.location).toString());
+const SERVICE_WORKER_PATH = new URL('service-worker.js', self.location.origin).pathname;
+const OFFLINE_MANIFEST_PATH = new URL('offline-manifest.json', self.location.origin).pathname;
+
+let activeCacheName = null;
+let pendingUpdate = null;
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    const stored = await readStoredManifest();
+    if (stored && typeof stored.version === 'string' && stored.version) {
+      activeCacheName = getCacheName(stored.version);
+    }
+
+    await cleanupCaches(activeCacheName);
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener('message', (event) => {
+  const data = event.data;
+  if (!data || data.type !== 'apply-manifest' || !data.manifest) {
+    return;
+  }
+
+  const manifest = data.manifest;
+  event.waitUntil(queueManifestUpdate(manifest));
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (url.pathname === SERVICE_WORKER_PATH) {
+    return;
+  }
+
+  if (url.pathname === OFFLINE_MANIFEST_PATH) {
+    event.respondWith(handleManifestRequest(event.request));
+    return;
+  }
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(handleNavigationRequest(event.request));
+    return;
+  }
+
+  event.respondWith(handleAssetRequest(event.request));
+});
+
+function getCacheName(version) {
+  return `${CACHE_PREFIX}${version}`;
+}
+
+async function queueManifestUpdate(manifest) {
+  if (!manifest || typeof manifest.version !== 'string' || !Array.isArray(manifest.assets)) {
+    return;
+  }
+
+  if (pendingUpdate) {
+    return pendingUpdate;
+  }
+
+  pendingUpdate = (async () => {
+    try {
+      await applyManifest(manifest);
+    } catch (error) {
+      console.error('Offline cache update failed', error);
+    } finally {
+      pendingUpdate = null;
+    }
+  })();
+
+  return pendingUpdate;
+}
+
+async function applyManifest(manifest) {
+  const version = manifest.version;
+  const assets = Array.isArray(manifest.assets) ? manifest.assets : [];
+  const totalAssets = assets.length;
+  const totalBytes = Number.isFinite(manifest.totalBytes)
+    ? manifest.totalBytes
+    : assets.reduce((sum, asset) => sum + (Number(asset.bytes) || 0), 0);
+  const cacheName = getCacheName(version);
+  const existingManifest = await readStoredManifest();
+  const cacheKeys = await caches.keys();
+  const cacheExists = cacheKeys.includes(cacheName);
+
+  if (existingManifest && existingManifest.version === version && cacheExists) {
+    activeCacheName = cacheName;
+    await broadcast({
+      type: 'offline-cache',
+      state: 'complete',
+      detail: {
+        version,
+        totalAssets,
+        totalBytes,
+        alreadyCached: true
+      }
+    });
+    return;
+  }
+
+  await broadcast({
+    type: 'offline-cache',
+    state: 'start',
+    detail: {
+      version,
+      totalAssets,
+      totalBytes
+    }
+  });
+
+  const cache = await caches.open(cacheName);
+  let loadedBytes = 0;
+  let completed = 0;
+
+  try {
+    for (const item of assets) {
+      const assetPath = item && typeof item.path === 'string' ? item.path : null;
+      if (!assetPath) {
+        continue;
+      }
+
+      const assetUrl = new URL(assetPath, self.location.origin).toString();
+      const request = new Request(assetUrl, { cache: 'reload' });
+      let response;
+
+      try {
+        response = await fetch(request);
+      } catch (error) {
+        await broadcast({
+          type: 'offline-cache',
+          state: 'error',
+          detail: {
+            version,
+            message: `Failed to fetch ${assetPath}`
+          }
+        });
+        throw error;
+      }
+
+      if (!response.ok) {
+        await broadcast({
+          type: 'offline-cache',
+          state: 'error',
+          detail: {
+            version,
+            message: `Unexpected response (${response.status}) for ${assetPath}`
+          }
+        });
+        throw new Error(`Failed to cache ${assetPath}`);
+      }
+
+      await cache.put(request, response.clone());
+
+      const assetBytes = Number(item.bytes) || 0;
+      loadedBytes += assetBytes;
+      completed += 1;
+
+      await broadcast({
+        type: 'offline-cache',
+        state: 'progress',
+        detail: {
+          version,
+          asset: {
+            path: assetPath,
+            bytes: assetBytes
+          },
+          completed,
+          totalAssets,
+          loadedBytes,
+          totalBytes
+        }
+      });
+    }
+  } catch (error) {
+    await caches.delete(cacheName).catch(() => {});
+    throw error;
+  }
+
+  const storedManifest = {
+    version,
+    generatedAt: manifest.generatedAt || new Date().toISOString(),
+    totalAssets,
+    totalBytes,
+    assets
+  };
+
+  await writeStoredManifest(storedManifest);
+  activeCacheName = cacheName;
+  await cleanupCaches(cacheName);
+
+  await broadcast({
+    type: 'offline-cache',
+    state: 'complete',
+    detail: {
+      version,
+      totalAssets,
+      totalBytes,
+      alreadyCached: false
+    }
+  });
+}
+
+async function handleManifestRequest(request) {
+  try {
+    const networkResponse = await fetch(request, { cache: 'no-store' });
+    if (networkResponse && networkResponse.ok) {
+      return networkResponse;
+    }
+  } catch (error) {
+    // Intentionally fall back to the stored manifest when offline.
+  }
+
+  const stored = await readStoredManifest();
+  if (stored) {
+    return new Response(JSON.stringify(stored), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store'
+      }
+    });
+  }
+
+  return fetch(request);
+}
+
+async function handleNavigationRequest(request) {
+  if (!activeCacheName) {
+    return fetch(request);
+  }
+
+  const cache = await caches.open(activeCacheName);
+  const url = new URL(request.url);
+  const candidates = [];
+
+  candidates.push(url.href);
+  if (url.pathname.endsWith('/')) {
+    candidates.push(new URL(`${url.pathname}index.html`, url.origin).href);
+  } else {
+    candidates.push(new URL(`${url.pathname}/index.html`, url.origin).href);
+  }
+  candidates.push(new URL('/index.html', url.origin).href);
+
+  for (const candidate of candidates) {
+    const cached = await cache.match(candidate);
+    if (cached) {
+      return cached;
+    }
+  }
+
+  try {
+    return await fetch(request);
+  } catch (error) {
+    const fallback = await cache.match(new URL('/index.html', url.origin).href);
+    if (fallback) {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+async function handleAssetRequest(request) {
+  if (!activeCacheName) {
+    return fetch(request);
+  }
+
+  const cache = await caches.open(activeCacheName);
+  const cached = await cache.match(request);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) {
+      cache.put(request, response.clone()).catch(() => {});
+    }
+    return response;
+  } catch (error) {
+    const fallback = await cache.match(request);
+    if (fallback) {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+async function broadcast(message) {
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+  clients.forEach((client) => {
+    try {
+      client.postMessage(message);
+    } catch (error) {
+      console.warn('Failed to post message to client', error);
+    }
+  });
+}
+
+async function readStoredManifest() {
+  const cache = await caches.open(METADATA_CACHE);
+  const response = await cache.match(METADATA_REQUEST);
+  if (!response) {
+    return null;
+  }
+
+  try {
+    return await response.json();
+  } catch (error) {
+    console.warn('Failed to parse stored offline manifest', error);
+    return null;
+  }
+}
+
+async function writeStoredManifest(manifest) {
+  const cache = await caches.open(METADATA_CACHE);
+  const response = new Response(JSON.stringify(manifest), {
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+  await cache.put(METADATA_REQUEST, response);
+}
+
+async function cleanupCaches(currentName) {
+  const keys = await caches.keys();
+  await Promise.all(keys.map((key) => {
+    if (key === METADATA_CACHE) {
+      return Promise.resolve(false);
+    }
+
+    if (!key.startsWith(CACHE_PREFIX)) {
+      return Promise.resolve(false);
+    }
+
+    if (currentName && key === currentName) {
+      return Promise.resolve(false);
+    }
+
+    return caches.delete(key);
+  }));
+}

--- a/tools/generate-offline-manifest.js
+++ b/tools/generate-offline-manifest.js
@@ -1,0 +1,127 @@
+const fs = require('fs/promises');
+const path = require('path');
+const crypto = require('crypto');
+
+const ROOT = process.cwd();
+const OUTPUT_PATH = path.join(ROOT, 'offline-manifest.json');
+const INCLUDE_DIRECTORIES = ['apps', 'data'];
+const INCLUDE_FILES = ['index.html', 'service-worker.js'];
+const ALLOWED_EXTENSIONS = new Set(['.html', '.js', '.json']);
+
+async function main() {
+  const assets = [];
+  const digest = crypto.createHash('sha256');
+
+  for (const filePath of INCLUDE_FILES) {
+    await addAsset(filePath, assets, digest);
+  }
+
+  for (const directory of INCLUDE_DIRECTORIES) {
+    await walk(directory, assets, digest);
+  }
+
+  assets.sort((a, b) => a.path.localeCompare(b.path));
+
+  const generatedAt = new Date().toISOString();
+  const versionSuffix = digest.digest('hex').slice(0, 12);
+  const version = `${generatedAt.slice(0, 10).replace(/-/g, '')}-${versionSuffix}`;
+  const totalBytes = assets.reduce((sum, asset) => sum + asset.bytes, 0);
+
+  const manifest = {
+    version,
+    generatedAt,
+    totalAssets: assets.length,
+    totalBytes,
+    assets
+  };
+
+  const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
+  await fs.writeFile(OUTPUT_PATH, manifestJson);
+  console.log(`Offline manifest ready: ${assets.length} assets, ${formatBytes(totalBytes)} total.`);
+}
+
+async function walk(directory, assets, digest) {
+  const absoluteDir = path.join(ROOT, directory);
+  let entries;
+
+  try {
+    entries = await fs.readdir(absoluteDir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return;
+    }
+
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      await walk(entryPath, assets, digest);
+    } else if (entry.isFile()) {
+      const extension = path.extname(entry.name).toLowerCase();
+      if (!ALLOWED_EXTENSIONS.has(extension)) {
+        continue;
+      }
+
+      await addAsset(entryPath, assets, digest);
+    }
+  }
+}
+
+async function addAsset(relativePath, assets, digest) {
+  const absolutePath = path.join(ROOT, relativePath);
+  let stats;
+
+  try {
+    stats = await fs.stat(absolutePath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return;
+    }
+
+    throw error;
+  }
+
+  if (!stats.isFile()) {
+    return;
+  }
+
+  const content = await fs.readFile(absolutePath);
+  const normalizedPath = toPosixPath(relativePath);
+
+  digest.update(normalizedPath);
+  digest.update(content);
+
+  assets.push({
+    path: normalizedPath,
+    bytes: stats.size
+  });
+}
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  const fractionDigits = value >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${Number(value.toFixed(fractionDigits))} ${units[unitIndex]}`;
+}
+
+main().catch((error) => {
+  console.error('Failed to generate offline manifest', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add an offline bundle card to the landing page with a progress indicator and iPhone install guidance
- register a service worker that precaches every asset from the manifest, tracks progress, and serves cached responses offline
- add an offline manifest generator script, snapshot, npm script, and documentation on updating the cache bundle

## Testing
- npm test *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d325f1fdcc8328b00fbc2bf15a6160