### PR TITLE
Improve offline bundle versioning and reset workflow

### DIFF
--- a/.github/workflows/update-offline-manifest.yml
+++ b/.github/workflows/update-offline-manifest.yml
@@ -1,0 +1,42 @@
+name: Refresh offline manifest
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  update-offline-manifest:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate offline manifest
+        env:
+          GITHUB_SHA: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+        run: node tools/generate-offline-manifest.js
+
+      - name: Commit offline manifest update
+        run: |
+          if git diff --quiet -- offline-manifest.json; then
+            echo "No offline manifest changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add offline-manifest.json
+          git commit -m "chore: refresh offline manifest for #${{ github.event.pull_request.number }}"
+          git push origin HEAD:${{ github.event.pull_request.base.ref }}

--- a/index.html
+++ b/index.html
@@ -259,6 +259,55 @@
       font-size: 0.9rem;
     }
 
+    .offline-card__actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin: 4px 0 0;
+    }
+
+    .offline-card__button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 10px 18px;
+      border-radius: 999px;
+      border: 1px solid var(--button-border);
+      background: var(--button-secondary-background);
+      color: var(--button-secondary-text);
+      font-weight: 600;
+      font-size: 0.95rem;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      box-shadow: var(--button-shadow);
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+    }
+
+    .offline-card__button:hover {
+      background: var(--button-secondary-hover);
+      transform: translateY(-1px);
+      box-shadow: var(--button-shadow-hover);
+    }
+
+    .offline-card__button:focus-visible {
+      outline: none;
+      transform: translateY(-1px);
+      box-shadow: 0 0 0 3px var(--focus-ring), var(--button-shadow-hover);
+    }
+
+    .offline-card__button[disabled] {
+      cursor: not-allowed;
+      opacity: 0.7;
+      transform: none;
+      box-shadow: var(--button-shadow);
+    }
+
+    .offline-card__button[disabled]:hover {
+      background: var(--button-secondary-background);
+      transform: none;
+    }
+
     .offline-progress {
       position: fixed;
       top: 0;
@@ -453,6 +502,11 @@
         <div class="offline-card__content">
           <p class="offline-card__meta" data-offline-meta hidden></p>
           <p class="offline-card__progress-note" data-offline-progress-note hidden></p>
+          <div class="offline-card__actions">
+            <button type="button" class="offline-card__button" data-offline-reset disabled aria-busy="false">
+              Refresh offline bundle
+            </button>
+          </div>
           <p class="offline-card__hint">
             On iPhone, open Safari’s Share menu and choose <strong>Add to Home Screen</strong> after the download completes to launch the toolbox like an app.
           </p>
@@ -482,14 +536,28 @@
       const progressFill = progressWrapper ? progressWrapper.querySelector('[data-offline-progress-fill]') : null;
       const progressDetail = progressWrapper ? progressWrapper.querySelector('[data-offline-progress-detail]') : null;
       const progressNote = offlineCard.querySelector('[data-offline-progress-note]');
+      const resetButton = offlineCard.querySelector('[data-offline-reset]');
+      const defaultResetLabel = resetButton ? ((resetButton.textContent || '').trim() || 'Refresh offline bundle') : 'Refresh offline bundle';
+      const resetBusyLabel = resetButton && resetButton.dataset && resetButton.dataset.busyLabel
+        ? resetButton.dataset.busyLabel
+        : 'Refreshing offline bundle…';
 
       if (!statusEl || !progressWrapper || !progressBar || !progressFill || !progressDetail) {
         return;
       }
 
+      if (resetButton) {
+        resetButton.disabled = true;
+        resetButton.setAttribute('aria-busy', 'false');
+        resetButton.textContent = defaultResetLabel;
+      }
+
       const formatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 });
       const state = {
-        manifest: null
+        manifest: null,
+        registration: null,
+        isCaching: false,
+        resetRequested: false
       };
 
       function setStatus(message) {
@@ -529,6 +597,74 @@
         return `${formatter.format(Number(value.toFixed(fractionDigits)))} ${units[unitIndex]}`;
       }
 
+      function getCommitLabel(commit) {
+        if (!commit || typeof commit !== 'object') {
+          return '';
+        }
+
+        const shortHash = typeof commit.short === 'string' && commit.short ? commit.short : '';
+        const fallback = typeof commit.hash === 'string' && commit.hash ? commit.hash.slice(0, 12) : '';
+        const label = shortHash || fallback;
+
+        if (!label) {
+          return '';
+        }
+
+        return commit.dirty ? `${label}-dirty` : label;
+      }
+
+      function buildBundleSummary(info) {
+        if (!info || !info.totalAssets) {
+          return '';
+        }
+
+        const versionLabel = info.version || '';
+        const commitLabel = getCommitLabel(info.commit);
+        const parts = [];
+
+        if (versionLabel) {
+          parts.push(`Bundle v${versionLabel}`);
+        }
+
+        if (commitLabel && (!versionLabel || !versionLabel.includes(commitLabel))) {
+          parts.push(`commit ${commitLabel}`);
+        }
+
+        parts.push(`${formatBytes(info.totalBytes)} across ${info.totalAssets} files`);
+
+        return parts.filter(Boolean).join(' · ');
+      }
+
+      function canUseReset() {
+        return Boolean(resetButton && state.manifest && state.registration && state.registration.active && !state.isCaching);
+      }
+
+      function updateResetAvailability() {
+        if (!resetButton || state.isCaching) {
+          return;
+        }
+
+        resetButton.disabled = !canUseReset();
+      }
+
+      function setResetBusy(isBusy) {
+        state.isCaching = Boolean(isBusy);
+
+        if (!resetButton) {
+          return;
+        }
+
+        if (state.isCaching) {
+          resetButton.disabled = true;
+          resetButton.setAttribute('aria-busy', 'true');
+          resetButton.textContent = resetBusyLabel;
+        } else {
+          resetButton.setAttribute('aria-busy', 'false');
+          resetButton.textContent = defaultResetLabel;
+          updateResetAvailability();
+        }
+      }
+
       function setProgress(value) {
         const clamped = Math.min(100, Math.max(0, value));
         progressBar.setAttribute('aria-valuenow', String(Math.round(clamped)));
@@ -559,19 +695,41 @@
         const detail = payload.detail || {};
         const totalAssets = typeof detail.totalAssets === 'number' ? detail.totalAssets : 0;
         const totalBytes = typeof detail.totalBytes === 'number' ? detail.totalBytes : 0;
-        const bundleSummary = totalAssets > 0 ? `Bundle v${detail.version || (state.manifest && state.manifest.version) || ''} · ${formatBytes(totalBytes)} across ${totalAssets} files` : '';
+        const bundleSummary = buildBundleSummary({
+          version: detail.version || (state.manifest && state.manifest.version) || '',
+          totalAssets,
+          totalBytes,
+          commit: detail.commit || (state.manifest && state.manifest.commit) || null
+        });
+
+        if (payload.state === 'resetting') {
+          state.resetRequested = true;
+          setResetBusy(true);
+          progressWrapper.hidden = false;
+          setProgress(0);
+          updateProgressDetail('Clearing offline cache…');
+          setStatus('Clearing offline cache…');
+          return;
+        }
 
         if (payload.state === 'start') {
+          setResetBusy(true);
           progressWrapper.hidden = false;
           setProgress(0);
           updateProgressDetail(`Downloading ${formatBytes(totalBytes)} of data…`);
           setStatus('Caching offline bundle…');
-        } else if (payload.state === 'progress') {
+          return;
+        }
+
+        if (payload.state === 'progress') {
           const completed = typeof detail.completed === 'number' ? detail.completed : 0;
           const loadedBytes = typeof detail.loadedBytes === 'number' ? detail.loadedBytes : 0;
           const assetPath = detail.asset && detail.asset.path ? detail.asset.path : '';
-          const percent = totalBytes > 0 ? (loadedBytes / Math.max(totalBytes, 1)) * 100 : (completed / Math.max(totalAssets, 1)) * 100;
+          const percent = totalBytes > 0
+            ? (loadedBytes / Math.max(totalBytes, 1)) * 100
+            : (completed / Math.max(totalAssets, 1)) * 100;
 
+          setResetBusy(true);
           progressWrapper.hidden = false;
           setProgress(percent);
           updateProgressDetail([
@@ -580,17 +738,57 @@
             assetPath ? assetPath : null
           ].filter(Boolean).join(' • '));
           setStatus('Caching offline bundle…');
-        } else if (payload.state === 'complete') {
+          return;
+        }
+
+        if (payload.state === 'complete') {
           progressWrapper.hidden = true;
           setProgress(100);
-          const readyText = detail.alreadyCached ? 'Offline bundle is up to date.' : 'Offline bundle ready for offline use.';
-          setStatus(readyText);
+          const readyText = detail.alreadyCached
+            ? 'Offline bundle is up to date.'
+            : state.resetRequested
+              ? 'Offline bundle refreshed for offline use.'
+              : 'Offline bundle ready for offline use.';
+          state.resetRequested = false;
+          setResetBusy(false);
           updateMeta(bundleSummary);
           updateProgressDetail('');
-        } else if (payload.state === 'error') {
+          setStatus(readyText);
+
+          if (state.manifest) {
+            if (detail.version) {
+              state.manifest.version = detail.version;
+            }
+            if (detail.commit) {
+              state.manifest.commit = detail.commit;
+            }
+            if (Number.isFinite(totalBytes)) {
+              state.manifest.totalBytes = totalBytes;
+            }
+            if (typeof totalAssets === 'number') {
+              state.manifest.totalAssets = totalAssets;
+            }
+          }
+
+          return;
+        }
+
+        if (payload.state === 'error') {
           progressWrapper.hidden = true;
+          state.resetRequested = false;
+          setResetBusy(false);
           updateProgressDetail('');
           setStatus('Offline caching failed. Refresh when you have a connection.');
+          return;
+        }
+
+        if (payload.state === 'reset-error') {
+          progressWrapper.hidden = true;
+          state.resetRequested = false;
+          setResetBusy(false);
+          const message = typeof detail.message === 'string' ? detail.message : '';
+          updateProgressDetail(message);
+          setStatus('Unable to reset the offline bundle. Refresh when you have a connection.');
         }
       }
 
@@ -602,6 +800,34 @@
         registration.active.postMessage({
           type: 'apply-manifest',
           manifest: state.manifest
+        });
+      }
+
+      if (resetButton) {
+        resetButton.addEventListener('click', () => {
+          if (!canUseReset() || !state.registration || !state.registration.active || !state.manifest) {
+            return;
+          }
+
+          state.resetRequested = true;
+          setResetBusy(true);
+          progressWrapper.hidden = false;
+          setProgress(0);
+          updateProgressDetail('Clearing offline cache…');
+          setStatus('Clearing offline cache…');
+
+          try {
+            state.registration.active.postMessage({
+              type: 'reset-offline-cache',
+              manifest: state.manifest
+            });
+          } catch (error) {
+            console.error('Failed to request offline cache reset', error);
+            state.resetRequested = false;
+            setResetBusy(false);
+            updateProgressDetail('');
+            setStatus('Unable to reset the offline bundle. Refresh when you have a connection.');
+          }
         });
       }
 
@@ -620,10 +846,27 @@
           const manifest = await response.json();
           state.manifest = manifest;
           const assets = Array.isArray(manifest.assets) ? manifest.assets : [];
-          const totalBytes = Number.isFinite(manifest.totalBytes) ? manifest.totalBytes : assets.reduce((total, asset) => total + (Number(asset.bytes) || 0), 0);
-          const summary = assets.length ? `Bundle v${manifest.version} · ${formatBytes(totalBytes)} across ${assets.length} files` : '';
+          const totalBytes = Number.isFinite(manifest.totalBytes)
+            ? manifest.totalBytes
+            : assets.reduce((total, asset) => total + (Number(asset.bytes) || 0), 0);
+
+          if (!Number.isFinite(manifest.totalBytes)) {
+            manifest.totalBytes = totalBytes;
+          }
+          if (typeof manifest.totalAssets !== 'number') {
+            manifest.totalAssets = assets.length;
+          }
+
+          const summary = buildBundleSummary({
+            version: manifest.version,
+            totalAssets: assets.length,
+            totalBytes,
+            commit: manifest.commit || null
+          });
+
           updateMeta(summary);
           setStatus('Offline bundle ready to download.');
+          updateResetAvailability();
         } catch (error) {
           console.error('Failed to load offline manifest', error);
           setStatus('Unable to load the offline manifest. Refresh when you are back online.');
@@ -633,8 +876,16 @@
         try {
           const registration = await navigator.serviceWorker.register('service-worker.js');
           navigator.serviceWorker.addEventListener('message', handleMessage);
+          navigator.serviceWorker.addEventListener('controllerchange', () => {
+            navigator.serviceWorker.ready.then((readyRegistration) => {
+              state.registration = readyRegistration;
+              updateResetAvailability();
+            }).catch(() => {});
+          });
 
           const readyRegistration = await navigator.serviceWorker.ready;
+          state.registration = readyRegistration;
+          updateResetAvailability();
           requestCaching(readyRegistration);
         } catch (error) {
           console.error('Service worker registration failed', error);

--- a/offline-manifest.json
+++ b/offline-manifest.json
@@ -1,8 +1,8 @@
 {
-  "version": "20250923-0aef3e87efed",
-  "generatedAt": "2025-09-23T23:33:25.182Z",
+  "version": "20250924-37e3b7097054-6a46f6e722c7-dirty",
+  "generatedAt": "2025-09-24T00:50:25.848Z",
   "totalAssets": 55,
-  "totalBytes": 5772295,
+  "totalBytes": 5778597,
   "assets": [
     {
       "path": "apps/asset-observatory/app.js",
@@ -18,15 +18,15 @@
     },
     {
       "path": "apps/embedding-explorer/app.js",
-      "bytes": 15714
+      "bytes": 15263
     },
     {
       "path": "apps/embedding-explorer/index.html",
-      "bytes": 18011
+      "bytes": 12647
     },
     {
       "path": "apps/embedding-explorer/sample-embeddings.js",
-      "bytes": 1997
+      "bytes": 1618
     },
     {
       "path": "apps/jokes/all-jokes-compact.html",
@@ -218,11 +218,16 @@
     },
     {
       "path": "index.html",
-      "bytes": 18920
+      "bytes": 28752
     },
     {
       "path": "service-worker.js",
-      "bytes": 8648
+      "bytes": 11312
     }
-  ]
+  ],
+  "commit": {
+    "hash": "6a46f6e722c7cad4f074d58f37a05be8100139aa",
+    "short": "6a46f6e722c7",
+    "dirty": true
+  }
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -25,12 +25,15 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('message', (event) => {
   const data = event.data;
-  if (!data || data.type !== 'apply-manifest' || !data.manifest) {
+  if (!data || typeof data.type !== 'string') {
     return;
   }
 
-  const manifest = data.manifest;
-  event.waitUntil(queueManifestUpdate(manifest));
+  if (data.type === 'apply-manifest' && data.manifest) {
+    event.waitUntil(queueManifestUpdate(data.manifest));
+  } else if (data.type === 'reset-offline-cache') {
+    event.waitUntil(resetOfflineCache(data.manifest || null));
+  }
 });
 
 self.addEventListener('fetch', (event) => {
@@ -64,10 +67,12 @@ function getCacheName(version) {
   return `${CACHE_PREFIX}${version}`;
 }
 
-async function queueManifestUpdate(manifest) {
+async function queueManifestUpdate(manifest, options = {}) {
   if (!manifest || typeof manifest.version !== 'string' || !Array.isArray(manifest.assets)) {
     return;
   }
+
+  const force = options.force === true;
 
   if (pendingUpdate) {
     return pendingUpdate;
@@ -75,7 +80,7 @@ async function queueManifestUpdate(manifest) {
 
   pendingUpdate = (async () => {
     try {
-      await applyManifest(manifest);
+      await applyManifest(manifest, { force });
     } catch (error) {
       console.error('Offline cache update failed', error);
     } finally {
@@ -86,7 +91,8 @@ async function queueManifestUpdate(manifest) {
   return pendingUpdate;
 }
 
-async function applyManifest(manifest) {
+async function applyManifest(manifest, options = {}) {
+  const force = options.force === true;
   const version = manifest.version;
   const assets = Array.isArray(manifest.assets) ? manifest.assets : [];
   const totalAssets = assets.length;
@@ -97,8 +103,9 @@ async function applyManifest(manifest) {
   const existingManifest = await readStoredManifest();
   const cacheKeys = await caches.keys();
   const cacheExists = cacheKeys.includes(cacheName);
+  const commitInfo = getCommitInfo(manifest.commit);
 
-  if (existingManifest && existingManifest.version === version && cacheExists) {
+  if (!force && existingManifest && existingManifest.version === version && cacheExists) {
     activeCacheName = cacheName;
     await broadcast({
       type: 'offline-cache',
@@ -107,7 +114,8 @@ async function applyManifest(manifest) {
         version,
         totalAssets,
         totalBytes,
-        alreadyCached: true
+        alreadyCached: true,
+        commit: commitInfo
       }
     });
     return;
@@ -119,7 +127,8 @@ async function applyManifest(manifest) {
     detail: {
       version,
       totalAssets,
-      totalBytes
+      totalBytes,
+      commit: commitInfo
     }
   });
 
@@ -141,28 +150,30 @@ async function applyManifest(manifest) {
       try {
         response = await fetch(request);
       } catch (error) {
-        await broadcast({
-          type: 'offline-cache',
-          state: 'error',
-          detail: {
-            version,
-            message: `Failed to fetch ${assetPath}`
-          }
-        });
-        throw error;
-      }
+      await broadcast({
+        type: 'offline-cache',
+        state: 'error',
+        detail: {
+          version,
+          message: `Failed to fetch ${assetPath}`,
+          commit: commitInfo
+        }
+      });
+      throw error;
+    }
 
-      if (!response.ok) {
-        await broadcast({
-          type: 'offline-cache',
-          state: 'error',
-          detail: {
-            version,
-            message: `Unexpected response (${response.status}) for ${assetPath}`
-          }
-        });
-        throw new Error(`Failed to cache ${assetPath}`);
-      }
+    if (!response.ok) {
+      await broadcast({
+        type: 'offline-cache',
+        state: 'error',
+        detail: {
+          version,
+          message: `Unexpected response (${response.status}) for ${assetPath}`,
+          commit: commitInfo
+        }
+      });
+      throw new Error(`Failed to cache ${assetPath}`);
+    }
 
       await cache.put(request, response.clone());
 
@@ -182,7 +193,8 @@ async function applyManifest(manifest) {
           completed,
           totalAssets,
           loadedBytes,
-          totalBytes
+          totalBytes,
+          commit: commitInfo
         }
       });
     }
@@ -199,6 +211,10 @@ async function applyManifest(manifest) {
     assets
   };
 
+  if (commitInfo) {
+    storedManifest.commit = commitInfo;
+  }
+
   await writeStoredManifest(storedManifest);
   activeCacheName = cacheName;
   await cleanupCaches(cacheName);
@@ -210,9 +226,67 @@ async function applyManifest(manifest) {
       version,
       totalAssets,
       totalBytes,
-      alreadyCached: false
+      alreadyCached: false,
+      commit: commitInfo
     }
   });
+}
+
+async function resetOfflineCache(manifest) {
+  if (!manifest || typeof manifest.version !== 'string' || !Array.isArray(manifest.assets)) {
+    await broadcast({
+      type: 'offline-cache',
+      state: 'reset-error',
+      detail: {
+        message: 'Missing offline manifest data.'
+      }
+    });
+    return;
+  }
+
+  const currentUpdate = pendingUpdate;
+  if (currentUpdate) {
+    try {
+      await currentUpdate;
+    } catch (error) {
+      // Ignore errors from prior updates while resetting.
+    }
+  }
+
+  const totalAssets = manifest.assets.length;
+  const totalBytes = Number.isFinite(manifest.totalBytes)
+    ? manifest.totalBytes
+    : manifest.assets.reduce((sum, asset) => sum + (Number(asset.bytes) || 0), 0);
+  const commitInfo = getCommitInfo(manifest.commit);
+
+  await broadcast({
+    type: 'offline-cache',
+    state: 'resetting',
+    detail: {
+      version: manifest.version,
+      totalAssets,
+      totalBytes,
+      commit: commitInfo
+    }
+  });
+
+  try {
+    await clearOfflineCaches();
+    activeCacheName = null;
+    await queueManifestUpdate(manifest, { force: true });
+  } catch (error) {
+    console.error('Offline cache reset failed', error);
+    await broadcast({
+      type: 'offline-cache',
+      state: 'reset-error',
+      detail: {
+        version: manifest.version,
+        message: error && error.message ? error.message : 'Failed to reset offline cache.',
+        commit: commitInfo
+      }
+    });
+    throw error;
+  }
 }
 
 async function handleManifestRequest(request) {
@@ -352,4 +426,34 @@ async function cleanupCaches(currentName) {
 
     return caches.delete(key);
   }));
+}
+
+async function clearOfflineCaches() {
+  const keys = await caches.keys();
+  await Promise.all(keys.map((key) => {
+    if (key === METADATA_CACHE || key.startsWith(CACHE_PREFIX)) {
+      return caches.delete(key);
+    }
+
+    return Promise.resolve(false);
+  }));
+}
+
+function getCommitInfo(rawCommit) {
+  if (!rawCommit || typeof rawCommit !== 'object') {
+    return null;
+  }
+
+  const info = {};
+  if (typeof rawCommit.hash === 'string') {
+    info.hash = rawCommit.hash;
+  }
+  if (typeof rawCommit.short === 'string') {
+    info.short = rawCommit.short;
+  }
+  if (typeof rawCommit.dirty === 'boolean') {
+    info.dirty = rawCommit.dirty;
+  }
+
+  return Object.keys(info).length > 0 ? info : null;
 }

--- a/tools/generate-offline-manifest.js
+++ b/tools/generate-offline-manifest.js
@@ -1,12 +1,15 @@
 const fs = require('fs/promises');
 const path = require('path');
 const crypto = require('crypto');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
 
 const ROOT = process.cwd();
 const OUTPUT_PATH = path.join(ROOT, 'offline-manifest.json');
 const INCLUDE_DIRECTORIES = ['apps', 'data'];
 const INCLUDE_FILES = ['index.html', 'service-worker.js'];
 const ALLOWED_EXTENSIONS = new Set(['.html', '.js', '.json']);
+const execFileAsync = promisify(execFile);
 
 async function main() {
   const assets = [];
@@ -24,7 +27,14 @@ async function main() {
 
   const generatedAt = new Date().toISOString();
   const versionSuffix = digest.digest('hex').slice(0, 12);
-  const version = `${generatedAt.slice(0, 10).replace(/-/g, '')}-${versionSuffix}`;
+  const commitInfo = await readCommitInfo();
+  const versionParts = [generatedAt.slice(0, 10).replace(/-/g, ''), versionSuffix];
+
+  if (commitInfo.short) {
+    versionParts.push(commitInfo.short + (commitInfo.dirty ? '-dirty' : ''));
+  }
+
+  const version = versionParts.join('-');
   const totalBytes = assets.reduce((sum, asset) => sum + asset.bytes, 0);
 
   const manifest = {
@@ -34,6 +44,12 @@ async function main() {
     totalBytes,
     assets
   };
+
+  if (commitInfo.hash) {
+    manifest.commit = commitInfo;
+  } else if (commitInfo.dirty) {
+    manifest.commit = { dirty: true };
+  }
 
   const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
   await fs.writeFile(OUTPUT_PATH, manifestJson);
@@ -97,6 +113,39 @@ async function addAsset(relativePath, assets, digest) {
     path: normalizedPath,
     bytes: stats.size
   });
+}
+
+async function readCommitInfo() {
+  const info = {
+    hash: null,
+    short: null,
+    dirty: false
+  };
+
+  const envSha = typeof process.env.GITHUB_SHA === 'string' ? process.env.GITHUB_SHA.trim() : '';
+  if (envSha) {
+    info.hash = envSha;
+  } else {
+    try {
+      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD']);
+      info.hash = stdout.trim();
+    } catch (error) {
+      // Ignore failures when git metadata is unavailable (for example, in production archives).
+    }
+  }
+
+  if (info.hash) {
+    info.short = info.hash.slice(0, 12);
+  }
+
+  try {
+    const { stdout } = await execFileAsync('git', ['status', '--porcelain']);
+    info.dirty = Boolean(stdout.trim());
+  } catch (error) {
+    info.dirty = false;
+  }
+
+  return info;
 }
 
 function toPosixPath(filePath) {


### PR DESCRIPTION
## Summary
- embed commit metadata in the offline manifest and propagate it through the service worker so version checks reflect the current commit
- add an offline bundle refresh control and UI logic to reset caches and show progress updates during manual recaches
- create a workflow that regenerates and commits the offline manifest with the merge commit hash whenever a pull request closes

## Testing
- node tools/generate-offline-manifest.js

------
https://chatgpt.com/codex/tasks/task_e_68d33ca65f54832881caf2275a743ad5