### PR TITLE
Handle offline manifest fetch failures gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,6 +541,7 @@
       const resetBusyLabel = resetButton && resetButton.dataset && resetButton.dataset.busyLabel
         ? resetButton.dataset.busyLabel
         : 'Refreshing offline bundle…';
+      const METADATA_CACHE_NAME = 'toolbox-offline-metadata';
 
       if (!statusEl || !progressWrapper || !progressBar || !progressFill || !progressDetail) {
         return;
@@ -595,6 +596,23 @@
 
         const fractionDigits = value >= 10 || unitIndex === 0 ? 0 : 1;
         return `${formatter.format(Number(value.toFixed(fractionDigits)))} ${units[unitIndex]}`;
+      }
+
+      async function readCachedManifest() {
+        try {
+          const cache = await caches.open(METADATA_CACHE_NAME);
+          const requestUrl = new URL('__toolbox-offline-manifest__', self.location.href).toString();
+          const response = await cache.match(requestUrl);
+          if (!response) {
+            return null;
+          }
+
+          const manifest = await response.json();
+          return manifest && typeof manifest === 'object' ? manifest : null;
+        } catch (error) {
+          console.warn('Failed to read cached offline manifest', error);
+          return null;
+        }
       }
 
       function getCommitLabel(commit) {
@@ -837,41 +855,53 @@
           return;
         }
 
+        let manifest;
+        let manifestSource = 'network';
+
         try {
           const response = await fetch('offline-manifest.json', { cache: 'no-store' });
           if (!response.ok) {
             throw new Error(`Manifest request failed with status ${response.status}`);
           }
 
-          const manifest = await response.json();
-          state.manifest = manifest;
-          const assets = Array.isArray(manifest.assets) ? manifest.assets : [];
-          const totalBytes = Number.isFinite(manifest.totalBytes)
-            ? manifest.totalBytes
-            : assets.reduce((total, asset) => total + (Number(asset.bytes) || 0), 0);
-
-          if (!Number.isFinite(manifest.totalBytes)) {
-            manifest.totalBytes = totalBytes;
-          }
-          if (typeof manifest.totalAssets !== 'number') {
-            manifest.totalAssets = assets.length;
-          }
-
-          const summary = buildBundleSummary({
-            version: manifest.version,
-            totalAssets: assets.length,
-            totalBytes,
-            commit: manifest.commit || null
-          });
-
-          updateMeta(summary);
-          setStatus('Offline bundle ready to download.');
-          updateResetAvailability();
+          manifest = await response.json();
         } catch (error) {
-          console.error('Failed to load offline manifest', error);
-          setStatus('Unable to load the offline manifest. Refresh when you are back online.');
-          return;
+          console.warn('Failed to load offline manifest from network, attempting cached copy.', error);
+          manifest = await readCachedManifest();
+          if (!manifest) {
+            console.error('Unable to load offline manifest from network or cache', error);
+            setStatus('Unable to load the offline manifest. Refresh when you are back online.');
+            return;
+          }
+          manifestSource = 'cache';
         }
+
+        const assets = Array.isArray(manifest.assets) ? manifest.assets : [];
+        const totalBytes = Number.isFinite(manifest.totalBytes)
+          ? manifest.totalBytes
+          : assets.reduce((total, asset) => total + (Number(asset.bytes) || 0), 0);
+
+        if (!Number.isFinite(manifest.totalBytes)) {
+          manifest.totalBytes = totalBytes;
+        }
+        if (typeof manifest.totalAssets !== 'number') {
+          manifest.totalAssets = assets.length;
+        }
+
+        state.manifest = manifest;
+
+        const summary = buildBundleSummary({
+          version: manifest.version,
+          totalAssets: assets.length,
+          totalBytes,
+          commit: manifest.commit || null
+        });
+
+        updateMeta(summary);
+        setStatus(manifestSource === 'cache' ? 'Offline bundle ready for offline use.' : 'Offline bundle ready to download.');
+        updateResetAvailability();
+
+        const shouldRequestCaching = manifestSource === 'network';
 
         try {
           const registration = await navigator.serviceWorker.register('service-worker.js');
@@ -886,7 +916,9 @@
           const readyRegistration = await navigator.serviceWorker.ready;
           state.registration = readyRegistration;
           updateResetAvailability();
-          requestCaching(readyRegistration);
+          if (shouldRequestCaching) {
+            requestCaching(readyRegistration);
+          }
         } catch (error) {
           console.error('Service worker registration failed', error);
           setStatus('Unable to register the offline service worker.');

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,6 +6,8 @@ const OFFLINE_MANIFEST_PATH = new URL('offline-manifest.json', self.location.ori
 
 let activeCacheName = null;
 let pendingUpdate = null;
+let cachedManifest = null;
+let activeCacheLookupPromise = null;
 
 self.addEventListener('install', (event) => {
   event.waitUntil(self.skipWaiting());
@@ -51,20 +53,69 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (url.pathname === OFFLINE_MANIFEST_PATH) {
-    event.respondWith(handleManifestRequest(event.request));
+    event.respondWith((async () => {
+      await ensureActiveCacheName();
+      return handleManifestRequest(event.request);
+    })());
     return;
   }
 
   if (event.request.mode === 'navigate') {
-    event.respondWith(handleNavigationRequest(event.request));
+    event.respondWith((async () => {
+      await ensureActiveCacheName();
+      return handleNavigationRequest(event.request);
+    })());
     return;
   }
 
-  event.respondWith(handleAssetRequest(event.request));
+  event.respondWith((async () => {
+    await ensureActiveCacheName();
+    return handleAssetRequest(event.request);
+  })());
 });
 
 function getCacheName(version) {
   return `${CACHE_PREFIX}${version}`;
+}
+
+async function ensureActiveCacheName() {
+  if (activeCacheName) {
+    return activeCacheName;
+  }
+
+  if (!activeCacheLookupPromise) {
+    activeCacheLookupPromise = (async () => {
+      let stored = null;
+      try {
+        stored = await readStoredManifest();
+      } catch (error) {
+        console.warn('Failed to read stored manifest while determining active cache', error);
+      }
+
+      if (stored && typeof stored.version === 'string' && stored.version) {
+        activeCacheName = getCacheName(stored.version);
+        return activeCacheName;
+      }
+
+      try {
+        const keys = await caches.keys();
+        const fallback = keys.find((key) => key.startsWith(CACHE_PREFIX));
+        if (fallback) {
+          activeCacheName = fallback;
+        }
+      } catch (error) {
+        console.warn('Failed to inspect caches for active cache name', error);
+      }
+
+      return activeCacheName;
+    })();
+  }
+
+  try {
+    return await activeCacheLookupPromise;
+  } finally {
+    activeCacheLookupPromise = null;
+  }
 }
 
 async function queueManifestUpdate(manifest, options = {}) {
@@ -100,6 +151,7 @@ async function applyManifest(manifest, options = {}) {
     ? manifest.totalBytes
     : assets.reduce((sum, asset) => sum + (Number(asset.bytes) || 0), 0);
   const cacheName = getCacheName(version);
+  await ensureActiveCacheName();
   const existingManifest = await readStoredManifest();
   const cacheKeys = await caches.keys();
   const cacheExists = cacheKeys.includes(cacheName);
@@ -385,16 +437,29 @@ async function broadcast(message) {
 }
 
 async function readStoredManifest() {
-  const cache = await caches.open(METADATA_CACHE);
+  if (cachedManifest) {
+    return cachedManifest;
+  }
+
+  let cache;
+  try {
+    cache = await caches.open(METADATA_CACHE);
+  } catch (error) {
+    console.warn('Failed to open offline metadata cache', error);
+    return null;
+  }
+
   const response = await cache.match(METADATA_REQUEST);
   if (!response) {
     return null;
   }
 
   try {
-    return await response.json();
+    cachedManifest = await response.json();
+    return cachedManifest;
   } catch (error) {
     console.warn('Failed to parse stored offline manifest', error);
+    cachedManifest = null;
     return null;
   }
 }
@@ -407,6 +472,7 @@ async function writeStoredManifest(manifest) {
     }
   });
   await cache.put(METADATA_REQUEST, response);
+  cachedManifest = manifest;
 }
 
 async function cleanupCaches(currentName) {
@@ -437,6 +503,7 @@ async function clearOfflineCaches() {
 
     return Promise.resolve(false);
   }));
+  cachedManifest = null;
 }
 
 function getCommitInfo(rawCommit) {


### PR DESCRIPTION
## Summary
- load the stored offline manifest from the metadata cache when the network request fails so the offline card still initializes while disconnected
- propagate the cached manifest through the setup flow, update status messaging, and skip cache refresh requests when we had to reuse the stored manifest

## Testing
- npx playwright install --with-deps chromium
- npm test *(fails: `tests/embedding-explorer.spec.js` expects three sample buttons but the page renders zero; this also reproduces when running the spec in isolation)*

------
https://chatgpt.com/codex/tasks/task_e_68d35a5683bc83289bed21489e937fc2