### PR TITLE
Rebrand wiki app as Project Blog

### DIFF
--- a/apps/wiki/AGENTS.md
+++ b/apps/wiki/AGENTS.md
@@ -1,0 +1,21 @@
+# Project Blog — Agent Notes
+
+## Voice and tone
+- Keep entries conversational, celebratory, and specific about what changed.
+- Anchor every post in the team's perspective—own the "we" voice and spotlight experiments, wins, and missteps.
+- Swap generic filler for vivid verbs and punchy phrases. Headlines should tease the story, not summarize it.
+
+## Recommended outline for new posts
+1. Open with a hooky `#` heading that names the update in plain English.
+2. Follow with a short paragraph that sets the scene—why this work mattered right now.
+3. Use `##` subheadings to break down the meat of the update. Popular beats:
+   - **Highlights** for notable launches or discoveries.
+   - **How we pulled it off** for process notes or tooling quirks.
+   - **What’s next** for upcoming experiments or follow-up tasks.
+4. Wrap with a call to action or reflection that invites future readers to build on the momentum.
+
+## Data file expectations
+- Store posts in `articles-data.js` as template strings; keep indentation at two spaces to match the rest of the repo.
+- Each entry needs a unique `slug`, a lively `summary`, and at least one `tag` that describes the theme.
+- Mention the blog by name (not "wiki") unless you are referencing a historical detail.
+- Favor bullet lists for quick wins and planned experiments—they mirror the outline readers scan for.

--- a/apps/wiki/app.js
+++ b/apps/wiki/app.js
@@ -288,7 +288,7 @@
       listEl.innerHTML = '';
       const emptyItem = document.createElement('li');
       emptyItem.className = 'article-empty';
-      emptyItem.textContent = 'No chronicles yet—check back soon!';
+      emptyItem.textContent = 'No dispatches yet—check back soon!';
       listEl.appendChild(emptyItem);
       return;
     }
@@ -401,7 +401,7 @@
     }
 
     highlightActive(article.slug);
-    document.title = `${article.title} · Project Wiki`;
+    document.title = `${article.title} · Project Blog`;
   }
 
   let activeSlug = null;

--- a/apps/wiki/articles-data.js
+++ b/apps/wiki/articles-data.js
@@ -1,25 +1,25 @@
 window.wikiArticles = [
   {
     "slug": "kickoff-chaos",
-    "title": "Kickoff Log: We Built a Wiki Instead of a Slide Deck",
-    "summary": "The day we traded status meetings for a narrative machine with jokes baked into the changelog.",
+    "title": "Kickoff Log: We Built a Blog Instead of a Slide Deck",
+    "summary": "The day we swapped status meetings for a punchy blog beaming updates straight from the lab.",
     "accentEmoji": "🎉",
     "published": "2024-03-14",
     "tags": ["origin story", "process"],
     "content": `
 # Welcome to the Build Diary
 
-We set out to have a tidy project sync. Fifteen minutes later, someone muttered "what if progress updates were actually fun?" and now there's a dedicated wiki living right inside the toolbox. Classic scope creep, but make it storytelling.
+We set out to have a tidy project sync. Fifteen minutes later, someone muttered "what if progress updates were actually fun?" and now there's a dedicated blog broadcasting right from the toolbox. Classic scope creep, but make it storytelling.
 
 ## Why we're doing this
 - Status updates should read like dispatches from a mischievous mission control.
- - Documentation belongs where the work happens, not in a folder named *final_v4_really_this_time*.
+- Documentation belongs where the work happens, not in a folder named *final_v4_really_this_time*.
 - Sharing the "why" behind decisions means future us won't squint at old commits wondering what possessed us.
 
 ## What changed today
-- Spun up the new \`apps/wiki/\` home with enough glow to feel celebratory, but not so much that sunglasses are required.
+- Spun up the new blog home inside \`apps/wiki/\` with enough glow to feel celebratory, but not so much that sunglasses are required.
 - Drafted the first crop of articles, all narrated with equal parts honesty and caffeine.
-- Added a left-hand dispatch list so you can hop between updates without spelunking through folders.
+- Added a left-hand dispatch board so you can hop between updates without spelunking through folders.
 
 ## Next experiments
 - Wire in URL support so you can bookmark a favorite saga for dramatic retellings.
@@ -30,14 +30,14 @@ We set out to have a tidy project sync. Fifteen minutes later, someone muttered 
   {
     "slug": "markdown-machinations",
     "title": "Markdown Shenanigans Without a Build Step",
-    "summary": "A peek under the hood at how we turn lightweight markdown into punchy HTML inside the browser.",
+    "summary": "A peek under the hood at how we turn lightweight markdown into punchy HTML inside the blog.",
     "accentEmoji": "🛠️",
     "published": "2024-03-18",
     "tags": ["markdown", "frontend"],
     "content": `
-# How the wiki digests markdown
+# How the blog digests markdown
 
-Confession time: we wanted the joy of markdown without unleashing a bundler hydra. So the wiki ships with a pocket-sized parser that handles the greatest hits—headings, lists, links, and the occasional code block—right in the browser.
+Confession time: we wanted the joy of markdown without unleashing a bundler hydra. So the blog ships with a pocket-sized parser that handles the greatest hits—headings, lists, links, and the occasional code block—right in the browser.
 
 ## The conversion game plan
 - Trim the markdown, line by line, so blank space doesn't spawn weird ghosts in the layout.
@@ -52,24 +52,24 @@ Confession time: we wanted the joy of markdown without unleashing a bundler hydr
 - One bullet to rule them all
 - Another bullet wearing a cape
 
-Remember: inline code like `npm run wiki` gets the spotlight treatment too.
+Remember: inline code like `npm run blog` gets the spotlight treatment too.
 ```
 
 ## Why it matters
-Keeping the parser tiny means no dependencies, instant loads, and zero build step drama. It also lowers the barrier for anyone to drop in a new article—just add a markdown string to the data file and the page does the rest.
+Keeping the parser tiny means no dependencies, instant loads, and zero build step drama. It also lowers the barrier for anyone to drop in a new dispatch—just add a markdown string to the data file and the page does the rest.
 `
   },
   {
     "slug": "navigation-nerdery",
     "title": "Navigation Nerdery: URLs, Reading Time, and Reader Delight",
-    "summary": "Tuning the experience so each update feels like a guided tour instead of a scavenger hunt.",
+    "summary": "Tuning the experience so each update feels like a guided tour through the blog instead of a scavenger hunt.",
     "accentEmoji": "🧭",
     "published": "2024-03-21",
     "tags": ["ux", "tooling"],
     "content": `
 # The reader experience tune-up
 
-The first version of the wiki asked you to keep track of where you were by sheer memory. Cute, but not ideal. Today we injected some quality-of-life boosts so catching up on the project feels like binging a mini-series.
+The first version of the blog asked you to keep track of where you were by sheer memory. Cute, but not ideal. Today we injected some quality-of-life boosts so catching up on the project feels like binging a mini-series.
 
 ## What's new
 - URLs now reflect the article you're reading thanks to query parameters. Shareable, bookmarkable, brag-worthy.
@@ -83,7 +83,7 @@ The first version of the wiki asked you to keep track of where you were by sheer
 - The layout snaps into a single column on phones so you can doomscroll our progress comfortably.
 
 ## TL;DR
-We're building an archive that's actually fun to read. If you spot any rough edges or dream up a feature, drop it in the next entry—we're all ears and probably already writing the punchline.
+We're building a blog that's actually fun to read. If you spot any rough edges or dream up a feature, drop it in the next entry—we're all ears and probably already writing the punchline.
 `
   }
 ];

--- a/apps/wiki/index.html
+++ b/apps/wiki/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Project Wiki</title>
+  <title>Project Blog</title>
   <style>
     :root {
       color-scheme: light dark;
@@ -442,29 +442,29 @@
           <span>Toolbox home</span>
         </a>
       </nav>
-      <h1>Project Wiki</h1>
-      <p class="page-tagline">A gloriously biased chronicle of how this project crawls, sprints, and occasionally cartwheels toward greatness.</p>
+      <h1>Project Blog</h1>
+      <p class="page-tagline">A lovingly chaotic chronicle of every experiment, victory lap, and mid-flight course correction powering this toolbox.</p>
     </header>
     <div class="wiki-layout">
       <aside class="article-panel" aria-labelledby="article-list-title">
         <div class="panel-header">
           <h2 id="article-list-title">Field notes</h2>
-          <p class="panel-description">Pick an entry to eavesdrop on our latest experiments, mishaps, and triumphs.</p>
-          <span class="count-pill" data-count>0 entries</span>
+          <p class="panel-description">Skim the latest dispatches—each one is a snapshot of what we tried, why it mattered, and what we might break next.</p>
+          <span class="count-pill" data-count>Loading entries…</span>
         </div>
         <ul class="article-list" data-article-list>
-          <li class="article-empty" data-empty-message>No chronicles yet—check back soon!</li>
+          <li class="article-empty" data-empty-message>No dispatches yet—check back soon!</li>
         </ul>
       </aside>
       <article class="article-view" data-article aria-labelledby="article-title">
         <header class="article-header">
-          <p class="article-kicker">Currently reading</p>
+          <p class="article-kicker">Now reading</p>
           <h2 class="article-title" id="article-title" data-article-title tabindex="-1">Pick an entry from the list</h2>
           <p class="article-meta" data-article-meta hidden></p>
           <ul class="tag-list" data-article-tags hidden aria-label="Topics"></ul>
         </header>
         <div class="article-body" data-article-body>
-          <p class="article-empty">Select an article from the left to dive into the chaos.</p>
+          <p class="article-empty">Choose a dispatch from the left to drop straight into the latest lab shenanigans.</p>
         </div>
       </article>
     </div>

--- a/index.html
+++ b/index.html
@@ -462,11 +462,11 @@
             </a>
           </div>
         </li>
-        <li class="app-row" data-group="wiki" role="group" aria-label="Project Wiki">
+        <li class="app-row" data-group="blog" role="group" aria-label="Project Blog">
           <div class="app-row__actions">
             <a class="app-button app-button--secondary" href="apps/wiki/">
               <span aria-hidden="true">📚</span>
-              <span>Project Wiki</span>
+              <span>Project Blog</span>
             </a>
           </div>
         </li>

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -14,7 +14,7 @@ test.describe('Landing page', () => {
     const groupLabels = await deckRows.evaluateAll((nodes) =>
       nodes.map((node) => node.getAttribute('aria-label')),
     );
-    expect(groupLabels).toEqual(['Jokes', 'Quotes', 'Slang', 'Project Wiki']);
+    expect(groupLabels).toEqual(['Jokes', 'Quotes', 'Slang', 'Project Blog']);
 
     const deckLinkSets = await deckRows.evaluateAll((nodes) =>
       nodes.map((node) =>
@@ -39,7 +39,7 @@ test.describe('Landing page', () => {
         { href: 'apps/slang/all-slang.html', text: 'All Slang' },
       ],
       [
-        { href: 'apps/wiki/', text: '📚 Project Wiki' },
+        { href: 'apps/wiki/', text: '📚 Project Blog' },
       ],
     ]);
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -27,9 +27,9 @@ test.describe('Landing page', () => {
         hrefs: ['apps/slang/', 'apps/slang/all-slang.html'],
       },
       {
-        group: 'wiki',
-        label: 'Project Wiki',
-        texts: ['📚 Project Wiki'],
+        group: 'blog',
+        label: 'Project Blog',
+        texts: ['📚 Project Blog'],
         hrefs: ['apps/wiki/'],
       },
     ];
@@ -62,7 +62,7 @@ test.describe('Landing page', () => {
 
     const toolSection = page.locator('section.app-groups').nth(1);
     const toolButtons = toolSection.locator('a.app-button');
-    await expect(toolButtons).toHaveCount(4);
+    await expect(toolButtons).toHaveCount(5);
 
     const toolInfo = await toolButtons.evaluateAll((nodes) =>
       nodes.map((node) => ({
@@ -76,6 +76,7 @@ test.describe('Landing page', () => {
       { text: '🧬 Embedding Explorer', href: 'apps/embedding-explorer/' },
       { text: '📊 Asset Observatory', href: 'apps/asset-observatory/' },
       { text: '🧰 Value Formatter', href: 'apps/value-formatter/' },
+      { text: '📚 AI Docs', href: 'ai_docs/' },
     ]);
 
     const valueFormatterButton = toolButtons.filter({ hasText: 'Value Formatter' });
@@ -84,6 +85,6 @@ test.describe('Landing page', () => {
     await expect(valueFormatterButton).not.toContainText('—');
 
     const allButtons = page.locator('a.app-button');
-    await expect(allButtons).toHaveCount(11);
+    await expect(allButtons).toHaveCount(12);
   });
 });


### PR DESCRIPTION
## Summary
- Rebrand the wiki experience as the Project Blog with livelier on-page copy and refreshed navigation labels.
- Update the blog article data to embrace the new tone and references, and add authoring guidance for future posts.
- Align Playwright expectations with the new branding and tool button counts on the landing page.

## Testing
- npx playwright test tests/index.spec.js tests/home.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d3655c484883289fd0d0d4f40c75d3