### PR TITLE
Render cosine lab embedding thumbnails via RGB bytes

### DIFF
--- a/apps/similarity-report/index.html
+++ b/apps/similarity-report/index.html
@@ -1554,18 +1554,35 @@
       function decodeEmbeddingVector(base64, expectedDimensions) {
         const bytes = base64ToUint8Array(base64);
         if (!bytes || !bytes.length) {
-          return null;
+          return { bytes: null, values: null };
         }
         const valueCount = Math.floor(bytes.byteLength / 4);
-        if (!valueCount) {
+        let floats = null;
+        if (valueCount) {
+          const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+          floats = new Float32Array(valueCount);
+          for (let index = 0; index < valueCount; index += 1) {
+            floats[index] = view.getFloat32(index * 4, true);
+          }
+        }
+        return { bytes, values: floats };
+      }
+
+      function float32ArrayToBytes(values) {
+        if (!(values instanceof Float32Array) || !values.length) {
           return null;
         }
-        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-        const floats = new Float32Array(valueCount);
-        for (let index = 0; index < valueCount; index += 1) {
-          floats[index] = view.getFloat32(index * 4, true);
+        try {
+          const buffer = new ArrayBuffer(values.length * 4);
+          const view = new DataView(buffer);
+          for (let index = 0; index < values.length; index += 1) {
+            view.setFloat32(index * 4, values[index], true);
+          }
+          return new Uint8Array(buffer);
+        } catch (error) {
+          console.error('Failed to encode embedding values as bytes', error);
+          return null;
         }
-        return floats;
       }
 
       function getSnugGridSize(totalValues) {
@@ -1636,78 +1653,52 @@
         };
       }
 
-      function createEmbeddingPreview(values) {
-        if (!values || !values.length) {
+      function createEmbeddingPreview(entry) {
+        if (!entry) {
           return null;
         }
-        const totalValues = values.length;
-        const { rows: rawRows, columns: rawColumns } = getSnugGridSize(totalValues);
-        const rows = Math.max(1, Math.round(rawRows || 0));
-        const columns = Math.max(1, Math.round(rawColumns || 0));
-        const cellSize = 10;
-        const pixelWidth = columns * cellSize;
-        const pixelHeight = rows * cellSize;
-        if (!pixelWidth || !pixelHeight) {
+        let bytes = entry.vectorBytes instanceof Uint8Array && entry.vectorBytes.length ? entry.vectorBytes : null;
+        if (!bytes && entry.values instanceof Float32Array && entry.values.length) {
+          bytes = float32ArrayToBytes(entry.values);
+          if (bytes) {
+            entry.vectorBytes = bytes;
+          }
+        }
+        if (!bytes || !bytes.length) {
           return null;
         }
-        const deviceRatio =
-          typeof window !== 'undefined' && Number.isFinite(window.devicePixelRatio) && window.devicePixelRatio > 0
-            ? window.devicePixelRatio
-            : 1;
-        const pixelRatio = deviceRatio || 1;
+        const pixelCount = Math.ceil(bytes.length / 3);
+        if (!pixelCount) {
+          return null;
+        }
+        const width = Math.max(1, Math.ceil(Math.sqrt(pixelCount)));
+        const height = Math.max(1, Math.ceil(pixelCount / width));
         const canvas = document.createElement('canvas');
-        canvas.width = pixelWidth * pixelRatio;
-        canvas.height = pixelHeight * pixelRatio;
+        canvas.width = width;
+        canvas.height = height;
         const context = canvas.getContext('2d');
         if (!context) {
           return null;
         }
-        context.scale(pixelRatio, pixelRatio);
-        context.fillStyle = 'rgba(15, 23, 42, 0.08)';
-        context.fillRect(0, 0, pixelWidth, pixelHeight);
-
-        let minValue = Infinity;
-        let maxValue = -Infinity;
-        for (let index = 0; index < values.length; index += 1) {
-          const value = values[index];
-          if (!Number.isFinite(value)) {
-            continue;
-          }
-          if (value < minValue) {
-            minValue = value;
-          }
-          if (value > maxValue) {
-            maxValue = value;
-          }
+        const imageData = context.createImageData(width, height);
+        const data = imageData.data;
+        let byteIndex = 0;
+        for (let index = 0; index < width * height; index += 1) {
+          data[index * 4] = bytes[byteIndex] ?? 0;
+          data[index * 4 + 1] = bytes[byteIndex + 1] ?? 0;
+          data[index * 4 + 2] = bytes[byteIndex + 2] ?? 0;
+          data[index * 4 + 3] = 255;
+          byteIndex += 3;
         }
-        if (!Number.isFinite(minValue) || !Number.isFinite(maxValue)) {
-          minValue = 0;
-          maxValue = 1;
-        }
-        if (minValue === maxValue) {
-          maxValue = minValue + 1;
-        }
-        const range = maxValue - minValue;
-        const totalCells = columns * rows;
-        for (let index = 0; index < totalCells; index += 1) {
-          const value = index < values.length && Number.isFinite(values[index]) ? values[index] : minValue;
-          const normalized = Math.min(1, Math.max(0, (value - minValue) / range));
-          const hue = Math.round((normalized * 320 + (index % columns) * 3) % 360);
-          const saturation = Math.min(100, Math.max(0, 58 + normalized * 32));
-          const lightness = Math.min(100, Math.max(0, 42 + normalized * 28));
-          const x = (index % columns) * cellSize;
-          const y = Math.floor(index / columns) * cellSize;
-          context.fillStyle = `hsl(${hue}, ${saturation}%, ${lightness}%)`;
-          context.fillRect(x, y, cellSize, cellSize);
-        }
-        const aspect = pixelHeight > 0 ? pixelWidth / pixelHeight : 0;
+        context.putImageData(imageData, 0, 0);
+        const aspect = height > 0 ? width / height : 0;
         return {
           url: canvas.toDataURL('image/png'),
-          width: pixelWidth,
-          height: pixelHeight,
+          width,
+          height,
           aspect,
-          columns,
-          rows,
+          columns: width,
+          rows: height,
         };
       }
 
@@ -1796,6 +1787,7 @@
           vectorSha256: '',
           textHash: '',
           values,
+          vectorBytes: float32ArrayToBytes(values),
           previewUrl: '',
           previewWidth: 0,
           previewHeight: 0,
@@ -1862,38 +1854,34 @@
         if (!entry) {
           return null;
         }
-        if (entry.values && entry.values.length) {
-          const hasWidth = Number.isFinite(entry.previewWidth) && entry.previewWidth > 0;
-          const hasHeight = Number.isFinite(entry.previewHeight) && entry.previewHeight > 0;
-          if (!entry.previewUrl || !hasWidth || !hasHeight) {
-            const preview = createEmbeddingPreview(entry.values);
-            if (preview) {
-              entry.previewUrl = preview.url;
-              entry.previewWidth = preview.width;
-              entry.previewHeight = preview.height;
-              entry.previewAspect = Number.isFinite(preview.aspect) && preview.aspect > 0 ? preview.aspect : 0;
-              if (Number.isFinite(preview.columns) && preview.columns > 0) {
-                entry.previewColumns = preview.columns;
-              }
-              if (Number.isFinite(preview.rows) && preview.rows > 0) {
-                entry.previewRows = preview.rows;
-              }
+        const hasWidth = Number.isFinite(entry.previewWidth) && entry.previewWidth > 0;
+        const hasHeight = Number.isFinite(entry.previewHeight) && entry.previewHeight > 0;
+        if (!entry.previewUrl || !hasWidth || !hasHeight) {
+          const preview = createEmbeddingPreview(entry);
+          if (preview) {
+            entry.previewUrl = preview.url;
+            entry.previewWidth = preview.width;
+            entry.previewHeight = preview.height;
+            entry.previewAspect = Number.isFinite(preview.aspect) && preview.aspect > 0 ? preview.aspect : 0;
+            if (Number.isFinite(preview.columns) && preview.columns > 0) {
+              entry.previewColumns = preview.columns;
+            }
+            if (Number.isFinite(preview.rows) && preview.rows > 0) {
+              entry.previewRows = preview.rows;
             }
           }
-          if (
-            !Number.isFinite(entry.previewColumns) ||
-            entry.previewColumns <= 0 ||
-            !Number.isFinite(entry.previewRows) ||
-            entry.previewRows <= 0
-          ) {
-            const grid = getSnugGridSize(entry.values.length);
-            if (grid) {
-              if (Number.isFinite(grid.columns) && grid.columns > 0) {
-                entry.previewColumns = grid.columns;
-              }
-              if (Number.isFinite(grid.rows) && grid.rows > 0) {
-                entry.previewRows = grid.rows;
-              }
+        }
+        if (
+          (!Number.isFinite(entry.previewColumns) || entry.previewColumns <= 0 || !Number.isFinite(entry.previewRows) || entry.previewRows <= 0) &&
+          entry.values && entry.values.length
+        ) {
+          const grid = getSnugGridSize(entry.values.length);
+          if (grid) {
+            if (Number.isFinite(grid.columns) && grid.columns > 0) {
+              entry.previewColumns = grid.columns;
+            }
+            if (Number.isFinite(grid.rows) && grid.rows > 0) {
+              entry.previewRows = grid.rows;
             }
           }
         }
@@ -2316,7 +2304,7 @@
             typeof record.dimensions === 'number' && Number.isFinite(record.dimensions)
               ? record.dimensions
               : fallbackDimensions;
-          const values = decodeEmbeddingVector(record.vector, recordDimensions);
+          const { bytes: vectorBytes, values } = decodeEmbeddingVector(record.vector, recordDimensions);
           map.set(id, {
             id,
             dataset,
@@ -2327,6 +2315,7 @@
             vectorSha256: typeof record.vectorSha256 === 'string' ? record.vectorSha256 : '',
             textHash: typeof record.textHash === 'string' ? record.textHash : '',
             values: values || null,
+            vectorBytes: vectorBytes || null,
             previewUrl: '',
             previewWidth: 0,
             previewHeight: 0,


### PR DESCRIPTION
## Summary
- store decoded embedding byte arrays alongside float vectors for cosine lab entries
- generate cosine lab thumbnails by projecting the raw bytes into RGB pixel grids, matching the Embedding Explorer visualizer
- keep synthetic previews in sync by exporting float arrays as bytes before rendering detail captions

## Testing
- `npm test` *(fails: Embedding Explorer spec could not find curated sample buttons; samples were absent during the run)*

------
https://chatgpt.com/codex/tasks/task_e_68d35110de508328863a7beac6a6180f