### PR TITLE
Fix asset data refresh workflow push rejections

### DIFF
--- a/.github/workflows/refresh-asset-data.yml
+++ b/.github/workflows/refresh-asset-data.yml
@@ -63,4 +63,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add apps/asset-observatory/asset-data.js
           git commit -m "chore: refresh asset observatory data for #${{ github.event.pull_request.number }}"
+          git pull --rebase origin ${{ github.event.pull_request.base.ref }}
           git push origin HEAD:${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
## Summary
- rebase the asset data refresh commit before pushing so the automation handles remote updates

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d345c209148328851be17d1b912658