### PR TITLE
Add Embedding Explorer regression coverage and refresh offline caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection of lightweight browser apps served from a single landing page. Each
 - **Cosine Similarity Lab** – Explore the 0.50+ cosine matches across jokes, quotes, and cross-deck blends, tweak the minimum score, and compare entries side by side with vector stats.
 - **Value Formatter** – Turn newline-separated entries into formatted key-value pairs for quick copy/paste in code reviews or data preparation.
 - **Asset Observatory** – Summarise dataset payloads, embedding stores, and similarity sweeps across the toolbox with nerdy charts and a full ledger view.
+- **Embedding Explorer** – Paste vectors or browse curated samples to visualise metrics, heatmaps, and notable dimensions of embedding payloads.
 
 ## Usage
 
@@ -50,6 +51,8 @@ The tests spin up a temporary `python -m http.server` instance and exercise ever
 - `tests/similarity-report.spec.js` exercises dataset toggles, thresholds, and similarity overlays.
 - `tests/asset-observatory.spec.js` keeps the asset dashboard honest so charts, summaries, and the ledger stay in sync.
 - `tests/home-navigation.spec.js` ensures every app exposes the Home shortcut.
+- `tests/embedding-explorer.spec.js` checks that the Embedding Explorer loads samples, recomputes statistics, and surfaces the strongest dimensions.
+- `tests/offline-manifest.spec.js` guards the offline cache manifest so every shipped HTML, JSON, and JavaScript asset remains downloadable.
 
 Use `npm run test:ui` if you want to watch the checks in the Playwright inspector while iterating locally. To focus on a single spec, pass its filename to Playwright, for example:
 
@@ -80,6 +83,8 @@ npm run build:offline
 ```
 
 The script walks every HTML, JSON, and JavaScript file we ship, computes their sizes and a combined SHA-256 digest, and writes an updated `offline-manifest.json`. Commit the refreshed manifest together with your changes so clients pick up the new bundle the next time they load the homepage.
+
+Run `npx playwright test tests/offline-manifest.spec.js` after adding or removing assets to confirm the manifest matches the shipped files before deploying.
 
 ## Data maintenance
 

--- a/offline-manifest.json
+++ b/offline-manifest.json
@@ -1,8 +1,8 @@
 {
-  "version": "20250923-3a6ea8d9e669",
-  "generatedAt": "2025-09-23T23:13:33.557Z",
-  "totalAssets": 52,
-  "totalBytes": 5505782,
+  "version": "20250923-0aef3e87efed",
+  "generatedAt": "2025-09-23T23:33:25.182Z",
+  "totalAssets": 55,
+  "totalBytes": 5772295,
   "assets": [
     {
       "path": "apps/asset-observatory/app.js",
@@ -15,6 +15,18 @@
     {
       "path": "apps/asset-observatory/index.html",
       "bytes": 14530
+    },
+    {
+      "path": "apps/embedding-explorer/app.js",
+      "bytes": 15714
+    },
+    {
+      "path": "apps/embedding-explorer/index.html",
+      "bytes": 18011
+    },
+    {
+      "path": "apps/embedding-explorer/sample-embeddings.js",
+      "bytes": 1997
     },
     {
       "path": "apps/jokes/all-jokes-compact.html",
@@ -34,7 +46,7 @@
     },
     {
       "path": "apps/jokes/jokes.js",
-      "bytes": 141344
+      "bytes": 142246
     },
     {
       "path": "apps/jokes/render-all.js",
@@ -54,7 +66,7 @@
     },
     {
       "path": "apps/quotes/quotes-data.js",
-      "bytes": 121995
+      "bytes": 123746
     },
     {
       "path": "apps/quotes/render-all.js",
@@ -66,23 +78,23 @@
     },
     {
       "path": "apps/slang/all-slang.html",
-      "bytes": 8592
+      "bytes": 8586
     },
     {
       "path": "apps/slang/app.js",
-      "bytes": 7649
+      "bytes": 7396
     },
     {
       "path": "apps/slang/index.html",
-      "bytes": 11360
+      "bytes": 11390
     },
     {
       "path": "apps/slang/render-all.js",
-      "bytes": 7325
+      "bytes": 7091
     },
     {
       "path": "apps/slang/slang.js",
-      "bytes": 19170
+      "bytes": 21613
     },
     {
       "path": "apps/value-formatter/index.html",
@@ -90,7 +102,7 @@
     },
     {
       "path": "data/curated-quotes.json",
-      "bytes": 22094
+      "bytes": 23552
     },
     {
       "path": "data/icanhazdadjokes-split.json",
@@ -106,7 +118,7 @@
     },
     {
       "path": "data/jokes-embeddings.json",
-      "bytes": 590939
+      "bytes": 594414
     },
     {
       "path": "data/jokes-manifest.json",
@@ -130,7 +142,7 @@
     },
     {
       "path": "data/quotes-manifest.json",
-      "bytes": 478829
+      "bytes": 485291
     },
     {
       "path": "data/similarity-overrides.json",
@@ -182,23 +194,23 @@
     },
     {
       "path": "data/similarity-report-slang.json",
-      "bytes": 162
+      "bytes": 161
     },
     {
       "path": "data/slang-embeddings-hfspace.json",
-      "bytes": 110258
+      "bytes": 230063
     },
     {
       "path": "data/slang-embeddings-synthetic128.json",
-      "bytes": 46900
+      "bytes": 97762
     },
     {
       "path": "data/slang-embeddings.json",
-      "bytes": 31508
+      "bytes": 65612
     },
     {
       "path": "data/slang-manifest.json",
-      "bytes": 51910
+      "bytes": 61664
     },
     {
       "path": "data/test-runs/latest.json",
@@ -206,7 +218,7 @@
     },
     {
       "path": "index.html",
-      "bytes": 18681
+      "bytes": 18920
     },
     {
       "path": "service-worker.js",

--- a/tests/embedding-explorer.spec.js
+++ b/tests/embedding-explorer.spec.js
@@ -1,0 +1,50 @@
+const { test, expect } = require('@playwright/test');
+
+const SAMPLE_BUTTON_SELECTOR = '[data-sample-list] .sample-button';
+const SUMMARY_VALUES_SELECTOR = '[data-summary-grid] dd';
+
+function summaryValue(locator, index) {
+  return locator.nth(index);
+}
+
+test.describe('Embedding Explorer app', () => {
+  test('loads samples and recomputes vector insights', async ({ page }) => {
+    await page.goto('/apps/embedding-explorer/');
+
+    const sampleButtons = page.locator(SAMPLE_BUTTON_SELECTOR);
+    await expect(sampleButtons).toHaveCount(3);
+
+    const sampleMeta = page.locator('[data-sample-meta]');
+    await expect(sampleMeta).toContainText('A sunny stroll through a park lined with trees and warm light.');
+
+    const summaryValues = page.locator(SUMMARY_VALUES_SELECTOR);
+    await expect(summaryValue(summaryValues, 0)).toHaveText('64');
+    await expect(summaryValue(summaryValues, 1)).toHaveText('4.105');
+    await expect(summaryValue(summaryValues, 2)).toHaveText('0.100');
+
+    await page.getByRole('button', { name: /Neon-lit crosswalk/ }).click();
+    await expect(sampleMeta).toContainText('Busy urban crossing at night with bright signage and a fast tempo.');
+
+    const input = page.locator('[data-embedding-input]');
+    await input.fill('1, -2, 3');
+    await page.getByRole('button', { name: 'Update visualizations' }).click();
+
+    await expect(summaryValue(summaryValues, 0)).toHaveText('3');
+    await expect(summaryValue(summaryValues, 1)).toHaveText('3.742');
+    await expect(summaryValue(summaryValues, 2)).toHaveText('0.667');
+    await expect(summaryValue(summaryValues, 4)).toHaveText('-2.000 / 3.000');
+    await expect(summaryValue(summaryValues, 5)).toHaveText('0%');
+
+    const positiveList = page.locator('[data-positive-list] li');
+    await expect(positiveList.first()).toHaveText('#33.000');
+    await expect(positiveList.nth(1)).toHaveText('#11.000');
+
+    const negativeList = page.locator('[data-negative-list] li');
+    await expect(negativeList.first()).toHaveText('#2-2.000');
+
+    const firstRow = page.locator('[data-value-table] tr').first();
+    await expect(firstRow.locator('td').nth(0)).toHaveText('#1');
+    await expect(firstRow.locator('td').nth(1).locator('span')).toHaveText('1.000');
+    await expect(firstRow.locator('td').nth(2).locator('span')).toHaveText('0.333');
+  });
+});

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -56,7 +56,7 @@ test.describe('Landing page', () => {
 
     const toolSection = page.locator('section.app-groups').nth(1);
     const toolButtons = toolSection.locator('a.app-button');
-    await expect(toolButtons).toHaveCount(3);
+    await expect(toolButtons).toHaveCount(4);
 
     const toolInfo = await toolButtons.evaluateAll((nodes) =>
       nodes.map((node) => ({
@@ -67,6 +67,7 @@ test.describe('Landing page', () => {
 
     expect(toolInfo).toEqual([
       { text: '🧪 Cosine Similarity Lab', href: 'apps/similarity-report/' },
+      { text: '🧬 Embedding Explorer', href: 'apps/embedding-explorer/' },
       { text: '📊 Asset Observatory', href: 'apps/asset-observatory/' },
       { text: '🧰 Value Formatter', href: 'apps/value-formatter/' },
     ]);
@@ -77,6 +78,6 @@ test.describe('Landing page', () => {
     await expect(valueFormatterButton).not.toContainText('—');
 
     const allButtons = page.locator('a.app-button');
-    await expect(allButtons).toHaveCount(9);
+    await expect(allButtons).toHaveCount(10);
   });
 });

--- a/tests/offline-manifest.spec.js
+++ b/tests/offline-manifest.spec.js
@@ -1,0 +1,85 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs/promises');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MANIFEST_PATH = path.join(ROOT, 'offline-manifest.json');
+const INCLUDE_DIRECTORIES = ['apps', 'data'];
+const INCLUDE_FILES = ['index.html', 'service-worker.js'];
+const ALLOWED_EXTENSIONS = new Set(['.html', '.js', '.json']);
+
+async function readManifest() {
+  const content = await fs.readFile(MANIFEST_PATH, 'utf8');
+  return JSON.parse(content);
+}
+
+async function collectExpectedAssets() {
+  const assets = new Set(INCLUDE_FILES);
+
+  for (const directory of INCLUDE_DIRECTORIES) {
+    await walk(directory, assets);
+  }
+
+  return assets;
+}
+
+async function walk(relativeDir, assets) {
+  const absoluteDir = path.join(ROOT, relativeDir);
+  let entries;
+
+  try {
+    entries = await fs.readdir(absoluteDir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(relativeDir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(entryPath, assets);
+    } else if (entry.isFile()) {
+      const extension = path.extname(entry.name).toLowerCase();
+      if (!ALLOWED_EXTENSIONS.has(extension)) {
+        continue;
+      }
+      assets.add(toPosixPath(entryPath));
+    }
+  }
+}
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+test.describe('Offline manifest', () => {
+  test('includes the Embedding Explorer bundle', async () => {
+    const manifest = await readManifest();
+    const assetPaths = manifest.assets.map((asset) => asset.path);
+
+    const required = [
+      'apps/embedding-explorer/index.html',
+      'apps/embedding-explorer/app.js',
+      'apps/embedding-explorer/sample-embeddings.js',
+    ];
+
+    for (const file of required) {
+      expect(assetPaths).toContain(file);
+    }
+  });
+
+  test('stays in sync with shipped HTML, JS, and JSON assets', async () => {
+    const manifest = await readManifest();
+    const manifestPaths = new Set(manifest.assets.map((asset) => asset.path));
+    const expectedPaths = await collectExpectedAssets();
+
+    const missing = [...expectedPaths].filter((pathName) => !manifestPaths.has(pathName));
+    const unexpected = [...manifestPaths].filter((pathName) => !expectedPaths.has(pathName));
+
+    expect(missing).toEqual([]);
+    expect(unexpected).toEqual([]);
+    expect(manifest.totalAssets).toBe(manifest.assets.length);
+  });
+});


### PR DESCRIPTION
## Summary
- regenerate the offline manifest so the Embedding Explorer assets ship with the service worker bundle
- add Playwright coverage for the Embedding Explorer UI and update the landing-page spec for the new lab button
- document the checks in the README and add a manifest smoke test to catch stale cache inventories

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d32cc5b33883289cd5c295719f18e8