### PR TITLE
Revamp embedding explorer for dataset selection

### DIFF
--- a/apps/embedding-explorer/app.js
+++ b/apps/embedding-explorer/app.js
@@ -1,533 +1,477 @@
 (function () {
-  const dataset = Array.isArray(window.sampleEmbeddings) ? window.sampleEmbeddings : [];
-  const sampleList = document.querySelector('[data-sample-list]');
-  const sampleMeta = document.querySelector('[data-sample-meta]');
-  const input = document.querySelector('[data-embedding-input]');
-  const parseButton = document.querySelector('[data-parse-button]');
-  const columnSlider = document.querySelector('[data-column-slider]');
-  const columnDisplay = document.querySelector('[data-column-display]');
-  const summaryGrid = document.querySelector('[data-summary-grid]');
-  const heatmapCanvas = document.querySelector('[data-heatmap]');
-  const lineCanvas = document.querySelector('[data-line-chart]');
-  const positiveList = document.querySelector('[data-positive-list]');
-  const negativeList = document.querySelector('[data-negative-list]');
-  const valueTable = document.querySelector('[data-value-table]');
+  const sources = Array.isArray(window.embeddingSources) ? window.embeddingSources : [];
+  const datasetSelect = document.querySelector('[data-dataset-select]');
+  const datasetInfo = document.querySelector('[data-dataset-info]');
+  const recordList = document.querySelector('[data-record-list]');
+  const recordStatus = document.querySelector('[data-record-status]');
+  const filterInput = document.querySelector('[data-record-filter]');
+  const previewCanvas = document.querySelector('[data-preview-canvas]');
+  const previewMeta = document.querySelector('[data-preview-meta]');
 
   if (
-    !sampleList ||
-    !sampleMeta ||
-    !input ||
-    !parseButton ||
-    !columnSlider ||
-    !columnDisplay ||
-    !summaryGrid ||
-    !heatmapCanvas ||
-    !lineCanvas ||
-    !positiveList ||
-    !negativeList ||
-    !valueTable
+    !datasetSelect ||
+    !datasetInfo ||
+    !recordList ||
+    !recordStatus ||
+    !filterInput ||
+    !previewCanvas ||
+    !previewMeta
   ) {
     return;
   }
 
-  let activeSampleId = '';
-  let sliderManuallyAdjusted = false;
+  const datasetCache = new Map();
+  let activeDatasetId = '';
+  let activeRecordId = '';
+  let currentRecords = [];
+  let filteredRecords = [];
 
-  const state = {
-    vector: [],
-    normalized: [],
-    stats: null,
-    columns: Number.parseInt(columnSlider.value, 10) || 8,
-  };
-
-  columnDisplay.textContent = columnSlider.value;
-
-  function formatNumber(value, digits = 3) {
-    if (!Number.isFinite(value)) {
-      return '0.000';
+  function formatDate(value) {
+    if (!value) {
+      return '—';
     }
-    return Number(value).toFixed(digits);
+
+    try {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return value;
+      }
+      return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+    } catch (error) {
+      console.error('Failed to format date', error);
+      return value;
+    }
   }
 
-  function parseVector(text) {
-    if (!text) {
-      return [];
+  function decodeVector(base64) {
+    if (!base64) {
+      return new Uint8Array();
     }
 
-    const tokens = text
-      .split(/[\s,]+/)
-      .map((token) => token.trim())
-      .filter(Boolean);
-
-    const numbers = tokens
-      .map((token) => Number.parseFloat(token))
-      .filter((value) => Number.isFinite(value));
-
-    return numbers;
+    try {
+      const binary = window.atob(base64);
+      const length = binary.length;
+      const bytes = new Uint8Array(length);
+      for (let index = 0; index < length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+      }
+      return bytes;
+    } catch (error) {
+      console.error('Failed to decode vector', error);
+      return new Uint8Array();
+    }
   }
 
-  function computeStats(vector) {
-    if (!vector.length) {
-      return null;
-    }
+  function populateDatasetSelect() {
+    datasetSelect.innerHTML = '';
 
-    let min = vector[0];
-    let max = vector[0];
-    let sum = 0;
-    let squaredSum = 0;
-    let absSum = 0;
-    let maxAbs = Math.abs(vector[0]);
-    let nearZero = 0;
-
-    for (const value of vector) {
-      if (value < min) {
-        min = value;
-      }
-      if (value > max) {
-        max = value;
-      }
-      sum += value;
-      squaredSum += value * value;
-      absSum += Math.abs(value);
-      const absValue = Math.abs(value);
-      if (absValue > maxAbs) {
-        maxAbs = absValue;
-      }
-      if (absValue < 0.05) {
-        nearZero += 1;
-      }
-    }
-
-    const mean = sum / vector.length;
-    let varianceSum = 0;
-
-    for (const value of vector) {
-      const diff = value - mean;
-      varianceSum += diff * diff;
-    }
-
-    const stdDev = Math.sqrt(varianceSum / vector.length);
-    const sorted = [...vector].sort((a, b) => a - b);
-    const mid = Math.floor(sorted.length / 2);
-    const median =
-      sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-
-    return {
-      length: vector.length,
-      min,
-      max,
-      sum,
-      mean,
-      median,
-      stdDev,
-      l2: Math.sqrt(squaredSum),
-      absSum,
-      maxAbs: maxAbs || 1,
-      nearZeroRatio: nearZero / vector.length,
-    };
-  }
-
-  function buildSummary(stats) {
-    if (!stats) {
-      summaryGrid.innerHTML = '<p class="placeholder">Paste an embedding to view its metrics.</p>';
+    if (!sources.length) {
+      datasetSelect.disabled = true;
+      const option = document.createElement('option');
+      option.value = '';
+      option.textContent = 'No datasets available';
+      datasetSelect.append(option);
+      datasetInfo.innerHTML = '<p class="placeholder">No embedding datasets are configured.</p>';
+      recordList.innerHTML = '<li><p class="placeholder">No datasets available.</p></li>';
+      recordStatus.textContent = 'No vectors to display.';
+      filterInput.disabled = true;
       return;
     }
 
-    const summaryItems = [
-      { label: 'Dimensions', value: stats.length.toLocaleString() },
-      { label: 'L2 norm', value: formatNumber(stats.l2) },
-      { label: 'Mean', value: formatNumber(stats.mean) },
-      { label: 'Std dev', value: formatNumber(stats.stdDev) },
-      { label: 'Min / Max', value: `${formatNumber(stats.min)} / ${formatNumber(stats.max)}` },
-      { label: 'Near zero', value: `${Math.round(stats.nearZeroRatio * 100)}%` },
+    sources.forEach((source, index) => {
+      const option = document.createElement('option');
+      option.value = source.id;
+      option.textContent = source.label;
+      datasetSelect.append(option);
+      if (index === 0) {
+        datasetSelect.value = source.id;
+      }
+    });
+
+    datasetSelect.disabled = false;
+  }
+
+  function updateDatasetInfo(meta, source) {
+    datasetInfo.innerHTML = '';
+
+    const list = document.createElement('dl');
+    list.className = 'meta-grid';
+
+    const items = [
+      { label: 'Collection', value: source?.collection || '—' },
+      { label: 'Provider', value: meta?.provider || '—' },
+      { label: 'Model', value: meta?.model || '—' },
+      {
+        label: 'Dimensions',
+        value: meta?.dimensions ? `${meta.dimensions.toLocaleString()}D` : '—',
+      },
+      {
+        label: 'Records',
+        value: meta?.recordCount ? meta.recordCount.toLocaleString() : '—',
+      },
+      {
+        label: 'Generated',
+        value: meta?.generatedAt ? formatDate(meta.generatedAt) : '—',
+      },
     ];
 
-    summaryGrid.innerHTML = '';
-    const fragment = document.createDocumentFragment();
-
-    summaryItems.forEach((item) => {
-      const dl = document.createElement('dl');
-      dl.className = 'summary-card';
-
+    items.forEach((item) => {
+      const wrapper = document.createElement('div');
       const dt = document.createElement('dt');
       dt.textContent = item.label;
-
       const dd = document.createElement('dd');
       dd.textContent = item.value;
-
-      dl.append(dt, dd);
-      fragment.appendChild(dl);
+      wrapper.append(dt, dd);
+      list.appendChild(wrapper);
     });
 
-    summaryGrid.appendChild(fragment);
+    datasetInfo.appendChild(list);
   }
 
-  function colorForValue(value) {
-    const clamped = Math.max(-1, Math.min(1, Number.isFinite(value) ? value : 0));
-    const intensity = Math.pow(Math.abs(clamped), 0.85);
-    const neutral = { r: 241, g: 245, b: 249 };
-    const positive = { r: 249, g: 115, b: 22 };
-    const negative = { r: 37, g: 99, b: 235 };
-
-    const mix = (source, target, amount) => ({
-      r: Math.round(source.r + (target.r - source.r) * amount),
-      g: Math.round(source.g + (target.g - source.g) * amount),
-      b: Math.round(source.b + (target.b - source.b) * amount),
-    });
-
-    const palette = clamped >= 0 ? mix(neutral, positive, intensity) : mix(neutral, negative, intensity);
-    return `rgb(${palette.r}, ${palette.g}, ${palette.b})`;
-  }
-
-  function drawHeatmap(normalized) {
-    const ctx = heatmapCanvas.getContext('2d');
-
-    if (!normalized.length) {
-      heatmapCanvas.width = 10;
-      heatmapCanvas.height = 10;
-      ctx.fillStyle = 'rgba(148, 163, 209, 0.18)';
-      ctx.fillRect(0, 0, heatmapCanvas.width, heatmapCanvas.height);
+  function updateRecordStatus() {
+    if (!currentRecords.length) {
+      recordStatus.textContent = 'No vectors available for this dataset.';
       return;
     }
 
-    const columns = Math.max(1, Math.min(state.columns, normalized.length));
-    const rows = Math.ceil(normalized.length / columns);
-
-    heatmapCanvas.width = columns;
-    heatmapCanvas.height = rows;
-
-    ctx.clearRect(0, 0, columns, rows);
-
-    normalized.forEach((value, index) => {
-      const column = index % columns;
-      const row = Math.floor(index / columns);
-      ctx.fillStyle = colorForValue(value);
-      ctx.fillRect(column, row, 1, 1);
-    });
-  }
-
-  function drawLinePlot(normalized) {
-    const ctx = lineCanvas.getContext('2d');
-    const dpr = window.devicePixelRatio || 1;
-    const width = lineCanvas.clientWidth || lineCanvas.parentElement?.clientWidth || 600;
-    const height = 220;
-
-    lineCanvas.width = width * dpr;
-    lineCanvas.height = height * dpr;
-    lineCanvas.style.width = `${width}px`;
-    lineCanvas.style.height = `${height}px`;
-
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    ctx.clearRect(0, 0, width, height);
-
-    const mid = height / 2;
-    ctx.strokeStyle = 'rgba(148, 163, 209, 0.35)';
-    ctx.lineWidth = 1;
-    ctx.setLineDash([6, 6]);
-    ctx.beginPath();
-    ctx.moveTo(0, mid);
-    ctx.lineTo(width, mid);
-    ctx.stroke();
-    ctx.setLineDash([]);
-
-    if (!normalized.length) {
+    if (!filteredRecords.length) {
+      const searchTerm = filterInput.value.trim();
+      recordStatus.textContent = searchTerm
+        ? `No matches for “${searchTerm}”.`
+        : 'No vectors match the current filter.';
       return;
     }
 
-    const amplitude = (height / 2) * 0.82;
-    const step = normalized.length === 1 ? width : width / (normalized.length - 1);
-
-    ctx.beginPath();
-    normalized.forEach((value, index) => {
-      const x = index * step;
-      const y = mid - value * amplitude;
-      if (index === 0) {
-        ctx.moveTo(x, y);
-      } else {
-        ctx.lineTo(x, y);
-      }
-    });
-
-    ctx.strokeStyle = 'rgba(96, 165, 250, 0.9)';
-    ctx.lineWidth = 2;
-    ctx.stroke();
-
-    ctx.lineTo(width, mid);
-    ctx.lineTo(0, mid);
-    ctx.closePath();
-    ctx.fillStyle = 'rgba(96, 165, 250, 0.18)';
-    ctx.fill();
+    recordStatus.textContent = `Showing ${filteredRecords.length.toLocaleString()} of ${currentRecords.length.toLocaleString()} vectors.`;
   }
 
-  function renderExtremes(vector, normalized) {
-    const entries = vector.map((value, index) => ({
-      index,
-      value,
-      normalized: normalized[index],
-    }));
+  function renderRecordList() {
+    recordList.innerHTML = '';
 
-    const positives = entries
-      .filter((entry) => entry.value > 0)
-      .sort((a, b) => b.value - a.value)
-      .slice(0, 6);
-
-    const negatives = entries
-      .filter((entry) => entry.value < 0)
-      .sort((a, b) => a.value - b.value)
-      .slice(0, 6);
-
-    const fallback = [{ index: null, value: 0, normalized: 0 }];
-
-    const renderList = (container, items, className) => {
-      container.innerHTML = '';
-      const list = items.length ? items : fallback;
-      const fragment = document.createDocumentFragment();
-
-      list.forEach((item) => {
-        const li = document.createElement('li');
-        const indexSpan = document.createElement('span');
-        indexSpan.textContent = item.index != null ? `#${item.index + 1}` : '–';
-        const valueSpan = document.createElement('span');
-        if (className && item.index != null) {
-          valueSpan.classList.add(className);
-        }
-        valueSpan.textContent = formatNumber(item.value);
-        li.append(indexSpan, valueSpan);
-        fragment.appendChild(li);
-      });
-
-      container.appendChild(fragment);
-    };
-
-    renderList(positiveList, positives, 'value-positive');
-    renderList(negativeList, negatives, 'value-negative');
-  }
-
-  function renderTable(vector, normalized) {
-    valueTable.innerHTML = '';
-
-    if (!vector.length) {
-      const row = document.createElement('tr');
-      const cell = document.createElement('td');
-      cell.colSpan = 3;
-      cell.textContent = 'Paste an embedding to populate the table.';
-      row.appendChild(cell);
-      valueTable.appendChild(row);
+    if (!filteredRecords.length) {
+      const item = document.createElement('li');
+      const placeholder = document.createElement('p');
+      placeholder.className = 'placeholder';
+      placeholder.textContent = currentRecords.length
+        ? 'No vectors match this filter.'
+        : 'No vectors available for this dataset.';
+      item.appendChild(placeholder);
+      recordList.appendChild(item);
       return;
     }
 
     const fragment = document.createDocumentFragment();
 
-    vector.forEach((value, index) => {
-      const row = document.createElement('tr');
+    filteredRecords.forEach((record) => {
+      const item = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'record-button';
+      button.dataset.recordId = record.id;
+      const isActive = record.id === activeRecordId;
+      button.dataset.active = isActive ? 'true' : 'false';
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
 
-      const indexCell = document.createElement('td');
-      indexCell.textContent = `#${index + 1}`;
+      const idSpan = document.createElement('span');
+      idSpan.className = 'record-button__id';
+      idSpan.textContent = record.id;
 
-      const valueCell = document.createElement('td');
-      const valueSpan = document.createElement('span');
-      if (value > 0) {
-        valueSpan.classList.add('value-positive');
-      } else if (value < 0) {
-        valueSpan.classList.add('value-negative');
-      }
-      valueSpan.textContent = formatNumber(value);
-      valueCell.appendChild(valueSpan);
+      const metaSpan = document.createElement('span');
+      metaSpan.className = 'record-button__meta';
+      metaSpan.textContent = record.updatedAt ? `Updated ${formatDate(record.updatedAt)}` : 'No timestamp available';
 
-      const normalizedCell = document.createElement('td');
-      const normalizedSpan = document.createElement('span');
-      if (normalized[index] > 0) {
-        normalizedSpan.classList.add('value-positive');
-      } else if (normalized[index] < 0) {
-        normalizedSpan.classList.add('value-negative');
-      }
-      normalizedSpan.textContent = formatNumber(normalized[index]);
-      normalizedCell.appendChild(normalizedSpan);
-
-      row.append(indexCell, valueCell, normalizedCell);
-      fragment.appendChild(row);
+      button.append(idSpan, metaSpan);
+      item.appendChild(button);
+      fragment.appendChild(item);
     });
 
-    valueTable.appendChild(fragment);
+    recordList.appendChild(fragment);
   }
 
-  function renderSampleMeta(sample) {
-    sampleMeta.innerHTML = '';
-
-    if (!sample) {
-      const placeholder = document.createElement('p');
-      placeholder.className = 'placeholder';
-      placeholder.textContent = 'Select a sample to preview its prompt and notes.';
-      sampleMeta.appendChild(placeholder);
-      return;
-    }
-
-    const promptParagraph = document.createElement('p');
-    const promptLabel = document.createElement('strong');
-    promptLabel.textContent = 'Prompt:';
-    promptParagraph.append(promptLabel, document.createTextNode(` ${sample.prompt}`));
-
-    const notesParagraph = document.createElement('p');
-    const notesLabel = document.createElement('strong');
-    notesLabel.textContent = 'Notes:';
-    notesParagraph.append(notesLabel, document.createTextNode(` ${sample.notes}`));
-
-    const dimensionsParagraph = document.createElement('p');
-    const dimensionsLabel = document.createElement('strong');
-    dimensionsLabel.textContent = 'Dimensions:';
-    dimensionsParagraph.append(
-      dimensionsLabel,
-      document.createTextNode(` ${sample.vector.length.toLocaleString()}`),
-    );
-
-    sampleMeta.append(promptParagraph, notesParagraph, dimensionsParagraph);
-  }
-
-  function renderAll() {
-    buildSummary(state.stats);
-    drawHeatmap(state.normalized);
-    requestAnimationFrame(() => {
-      drawLinePlot(state.normalized);
-    });
-    renderExtremes(state.vector, state.normalized);
-    renderTable(state.vector, state.normalized);
-  }
-
-  function updateColumnSliderMax(length) {
-    const max = Math.max(1, Math.min(64, length));
-    columnSlider.max = String(max);
-
-    if (!sliderManuallyAdjusted) {
-      const suggested = Math.max(1, Math.round(Math.sqrt(length)) || 1);
-      const nextValue = Math.min(max, suggested);
-      state.columns = nextValue;
-      columnSlider.value = String(nextValue);
-    } else if (state.columns > max) {
-      state.columns = max;
-      columnSlider.value = String(max);
-    } else {
-      const safeValue = Math.min(Math.max(state.columns, 1), max);
-      state.columns = safeValue;
-      columnSlider.value = String(safeValue);
-    }
-
-    columnDisplay.textContent = columnSlider.value;
-  }
-
-  function updateStateFromInput() {
-    const values = parseVector(input.value);
-    state.vector = values;
-    state.stats = computeStats(values);
-
-    if (!values.length || !state.stats) {
-      state.normalized = [];
-      columnSlider.disabled = true;
-      columnDisplay.textContent = '–';
-      renderAll();
-      return;
-    }
-
-    columnSlider.disabled = false;
-    columnDisplay.textContent = columnSlider.value;
-
-    updateColumnSliderMax(values.length);
-
-    state.normalized = values.map((value) => (state.stats.maxAbs ? value / state.stats.maxAbs : 0));
-
-    renderAll();
-  }
-
-  function updateActiveButtons() {
-    const buttons = sampleList.querySelectorAll('.sample-button');
+  function updateActiveRecordButton() {
+    const buttons = recordList.querySelectorAll('.record-button');
     buttons.forEach((button) => {
-      const isActive = button.dataset.sampleId === activeSampleId;
+      const isActive = button.dataset.recordId === activeRecordId;
       button.dataset.active = isActive ? 'true' : 'false';
       button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
     });
   }
 
-  function handleSampleSelection(sample) {
-    if (!sample) {
+  function renderPreview(record, datasetMeta, source) {
+    const ctx = previewCanvas.getContext('2d');
+    if (!ctx) {
       return;
     }
-    sliderManuallyAdjusted = false;
-    activeSampleId = sample.id;
-    input.value = sample.vector.join(', ');
-    renderSampleMeta(sample);
-    updateActiveButtons();
-    updateStateFromInput();
+
+    if (!record) {
+      ctx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
+      previewCanvas.width = 1;
+      previewCanvas.height = 1;
+      previewCanvas.style.width = '';
+      previewCanvas.style.height = '';
+      previewMeta.innerHTML = '<p class="placeholder">Select a vector to inspect its details.</p>';
+      return;
+    }
+
+    const bytes = decodeVector(record.vector);
+    const pixelCount = Math.ceil(bytes.length / 3);
+    const width = Math.max(1, Math.ceil(Math.sqrt(pixelCount)));
+    const height = Math.max(1, Math.ceil(pixelCount / width));
+
+    previewCanvas.width = width;
+    previewCanvas.height = height;
+
+    const imageData = ctx.createImageData(width, height);
+    const data = imageData.data;
+    let byteIndex = 0;
+
+    for (let index = 0; index < width * height; index += 1) {
+      data[index * 4] = bytes[byteIndex] ?? 0;
+      data[index * 4 + 1] = bytes[byteIndex + 1] ?? 0;
+      data[index * 4 + 2] = bytes[byteIndex + 2] ?? 0;
+      data[index * 4 + 3] = 255;
+      byteIndex += 3;
+    }
+
+    ctx.putImageData(imageData, 0, 0);
+
+    const maxDisplay = Math.max(200, Math.min(480, previewCanvas.parentElement?.clientWidth || 320));
+    const scale = Math.max(1, Math.floor(maxDisplay / Math.max(width, height)));
+    previewCanvas.style.width = `${width * scale}px`;
+    previewCanvas.style.height = `${height * scale}px`;
+
+    const hash = record.vectorSha256 || '';
+    const hashPreview = hash ? `${hash.slice(0, 16)}…` : '—';
+
+    const metaItems = [
+      { label: 'Vector id', value: record.id },
+      { label: 'Collection', value: source?.collection || '—' },
+      { label: 'Provider', value: record.provider || datasetMeta?.provider || '—' },
+      { label: 'Model', value: record.model || datasetMeta?.model || '—' },
+      {
+        label: 'Dimensions',
+        value: record.dimensions
+          ? `${record.dimensions.toLocaleString()}D`
+          : datasetMeta?.dimensions
+          ? `${datasetMeta.dimensions.toLocaleString()}D`
+          : '—',
+      },
+      { label: 'Binary bytes', value: bytes.length.toLocaleString() },
+      { label: 'Pixel grid', value: `${width} × ${height}` },
+      { label: 'Vector hash', value: hashPreview },
+      { label: 'Updated', value: record.updatedAt ? formatDate(record.updatedAt) : '—' },
+    ];
+
+    previewMeta.innerHTML = '';
+    const list = document.createElement('dl');
+    list.className = 'meta-grid';
+
+    metaItems.forEach((item) => {
+      const wrapper = document.createElement('div');
+      const dt = document.createElement('dt');
+      dt.textContent = item.label;
+      const dd = document.createElement('dd');
+      dd.textContent = item.value;
+      wrapper.append(dt, dd);
+      list.appendChild(wrapper);
+    });
+
+    previewMeta.appendChild(list);
   }
 
-  function hydrateSamples() {
-    sampleList.innerHTML = '';
-
-    if (!dataset.length) {
-      const placeholder = document.createElement('p');
-      placeholder.className = 'placeholder';
-      placeholder.textContent = 'No sample embeddings were provided.';
-      sampleList.appendChild(placeholder);
+  function setActiveRecord(recordId) {
+    const datasetData = datasetCache.get(activeDatasetId);
+    if (!datasetData) {
       return;
     }
 
-    const fragment = document.createDocumentFragment();
+    if (!recordId) {
+      activeRecordId = '';
+      updateActiveRecordButton();
+      renderPreview(null, datasetData.meta, datasetData.source);
+      return;
+    }
 
-    dataset.forEach((sample) => {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'sample-button';
-      button.dataset.sampleId = sample.id;
-      button.dataset.active = 'false';
-      button.setAttribute('aria-pressed', 'false');
+    const record = datasetData.records.find((entry) => entry.id === recordId);
+    if (!record) {
+      return;
+    }
 
-      const labelSpan = document.createElement('span');
-      labelSpan.textContent = sample.label;
-      const dimsSpan = document.createElement('span');
-      dimsSpan.className = 'pill';
-      dimsSpan.textContent = `${sample.vector.length}D`;
+    activeRecordId = recordId;
+    updateActiveRecordButton();
+    renderPreview(record, datasetData.meta, datasetData.source);
+  }
 
-      button.append(labelSpan, dimsSpan);
-      button.addEventListener('click', () => {
-        handleSampleSelection(sample);
+  function applyFilter() {
+    const datasetData = datasetCache.get(activeDatasetId);
+    if (!datasetData) {
+      return;
+    }
+
+    const term = filterInput.value.trim().toLowerCase();
+
+    if (!term) {
+      filteredRecords = currentRecords;
+    } else {
+      filteredRecords = currentRecords.filter((record) => {
+        if (record.id.toLowerCase().includes(term)) {
+          return true;
+        }
+        if (record.vectorSha256 && record.vectorSha256.toLowerCase().includes(term)) {
+          return true;
+        }
+        if (record.textHash && record.textHash.toLowerCase().includes(term)) {
+          return true;
+        }
+        return false;
       });
-      fragment.appendChild(button);
-    });
-
-    sampleList.appendChild(fragment);
-  }
-
-  parseButton.addEventListener('click', () => {
-    updateStateFromInput();
-  });
-
-  columnSlider.addEventListener('input', () => {
-    sliderManuallyAdjusted = true;
-    state.columns = Number.parseInt(columnSlider.value, 10) || 1;
-    columnDisplay.textContent = columnSlider.value;
-    drawHeatmap(state.normalized);
-  });
-
-  input.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-      event.preventDefault();
-      updateStateFromInput();
     }
-  });
 
-  window.addEventListener('resize', () => {
-    if (!state.normalized.length) {
+    renderRecordList();
+    updateRecordStatus();
+
+    if (!filteredRecords.length) {
+      activeRecordId = '';
+      renderPreview(null, datasetData.meta, datasetData.source);
+      updateActiveRecordButton();
       return;
     }
-    requestAnimationFrame(() => {
-      drawLinePlot(state.normalized);
-    });
+
+    const current = filteredRecords.find((record) => record.id === activeRecordId);
+    if (current) {
+      renderPreview(current, datasetData.meta, datasetData.source);
+      updateActiveRecordButton();
+      return;
+    }
+
+    activeRecordId = filteredRecords[0].id;
+    renderPreview(filteredRecords[0], datasetData.meta, datasetData.source);
+    updateActiveRecordButton();
+  }
+
+  function handleDatasetChange() {
+    const datasetId = datasetSelect.value;
+    activeDatasetId = datasetId;
+    activeRecordId = '';
+    currentRecords = [];
+    filteredRecords = [];
+
+    filterInput.value = '';
+    filterInput.disabled = true;
+
+    const ctx = previewCanvas.getContext('2d');
+    if (ctx) {
+      ctx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
+    }
+    previewCanvas.width = 1;
+    previewCanvas.height = 1;
+    previewCanvas.style.width = '';
+    previewCanvas.style.height = '';
+    previewMeta.innerHTML = '<p class="placeholder">Select a vector to inspect its details.</p>';
+
+    if (!datasetId) {
+      datasetInfo.innerHTML = '<p class="placeholder">Choose a dataset to inspect its metadata.</p>';
+      recordList.innerHTML = '<li><p class="placeholder">Select a dataset to load its vectors.</p></li>';
+      recordStatus.textContent = 'No dataset selected.';
+      return;
+    }
+
+    const source = sources.find((entry) => entry.id === datasetId);
+    if (!source) {
+      datasetInfo.innerHTML = '<p class="placeholder">The selected dataset is not configured.</p>';
+      recordList.innerHTML = '<li><p class="placeholder">Unable to load this dataset.</p></li>';
+      recordStatus.textContent = 'Dataset configuration error.';
+      return;
+    }
+
+    recordList.innerHTML = '<li><p class="placeholder">Loading vectors…</p></li>';
+    recordStatus.textContent = 'Loading vectors…';
+
+    if (datasetCache.has(datasetId)) {
+      const cached = datasetCache.get(datasetId);
+      currentRecords = cached.records;
+      filteredRecords = cached.records;
+      updateDatasetInfo(cached.meta, cached.source);
+      filterInput.disabled = !currentRecords.length;
+      renderRecordList();
+      updateRecordStatus();
+      if (filteredRecords.length) {
+        activeRecordId = filteredRecords[0].id;
+        renderPreview(filteredRecords[0], cached.meta, cached.source);
+        updateActiveRecordButton();
+      } else {
+        previewMeta.innerHTML = '<p class="placeholder">This dataset does not include any vectors.</p>';
+      }
+      return;
+    }
+
+    fetch(source.url)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load ${source.url}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        const meta = data?.meta || {};
+        const recordsObject = data?.records || {};
+        const records = Object.keys(recordsObject).map((id) => ({
+          id,
+          ...recordsObject[id],
+        }));
+
+        records.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: 'base' }));
+
+        const datasetData = { source, meta, records };
+        datasetCache.set(datasetId, datasetData);
+
+        currentRecords = records;
+        filteredRecords = records;
+        updateDatasetInfo(meta, source);
+        filterInput.disabled = !records.length;
+        renderRecordList();
+        updateRecordStatus();
+
+        if (records.length) {
+          activeRecordId = records[0].id;
+          renderPreview(records[0], meta, source);
+          updateActiveRecordButton();
+        } else {
+          previewMeta.innerHTML = '<p class="placeholder">This dataset does not include any vectors.</p>';
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to load dataset', error);
+        datasetInfo.innerHTML = '<p class="placeholder">Failed to load dataset metadata.</p>';
+        recordList.innerHTML = '<li><p class="placeholder">Could not load vectors. Please try again.</p></li>';
+        recordStatus.textContent = 'Failed to load dataset.';
+        filterInput.disabled = true;
+      });
+  }
+
+  datasetSelect.addEventListener('change', () => {
+    handleDatasetChange();
   });
 
-  hydrateSamples();
-  renderSampleMeta(null);
+  recordList.addEventListener('click', (event) => {
+    const button = event.target.closest('.record-button');
+    if (!button) {
+      return;
+    }
+    const recordId = button.dataset.recordId;
+    if (!recordId || recordId === activeRecordId) {
+      return;
+    }
+    setActiveRecord(recordId);
+  });
 
-  if (dataset.length) {
-    handleSampleSelection(dataset[0]);
-  } else {
-    updateStateFromInput();
+  filterInput.addEventListener('input', () => {
+    applyFilter();
+  });
+
+  populateDatasetSelect();
+
+  if (datasetSelect.value) {
+    handleDatasetChange();
   }
 })();

--- a/apps/embedding-explorer/index.html
+++ b/apps/embedding-explorer/index.html
@@ -27,9 +27,6 @@
       --input-background: rgba(15, 23, 42, 0.78);
       --input-border: rgba(148, 163, 209, 0.36);
       --input-focus: rgba(96, 165, 250, 0.6);
-      --chip-background: rgba(96, 165, 250, 0.14);
-      --chip-text: var(--text-primary);
-      --table-header: rgba(15, 23, 42, 0.72);
     }
 
     @media (prefers-color-scheme: light) {
@@ -53,9 +50,6 @@
         --input-background: rgba(241, 245, 249, 0.92);
         --input-border: rgba(148, 163, 184, 0.4);
         --input-focus: rgba(59, 130, 246, 0.6);
-        --chip-background: rgba(59, 130, 246, 0.12);
-        --chip-text: #1e3a8a;
-        --table-header: rgba(226, 232, 240, 0.86);
       }
     }
 
@@ -163,7 +157,7 @@
       font-size: 1.05rem;
       line-height: 1.6;
       color: var(--text-secondary);
-      max-width: 60ch;
+      max-width: 65ch;
     }
 
     .workspace {
@@ -197,297 +191,10 @@
       grid-column: 1 / -1;
     }
 
-    .sample-buttons {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-    }
-
-    .sample-button {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 8px 14px;
-      border-radius: 999px;
-      border: 1px solid var(--accent);
-      background: var(--chip-background);
-      color: var(--chip-text);
-      font-weight: 600;
-      font-size: 0.92rem;
-      letter-spacing: 0.01em;
-      cursor: pointer;
-      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
-    }
-
-    .sample-button:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 12px 24px color-mix(in srgb, var(--accent) 35%, transparent);
-    }
-
-    .sample-button:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 3px var(--input-focus);
-    }
-
-    .sample-button[data-active="true"] {
-      background: var(--accent);
-      color: var(--accent-contrast);
-    }
-
-    .sample-meta {
-      background: rgba(59, 130, 246, 0.12);
-      border: 1px solid var(--surface-border);
-      border-radius: 18px;
-      padding: 12px 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-
-    .sample-meta p {
-      margin: 0;
-      color: var(--text-secondary);
-      line-height: 1.4;
-    }
-
-    .sample-meta strong {
-      color: var(--text-primary);
-    }
-
-    textarea {
-      width: 100%;
-      min-height: 140px;
-      border-radius: 16px;
-      padding: 16px;
-      border: 1px solid var(--input-border);
-      background: var(--input-background);
-      color: var(--text-primary);
-      font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-      font-size: 0.95rem;
-      line-height: 1.5;
-      resize: vertical;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    textarea:focus-visible {
-      outline: none;
-      border-color: var(--accent);
-      box-shadow: 0 0 0 3px var(--input-focus);
-    }
-
-    .control-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    .control-row label {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-      font-weight: 600;
-      color: var(--text-secondary);
-      font-size: 0.9rem;
-    }
-
-    .control-row input[type="range"] {
-      width: min(260px, 100%);
-      accent-color: var(--accent-strong);
-    }
-
-    .control-row output {
-      font-variant-numeric: tabular-nums;
-      font-weight: 600;
-    }
-
-    .primary-button {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 12px 20px;
-      border-radius: 999px;
-      border: none;
-      background: linear-gradient(135deg, var(--accent), color-mix(in srgb, var(--accent) 70%, #ffffff));
-      color: var(--accent-contrast);
-      font-weight: 600;
-      font-size: 1rem;
-      cursor: pointer;
-      box-shadow: 0 16px 28px color-mix(in srgb, var(--accent) 35%, transparent);
-      transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
-    }
-
-    .primary-button:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 20px 36px color-mix(in srgb, var(--accent) 45%, transparent);
-    }
-
-    .primary-button:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 3px var(--input-focus), 0 20px 36px color-mix(in srgb, var(--accent) 45%, transparent);
-    }
-
-    .summary-grid {
-      display: grid;
-      gap: 12px;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    }
-
-    .summary-card {
-      background: var(--muted-background);
-      border: 1px solid var(--muted-border);
-      border-radius: 18px;
-      padding: 12px 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-
-    .summary-card dt {
-      margin: 0;
-      font-size: 0.85rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--text-secondary);
-    }
-
-    .summary-card dd {
-      margin: 0;
-      font-size: 1.3rem;
-      font-weight: 700;
-      font-variant-numeric: tabular-nums;
-    }
-
-    .visual-group {
-      display: grid;
-      gap: 18px;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    }
-
-    .visual-panel {
-      background: var(--surface-strong);
-      border-radius: 22px;
-      border: 1px solid var(--surface-border);
-      padding: clamp(14px, 2vw, 20px);
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-
-    .visual-panel h3 {
-      margin: 0;
-      font-size: 1.05rem;
-    }
-
-    .visual-panel p {
+    .panel-sub {
       margin: 0;
       color: var(--text-secondary);
       font-size: 0.92rem;
-    }
-
-    canvas {
-      width: 100%;
-      border-radius: 18px;
-      border: 1px solid var(--surface-border);
-      background: rgba(15, 23, 42, 0.45);
-    }
-
-    canvas.heatmap {
-      image-rendering: pixelated;
-      aspect-ratio: 1 / 1;
-    }
-
-    .extremes {
-      display: grid;
-      gap: 16px;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    }
-
-    .extreme-card {
-      background: var(--surface-strong);
-      border-radius: 20px;
-      border: 1px solid var(--surface-border);
-      padding: 14px 18px;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-
-    .extreme-card h3 {
-      margin: 0;
-      font-size: 1.05rem;
-    }
-
-    .extreme-card ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-
-    .extreme-card li {
-      display: flex;
-      justify-content: space-between;
-      font-variant-numeric: tabular-nums;
-      padding: 8px 12px;
-      border-radius: 14px;
-      background: rgba(59, 130, 246, 0.12);
-    }
-
-    .extreme-card li span:first-child {
-      font-weight: 600;
-    }
-
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      background: var(--surface-strong);
-      border-radius: 20px;
-      overflow: hidden;
-      border: 1px solid var(--surface-border);
-    }
-
-    .table-wrapper {
-      width: 100%;
-      overflow: auto;
-      border-radius: 20px;
-    }
-
-    thead {
-      background: var(--table-header);
-    }
-
-    th {
-      padding: 12px 14px;
-      text-align: left;
-      font-size: 0.85rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--text-secondary);
-    }
-
-    td {
-      padding: 12px 14px;
-      border-top: 1px solid var(--surface-border);
-      font-size: 0.95rem;
-      font-variant-numeric: tabular-nums;
-    }
-
-    tbody tr:hover td {
-      background: rgba(96, 165, 250, 0.12);
-    }
-
-    .value-positive {
-      color: #f97316;
-      font-weight: 600;
-    }
-
-    .value-negative {
-      color: #60a5fa;
-      font-weight: 600;
     }
 
     .pill {
@@ -504,6 +211,166 @@
       text-transform: uppercase;
     }
 
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-weight: 600;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    select,
+    input[type="search"] {
+      width: 100%;
+      border-radius: 14px;
+      border: 1px solid var(--input-border);
+      background: var(--input-background);
+      color: var(--text-primary);
+      padding: 10px 14px;
+      font-size: 0.95rem;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    select:focus-visible,
+    input[type="search"]:focus-visible {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--input-focus);
+    }
+
+    .info-block {
+      border-radius: 18px;
+      border: 1px solid var(--surface-border);
+      background: rgba(15, 23, 42, 0.45);
+      padding: 14px 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .meta-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .meta-grid > div {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .meta-grid dt {
+      margin: 0;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+    }
+
+    .meta-grid dd {
+      margin: 0;
+      font-weight: 600;
+      font-size: 1.05rem;
+      color: var(--text-primary);
+      word-break: break-word;
+    }
+
+    .record-status {
+      margin: 0;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    .record-list-wrapper {
+      border-radius: 18px;
+      border: 1px solid var(--surface-border);
+      background: rgba(15, 23, 42, 0.35);
+      padding: 8px;
+      max-height: clamp(220px, 40vh, 360px);
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .record-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .record-list li {
+      margin: 0;
+      padding: 0;
+    }
+
+    .record-button {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+      padding: 10px 14px;
+      border-radius: 14px;
+      border: 1px solid transparent;
+      background: rgba(96, 165, 250, 0.08);
+      color: var(--text-primary);
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+    }
+
+    .record-button:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+    }
+
+    .record-button:focus-visible {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--input-focus);
+    }
+
+    .record-button[data-active="true"] {
+      background: var(--accent);
+      color: var(--accent-contrast);
+      border-color: var(--accent);
+      box-shadow: 0 14px 24px color-mix(in srgb, var(--accent) 35%, transparent);
+    }
+
+    .record-button[data-active="true"] .record-button__meta {
+      color: color-mix(in srgb, var(--accent-contrast) 75%, transparent);
+    }
+
+    .record-button__id {
+      font-weight: 600;
+      font-size: 1rem;
+    }
+
+    .record-button__meta {
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+    }
+
+    .embedding-canvas {
+      border-radius: 18px;
+      border: 1px solid var(--surface-border);
+      background: rgba(15, 23, 42, 0.45);
+      image-rendering: pixelated;
+      align-self: center;
+    }
+
+    .caption {
+      margin: 0;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
     .placeholder {
       margin: 0;
       padding: 12px 14px;
@@ -518,13 +385,9 @@
         padding: clamp(18px, 5vw, 28px);
       }
 
-      .control-row {
-        flex-direction: column;
-        align-items: stretch;
-      }
-
-      .control-row input[type="range"] {
-        width: 100%;
+      .embedding-canvas {
+        width: 100% !important;
+        height: auto !important;
       }
     }
   </style>
@@ -538,95 +401,48 @@
       </a>
     </nav>
     <header class="page-header">
-      <p class="eyebrow">Vector playground</p>
+      <p class="eyebrow">Vector archive</p>
       <h1>Embedding Explorer</h1>
-      <p class="lead">Paste an embedding vector or pick one of the sample encodings to inspect its shape, highlight its strongest
-        features, and project the high-dimensional signal into an interactive image.</p>
+      <p class="lead">Browse the stored embedding exports, pick any record, and project its raw binary signal into an RGB pixel
+        grid.</p>
     </header>
     <section class="workspace" aria-label="Embedding workspace">
-      <article class="panel panel--wide" aria-labelledby="load-heading">
-        <div class="pill" id="load-heading">Load an embedding</div>
-        <p>Select one of the curated examples or paste your own comma, space, or newline separated list of numbers. The
-          explorer normalizes the values automatically and skips invalid tokens so that every visualization stays in
-          sync.</p>
-        <div class="sample-buttons" data-sample-list>
-          <p class="placeholder">Sample embeddings load here once the page is ready.</p>
-        </div>
-        <div class="sample-meta" data-sample-meta>
-          <p class="placeholder">Select a sample to preview its prompt and notes.</p>
-        </div>
-        <label class="sr-only" for="embedding-input">Embedding values</label>
-        <textarea id="embedding-input" data-embedding-input placeholder="0.12, -0.34, 0.56, ..."></textarea>
-        <div class="control-row">
-          <button class="primary-button" type="button" data-parse-button>
-            <span aria-hidden="true">✨</span>
-            <span>Update visualizations</span>
-          </button>
-          <label>
-            Columns for heatmap
-            <input type="range" min="1" max="32" value="8" data-column-slider>
-            <output data-column-display>8</output>
-          </label>
+      <article class="panel" aria-labelledby="dataset-heading">
+        <div class="pill" id="dataset-heading">Choose a dataset</div>
+        <p>Select one of the existing embedding dumps bundled with the site. Metadata loads automatically so you can compare
+          providers and models.</p>
+        <label for="dataset-select">
+          Embedding collection
+          <select id="dataset-select" data-dataset-select></select>
+        </label>
+        <div class="info-block" data-dataset-info>
+          <p class="placeholder">Pick a dataset to inspect its metadata.</p>
         </div>
       </article>
-      <article class="panel" aria-labelledby="summary-heading">
-        <h2 id="summary-heading">Vector summary</h2>
-        <div class="summary-grid" data-summary-grid>
-          <p class="placeholder">Paste an embedding to view its metrics.</p>
+      <article class="panel" aria-labelledby="record-heading">
+        <h2 id="record-heading">Vectors</h2>
+        <p class="panel-sub">Load any record from the selected dataset to render its RGB projection.</p>
+        <label for="record-filter">
+          Filter by id or hash
+          <input id="record-filter" type="search" placeholder="Start typing to narrow the list" data-record-filter disabled>
+        </label>
+        <p class="record-status" data-record-status>Choose a dataset to load its vectors.</p>
+        <div class="record-list-wrapper">
+          <ul class="record-list" data-record-list>
+            <li>
+              <p class="placeholder">Vectors appear here once a dataset finishes loading.</p>
+            </li>
+          </ul>
         </div>
       </article>
-      <article class="panel" aria-labelledby="distribution-heading">
-        <h2 id="distribution-heading">Distribution</h2>
-        <div class="visual-group">
-          <div class="visual-panel" aria-labelledby="heatmap-heading">
-            <h3 id="heatmap-heading">Embedding heatmap</h3>
-            <canvas class="heatmap" data-heatmap aria-describedby="heatmap-caption"></canvas>
-            <p id="heatmap-caption">Negative activations map to cool blues, zero stays neutral, and positive features glow in
-              coral.
-            </p>
-          </div>
-          <div class="visual-panel" aria-labelledby="line-heading">
-            <h3 id="line-heading">Value profile</h3>
-            <canvas class="line-plot" data-line-chart aria-describedby="line-caption"></canvas>
-            <p id="line-caption">A smoothed line plot reveals transitions between nearby dimensions.</p>
-          </div>
-        </div>
-      </article>
-      <article class="panel panel--wide" aria-labelledby="extremes-heading">
-        <h2 id="extremes-heading">Notable dimensions</h2>
-        <div class="extremes">
-          <div class="extreme-card" aria-labelledby="positive-heading">
-            <h3 id="positive-heading">Top positive</h3>
-            <ul data-positive-list>
-              <li><span>–</span><span>0.000</span></li>
-            </ul>
-          </div>
-          <div class="extreme-card" aria-labelledby="negative-heading">
-            <h3 id="negative-heading">Top negative</h3>
-            <ul data-negative-list>
-              <li><span>–</span><span>0.000</span></li>
-            </ul>
-          </div>
-        </div>
-      </article>
-      <article class="panel panel--wide" aria-labelledby="table-heading">
-        <h2 id="table-heading">All dimensions</h2>
-        <div class="table-wrapper">
-          <table aria-describedby="table-caption">
-            <caption id="table-caption" class="sr-only">Embedding dimensions with index and normalized value.</caption>
-            <thead>
-              <tr>
-                <th scope="col">Index</th>
-                <th scope="col">Value</th>
-                <th scope="col">Normalized</th>
-              </tr>
-            </thead>
-            <tbody data-value-table>
-              <tr>
-                <td colspan="3">Paste an embedding to populate the table.</td>
-              </tr>
-            </tbody>
-          </table>
+      <article class="panel panel--wide" aria-labelledby="preview-heading">
+        <h2 id="preview-heading">Binary preview</h2>
+        <p class="panel-sub">Each pixel consumes three bytes from the underlying vector. Extra space pads with zeros so the grid
+          stays rectangular.</p>
+        <canvas class="embedding-canvas" data-preview-canvas aria-describedby="preview-caption"></canvas>
+        <p id="preview-caption" class="caption">Switch between vectors to compare their byte-level fingerprints.</p>
+        <div class="info-block" data-preview-meta>
+          <p class="placeholder">Select a vector to inspect its details.</p>
         </div>
       </article>
     </section>

--- a/apps/embedding-explorer/sample-embeddings.js
+++ b/apps/embedding-explorer/sample-embeddings.js
@@ -1,23 +1,56 @@
-window.sampleEmbeddings = [
+window.embeddingSources = [
   {
-    "id": "radiant-morning",
-    "label": "Radiant morning scene",
-    "prompt": "A sunny stroll through a park lined with trees and warm light.",
-    "notes": "Smoothly varying positive signal with a gentle dip into negative values.",
-    "vector": [0.2,0.298,0.391,0.477,0.552,0.614,0.662,0.694,0.709,0.707,0.686,0.648,0.593,0.522,0.437,0.34,0.233,0.119,0.001,-0.118,-0.236,-0.349,-0.454,-0.549,-0.632,-0.7,-0.751,-0.785,-0.799,-0.795,-0.772,-0.73,-0.671,-0.596,-0.508,-0.408,-0.298,-0.183,-0.064,0.055,0.172,0.282,0.385,0.477,0.556,0.62,0.667,0.697,0.71,0.705,0.682,0.642,0.588,0.519,0.439,0.35,0.254,0.155,0.054,-0.046,-0.141,-0.229,-0.309,-0.377]
+    "id": "jokes-synthetic",
+    "label": "Dad jokes — synthetic 64d",
+    "collection": "Dad jokes",
+    "url": "../../data/jokes-embeddings.json"
   },
   {
-    "id": "neon-crosswalk",
-    "label": "Neon-lit crosswalk",
-    "prompt": "Busy urban crossing at night with bright signage and a fast tempo.",
-    "notes": "Oscillates around zero with a strong negative mid-section and rising finale.",
-    "vector": [0.55,0.465,0.363,0.249,0.131,0.012,-0.1,-0.202,-0.289,-0.358,-0.408,-0.438,-0.448,-0.439,-0.413,-0.373,-0.322,-0.263,-0.2,-0.135,-0.072,-0.012,0.043,0.091,0.132,0.166,0.193,0.214,0.229,0.24,0.247,0.25,0.249,0.246,0.239,0.227,0.211,0.189,0.161,0.126,0.083,0.034,-0.022,-0.082,-0.146,-0.211,-0.274,-0.331,-0.381,-0.418,-0.442,-0.448,-0.435,-0.401,-0.348,-0.275,-0.186,-0.082,0.032,0.151,0.269,0.381,0.48,0.562]
+    "id": "jokes-openai",
+    "label": "Dad jokes — OpenAI text-embedding-3-large",
+    "collection": "Dad jokes",
+    "url": "../../data/jokes-embeddings-openai.json"
   },
   {
-    "id": "ocean-dusk",
-    "label": "Ocean at dusk",
-    "prompt": "Gentle ocean waves at sunset with a calm breeze and pastel sky.",
-    "notes": "Alternates between calm rises and deeper valleys with a soft cadence.",
-    "vector": [0,0.171,0.329,0.461,0.557,0.61,0.621,0.59,0.524,0.433,0.329,0.225,0.131,0.059,0.014,0.001,0.017,0.059,0.118,0.183,0.243,0.286,0.303,0.286,0.233,0.144,0.024,-0.118,-0.271,-0.421,-0.555,-0.66,-0.727,-0.75,-0.726,-0.658,-0.551,-0.417,-0.267,-0.114,0.027,0.147,0.235,0.287,0.303,0.286,0.242,0.182,0.116,0.058,0.017,0.001,0.015,0.06,0.133,0.227,0.332,0.436,0.526,0.591,0.621,0.61,0.554,0.458]
+    "id": "jokes-cohere",
+    "label": "Dad jokes — Cohere embed-english-v3.0",
+    "collection": "Dad jokes",
+    "url": "../../data/jokes-embeddings-cohere.json"
+  },
+  {
+    "id": "quotes-synthetic",
+    "label": "Curated quotes — synthetic 64d",
+    "collection": "Curated quotes",
+    "url": "../../data/quotes-embeddings.json"
+  },
+  {
+    "id": "quotes-openai",
+    "label": "Curated quotes — OpenAI text-embedding-3-large",
+    "collection": "Curated quotes",
+    "url": "../../data/quotes-embeddings-openai.json"
+  },
+  {
+    "id": "quotes-cohere",
+    "label": "Curated quotes — Cohere embed-english-v3.0",
+    "collection": "Curated quotes",
+    "url": "../../data/quotes-embeddings-cohere.json"
+  },
+  {
+    "id": "slang-synthetic",
+    "label": "Internet slang — synthetic 64d",
+    "collection": "Internet slang",
+    "url": "../../data/slang-embeddings.json"
+  },
+  {
+    "id": "slang-s128",
+    "label": "Internet slang — synthetic 128d",
+    "collection": "Internet slang",
+    "url": "../../data/slang-embeddings-synthetic128.json"
+  },
+  {
+    "id": "slang-hfspace",
+    "label": "Internet slang — MiniLM (hf.space)",
+    "collection": "Internet slang",
+    "url": "../../data/slang-embeddings-hfspace.json"
   }
 ];


### PR DESCRIPTION
## Summary
- replace the manual vector entry UI with a dataset selector and record list driven by configured embedding exports
- visualize vectors as RGB pixel grids and surface metadata about the selected record
- catalog jokes, quotes, and slang embedding dumps for the explorer to load

## Testing
- CI=1 npm test *(fails: browser dependencies missing in the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d3370b33748328848f722c5b3deba4