### PR TITLE
Add AI Docs link to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,6 +491,12 @@
             <span>Value Formatter</span>
           </a>
         </li>
+        <li>
+          <a class="app-button app-button--secondary app-button--wide" href="ai_docs/">
+            <span aria-hidden="true">📚</span>
+            <span>AI Docs</span>
+          </a>
+        </li>
       </ul>
     </section>
     <section class="offline-section" aria-labelledby="offline-title">


### PR DESCRIPTION
## Summary
- add an "AI Docs" button to the Labs & tools section on the landing page so the documentation hub is easy to find

## Testing
- npx playwright test tests/home-navigation.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d3620b52d08328b2b2b837512cbc0c