### PR TITLE
Ensure Playwright dependencies and update landing page test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A collection of lightweight browser apps served from a single landing page. Each mini-app focuses on quick interactions, from shuffling curated decks to formatting lists for development workflows.",
   "main": "index.js",
   "scripts": {
+    "pretest": "playwright install chromium",
     "build:offline": "node tools/generate-offline-manifest.js",
     "test": "playwright test",
     "test:ui": "playwright test --ui",

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -56,7 +56,7 @@ test.describe('Landing page', () => {
 
     const toolSection = page.locator('section.app-groups').nth(1);
     const toolButtons = toolSection.locator('a.app-button');
-    await expect(toolButtons).toHaveCount(3);
+    await expect(toolButtons).toHaveCount(4);
 
     const toolInfo = await toolButtons.evaluateAll((nodes) =>
       nodes.map((node) => ({
@@ -67,6 +67,7 @@ test.describe('Landing page', () => {
 
     expect(toolInfo).toEqual([
       { text: '🧪 Cosine Similarity Lab', href: 'apps/similarity-report/' },
+      { text: '🧬 Embedding Explorer', href: 'apps/embedding-explorer/' },
       { text: '📊 Asset Observatory', href: 'apps/asset-observatory/' },
       { text: '🧰 Value Formatter', href: 'apps/value-formatter/' },
     ]);
@@ -77,6 +78,6 @@ test.describe('Landing page', () => {
     await expect(valueFormatterButton).not.toContainText('—');
 
     const allButtons = page.locator('a.app-button');
-    await expect(allButtons).toHaveCount(9);
+    await expect(allButtons).toHaveCount(10);
   });
 });


### PR DESCRIPTION
## Summary
- install Chromium automatically before running the Playwright test suite
- update the landing page Playwright spec to cover the Embedding Explorer button and the new button counts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d32b4f89fc8328bc339515cc310a89