### PR TITLE
Add narrative wiki mini app

### DIFF
--- a/apps/embedding-explorer/app.js
+++ b/apps/embedding-explorer/app.js
@@ -49,6 +49,314 @@
     return;
   }
 
+  const summaryCells = summaryGrid ? Array.from(summaryGrid.querySelectorAll('dd')) : [];
+  const valueTableBody = valueTable;
+  let activeSampleId = '';
+
+  function formatDecimal(value) {
+    if (!Number.isFinite(value)) {
+      return '0.000';
+    }
+    const rounded = Math.round(value * 1000) / 1000;
+    return rounded.toFixed(3);
+  }
+
+  function formatRange(min, max) {
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      return '— / —';
+    }
+    return `${formatDecimal(min)} / ${formatDecimal(max)}`;
+  }
+
+  function calculateStats(vector) {
+    const values = Array.isArray(vector) ? vector.map((entry) => Number(entry)).filter((entry) => Number.isFinite(entry)) : [];
+    const length = values.length;
+
+    if (!length) {
+      return {
+        values: [],
+        dimensions: 0,
+        magnitude: 0,
+        mean: 0,
+        deviation: 0,
+        min: null,
+        max: null,
+        zeroShare: 0,
+      };
+    }
+
+    let sum = 0;
+    let sumSquares = 0;
+    let min = values[0];
+    let max = values[0];
+    let zeroCount = 0;
+
+    values.forEach((value) => {
+      sum += value;
+      sumSquares += value * value;
+      if (value < min) {
+        min = value;
+      }
+      if (value > max) {
+        max = value;
+      }
+      if (Math.abs(value) < 1e-9) {
+        zeroCount += 1;
+      }
+    });
+
+    const mean = sum / length;
+    let variance = 0;
+    values.forEach((value) => {
+      const delta = value - mean;
+      variance += delta * delta;
+    });
+    variance /= length;
+
+    return {
+      values,
+      dimensions: length,
+      magnitude: Math.sqrt(sumSquares),
+      mean,
+      deviation: Math.sqrt(variance),
+      min,
+      max,
+      zeroShare: length ? zeroCount / length : 0,
+    };
+  }
+
+  function updateSummary(stats) {
+    if (!summaryCells.length) {
+      return;
+    }
+
+    const entries = [
+      stats.dimensions.toLocaleString(),
+      formatDecimal(stats.magnitude),
+      formatDecimal(stats.mean),
+      formatDecimal(stats.deviation),
+      formatRange(stats.min, stats.max),
+      `${Math.round(stats.zeroShare * 100)}%`,
+    ];
+
+    entries.forEach((value, index) => {
+      if (summaryCells[index]) {
+        summaryCells[index].textContent = value;
+      }
+    });
+  }
+
+  function renderExtrema(listElement, entries, placeholder) {
+    if (!listElement) {
+      return;
+    }
+
+    listElement.innerHTML = '';
+
+    if (!entries.length) {
+      const item = document.createElement('li');
+      const text = document.createElement('span');
+      text.className = 'placeholder';
+      text.textContent = placeholder;
+      item.appendChild(text);
+      listElement.appendChild(item);
+      return;
+    }
+
+    entries.forEach((entry) => {
+      const item = document.createElement('li');
+      item.textContent = `#${entry.index}${formatDecimal(entry.value)}`;
+      listElement.appendChild(item);
+    });
+  }
+
+  function renderValueRows(values) {
+    if (!valueTableBody) {
+      return;
+    }
+
+    valueTableBody.innerHTML = '';
+
+    if (!values.length) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 3;
+      cell.innerHTML = '<p class="placeholder">Enter an embedding vector to populate this table.</p>';
+      row.appendChild(cell);
+      valueTableBody.appendChild(row);
+      return;
+    }
+
+    const maxAbs = values.reduce((max, value) => {
+      const magnitude = Math.abs(value);
+      return magnitude > max ? magnitude : max;
+    }, 0);
+
+    values.forEach((value, index) => {
+      const row = document.createElement('tr');
+      const indexCell = document.createElement('td');
+      indexCell.textContent = `#${index + 1}`;
+
+      const valueCell = document.createElement('td');
+      const valueSpan = document.createElement('span');
+      valueSpan.textContent = formatDecimal(value);
+      valueCell.appendChild(valueSpan);
+
+      const normalizedCell = document.createElement('td');
+      const normalizedSpan = document.createElement('span');
+      const normalized = maxAbs > 0 ? Math.abs(value) / maxAbs : 0;
+      normalizedSpan.textContent = formatDecimal(normalized);
+      normalizedCell.appendChild(normalizedSpan);
+
+      row.append(indexCell, valueCell, normalizedCell);
+      valueTableBody.appendChild(row);
+    });
+  }
+
+  function updateInsights(vector) {
+    const stats = calculateStats(vector);
+    updateSummary(stats);
+
+    const entries = stats.values.map((value, index) => ({ index: index + 1, value }));
+    const positive = entries
+      .filter((entry) => entry.value > 0)
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 3);
+    const negative = entries
+      .filter((entry) => entry.value < 0)
+      .sort((a, b) => a.value - b.value)
+      .slice(0, 3);
+
+    renderExtrema(positiveList, positive, 'Positive values appear here.');
+    renderExtrema(negativeList, negative, 'Negative values appear here.');
+    renderValueRows(stats.values);
+  }
+
+  function formatVectorForInput(values) {
+    return values.map((value) => formatDecimal(value)).join(', ');
+  }
+
+  function setSampleMeta(description) {
+    if (!sampleMeta) {
+      return;
+    }
+
+    sampleMeta.innerHTML = '';
+    const paragraph = document.createElement('p');
+    paragraph.textContent = description || 'Choose a sample to populate its description.';
+    sampleMeta.appendChild(paragraph);
+  }
+
+  function highlightSampleButtons() {
+    if (!sampleList) {
+      return;
+    }
+
+    const buttons = sampleList.querySelectorAll('.sample-button');
+    buttons.forEach((button) => {
+      const isActive = button.dataset.sampleId === activeSampleId;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  function parseVectorInput(input) {
+    if (typeof input !== 'string') {
+      return [];
+    }
+
+    return input
+      .split(/[,\s]+/)
+      .map((chunk) => Number.parseFloat(chunk))
+      .filter((value) => Number.isFinite(value));
+  }
+
+  function selectSample(sample) {
+    if (!sample) {
+      activeSampleId = '';
+      highlightSampleButtons();
+      updateInsights([]);
+      setSampleMeta('Choose a sample to populate its description.');
+      return;
+    }
+
+    activeSampleId = sample.id;
+    highlightSampleButtons();
+    const vector = Array.isArray(sample.vector) ? sample.vector : [];
+    updateInsights(vector);
+    setSampleMeta(sample.description || '');
+
+    if (embeddingInput) {
+      embeddingInput.value = formatVectorForInput(vector);
+    }
+  }
+
+  function renderSampleToolbar() {
+    if (!sampleList) {
+      return;
+    }
+
+    sampleList.innerHTML = '';
+
+    if (!samples.length) {
+      const placeholder = document.createElement('p');
+      placeholder.className = 'placeholder';
+      placeholder.textContent = 'No curated samples available.';
+      sampleList.appendChild(placeholder);
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    samples.slice(0, 3).forEach((sample, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'sample-button';
+      button.dataset.sampleId = sample.id;
+      button.textContent = sample.label || `Sample ${index + 1}`;
+      button.addEventListener('click', () => {
+        selectSample(sample);
+      });
+      fragment.appendChild(button);
+    });
+
+    sampleList.appendChild(fragment);
+  }
+
+  function setupSamples() {
+    if (!sampleList || !sampleMeta || !summaryGrid || !valueTableBody) {
+      return;
+    }
+
+    renderSampleToolbar();
+    if (samples.length) {
+      selectSample(samples[0]);
+    } else {
+      updateInsights([]);
+    }
+  }
+
+  function setupManualInput() {
+    if (!updateButton || !embeddingInput) {
+      return;
+    }
+
+    updateButton.addEventListener('click', () => {
+      const values = parseVectorInput(embeddingInput.value);
+      if (!values.length) {
+        activeSampleId = '';
+        highlightSampleButtons();
+        updateInsights([]);
+        setSampleMeta('Enter numbers separated by commas or spaces to update the insights.');
+        return;
+      }
+
+      activeSampleId = '';
+      highlightSampleButtons();
+      updateInsights(values);
+      setSampleMeta('Custom embedding applied.');
+    });
+  }
+
   const datasetCache = new Map();
   let activeDatasetId = '';
   let activeRecordId = '';
@@ -1136,6 +1444,8 @@
     applyFilter();
   });
 
+  setupSamples();
+  setupManualInput();
   populateDatasetSelect();
 
   if (datasetSelect.value) {

--- a/apps/wiki/app.js
+++ b/apps/wiki/app.js
@@ -1,0 +1,501 @@
+(function () {
+  const listEl = document.querySelector('[data-article-list]');
+  const countEl = document.querySelector('[data-count]');
+  const articleTitleEl = document.querySelector('[data-article-title]');
+  const articleMetaEl = document.querySelector('[data-article-meta]');
+  const articleBodyEl = document.querySelector('[data-article-body]');
+  const articleTagsEl = document.querySelector('[data-article-tags]');
+  const emptyMessageEl = document.querySelector('[data-empty-message]');
+
+  if (!listEl || !countEl || !articleTitleEl || !articleMetaEl || !articleBodyEl || !articleTagsEl) {
+    return;
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function escapeAttribute(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function formatInline(text, allowLinks = true) {
+    if (typeof text !== 'string') {
+      return '';
+    }
+
+    let safe = escapeHtml(text);
+
+    if (allowLinks) {
+      safe = safe.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, rawLabel, rawHref) => {
+        const labelHtml = formatInline(rawLabel, false);
+        const decodedHref = rawHref.replace(/&amp;/g, '&').trim();
+        const forbidden = decodedHref.toLowerCase().startsWith('javascript:');
+        const hrefValue = forbidden || !decodedHref ? '#' : decodedHref;
+        const escapedHref = escapeAttribute(hrefValue);
+        return `<a href="${escapedHref}" target="_blank" rel="noreferrer noopener">${labelHtml}</a>`;
+      });
+    }
+
+    safe = safe.replace(/`([^`]+)`/g, (match, code) => `<code>${code}</code>`);
+    safe = safe.replace(/\*\*([^*]+)\*\*/g, (match, bold) => `<strong>${bold}</strong>`);
+    safe = safe.replace(/(^|[\s>])\*([^*]+)\*(?=[\s<.,!?:;)]|$)/g, (match, prefix, italic) => `${prefix}<em>${italic}</em>`);
+    safe = safe.replace(/(^|[\s>])_([^_]+)_(?=[\s<.,!?:;)]|$)/g, (match, prefix, italic) => `${prefix}<em>${italic}</em>`);
+
+    return safe;
+  }
+
+  function renderMarkdown(markdown) {
+    if (typeof markdown !== 'string') {
+      return '<p>No story yet.</p>';
+    }
+
+    const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+    const html = [];
+    let paragraphLines = [];
+    let inList = false;
+    let listItems = [];
+    let inCodeBlock = false;
+    let codeLines = [];
+    let codeLanguage = '';
+
+    function flushParagraph() {
+      if (!paragraphLines.length) {
+        return;
+      }
+
+      const paragraphText = paragraphLines.join(' ').trim();
+      if (paragraphText) {
+        html.push(`<p>${formatInline(paragraphText)}</p>`);
+      }
+      paragraphLines = [];
+    }
+
+    function flushList() {
+      if (!inList) {
+        return;
+      }
+
+      html.push(`<ul>${listItems.join('')}</ul>`);
+      inList = false;
+      listItems = [];
+    }
+
+    function flushCode() {
+      const codeText = codeLines.join('\n');
+      const escaped = escapeHtml(codeText);
+      const languageAttr = codeLanguage ? ` data-language="${escapeAttribute(codeLanguage)}"` : '';
+      html.push(`<pre><code${languageAttr}>${escaped}</code></pre>`);
+      codeLines = [];
+      codeLanguage = '';
+    }
+
+    lines.forEach((rawLine) => {
+      const line = rawLine.replace(/\s+$/g, '');
+      const trimmed = line.trim();
+
+      if (!inCodeBlock && trimmed.startsWith('```')) {
+        flushParagraph();
+        flushList();
+        inCodeBlock = true;
+        codeLanguage = trimmed.slice(3).trim();
+        codeLines = [];
+        return;
+      }
+
+      if (inCodeBlock) {
+        if (trimmed.startsWith('```')) {
+          flushCode();
+          inCodeBlock = false;
+          return;
+        }
+
+        codeLines.push(line);
+        return;
+      }
+
+      if (trimmed === '') {
+        flushParagraph();
+        flushList();
+        return;
+      }
+
+      if (/^[-*]\s+/.test(trimmed)) {
+        flushParagraph();
+        const listText = trimmed.replace(/^[-*]\s+/, '');
+        listItems.push(`<li>${formatInline(listText)}</li>`);
+        inList = true;
+        return;
+      }
+
+      const headingMatch = trimmed.match(/^(#{1,3})\s+(.*)$/);
+      if (headingMatch) {
+        flushParagraph();
+        flushList();
+        const level = headingMatch[1].length;
+        const headingText = formatInline(headingMatch[2]);
+        html.push(`<h${level}>${headingText}</h${level}>`);
+        return;
+      }
+
+      if (/^>\s?/.test(trimmed)) {
+        flushParagraph();
+        flushList();
+        const quoteText = formatInline(trimmed.replace(/^>\s?/, ''));
+        html.push(`<blockquote>${quoteText}</blockquote>`);
+        return;
+      }
+
+      if (/^[-]{3,}$/.test(trimmed)) {
+        flushParagraph();
+        flushList();
+        html.push('<hr>');
+        return;
+      }
+
+      paragraphLines.push(line);
+    });
+
+    if (inCodeBlock) {
+      flushCode();
+    }
+
+    flushParagraph();
+    flushList();
+
+    return html.join('');
+  }
+
+  function parseDate(value) {
+    if (typeof value !== 'string' || !value.trim()) {
+      return null;
+    }
+
+    const timestamp = Date.parse(value);
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+
+  function formatDate(value) {
+    const timestamp = parseDate(value);
+    if (!timestamp) {
+      return null;
+    }
+
+    try {
+      return new Intl.DateTimeFormat('en', {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric'
+      }).format(new Date(timestamp));
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function estimateReadingTime(content) {
+    if (typeof content !== 'string') {
+      return null;
+    }
+
+    const words = content
+      .replace(/[`*_#>\-]/g, ' ')
+      .split(/\s+/)
+      .filter(Boolean);
+    if (!words.length) {
+      return null;
+    }
+
+    const minutes = Math.max(1, Math.round(words.length / 170));
+    return `${minutes} min read`;
+  }
+
+  const articles = Array.isArray(window.wikiArticles)
+    ? window.wikiArticles
+        .map((entry) => {
+          const slug = entry && typeof entry.slug === 'string' ? entry.slug.trim() : '';
+          const title = entry && typeof entry.title === 'string' ? entry.title.trim() : '';
+          const summary = entry && typeof entry.summary === 'string' ? entry.summary.trim() : '';
+          const accentEmoji = entry && typeof entry.accentEmoji === 'string' ? entry.accentEmoji.trim() : '';
+          const published = entry && typeof entry.published === 'string' ? entry.published.trim() : '';
+          const content = entry && typeof entry.content === 'string' ? entry.content : '';
+          const tags = Array.isArray(entry && entry.tags)
+            ? entry.tags
+                .map((tag) => (typeof tag === 'string' ? tag.trim() : ''))
+                .filter(Boolean)
+            : [];
+
+          if (!slug || !title || !content) {
+            return null;
+          }
+
+          const readingTime = estimateReadingTime(content);
+          return {
+            slug,
+            title,
+            summary,
+            accentEmoji,
+            published,
+            content,
+            tags,
+            readingTime
+          };
+        })
+        .filter(Boolean)
+    : [];
+
+  articles.sort((a, b) => {
+    const timeA = parseDate(a.published);
+    const timeB = parseDate(b.published);
+
+    if (timeA && timeB) {
+      return timeB - timeA;
+    }
+
+    if (timeA && !timeB) {
+      return -1;
+    }
+
+    if (!timeA && timeB) {
+      return 1;
+    }
+
+    return a.title.localeCompare(b.title);
+  });
+
+  function updateCountBadge() {
+    if (!countEl) {
+      return;
+    }
+
+    const count = articles.length;
+    if (!count) {
+      countEl.textContent = '0 entries';
+      return;
+    }
+
+    const label = count === 1 ? 'entry' : 'entries';
+    countEl.textContent = `${count.toLocaleString()} ${label}`;
+  }
+
+  function buildList() {
+    if (!articles.length) {
+      listEl.innerHTML = '';
+      const emptyItem = document.createElement('li');
+      emptyItem.className = 'article-empty';
+      emptyItem.textContent = 'No chronicles yet—check back soon!';
+      listEl.appendChild(emptyItem);
+      return;
+    }
+
+    if (emptyMessageEl) {
+      emptyMessageEl.remove();
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    articles.forEach((article) => {
+      const item = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'article-card';
+      button.dataset.articleSlug = article.slug;
+      button.setAttribute('aria-pressed', 'false');
+
+      const emojiSpan = document.createElement('span');
+      emojiSpan.className = 'article-card__emoji';
+      emojiSpan.textContent = article.accentEmoji || '📝';
+      button.appendChild(emojiSpan);
+
+      const contentWrapper = document.createElement('span');
+      contentWrapper.className = 'article-card__content';
+
+      const titleSpan = document.createElement('span');
+      titleSpan.className = 'article-card__title';
+      titleSpan.textContent = article.title;
+      contentWrapper.appendChild(titleSpan);
+
+      const summarySpan = document.createElement('span');
+      summarySpan.className = 'article-card__summary';
+      summarySpan.textContent = article.summary || 'Tap to read the full saga.';
+      contentWrapper.appendChild(summarySpan);
+
+      const metaSpan = document.createElement('span');
+      metaSpan.className = 'article-card__meta';
+      const dateLabel = formatDate(article.published);
+      const metaParts = [];
+      if (dateLabel) {
+        metaParts.push(dateLabel);
+      }
+      if (article.readingTime) {
+        metaParts.push(article.readingTime);
+      }
+      metaSpan.textContent = metaParts.join(' • ');
+      contentWrapper.appendChild(metaSpan);
+
+      button.appendChild(contentWrapper);
+      item.appendChild(button);
+      fragment.appendChild(item);
+    });
+
+    listEl.innerHTML = '';
+    listEl.appendChild(fragment);
+  }
+
+  function highlightActive(slug) {
+    const buttons = listEl.querySelectorAll('.article-card');
+    buttons.forEach((button) => {
+      const matches = button.dataset.articleSlug === slug;
+      button.classList.toggle('is-active', matches);
+      button.setAttribute('aria-pressed', matches ? 'true' : 'false');
+    });
+  }
+
+  function renderTags(tags) {
+    articleTagsEl.innerHTML = '';
+    if (!tags || !tags.length) {
+      articleTagsEl.hidden = true;
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    tags.forEach((tag) => {
+      const item = document.createElement('li');
+      item.textContent = tag;
+      fragment.appendChild(item);
+    });
+    articleTagsEl.appendChild(fragment);
+    articleTagsEl.hidden = false;
+  }
+
+  function renderArticle(article, options) {
+    const metaParts = [];
+    const dateLabel = formatDate(article.published);
+    if (dateLabel) {
+      metaParts.push(dateLabel);
+    }
+    if (article.readingTime) {
+      metaParts.push(article.readingTime);
+    }
+
+    if (metaParts.length) {
+      articleMetaEl.hidden = false;
+      articleMetaEl.textContent = metaParts.join(' • ');
+    } else {
+      articleMetaEl.hidden = true;
+      articleMetaEl.textContent = '';
+    }
+
+    articleTitleEl.textContent = article.title;
+    const html = renderMarkdown(article.content);
+    articleBodyEl.innerHTML = html || '<p class="article-empty">No story yet.</p>';
+    renderTags(article.tags);
+
+    if (options && options.focus && articleTitleEl.focus) {
+      articleTitleEl.focus();
+    }
+
+    highlightActive(article.slug);
+    document.title = `${article.title} · Project Wiki`;
+  }
+
+  let activeSlug = null;
+
+  function selectArticle(slug, options = {}) {
+    if (!slug) {
+      return;
+    }
+
+    const match = articles.find((article) => article.slug === slug);
+    if (!match) {
+      return;
+    }
+
+    activeSlug = match.slug;
+    renderArticle(match, options);
+
+    if (options.updateHistory !== false) {
+      try {
+        const url = new URL(window.location.href);
+        url.searchParams.set('article', match.slug);
+        window.history.replaceState({ article: match.slug }, '', url);
+      } catch (error) {
+        // ignore URL update errors
+      }
+    }
+  }
+
+  function applyInitialSelection() {
+    if (!articles.length) {
+      return;
+    }
+
+    let slug = null;
+    try {
+      const url = new URL(window.location.href);
+      slug = url.searchParams.get('article');
+    } catch (error) {
+      slug = null;
+    }
+
+    if (slug && articles.some((article) => article.slug === slug)) {
+      selectArticle(slug, { updateHistory: false });
+      return;
+    }
+
+    selectArticle(articles[0].slug, { updateHistory: false });
+  }
+
+  function handlePopState() {
+    if (!articles.length) {
+      return;
+    }
+
+    let slug = null;
+    try {
+      const url = new URL(window.location.href);
+      slug = url.searchParams.get('article');
+    } catch (error) {
+      slug = null;
+    }
+
+    if (slug && articles.some((article) => article.slug === slug)) {
+      selectArticle(slug, { updateHistory: false, focus: true });
+      return;
+    }
+
+    if (activeSlug && articles.some((article) => article.slug === activeSlug)) {
+      selectArticle(activeSlug, { updateHistory: false, focus: true });
+    } else {
+      selectArticle(articles[0].slug, { updateHistory: false, focus: true });
+    }
+  }
+
+  function bindEvents() {
+    listEl.addEventListener('click', (event) => {
+      const button = event.target.closest('.article-card');
+      if (!button) {
+        return;
+      }
+
+      const slug = button.dataset.articleSlug;
+      if (!slug) {
+        return;
+      }
+
+      selectArticle(slug, { focus: true });
+    });
+
+    window.addEventListener('popstate', handlePopState);
+  }
+
+  updateCountBadge();
+  buildList();
+  bindEvents();
+  applyInitialSelection();
+})();

--- a/apps/wiki/articles-data.js
+++ b/apps/wiki/articles-data.js
@@ -1,0 +1,89 @@
+window.wikiArticles = [
+  {
+    "slug": "kickoff-chaos",
+    "title": "Kickoff Log: We Built a Wiki Instead of a Slide Deck",
+    "summary": "The day we traded status meetings for a narrative machine with jokes baked into the changelog.",
+    "accentEmoji": "🎉",
+    "published": "2024-03-14",
+    "tags": ["origin story", "process"],
+    "content": `
+# Welcome to the Build Diary
+
+We set out to have a tidy project sync. Fifteen minutes later, someone muttered "what if progress updates were actually fun?" and now there's a dedicated wiki living right inside the toolbox. Classic scope creep, but make it storytelling.
+
+## Why we're doing this
+- Status updates should read like dispatches from a mischievous mission control.
+ - Documentation belongs where the work happens, not in a folder named *final_v4_really_this_time*.
+- Sharing the "why" behind decisions means future us won't squint at old commits wondering what possessed us.
+
+## What changed today
+- Spun up the new \`apps/wiki/\` home with enough glow to feel celebratory, but not so much that sunglasses are required.
+- Drafted the first crop of articles, all narrated with equal parts honesty and caffeine.
+- Added a left-hand dispatch list so you can hop between updates without spelunking through folders.
+
+## Next experiments
+- Wire in URL support so you can bookmark a favorite saga for dramatic retellings.
+- Expand the article data set as milestones land, using this markdown-friendly format for fast edits.
+- Invite guest narrators from the team. The more chaotic energy, the merrier.
+`
+  },
+  {
+    "slug": "markdown-machinations",
+    "title": "Markdown Shenanigans Without a Build Step",
+    "summary": "A peek under the hood at how we turn lightweight markdown into punchy HTML inside the browser.",
+    "accentEmoji": "🛠️",
+    "published": "2024-03-18",
+    "tags": ["markdown", "frontend"],
+    "content": `
+# How the wiki digests markdown
+
+Confession time: we wanted the joy of markdown without unleashing a bundler hydra. So the wiki ships with a pocket-sized parser that handles the greatest hits—headings, lists, links, and the occasional code block—right in the browser.
+
+## The conversion game plan
+- Trim the markdown, line by line, so blank space doesn't spawn weird ghosts in the layout.
+- Look for headings (one to three \`#\` characters) and convert them into proper semantic tags.
+- Detect bullet lists and wrap them in \`<ul>\` elements so screen readers stay happy.
+- Escape anything suspicious before adding emphasis, links, or \`<code>\` snippets.
+
+## Sample markdown
+```
+# Sample heading
+
+- One bullet to rule them all
+- Another bullet wearing a cape
+
+Remember: inline code like `npm run wiki` gets the spotlight treatment too.
+```
+
+## Why it matters
+Keeping the parser tiny means no dependencies, instant loads, and zero build step drama. It also lowers the barrier for anyone to drop in a new article—just add a markdown string to the data file and the page does the rest.
+`
+  },
+  {
+    "slug": "navigation-nerdery",
+    "title": "Navigation Nerdery: URLs, Reading Time, and Reader Delight",
+    "summary": "Tuning the experience so each update feels like a guided tour instead of a scavenger hunt.",
+    "accentEmoji": "🧭",
+    "published": "2024-03-21",
+    "tags": ["ux", "tooling"],
+    "content": `
+# The reader experience tune-up
+
+The first version of the wiki asked you to keep track of where you were by sheer memory. Cute, but not ideal. Today we injected some quality-of-life boosts so catching up on the project feels like binging a mini-series.
+
+## What's new
+- URLs now reflect the article you're reading thanks to query parameters. Shareable, bookmarkable, brag-worthy.
+- Each entry announces an approximate reading time, calculated by a friendly script that counts words instead of vibes.
+- Selected articles steal focus (politely) so keyboard users jump straight to the juicy headline.
+
+## Helpful tidbits
+> Bookmark the article list view to keep an eye on how many dispatches we've shipped. The badge updates automatically as new posts land.
+
+- Tag pills highlight the theme of each entry, making it easy to skim for tech dives vs. retro musings.
+- The layout snaps into a single column on phones so you can doomscroll our progress comfortably.
+
+## TL;DR
+We're building an archive that's actually fun to read. If you spot any rough edges or dream up a feature, drop it in the next entry—we're all ears and probably already writing the punchline.
+`
+  }
+];

--- a/apps/wiki/index.html
+++ b/apps/wiki/index.html
@@ -1,0 +1,475 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Project Wiki</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      --body-background: radial-gradient(circle at top, rgba(88, 119, 255, 0.22), rgba(12, 18, 40, 0.12) 60%);
+      --body-base: #f4f6ff;
+      --text-primary: #111832;
+      --text-secondary: rgba(17, 24, 50, 0.72);
+      --surface: rgba(255, 255, 255, 0.94);
+      --surface-alt: rgba(255, 255, 255, 0.86);
+      --surface-border: rgba(74, 99, 255, 0.18);
+      --surface-shadow: 0 24px 60px rgba(15, 23, 42, 0.15);
+      --list-border: rgba(74, 99, 255, 0.12);
+      --accent: #4a63ff;
+      --accent-soft: rgba(74, 99, 255, 0.12);
+      --accent-strong: rgba(74, 99, 255, 0.18);
+      --focus-ring: rgba(121, 134, 255, 0.45);
+      --badge-background: rgba(74, 99, 255, 0.16);
+      --badge-text: #111832;
+      --code-background: rgba(17, 24, 50, 0.08);
+      --code-border: rgba(17, 24, 50, 0.12);
+      --blockquote-border: rgba(74, 99, 255, 0.35);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --body-background: radial-gradient(circle at top, rgba(88, 119, 255, 0.32), rgba(4, 9, 22, 0.92) 65%);
+        --body-base: #070b1a;
+        --text-primary: #f5f7ff;
+        --text-secondary: rgba(245, 247, 255, 0.72);
+        --surface: rgba(14, 20, 40, 0.82);
+        --surface-alt: rgba(14, 20, 40, 0.76);
+        --surface-border: rgba(155, 169, 255, 0.22);
+        --surface-shadow: 0 26px 70px rgba(0, 0, 0, 0.4);
+        --list-border: rgba(155, 169, 255, 0.22);
+        --accent: #95a2ff;
+        --accent-soft: rgba(149, 162, 255, 0.18);
+        --accent-strong: rgba(149, 162, 255, 0.28);
+        --badge-background: rgba(149, 162, 255, 0.24);
+        --badge-text: #f5f7ff;
+        --code-background: rgba(10, 14, 28, 0.94);
+        --code-border: rgba(149, 162, 255, 0.28);
+        --blockquote-border: rgba(149, 162, 255, 0.45);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(20px, 3vw, 40px);
+      background: var(--body-background);
+      background-color: var(--body-base);
+      color: var(--text-primary);
+    }
+
+    main {
+      width: min(1080px, 100%);
+      background: var(--surface);
+      border-radius: 24px;
+      border: 1px solid var(--surface-border);
+      box-shadow: var(--surface-shadow);
+      backdrop-filter: blur(18px);
+      padding: clamp(18px, 3vw, 32px);
+      display: flex;
+      flex-direction: column;
+      gap: clamp(18px, 2.6vw, 32px);
+    }
+
+    .home-nav {
+      display: flex;
+      justify-content: flex-start;
+    }
+
+    .home-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid var(--surface-border);
+      color: inherit;
+      text-decoration: none;
+      font-weight: 600;
+      background: var(--accent-soft);
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+    }
+
+    .home-link span[aria-hidden="true"] {
+      font-size: 1.15rem;
+    }
+
+    .home-link:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 30px rgba(74, 99, 255, 0.28);
+      background: var(--accent-strong);
+    }
+
+    .home-link:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px var(--focus-ring);
+    }
+
+    .page-header {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .page-header h1 {
+      margin: 0;
+      font-size: clamp(2rem, 1.4vw + 1.8rem, 2.6rem);
+      letter-spacing: -0.01em;
+    }
+
+    .page-tagline {
+      margin: 0;
+      max-width: 52ch;
+      font-size: clamp(1rem, 0.4vw + 0.95rem, 1.1rem);
+      color: var(--text-secondary);
+    }
+
+    .wiki-layout {
+      display: grid;
+      grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+      gap: clamp(18px, 2.4vw, 36px);
+    }
+
+    .article-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      background: var(--surface-alt);
+      border: 1px solid var(--list-border);
+      border-radius: 18px;
+      padding: clamp(16px, 2.2vw, 22px);
+    }
+
+    .panel-header {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .panel-header h2 {
+      margin: 0;
+      font-size: clamp(1.1rem, 0.4vw + 1rem, 1.3rem);
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+
+    .panel-description {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+    }
+
+    .count-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: var(--badge-background);
+      color: var(--badge-text);
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      width: fit-content;
+    }
+
+    .article-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .article-card {
+      width: 100%;
+      border: 1px solid transparent;
+      border-radius: 16px;
+      padding: 14px 16px;
+      background: rgba(255, 255, 255, 0.72);
+      color: inherit;
+      text-align: left;
+      display: flex;
+      gap: 14px;
+      align-items: flex-start;
+      cursor: pointer;
+      font: inherit;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+    }
+
+    .article-card:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 28px rgba(74, 99, 255, 0.16);
+      border-color: var(--surface-border);
+      background: rgba(255, 255, 255, 0.86);
+    }
+
+    .article-card:focus-visible {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--focus-ring);
+    }
+
+    .article-card__emoji {
+      font-size: 1.6rem;
+      flex-shrink: 0;
+      line-height: 1;
+    }
+
+    .article-card__content {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    .article-card__title {
+      font-weight: 650;
+      font-size: 1.05rem;
+      line-height: 1.3;
+      word-break: break-word;
+    }
+
+    .article-card__summary {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+      line-height: 1.4;
+    }
+
+    .article-card__meta {
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+
+    .article-card.is-active {
+      border-color: var(--accent);
+      background: rgba(74, 99, 255, 0.12);
+      box-shadow: inset 0 0 0 1px rgba(74, 99, 255, 0.2);
+    }
+
+    .article-view {
+      background: var(--surface-alt);
+      border: 1px solid var(--surface-border);
+      border-radius: 18px;
+      padding: clamp(18px, 2.6vw, 28px);
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+      min-height: 420px;
+    }
+
+    .article-header {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .article-kicker {
+      margin: 0;
+      font-size: 0.95rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+    }
+
+    .article-title {
+      margin: 0;
+      font-size: clamp(1.5rem, 1vw + 1.4rem, 2rem);
+      line-height: 1.25;
+    }
+
+    .article-meta {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+    }
+
+    .tag-list {
+      list-style: none;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 0;
+      padding: 0;
+    }
+
+    .tag-list li {
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      color: var(--badge-text);
+      font-size: 0.85rem;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+
+    .article-body {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      line-height: 1.65;
+      font-size: 1rem;
+    }
+
+    .article-body h2,
+    .article-body h3 {
+      margin: 18px 0 8px;
+      line-height: 1.3;
+    }
+
+    .article-body h2:first-child,
+    .article-body h3:first-child {
+      margin-top: 0;
+    }
+
+    .article-body p {
+      margin: 0;
+    }
+
+    .article-body ul {
+      margin: 0;
+      padding-left: 22px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .article-body li {
+      margin: 0;
+    }
+
+    .article-body pre {
+      margin: 0;
+      padding: 14px 16px;
+      border-radius: 12px;
+      background: var(--code-background);
+      border: 1px solid var(--code-border);
+      overflow: auto;
+      font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .article-body code {
+      background: rgba(74, 99, 255, 0.12);
+      padding: 2px 6px;
+      border-radius: 6px;
+      font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+      font-size: 0.95rem;
+    }
+
+    .article-body blockquote {
+      margin: 0;
+      padding-left: 16px;
+      border-left: 3px solid var(--blockquote-border);
+      color: var(--text-secondary);
+      font-style: italic;
+    }
+
+    .article-empty {
+      margin: 0;
+      color: var(--text-secondary);
+    }
+
+    .article-body a {
+      color: var(--accent);
+      font-weight: 600;
+      text-decoration: none;
+    }
+
+    .article-body a:hover {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 960px) {
+      .wiki-layout {
+        grid-template-columns: 1fr;
+      }
+
+      .article-panel,
+      .article-view {
+        padding: clamp(16px, 3vw, 22px);
+      }
+
+      .article-panel {
+        order: 1;
+      }
+
+      .article-view {
+        order: 2;
+      }
+    }
+
+    @media (max-width: 620px) {
+      body {
+        padding: 14px;
+      }
+
+      main {
+        border-radius: 18px;
+      }
+
+      .article-card {
+        padding: 12px 14px;
+      }
+
+      .article-body {
+        font-size: 0.98rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header class="page-header">
+      <nav class="home-nav" aria-label="Back to toolbox">
+        <a class="home-link" href="../../index.html">
+          <span aria-hidden="true">🏠</span>
+          <span>Toolbox home</span>
+        </a>
+      </nav>
+      <h1>Project Wiki</h1>
+      <p class="page-tagline">A gloriously biased chronicle of how this project crawls, sprints, and occasionally cartwheels toward greatness.</p>
+    </header>
+    <div class="wiki-layout">
+      <aside class="article-panel" aria-labelledby="article-list-title">
+        <div class="panel-header">
+          <h2 id="article-list-title">Field notes</h2>
+          <p class="panel-description">Pick an entry to eavesdrop on our latest experiments, mishaps, and triumphs.</p>
+          <span class="count-pill" data-count>0 entries</span>
+        </div>
+        <ul class="article-list" data-article-list>
+          <li class="article-empty" data-empty-message>No chronicles yet—check back soon!</li>
+        </ul>
+      </aside>
+      <article class="article-view" data-article aria-labelledby="article-title">
+        <header class="article-header">
+          <p class="article-kicker">Currently reading</p>
+          <h2 class="article-title" id="article-title" data-article-title tabindex="-1">Pick an entry from the list</h2>
+          <p class="article-meta" data-article-meta hidden></p>
+          <ul class="tag-list" data-article-tags hidden aria-label="Topics"></ul>
+        </header>
+        <div class="article-body" data-article-body>
+          <p class="article-empty">Select an article from the left to dive into the chaos.</p>
+        </div>
+      </article>
+    </div>
+  </main>
+  <script src="articles-data.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -462,6 +462,14 @@
             </a>
           </div>
         </li>
+        <li class="app-row" data-group="wiki" role="group" aria-label="Project Wiki">
+          <div class="app-row__actions">
+            <a class="app-button app-button--secondary" href="apps/wiki/">
+              <span aria-hidden="true">📚</span>
+              <span>Project Wiki</span>
+            </a>
+          </div>
+        </li>
       </ul>
     </section>
     <section class="app-groups" aria-labelledby="tools-section">

--- a/offline-manifest.json
+++ b/offline-manifest.json
@@ -1,8 +1,8 @@
 {
-  "version": "20250924-3287697f16d2-7da0701dac54",
-  "generatedAt": "2025-09-24T02:37:39.689Z",
-  "totalAssets": 55,
-  "totalBytes": 6198330,
+  "version": "20250924-328c9a1a93e0-cf6f09977bc4-dirty",
+  "generatedAt": "2025-09-24T03:16:41.980Z",
+  "totalAssets": 58,
+  "totalBytes": 6237324,
   "assets": [
     {
       "path": "apps/asset-observatory/app.js",
@@ -18,7 +18,7 @@
     },
     {
       "path": "apps/embedding-explorer/app.js",
-      "bytes": 37605
+      "bytes": 45900
     },
     {
       "path": "apps/embedding-explorer/index.html",
@@ -99,6 +99,18 @@
     {
       "path": "apps/value-formatter/index.html",
       "bytes": 2832
+    },
+    {
+      "path": "apps/wiki/app.js",
+      "bytes": 13803
+    },
+    {
+      "path": "apps/wiki/articles-data.js",
+      "bytes": 4490
+    },
+    {
+      "path": "apps/wiki/index.html",
+      "bytes": 12065
     },
     {
       "path": "data/curated-quotes.json",
@@ -218,7 +230,7 @@
     },
     {
       "path": "index.html",
-      "bytes": 28752
+      "bytes": 29093
     },
     {
       "path": "service-worker.js",
@@ -226,8 +238,8 @@
     }
   ],
   "commit": {
-    "hash": "7da0701dac541a22181118fa7012f29578e5dcab",
-    "short": "7da0701dac54",
-    "dirty": false
+    "hash": "cf6f09977bc459538c2b730bec5d0f0896f95f63",
+    "short": "cf6f09977bc4",
+    "dirty": true
   }
 }

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -8,13 +8,13 @@ test.describe('Landing page', () => {
     await expect(header.locator('h1')).toHaveText('Toolbox');
 
     const deckRows = page.locator('.app-row');
-    await expect(deckRows).toHaveCount(3);
+    await expect(deckRows).toHaveCount(4);
     await expect(deckRows.first()).toHaveAttribute('role', 'group');
 
     const groupLabels = await deckRows.evaluateAll((nodes) =>
       nodes.map((node) => node.getAttribute('aria-label')),
     );
-    expect(groupLabels).toEqual(['Jokes', 'Quotes', 'Slang']);
+    expect(groupLabels).toEqual(['Jokes', 'Quotes', 'Slang', 'Project Wiki']);
 
     const deckLinkSets = await deckRows.evaluateAll((nodes) =>
       nodes.map((node) =>
@@ -37,6 +37,9 @@ test.describe('Landing page', () => {
       [
         { href: 'apps/slang/', text: '🗣️ Slang' },
         { href: 'apps/slang/all-slang.html', text: 'All Slang' },
+      ],
+      [
+        { href: 'apps/wiki/', text: '📚 Project Wiki' },
       ],
     ]);
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -5,7 +5,7 @@ test.describe('Landing page', () => {
     await page.goto('/');
 
     const groupedRows = page.locator('.app-row[data-group]');
-    await expect(groupedRows).toHaveCount(3);
+    await expect(groupedRows).toHaveCount(4);
 
     const expectedRows = [
       {
@@ -25,6 +25,12 @@ test.describe('Landing page', () => {
         label: 'Slang',
         texts: ['🗣️ Slang', 'All Slang'],
         hrefs: ['apps/slang/', 'apps/slang/all-slang.html'],
+      },
+      {
+        group: 'wiki',
+        label: 'Project Wiki',
+        texts: ['📚 Project Wiki'],
+        hrefs: ['apps/wiki/'],
       },
     ];
 
@@ -78,6 +84,6 @@ test.describe('Landing page', () => {
     await expect(valueFormatterButton).not.toContainText('—');
 
     const allButtons = page.locator('a.app-button');
-    await expect(allButtons).toHaveCount(10);
+    await expect(allButtons).toHaveCount(11);
   });
 });


### PR DESCRIPTION
## Summary
- add a Project Wiki mini-app with markdown-driven articles and navigation from the landing page
- expand the Embedding Explorer to load manual vectors, summarize stats, and keep sample data interactive for Playwright
- regenerate the offline manifest and update landing page tests for the new wiki entry

## Testing
- npm run build:offline
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d35da69d5483289e633e8c4984efef