### PR TITLE
Add CI coverage and asset snapshot automation

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -1,0 +1,35 @@
+name: Playwright smoke tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 5 * * 1'
+
+jobs:
+  run-playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm test

--- a/.github/workflows/refresh-asset-data.yml
+++ b/.github/workflows/refresh-asset-data.yml
@@ -1,0 +1,66 @@
+name: Refresh asset observatory data
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  update-asset-data:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Detect dataset changes
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path')
+          printf '%s\n' "$files" > changed-files.txt
+          echo "Files changed in #${{ github.event.pull_request.number }}:"  
+          if [ -n "$files" ]; then
+            printf '%s\n' "$files"
+          else
+            echo "(none reported)"
+          fi
+          if printf '%s\n' "$files" | grep -Eq '^(apps/|data/|tools/generate-asset-report\.js)'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip refresh when no relevant files changed
+        if: steps.changes.outputs.should_run != 'true'
+        run: echo "No dataset or tooling changes detected; skipping asset observatory refresh."
+
+      - name: Set up Node.js
+        if: steps.changes.outputs.should_run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate asset observatory snapshot
+        if: steps.changes.outputs.should_run == 'true'
+        run: node tools/generate-asset-report.js
+
+      - name: Commit asset data update
+        if: steps.changes.outputs.should_run == 'true'
+        run: |
+          if git diff --quiet -- apps/asset-observatory/asset-data.js; then
+            echo "Asset data already up to date; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add apps/asset-observatory/asset-data.js
+          git commit -m "chore: refresh asset observatory data for #${{ github.event.pull_request.number }}"
+          git push origin HEAD:${{ github.event.pull_request.base.ref }}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ node tools/generate-asset-report.js
 
 The script inspects every deck’s dataset, manifest, embedding store, similarity report, and upstream source file. It then writes an updated `apps/asset-observatory/asset-data.js` snapshot that the dashboard consumes to render charts and tables. Commit the refreshed file alongside your changes.
 
+## Automated maintenance
+
+GitHub Actions keep the toolbox refreshed after each merge so the static bundle never drifts from the source files:
+
+- **Playwright smoke tests** run on every push, pull request, and a weekly schedule to ensure the landing page and mini-apps stay healthy.
+- **Refresh offline manifest** re-generates `offline-manifest.json` whenever a pull request merges so the service worker cache tracks new assets.
+- **Refresh asset observatory data** inspects merged pull requests for dataset changes and re-runs `tools/generate-asset-report.js`, committing an updated `apps/asset-observatory/asset-data.js` snapshot when needed.
+
 ## Offline bundle
 
 Load the homepage once while you have a connection to download the entire toolbox. A new service worker caches every HTML, JavaScript, and JSON asset referenced by `offline-manifest.json`, and the landing page shows a progress indicator while the larger embedding stores stream in. On iPhone, tap the Share icon in Safari and pick **Add to Home Screen** after the download finishes to launch the toolbox like an installed app.


### PR DESCRIPTION
## Summary
- add a Playwright smoke test workflow that exercises the toolbox on pushes, pull requests, and a weekly cadence
- add an asset observatory refresh workflow that regenerates `apps/asset-observatory/asset-data.js` when dataset files change in a merged PR
- document the automated maintenance jobs in the README so contributors know what the bots handle

## Testing
- npx playwright install --with-deps chromium
- npm test *(fails: Embedding Explorer spec expects legacy sample buttons and reports 0 buttons present)*

------
https://chatgpt.com/codex/tasks/task_e_68d343015a808328b8fe488d0b7ce4c3