### PR TITLE
Add neighbor comparison to embedding explorer

### DIFF
--- a/apps/embedding-explorer/app.js
+++ b/apps/embedding-explorer/app.js
@@ -5,8 +5,16 @@
   const recordList = document.querySelector('[data-record-list]');
   const recordStatus = document.querySelector('[data-record-status]');
   const filterInput = document.querySelector('[data-record-filter]');
-  const previewCanvas = document.querySelector('[data-preview-canvas]');
-  const previewMeta = document.querySelector('[data-preview-meta]');
+  const neighborList = document.querySelector('[data-neighbor-list]');
+  const neighborStatus = document.querySelector('[data-neighbor-status]');
+  const primaryCanvas = document.querySelector('[data-primary-canvas]');
+  const primaryMeta = document.querySelector('[data-primary-meta]');
+  const primaryText = document.querySelector('[data-primary-text]');
+  const secondaryCanvas = document.querySelector('[data-secondary-canvas]');
+  const secondaryMeta = document.querySelector('[data-secondary-meta]');
+  const secondaryText = document.querySelector('[data-secondary-text]');
+  const primaryCaption = document.querySelector('[data-primary-caption]');
+  const secondaryCaption = document.querySelector('[data-secondary-caption]');
 
   if (
     !datasetSelect ||
@@ -14,8 +22,16 @@
     !recordList ||
     !recordStatus ||
     !filterInput ||
-    !previewCanvas ||
-    !previewMeta
+    !neighborList ||
+    !neighborStatus ||
+    !primaryCanvas ||
+    !primaryMeta ||
+    !primaryText ||
+    !secondaryCanvas ||
+    !secondaryMeta ||
+    !secondaryText ||
+    !primaryCaption ||
+    !secondaryCaption
   ) {
     return;
   }
@@ -23,8 +39,35 @@
   const datasetCache = new Map();
   let activeDatasetId = '';
   let activeRecordId = '';
+  let activeNeighborId = '';
   let currentRecords = [];
   let filteredRecords = [];
+  let neighborRecords = [];
+
+  const contentMaps = buildContentMaps();
+  const collectionContentKeys = new Map([
+    ['Dad jokes', 'jokes'],
+    ['Curated quotes', 'quotes'],
+    ['Internet slang', 'slang'],
+  ]);
+
+  const primaryPane = {
+    canvas: primaryCanvas,
+    meta: primaryMeta,
+    text: primaryText,
+    caption: primaryCaption,
+  };
+
+  const secondaryPane = {
+    canvas: secondaryCanvas,
+    meta: secondaryMeta,
+    text: secondaryText,
+    caption: secondaryCaption,
+  };
+
+  function safeText(value) {
+    return typeof value === 'string' ? value.trim() : '';
+  }
 
   function formatDate(value) {
     if (!value) {
@@ -43,8 +86,15 @@
     }
   }
 
-  function decodeVector(base64) {
-    if (!base64) {
+  function formatSimilarity(value) {
+    if (!Number.isFinite(value)) {
+      return '—';
+    }
+    return value.toFixed(3);
+  }
+
+  function decodeVectorBytes(base64) {
+    if (typeof base64 !== 'string' || !base64) {
       return new Uint8Array();
     }
 
@@ -62,6 +112,264 @@
     }
   }
 
+  function bytesToFloat32(bytes) {
+    if (!(bytes instanceof Uint8Array) || bytes.byteLength % 4 !== 0) {
+      return new Float32Array();
+    }
+
+    try {
+      return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
+    } catch (error) {
+      console.error('Failed to interpret vector as Float32Array', error);
+      return new Float32Array();
+    }
+  }
+
+  function computeMagnitude(values) {
+    if (!(values instanceof Float32Array) || !values.length) {
+      return 0;
+    }
+
+    let sum = 0;
+    for (let index = 0; index < values.length; index += 1) {
+      const value = values[index];
+      sum += value * value;
+    }
+    return Math.sqrt(sum);
+  }
+
+  function ensureVectorData(record) {
+    if (!record || typeof record !== 'object') {
+      return;
+    }
+
+    if (!(record.vectorBytes instanceof Uint8Array)) {
+      record.vectorBytes = decodeVectorBytes(record.vector);
+    }
+
+    if (!(record.floatVector instanceof Float32Array)) {
+      if (record.vectorBytes instanceof Uint8Array) {
+        record.floatVector = bytesToFloat32(record.vectorBytes);
+      } else {
+        record.floatVector = new Float32Array();
+      }
+    }
+
+    if (!Number.isFinite(record.vectorMagnitude)) {
+      record.vectorMagnitude = computeMagnitude(record.floatVector);
+    }
+  }
+
+  function buildContentMaps() {
+    const jokesMap = new Map();
+    const quotesMap = new Map();
+    const slangMap = new Map();
+
+    if (Array.isArray(window.jokes)) {
+      window.jokes.forEach((entry) => {
+        if (!entry || typeof entry.id !== 'string') {
+          return;
+        }
+        jokesMap.set(entry.id, {
+          id: entry.id,
+          setup: safeText(entry.joke),
+          punchline: safeText(entry.punchline),
+        });
+      });
+    }
+
+    if (Array.isArray(window.quotesData)) {
+      window.quotesData.forEach((category) => {
+        const categoryId = safeText(category && category.id);
+        const categoryLabel = safeText(category && category.label);
+        const quotes = Array.isArray(category && category.quotes) ? category.quotes : [];
+        quotes.forEach((quote) => {
+          if (!quote || typeof quote.id !== 'string') {
+            return;
+          }
+          quotesMap.set(quote.id, {
+            id: quote.id,
+            text: safeText(quote.text),
+            author: safeText(quote.author),
+            categoryId,
+            category: categoryLabel,
+          });
+        });
+      });
+    }
+
+    if (Array.isArray(window.slangEntries)) {
+      window.slangEntries.forEach((entry) => {
+        if (!entry || typeof entry.id !== 'string') {
+          return;
+        }
+        slangMap.set(entry.id, {
+          id: entry.id,
+          term: safeText(entry.term),
+          definition: safeText(entry.definition),
+          example: safeText(entry.example),
+          hint: safeText(entry.hint),
+          category: safeText(entry.category),
+        });
+      });
+    }
+
+    return { jokes: jokesMap, quotes: quotesMap, slang: slangMap };
+  }
+  function getContentEntry(contentKey, recordId) {
+    if (!recordId) {
+      return null;
+    }
+
+    if (contentKey === 'jokes') {
+      return contentMaps.jokes.get(recordId) || null;
+    }
+    if (contentKey === 'quotes') {
+      return contentMaps.quotes.get(recordId) || null;
+    }
+    if (contentKey === 'slang') {
+      return contentMaps.slang.get(recordId) || null;
+    }
+    return null;
+  }
+
+  function getContentTitle(contentKey) {
+    switch (contentKey) {
+      case 'jokes':
+        return 'Dad joke';
+      case 'quotes':
+        return 'Quote';
+      case 'slang':
+        return 'Slang entry';
+      default:
+        return 'Source text';
+    }
+  }
+
+  function getContentFields(contentKey, entry) {
+    if (!entry) {
+      return [];
+    }
+
+    switch (contentKey) {
+      case 'jokes':
+        return [
+          { label: 'Setup', value: entry.setup },
+          { label: 'Punchline', value: entry.punchline },
+        ].filter((item) => item.value);
+      case 'quotes':
+        return [
+          { label: 'Quote', value: entry.text },
+          { label: 'Author', value: entry.author },
+          { label: 'Category', value: entry.category },
+        ].filter((item) => item.value);
+      case 'slang':
+        return [
+          { label: 'Term', value: entry.term },
+          { label: 'Definition', value: entry.definition },
+          { label: 'Example', value: entry.example },
+          { label: 'Hint', value: entry.hint },
+          { label: 'Category', value: entry.category },
+        ].filter((item) => item.value);
+      default:
+        return [];
+    }
+  }
+
+  function renderContentText(container, contentKey, entry, placeholder) {
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = '';
+
+    if (!entry) {
+      const message = document.createElement('p');
+      message.className = 'placeholder';
+      message.textContent = placeholder || 'Source text not available for this vector.';
+      container.appendChild(message);
+      return;
+    }
+
+    const fields = getContentFields(contentKey, entry);
+
+    if (!fields.length) {
+      const message = document.createElement('p');
+      message.className = 'placeholder';
+      message.textContent = placeholder || 'Source text not available for this vector.';
+      container.appendChild(message);
+      return;
+    }
+
+    const wrapper = document.createElement('article');
+    wrapper.className = 'text-record';
+
+    const heading = document.createElement('h3');
+    heading.className = 'text-record__heading';
+    heading.textContent = getContentTitle(contentKey);
+    wrapper.appendChild(heading);
+
+    const list = document.createElement('dl');
+    list.className = 'text-record__list';
+
+    fields.forEach((field) => {
+      const dt = document.createElement('dt');
+      dt.textContent = field.label;
+      const dd = document.createElement('dd');
+      dd.textContent = field.value;
+      list.append(dt, dd);
+    });
+
+    wrapper.appendChild(list);
+    container.appendChild(wrapper);
+  }
+
+  function getContentPreview(contentKey, entry) {
+    if (!entry) {
+      return '';
+    }
+
+    switch (contentKey) {
+      case 'jokes': {
+        const parts = [entry.setup, entry.punchline].filter(Boolean);
+        return parts.join(' • ');
+      }
+      case 'quotes': {
+        if (entry.text && entry.author) {
+          return `${entry.text} — ${entry.author}`;
+        }
+        return entry.text || entry.author || '';
+      }
+      case 'slang': {
+        if (entry.term && entry.definition) {
+          return `${entry.term}: ${entry.definition}`;
+        }
+        return entry.definition || entry.term || '';
+      }
+      default:
+        return '';
+    }
+  }
+
+  function truncateText(value, maxLength) {
+    if (typeof value !== 'string' || !value.length) {
+      return '';
+    }
+    if (value.length <= maxLength) {
+      return value;
+    }
+    return `${value.slice(0, Math.max(0, maxLength - 1))}…`;
+  }
+
+  function createPlaceholderItem(message) {
+    const item = document.createElement('li');
+    const paragraph = document.createElement('p');
+    paragraph.className = 'placeholder';
+    paragraph.textContent = message;
+    item.appendChild(paragraph);
+    return item;
+  }
+
   function populateDatasetSelect() {
     datasetSelect.innerHTML = '';
 
@@ -74,6 +382,9 @@
       datasetInfo.innerHTML = '<p class="placeholder">No embedding datasets are configured.</p>';
       recordList.innerHTML = '<li><p class="placeholder">No datasets available.</p></li>';
       recordStatus.textContent = 'No vectors to display.';
+      neighborList.innerHTML = '';
+      neighborList.appendChild(createPlaceholderItem('No datasets available.'));
+      neighborStatus.textContent = 'No neighbors to display.';
       filterInput.disabled = true;
       return;
     }
@@ -197,34 +508,178 @@
     });
   }
 
-  function renderPreview(record, datasetMeta, source) {
-    const ctx = previewCanvas.getContext('2d');
+  function updateActiveNeighborButton() {
+    const buttons = neighborList.querySelectorAll('.neighbor-button');
+    buttons.forEach((button) => {
+      const isActive = button.dataset.neighborId === activeNeighborId;
+      button.dataset.active = isActive ? 'true' : 'false';
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  function renderNeighborList(datasetData) {
+    neighborList.innerHTML = '';
+
+    if (!activeDatasetId || !datasetData) {
+      neighborStatus.textContent = 'Select a dataset to compute neighbors.';
+      neighborList.appendChild(createPlaceholderItem('Choose a dataset to load vectors before exploring neighbors.'));
+      return;
+    }
+
+    if (!activeRecordId) {
+      neighborStatus.textContent = 'Select a vector to compute its nearest neighbors.';
+      neighborList.appendChild(createPlaceholderItem('Neighbors appear here once you choose a vector.'));
+      return;
+    }
+
+    if (!neighborRecords.length) {
+      neighborStatus.textContent = 'No comparable vectors found for this selection.';
+      neighborList.appendChild(createPlaceholderItem('No similar vectors were detected for the selected entry.'));
+      return;
+    }
+
+    neighborStatus.textContent = `Top ${neighborRecords.length} matches for ${activeRecordId}.`;
+
+    const fragment = document.createDocumentFragment();
+
+    neighborRecords.forEach((entry) => {
+      const item = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'neighbor-button';
+      button.dataset.neighborId = entry.id;
+      const isActive = entry.id === activeNeighborId;
+      button.dataset.active = isActive ? 'true' : 'false';
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      if (activeRecordId) {
+        button.setAttribute('aria-label', `Compare ${entry.record.id} with ${activeRecordId} (similarity ${formatSimilarity(entry.similarity)})`);
+      }
+
+      const header = document.createElement('div');
+      header.className = 'neighbor-button__header';
+
+      const idSpan = document.createElement('span');
+      idSpan.className = 'neighbor-button__id';
+      idSpan.textContent = entry.record.id;
+
+      const scoreSpan = document.createElement('span');
+      scoreSpan.className = 'neighbor-button__score';
+      scoreSpan.textContent = formatSimilarity(entry.similarity);
+
+      header.append(idSpan, scoreSpan);
+
+      const snippetSpan = document.createElement('span');
+      snippetSpan.className = 'neighbor-button__snippet';
+      const contentEntry = getContentEntry(datasetData.contentKey, entry.record.id);
+      const fullPreview = getContentPreview(datasetData.contentKey, contentEntry);
+      const preview = truncateText(fullPreview, 120);
+      snippetSpan.textContent = preview || 'No source text available.';
+      if (fullPreview && preview !== fullPreview) {
+        snippetSpan.setAttribute('title', fullPreview);
+      }
+
+      button.append(header, snippetSpan);
+      item.appendChild(button);
+      fragment.appendChild(item);
+    });
+
+    neighborList.appendChild(fragment);
+  }
+  function computeNeighbors(record, datasetData) {
+    if (!record || !datasetData) {
+      return [];
+    }
+
+    ensureVectorData(record);
+    const baseVector = record.floatVector;
+    const baseMagnitude = record.vectorMagnitude;
+
+    if (!(baseVector instanceof Float32Array) || !baseVector.length || !Number.isFinite(baseMagnitude) || baseMagnitude === 0) {
+      return [];
+    }
+
+    const neighbors = [];
+
+    datasetData.records.forEach((candidate) => {
+      if (!candidate || candidate.id === record.id) {
+        return;
+      }
+
+      ensureVectorData(candidate);
+      const compareVector = candidate.floatVector;
+      const compareMagnitude = candidate.vectorMagnitude;
+
+      if (!(compareVector instanceof Float32Array) || compareVector.length !== baseVector.length) {
+        return;
+      }
+
+      if (!Number.isFinite(compareMagnitude) || compareMagnitude === 0) {
+        return;
+      }
+
+      let dot = 0;
+      for (let index = 0; index < baseVector.length; index += 1) {
+        dot += baseVector[index] * compareVector[index];
+      }
+
+      const similarity = dot / (baseMagnitude * compareMagnitude);
+      if (!Number.isFinite(similarity)) {
+        return;
+      }
+
+      neighbors.push({ id: candidate.id, record: candidate, similarity });
+    });
+
+    neighbors.sort((a, b) => b.similarity - a.similarity);
+    return neighbors.slice(0, 10);
+  }
+
+  function renderPane(pane, record, datasetMeta, source, options = {}) {
+    if (!pane || !pane.canvas) {
+      return;
+    }
+
+    const metaPlaceholder = options.metaPlaceholder || 'Select a vector to inspect its details.';
+    const textPlaceholder = options.textPlaceholder || 'Select a vector to view its source text.';
+    const captionIdle = options.captionIdle || '';
+    const captionActive = options.captionActive || captionIdle;
+
+    if (pane.caption) {
+      pane.caption.textContent = record ? captionActive : captionIdle;
+    }
+
+    const ctx = pane.canvas.getContext('2d');
     if (!ctx) {
       return;
     }
 
     if (!record) {
-      ctx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
-      previewCanvas.width = 1;
-      previewCanvas.height = 1;
-      previewCanvas.style.width = '';
-      previewCanvas.style.height = '';
-      previewMeta.innerHTML = '<p class="placeholder">Select a vector to inspect its details.</p>';
+      ctx.clearRect(0, 0, pane.canvas.width, pane.canvas.height);
+      pane.canvas.width = 1;
+      pane.canvas.height = 1;
+      pane.canvas.style.width = '';
+      pane.canvas.style.height = '';
+      if (pane.meta) {
+        pane.meta.innerHTML = `<p class="placeholder">${metaPlaceholder}</p>`;
+      }
+      if (pane.text) {
+        pane.text.innerHTML = `<p class="placeholder">${textPlaceholder}</p>`;
+      }
       return;
     }
 
-    const bytes = decodeVector(record.vector);
+    ensureVectorData(record);
+    const bytes = record.vectorBytes instanceof Uint8Array ? record.vectorBytes : new Uint8Array();
     const pixelCount = Math.ceil(bytes.length / 3);
     const width = Math.max(1, Math.ceil(Math.sqrt(pixelCount)));
     const height = Math.max(1, Math.ceil(pixelCount / width));
 
-    previewCanvas.width = width;
-    previewCanvas.height = height;
+    pane.canvas.width = width;
+    pane.canvas.height = height;
 
     const imageData = ctx.createImageData(width, height);
     const data = imageData.data;
     let byteIndex = 0;
-
     for (let index = 0; index < width * height; index += 1) {
       data[index * 4] = bytes[byteIndex] ?? 0;
       data[index * 4 + 1] = bytes[byteIndex + 1] ?? 0;
@@ -235,48 +690,142 @@
 
     ctx.putImageData(imageData, 0, 0);
 
-    const maxDisplay = Math.max(200, Math.min(480, previewCanvas.parentElement?.clientWidth || 320));
+    const containerWidth = pane.canvas.parentElement?.clientWidth || 220;
+    const maxDisplay = Math.max(140, Math.min(260, containerWidth));
     const scale = Math.max(1, Math.floor(maxDisplay / Math.max(width, height)));
-    previewCanvas.style.width = `${width * scale}px`;
-    previewCanvas.style.height = `${height * scale}px`;
+    pane.canvas.style.width = `${width * scale}px`;
+    pane.canvas.style.height = `${height * scale}px`;
 
-    const hash = record.vectorSha256 || '';
-    const hashPreview = hash ? `${hash.slice(0, 16)}…` : '—';
+    if (pane.meta) {
+      const hash = record.vectorSha256 || '';
+      const hashPreview = hash ? `${hash.slice(0, 16)}…` : '—';
+      const textHash = record.textHash || '';
+      const textHashPreview = textHash ? `${textHash.slice(0, 16)}…` : '—';
 
-    const metaItems = [
-      { label: 'Vector id', value: record.id },
-      { label: 'Collection', value: source?.collection || '—' },
-      { label: 'Provider', value: record.provider || datasetMeta?.provider || '—' },
-      { label: 'Model', value: record.model || datasetMeta?.model || '—' },
-      {
-        label: 'Dimensions',
-        value: record.dimensions
-          ? `${record.dimensions.toLocaleString()}D`
-          : datasetMeta?.dimensions
-          ? `${datasetMeta.dimensions.toLocaleString()}D`
-          : '—',
-      },
-      { label: 'Binary bytes', value: bytes.length.toLocaleString() },
-      { label: 'Pixel grid', value: `${width} × ${height}` },
-      { label: 'Vector hash', value: hashPreview },
-      { label: 'Updated', value: record.updatedAt ? formatDate(record.updatedAt) : '—' },
-    ];
+      const metaItems = [
+        { label: 'Vector id', value: record.id },
+        { label: 'Collection', value: source?.collection || '—' },
+        { label: 'Provider', value: record.provider || datasetMeta?.provider || '—' },
+        { label: 'Model', value: record.model || datasetMeta?.model || '—' },
+        {
+          label: 'Dimensions',
+          value: record.dimensions
+            ? `${record.dimensions.toLocaleString()}D`
+            : datasetMeta?.dimensions
+            ? `${datasetMeta.dimensions.toLocaleString()}D`
+            : '—',
+        },
+        { label: 'Binary bytes', value: bytes.length.toLocaleString() },
+        { label: 'Pixel grid', value: `${width} × ${height}` },
+        { label: 'Vector hash', value: hashPreview, title: hash },
+        { label: 'Text hash', value: textHash ? textHashPreview : '—', title: textHash },
+        { label: 'Updated', value: record.updatedAt ? formatDate(record.updatedAt) : '—' },
+      ];
 
-    previewMeta.innerHTML = '';
-    const list = document.createElement('dl');
-    list.className = 'meta-grid';
+      const extraMeta = Array.isArray(options.extraMeta) ? options.extraMeta.filter((item) => item && item.label) : [];
+      const combined = [...metaItems];
 
-    metaItems.forEach((item) => {
-      const wrapper = document.createElement('div');
-      const dt = document.createElement('dt');
-      dt.textContent = item.label;
-      const dd = document.createElement('dd');
-      dd.textContent = item.value;
-      wrapper.append(dt, dd);
-      list.appendChild(wrapper);
+      extraMeta.forEach((item) => {
+        const value = typeof item.value === 'string' ? item.value : String(item.value ?? '');
+        combined.push({ label: item.label, value: value || '—', title: item.title || '' });
+      });
+
+      pane.meta.innerHTML = '';
+      const list = document.createElement('dl');
+      list.className = 'meta-grid';
+
+      combined.forEach((item) => {
+        const wrapper = document.createElement('div');
+        const dt = document.createElement('dt');
+        dt.textContent = item.label;
+        const dd = document.createElement('dd');
+        dd.textContent = item.value || '—';
+        if (item.title) {
+          dd.setAttribute('title', item.title);
+        }
+        wrapper.append(dt, dd);
+        list.appendChild(wrapper);
+      });
+
+      pane.meta.appendChild(list);
+    }
+
+    if (pane.text) {
+      renderContentText(pane.text, options.contentKey || '', options.contentEntry || null, textPlaceholder);
+    }
+  }
+  function renderPrimaryPane(record, datasetData) {
+    const contentKey = datasetData?.contentKey || '';
+    const contentEntry = record ? getContentEntry(contentKey, record.id) : null;
+    const captionIdle = 'Pick a vector to render its fingerprint.';
+    const captionActive = record ? `Binary fingerprint for ${record.id}.` : captionIdle;
+
+    renderPane(primaryPane, record, datasetData?.meta, datasetData?.source, {
+      metaPlaceholder: 'Select a vector to inspect its details.',
+      textPlaceholder: 'Choose a vector to load its source text.',
+      captionIdle,
+      captionActive,
+      contentKey,
+      contentEntry,
     });
+  }
 
-    previewMeta.appendChild(list);
+  function renderSecondaryPane(primaryRecord, neighborEntry, datasetData) {
+    const contentKey = datasetData?.contentKey || '';
+    const record = neighborEntry ? neighborEntry.record : null;
+    const contentEntry = record ? getContentEntry(contentKey, record.id) : null;
+    const captionIdle = primaryRecord
+      ? 'Select a neighbor to view its fingerprint.'
+      : 'Choose a vector to compute neighbors.';
+    let captionActive = captionIdle;
+
+    if (primaryRecord && record) {
+      captionActive = `Comparing ${record.id} with ${primaryRecord.id}.`;
+    }
+
+    const extraMeta = [];
+    if (neighborEntry && Number.isFinite(neighborEntry.similarity)) {
+      extraMeta.push({ label: 'Cosine similarity', value: formatSimilarity(neighborEntry.similarity) });
+    }
+
+    renderPane(secondaryPane, record, datasetData?.meta, datasetData?.source, {
+      metaPlaceholder: primaryRecord
+        ? 'Pick a neighbor to inspect its details.'
+        : 'Select a vector to compute its nearest neighbors.',
+      textPlaceholder: primaryRecord
+        ? 'Choose a neighbor to view its source text.'
+        : 'Select a vector first to reveal similar entries.',
+      captionIdle,
+      captionActive,
+      contentKey,
+      contentEntry,
+      extraMeta,
+    });
+  }
+
+  function setActiveNeighbor(neighborId) {
+    const datasetData = datasetCache.get(activeDatasetId);
+    if (!datasetData || !activeRecordId) {
+      return;
+    }
+
+    if (!neighborId) {
+      activeNeighborId = '';
+      updateActiveNeighborButton();
+      const primaryRecord = datasetData.recordMap.get(activeRecordId) || null;
+      renderSecondaryPane(primaryRecord, null, datasetData);
+      return;
+    }
+
+    const neighbor = neighborRecords.find((entry) => entry.id === neighborId);
+    if (!neighbor) {
+      return;
+    }
+
+    activeNeighborId = neighborId;
+    updateActiveNeighborButton();
+    const primaryRecord = datasetData.recordMap.get(activeRecordId) || null;
+    renderSecondaryPane(primaryRecord, neighbor, datasetData);
   }
 
   function setActiveRecord(recordId) {
@@ -287,19 +836,34 @@
 
     if (!recordId) {
       activeRecordId = '';
+      neighborRecords = [];
+      activeNeighborId = '';
       updateActiveRecordButton();
-      renderPreview(null, datasetData.meta, datasetData.source);
+      renderPrimaryPane(null, datasetData);
+      renderNeighborList(datasetData);
+      renderSecondaryPane(null, null, datasetData);
+      updateActiveNeighborButton();
       return;
     }
 
-    const record = datasetData.records.find((entry) => entry.id === recordId);
+    const record = datasetData.recordMap.get(recordId);
     if (!record) {
       return;
     }
 
     activeRecordId = recordId;
     updateActiveRecordButton();
-    renderPreview(record, datasetData.meta, datasetData.source);
+    renderPrimaryPane(record, datasetData);
+    neighborRecords = computeNeighbors(record, datasetData);
+    if (!neighborRecords.length) {
+      activeNeighborId = '';
+    } else if (!neighborRecords.some((entry) => entry.id === activeNeighborId)) {
+      activeNeighborId = neighborRecords[0].id;
+    }
+    renderNeighborList(datasetData);
+    updateActiveNeighborButton();
+    const neighborEntry = neighborRecords.find((entry) => entry.id === activeNeighborId) || null;
+    renderSecondaryPane(record, neighborEntry, datasetData);
   }
 
   function applyFilter() {
@@ -331,48 +895,40 @@
     updateRecordStatus();
 
     if (!filteredRecords.length) {
-      activeRecordId = '';
-      renderPreview(null, datasetData.meta, datasetData.source);
-      updateActiveRecordButton();
+      setActiveRecord('');
       return;
     }
 
     const current = filteredRecords.find((record) => record.id === activeRecordId);
     if (current) {
-      renderPreview(current, datasetData.meta, datasetData.source);
-      updateActiveRecordButton();
+      setActiveRecord(current.id);
       return;
     }
 
-    activeRecordId = filteredRecords[0].id;
-    renderPreview(filteredRecords[0], datasetData.meta, datasetData.source);
-    updateActiveRecordButton();
+    setActiveRecord(filteredRecords[0].id);
   }
-
   function handleDatasetChange() {
     const datasetId = datasetSelect.value;
     activeDatasetId = datasetId;
     activeRecordId = '';
+    activeNeighborId = '';
     currentRecords = [];
     filteredRecords = [];
+    neighborRecords = [];
 
     filterInput.value = '';
     filterInput.disabled = true;
 
-    const ctx = previewCanvas.getContext('2d');
-    if (ctx) {
-      ctx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
-    }
-    previewCanvas.width = 1;
-    previewCanvas.height = 1;
-    previewCanvas.style.width = '';
-    previewCanvas.style.height = '';
-    previewMeta.innerHTML = '<p class="placeholder">Select a vector to inspect its details.</p>';
+    renderPrimaryPane(null, null);
+    renderSecondaryPane(null, null, null);
 
     if (!datasetId) {
       datasetInfo.innerHTML = '<p class="placeholder">Choose a dataset to inspect its metadata.</p>';
       recordList.innerHTML = '<li><p class="placeholder">Select a dataset to load its vectors.</p></li>';
       recordStatus.textContent = 'No dataset selected.';
+      neighborList.innerHTML = '';
+      neighborList.appendChild(createPlaceholderItem('Select a dataset to explore similar vectors.'));
+      neighborStatus.textContent = 'Select a dataset to compute neighbors.';
       return;
     }
 
@@ -381,11 +937,17 @@
       datasetInfo.innerHTML = '<p class="placeholder">The selected dataset is not configured.</p>';
       recordList.innerHTML = '<li><p class="placeholder">Unable to load this dataset.</p></li>';
       recordStatus.textContent = 'Dataset configuration error.';
+      neighborList.innerHTML = '';
+      neighborList.appendChild(createPlaceholderItem('Fix the dataset configuration to continue.'));
+      neighborStatus.textContent = 'Unable to compute neighbors for this dataset.';
       return;
     }
 
     recordList.innerHTML = '<li><p class="placeholder">Loading vectors…</p></li>';
     recordStatus.textContent = 'Loading vectors…';
+    neighborList.innerHTML = '';
+    neighborList.appendChild(createPlaceholderItem('Neighbors appear after the vector list loads.'));
+    neighborStatus.textContent = 'Select a vector to compute its nearest neighbors.';
 
     if (datasetCache.has(datasetId)) {
       const cached = datasetCache.get(datasetId);
@@ -396,11 +958,12 @@
       renderRecordList();
       updateRecordStatus();
       if (filteredRecords.length) {
-        activeRecordId = filteredRecords[0].id;
-        renderPreview(filteredRecords[0], cached.meta, cached.source);
-        updateActiveRecordButton();
+        setActiveRecord(filteredRecords[0].id);
       } else {
-        previewMeta.innerHTML = '<p class="placeholder">This dataset does not include any vectors.</p>';
+        setActiveRecord('');
+        neighborList.innerHTML = '';
+        neighborList.appendChild(createPlaceholderItem('No neighbors available without any vectors.'));
+        neighborStatus.textContent = 'This dataset does not include any vectors.';
       }
       return;
     }
@@ -415,14 +978,36 @@
       .then((data) => {
         const meta = data?.meta || {};
         const recordsObject = data?.records || {};
-        const records = Object.keys(recordsObject).map((id) => ({
-          id,
-          ...recordsObject[id],
-        }));
+        const records = Object.keys(recordsObject).map((id) => {
+          const entry = recordsObject[id] || {};
+          const vectorString = typeof entry.vector === 'string' ? entry.vector : '';
+          const vectorBytes = decodeVectorBytes(vectorString);
+          const floatVector = bytesToFloat32(vectorBytes);
+          return {
+            id,
+            ...entry,
+            vector: vectorString,
+            vectorBytes,
+            floatVector,
+            vectorMagnitude: computeMagnitude(floatVector),
+          };
+        });
 
         records.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: 'base' }));
 
-        const datasetData = { source, meta, records };
+        const recordMap = new Map();
+        records.forEach((record) => {
+          recordMap.set(record.id, record);
+        });
+
+        const datasetData = {
+          source,
+          meta,
+          records,
+          recordMap,
+          contentKey: collectionContentKeys.get(source.collection) || '',
+        };
+
         datasetCache.set(datasetId, datasetData);
 
         currentRecords = records;
@@ -433,11 +1018,12 @@
         updateRecordStatus();
 
         if (records.length) {
-          activeRecordId = records[0].id;
-          renderPreview(records[0], meta, source);
-          updateActiveRecordButton();
+          setActiveRecord(records[0].id);
         } else {
-          previewMeta.innerHTML = '<p class="placeholder">This dataset does not include any vectors.</p>';
+          setActiveRecord('');
+          neighborList.innerHTML = '';
+          neighborList.appendChild(createPlaceholderItem('No neighbors available without any vectors.'));
+          neighborStatus.textContent = 'This dataset does not include any vectors.';
         }
       })
       .catch((error) => {
@@ -446,6 +1032,11 @@
         recordList.innerHTML = '<li><p class="placeholder">Could not load vectors. Please try again.</p></li>';
         recordStatus.textContent = 'Failed to load dataset.';
         filterInput.disabled = true;
+        neighborList.innerHTML = '';
+        neighborList.appendChild(createPlaceholderItem('Neighbors cannot load without the vector data.'));
+        neighborStatus.textContent = 'Unable to compute neighbors.';
+        renderPrimaryPane(null, null);
+        renderSecondaryPane(null, null, null);
       });
   }
 
@@ -465,6 +1056,18 @@
     setActiveRecord(recordId);
   });
 
+  neighborList.addEventListener('click', (event) => {
+    const button = event.target.closest('.neighbor-button');
+    if (!button) {
+      return;
+    }
+    const neighborId = button.dataset.neighborId;
+    if (!neighborId || neighborId === activeNeighborId) {
+      return;
+    }
+    setActiveNeighbor(neighborId);
+  });
+
   filterInput.addEventListener('input', () => {
     applyFilter();
   });
@@ -473,5 +1076,9 @@
 
   if (datasetSelect.value) {
     handleDatasetChange();
+  } else {
+    neighborList.innerHTML = '';
+    neighborList.appendChild(createPlaceholderItem('Select a dataset to explore similar vectors.'));
+    neighborStatus.textContent = 'Select a dataset to compute neighbors.';
   }
 })();

--- a/apps/embedding-explorer/index.html
+++ b/apps/embedding-explorer/index.html
@@ -277,7 +277,8 @@
       word-break: break-word;
     }
 
-    .record-status {
+    .record-status,
+    .neighbor-status {
       margin: 0;
       font-size: 0.85rem;
       color: var(--text-secondary);
@@ -309,7 +310,8 @@
       padding: 0;
     }
 
-    .record-button {
+    .record-button,
+    .neighbor-button {
       width: 100%;
       display: flex;
       flex-direction: column;
@@ -325,25 +327,29 @@
       transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
     }
 
-    .record-button:hover {
+    .record-button:hover,
+    .neighbor-button:hover {
       transform: translateY(-1px);
       border-color: var(--accent);
     }
 
-    .record-button:focus-visible {
+    .record-button:focus-visible,
+    .neighbor-button:focus-visible {
       outline: none;
       border-color: var(--accent);
       box-shadow: 0 0 0 3px var(--input-focus);
     }
 
-    .record-button[data-active="true"] {
+    .record-button[data-active="true"],
+    .neighbor-button[data-active="true"] {
       background: var(--accent);
       color: var(--accent-contrast);
       border-color: var(--accent);
       box-shadow: 0 14px 24px color-mix(in srgb, var(--accent) 35%, transparent);
     }
 
-    .record-button[data-active="true"] .record-button__meta {
+    .record-button[data-active="true"] .record-button__meta,
+    .neighbor-button[data-active="true"] .neighbor-button__snippet {
       color: color-mix(in srgb, var(--accent-contrast) 75%, transparent);
     }
 
@@ -357,18 +363,117 @@
       color: var(--text-secondary);
     }
 
+    .neighbor-button__header {
+      width: 100%;
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 10px;
+    }
+
+    .neighbor-button__id {
+      font-weight: 600;
+      font-size: 1rem;
+    }
+
+    .neighbor-button__score {
+      font-variant-numeric: tabular-nums;
+      font-size: 0.85rem;
+      color: var(--accent);
+    }
+
+    .neighbor-button__snippet {
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+    }
+
+    .neighbor-button[data-active="true"] .neighbor-button__score {
+      color: color-mix(in srgb, var(--accent-contrast) 75%, transparent);
+    }
+
     .embedding-canvas {
       border-radius: 18px;
       border: 1px solid var(--surface-border);
       background: rgba(15, 23, 42, 0.45);
       image-rendering: pixelated;
       align-self: center;
+      max-width: 100%;
     }
 
     .caption {
       margin: 0;
       font-size: 0.85rem;
       color: var(--text-secondary);
+    }
+
+    .comparison {
+      display: grid;
+      gap: clamp(16px, 3vw, 28px);
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .comparison__column {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(12px, 2vw, 18px);
+    }
+
+    .comparison__title {
+      margin: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .comparison__title span[aria-hidden="true"] {
+      font-size: 1.4rem;
+    }
+
+    .comparison__canvas {
+      align-self: flex-start;
+      max-width: 260px;
+    }
+
+    .text-record {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .text-record__heading {
+      margin: 0;
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+    }
+
+    .text-record__list {
+      margin: 0;
+      display: grid;
+      gap: 10px;
+    }
+
+    .text-record__list dt {
+      margin: 0;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+    }
+
+    .text-record__list dd {
+      margin: 0;
+      font-size: 0.95rem;
+      line-height: 1.6;
+      color: var(--text-primary);
+      word-break: break-word;
     }
 
     .placeholder {
@@ -435,19 +540,59 @@
           </ul>
         </div>
       </article>
-      <article class="panel panel--wide" aria-labelledby="preview-heading">
-        <h2 id="preview-heading">Binary preview</h2>
-        <p class="panel-sub">Each pixel consumes three bytes from the underlying vector. Extra space pads with zeros so the grid
-          stays rectangular.</p>
-        <canvas class="embedding-canvas" data-preview-canvas aria-describedby="preview-caption"></canvas>
-        <p id="preview-caption" class="caption">Switch between vectors to compare their byte-level fingerprints.</p>
-        <div class="info-block" data-preview-meta>
-          <p class="placeholder">Select a vector to inspect its details.</p>
+      <article class="panel" aria-labelledby="neighbors-heading">
+        <h2 id="neighbors-heading">Closest matches</h2>
+        <p class="panel-sub">Cosine similarity ranks the nearest vectors within the selected dataset.</p>
+        <p class="neighbor-status" data-neighbor-status>Select a vector to compute its nearest neighbors.</p>
+        <div class="record-list-wrapper neighbor-list-wrapper">
+          <ul class="record-list neighbor-list" data-neighbor-list>
+            <li>
+              <p class="placeholder">Neighbors appear here once you choose a vector.</p>
+            </li>
+          </ul>
+        </div>
+      </article>
+      <article class="panel panel--wide" aria-labelledby="comparison-heading">
+        <h2 id="comparison-heading">Vector comparison</h2>
+        <p class="panel-sub">Inspect the active vector alongside any of its closest matches, including their binary fingerprints and
+          source text.</p>
+        <div class="comparison" data-comparison-root>
+          <section class="comparison__column" aria-labelledby="primary-column-heading">
+            <h3 id="primary-column-heading" class="comparison__title">
+              <span aria-hidden="true">🧭</span>
+              <span>Selected vector</span>
+            </h3>
+            <canvas class="embedding-canvas comparison__canvas" data-primary-canvas aria-describedby="primary-caption"></canvas>
+            <p id="primary-caption" class="caption" data-primary-caption>Pick a vector to render its fingerprint.</p>
+            <div class="info-block" data-primary-meta>
+              <p class="placeholder">Select a vector to inspect its details.</p>
+            </div>
+            <div class="info-block" data-primary-text>
+              <p class="placeholder">Choose a vector to load its source text.</p>
+            </div>
+          </section>
+          <section class="comparison__column" aria-labelledby="secondary-column-heading">
+            <h3 id="secondary-column-heading" class="comparison__title">
+              <span aria-hidden="true">🤝</span>
+              <span>Neighbor vector</span>
+            </h3>
+            <canvas class="embedding-canvas comparison__canvas" data-secondary-canvas aria-describedby="secondary-caption"></canvas>
+            <p id="secondary-caption" class="caption" data-secondary-caption>Select a neighbor to view its fingerprint.</p>
+            <div class="info-block" data-secondary-meta>
+              <p class="placeholder">Pick a neighbor to inspect its details.</p>
+            </div>
+            <div class="info-block" data-secondary-text>
+              <p class="placeholder">Choose a neighbor to view its source text.</p>
+            </div>
+          </section>
         </div>
       </article>
     </section>
   </main>
-  <script src="sample-embeddings.js"></script>
-  <script src="app.js"></script>
+  <script defer src="../jokes/jokes.js"></script>
+  <script defer src="../quotes/quotes-data.js"></script>
+  <script defer src="../slang/slang.js"></script>
+  <script defer src="sample-embeddings.js"></script>
+  <script defer src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the embedding explorer layout to add a nearest-neighbor panel and side-by-side comparison section
- load jokes, quotes, and slang text so the comparison view surfaces source content alongside the vectors
- compute cosine similarities in app.js, render the neighbor list, and update the dual canvas previews with metadata

## Testing
- npm test *(fails: missing Playwright browser dependencies in the runner image)*

------
https://chatgpt.com/codex/tasks/task_e_68d34493ad4c8328982a6e6f9de6f03c