### PR TITLE
Switch ai docs to Jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 playwright-report/
 test-results/
+_site/

--- a/.nojekyll
+++ b/.nojekyll
@@ -1,1 +1,0 @@
-# Disables the default GitHub Pages Jekyll build.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,5 +32,5 @@ This project is a static toolbox site. The landing page (`index.html`) lists sma
 
 ## Documentation
 - The `ai_docs/` directory hosts the Markdown knowledge base. Update the relevant guides whenever you change workflows, scripts, or datasets so the docs remain authoritative.
-- When you add, remove, or rename a guide, update the `guides` array in `ai_docs/index.html` so the navigation stays in sync.
-- After editing documentation, open `ai_docs/index.html` in a browser (or via `npx serve .`) to confirm the Markdown renders through Marked and the hash navigation works.
+- Guides are rendered by Jekyll now—add or rename a page by editing the Markdown in `ai_docs/docs/`, keeping the YAML front matter (`layout`, `title`, `summary`, `nav_order`, `permalink`, and `last_updated`) up to date.
+- After editing documentation, run `bundle exec jekyll build` (or `bundle exec jekyll serve`) to confirm the site compiles and the navigation reflects your changes before committing.

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,162 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.2.3)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.32.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.15.0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.6.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.93.2)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.93.2-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+  webrick (~> 1.8)
+
+BUNDLED WITH
+   2.6.7

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,31 @@
+# Jekyll configuration for the toolbox site
+
+# Site metadata
+name: "denisvaleev.github.io"
+title: "denisvaleev.github.io"
+description: "Static toolbox of browser-based utilities and documentation."
+baseurl: ""
+url: ""
+
+# Markdown processing
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+
+# Output options
+permalink: pretty
+
+# Directories that should be ignored when building the site
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - package-lock.json
+  - package.json
+  - playwright-report
+  - test-results
+  - tools
+  - tests
+
+# Keep everything else so existing static assets ship unchanged

--- a/_layouts/ai_docs.html
+++ b/_layouts/ai_docs.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Toolbox Documentation</title>
+  <title>{% if page.title %}{{ page.title | escape }} • {% endif %}Toolbox Documentation</title>
   <style>
     :root {
       color-scheme: light dark;
@@ -125,6 +125,11 @@
       gap: 6px;
     }
 
+    nav.doc-nav li {
+      margin: 0;
+      padding: 0;
+    }
+
     nav.doc-nav a {
       display: flex;
       align-items: center;
@@ -177,7 +182,7 @@
     section.doc-content header.content-meta {
       display: flex;
       flex-direction: column;
-      gap: 4px;
+      gap: 6px;
     }
 
     section.doc-content header.content-meta h2 {
@@ -189,6 +194,10 @@
       margin: 0;
       color: var(--text-muted);
       font-size: 0.95rem;
+    }
+
+    section.doc-content header.content-meta p.doc-updated {
+      font-size: 0.85rem;
     }
 
     article.markdown-body {
@@ -265,12 +274,6 @@
       background: transparent;
     }
 
-    .doc-status {
-      min-height: 1.4em;
-      color: var(--text-muted);
-      font-size: 0.9rem;
-    }
-
     @media (max-width: 960px) {
       main.doc-shell {
         grid-template-columns: 1fr;
@@ -296,179 +299,35 @@
     <div class="doc-layout">
       <nav class="doc-nav" aria-label="Documentation navigation">
         <h2>Guides</h2>
-        <ul data-doc-nav></ul>
+        <ul>
+          {% assign guides = site.pages | where_exp: "doc", "doc.path contains 'ai_docs/docs/'" | sort: "nav_order" %}
+          {% for guide in guides %}
+            <li>
+              <a href="{{ guide.url | relative_url }}"{% if guide.url == page.url %} class="is-active" aria-current="page"{% endif %}>
+                {{ guide.title }}
+                {% if guide.summary %}
+                  <span class="badge">{{ guide.summary }}</span>
+                {% endif %}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
       </nav>
       <section class="doc-content" aria-live="polite">
         <header class="content-meta">
-          <h2 data-doc-title>Loading…</h2>
-          <p data-doc-updated hidden></p>
+          <h2>{{ page.title }}</h2>
+          {% if page.summary %}
+            <p class="doc-summary">{{ page.summary }}</p>
+          {% endif %}
+          {% if page.last_updated %}
+            <p class="doc-updated">Last updated {{ page.last_updated | date: "%B %-d, %Y" }}</p>
+          {% endif %}
         </header>
-        <p class="doc-status" data-doc-status></p>
-        <article class="markdown-body" data-doc-content>
-          <p>Select a guide from the navigation to load documentation.</p>
+        <article class="markdown-body">
+          {{ content }}
         </article>
       </section>
     </div>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script>
-    (function () {
-      const docListEl = document.querySelector('[data-doc-nav]');
-      const contentEl = document.querySelector('[data-doc-content]');
-      const titleEl = document.querySelector('[data-doc-title]');
-      const updatedEl = document.querySelector('[data-doc-updated]');
-      const statusEl = document.querySelector('[data-doc-status]');
-
-      if (!docListEl || !contentEl || !titleEl || !updatedEl || !statusEl) {
-        return;
-      }
-
-      const guides = [
-        { id: 'overview', title: 'Overview', file: 'docs/overview.md', summary: 'Start here' },
-        { id: 'architecture', title: 'Site architecture', file: 'docs/architecture.md', summary: 'How the landing page, manifest, and worker interact' },
-        { id: 'apps', title: 'App catalog', file: 'docs/apps.md', summary: 'Mini-app responsibilities and regressions' },
-        { id: 'data-maintenance', title: 'Data maintenance', file: 'docs/data-maintenance.md', summary: 'Datasets, manifests, and embeddings' },
-        { id: 'testing-automation', title: 'Testing & automation', file: 'docs/testing-and-automation.md', summary: 'Playwright suite and CI workflows' },
-        { id: 'development-guide', title: 'Development guide', file: 'docs/development-guide.md', summary: 'Coding conventions and contributor tasks' }
-      ];
-
-      const guideMap = new Map(guides.map((guide) => [guide.id, guide]));
-
-      function renderNav() {
-        docListEl.innerHTML = '';
-        guides.forEach((guide) => {
-          const item = document.createElement('li');
-          const link = document.createElement('a');
-          link.href = `#${guide.id}`;
-          link.dataset.docId = guide.id;
-          link.textContent = guide.title;
-
-          if (guide.summary) {
-            const badge = document.createElement('span');
-            badge.className = 'badge';
-            badge.textContent = guide.summary;
-            link.appendChild(badge);
-          }
-
-          link.addEventListener('click', (event) => {
-            event.preventDefault();
-            loadGuide(guide.id, { pushState: true });
-          });
-
-          item.appendChild(link);
-          docListEl.appendChild(item);
-        });
-      }
-
-      function setActive(id) {
-        const links = docListEl.querySelectorAll('a[data-doc-id]');
-        links.forEach((link) => {
-          const isActive = link.dataset.docId === id;
-          link.classList.toggle('is-active', isActive);
-          if (isActive) {
-            link.setAttribute('aria-current', 'page');
-          } else {
-            link.removeAttribute('aria-current');
-          }
-        });
-      }
-
-      function formatUpdated(text) {
-        if (!text) {
-          return '';
-        }
-        try {
-          const date = new Date(text);
-          if (!Number.isNaN(date.getTime())) {
-            return `Last updated ${date.toLocaleString()}`;
-          }
-        } catch (error) {
-          return '';
-        }
-        return '';
-      }
-
-      async function loadGuide(id, options = {}) {
-        const guide = guideMap.get(id) || guides[0];
-        if (!guide) {
-          return;
-        }
-
-        if (options.pushState) {
-          window.history.pushState({ docId: guide.id }, '', `#${guide.id}`);
-        } else if (window.location.hash.replace('#', '') !== guide.id) {
-          window.history.replaceState({ docId: guide.id }, '', `#${guide.id}`);
-        }
-
-        statusEl.textContent = 'Loading…';
-        updatedEl.hidden = true;
-        updatedEl.textContent = '';
-
-        try {
-          const response = await fetch(guide.file, { cache: 'no-cache' });
-          if (!response.ok) {
-            throw new Error(`Failed to load ${guide.file}`);
-          }
-
-          const text = await response.text();
-          const parsed = typeof marked !== 'undefined' && marked && typeof marked.parse === 'function'
-            ? marked.parse(text)
-            : text;
-
-          contentEl.innerHTML = parsed;
-          titleEl.textContent = guide.title;
-          setActive(guide.id);
-          statusEl.textContent = '';
-
-          const lastModified = response.headers.get('last-modified');
-          const fallback = formatUpdated(lastModified);
-          if (fallback) {
-            updatedEl.textContent = fallback;
-            updatedEl.hidden = false;
-          } else {
-            const nowLabel = `Loaded ${new Date().toLocaleString()}`;
-            updatedEl.textContent = nowLabel;
-            updatedEl.hidden = false;
-          }
-        } catch (error) {
-          console.error(error);
-          contentEl.innerHTML = '<p>Failed to load the requested guide. Please try again.</p>';
-          titleEl.textContent = guide.title;
-          statusEl.textContent = 'An error occurred while loading the guide.';
-          setActive(guide.id);
-        }
-      }
-
-      function getInitialGuideId() {
-        const hash = window.location.hash.replace('#', '').trim();
-        if (hash && guideMap.has(hash)) {
-          return hash;
-        }
-        const state = window.history.state;
-        if (state && typeof state.docId === 'string' && guideMap.has(state.docId)) {
-          return state.docId;
-        }
-        return guides[0] ? guides[0].id : '';
-      }
-
-      window.addEventListener('popstate', (event) => {
-        const state = event.state;
-        if (state && state.docId && guideMap.has(state.docId)) {
-          loadGuide(state.docId, { pushState: false });
-        } else {
-          const fallbackId = getInitialGuideId();
-          if (fallbackId) {
-            loadGuide(fallbackId, { pushState: false });
-          }
-        }
-      });
-
-      renderNav();
-      const initialId = getInitialGuideId();
-      if (initialId) {
-        loadGuide(initialId, { pushState: false });
-      }
-    })();
-  </script>
 </body>
 </html>

--- a/ai_docs/AGENTS.md
+++ b/ai_docs/AGENTS.md
@@ -1,7 +1,7 @@
 # AI documentation workspace
 
-- Keep documentation in Markdown under `ai_docs/docs/`. Use descriptive headings and prefer tables for directory overviews.
-- Whenever you add a new guide, update `ai_docs/index.html` so the navigation lists the page. Each entry in the `guides` array should include an `id`, `title`, `file`, and concise `summary`.
+- Keep documentation in Markdown under `ai_docs/docs/`. Every guide needs YAML front matter with `layout: ai_docs`, a human-readable `title`, `summary`, numeric `nav_order`, the canonical `permalink`, and a `last_updated` ISO date.
+- Navigation is generated automatically from the front matter. When adding a guide, give it the next `nav_order` slot and confirm the rendered nav reflects the new entry.
 - Render tweaks should preserve the two-space indentation used throughout the HTML and CSS. Stick with the existing palette and typography to keep the docs visually aligned with the landing page.
-- After editing docs, load `ai_docs/index.html` in a browser (or via `npx serve .`) to confirm the Markdown renders and navigation links update the hash correctly.
-- Keep cross-references current: when workflows, scripts, or tests change, update the relevant Markdown sections and summaries so the knowledge base stays authoritative.
+- After editing docs, run `bundle exec jekyll build` (or `bundle exec jekyll serve`) to ensure the site compiles and review `http://localhost:4000/ai_docs/` for regressions.
+- Keep cross-references current: when workflows, scripts, or tests change, update the relevant Markdown sections, `summary` fields, and `last_updated` metadata so the knowledge base stays authoritative.

--- a/ai_docs/docs/apps.md
+++ b/ai_docs/docs/apps.md
@@ -1,3 +1,12 @@
+---
+layout: ai_docs
+title: App catalog
+summary: Mini-app responsibilities and regressions
+nav_order: 3
+permalink: /ai_docs/apps/
+last_updated: 2024-05-07
+---
+
 # App catalog
 
 Each mini app lives under `apps/<name>/` with inline styles, a focused script, and any supporting datasets it needs. The landing page links directly to every `index.html`, and many collections ship an additional `all-*.html` archive that renders the full dataset in a searchable table. This catalog summarises the responsibilities, data dependencies, and regression coverage for each tool.

--- a/ai_docs/docs/architecture.md
+++ b/ai_docs/docs/architecture.md
@@ -1,3 +1,12 @@
+---
+layout: ai_docs
+title: Site architecture
+summary: How the landing page, manifest, and worker interact
+nav_order: 2
+permalink: /ai_docs/architecture/
+last_updated: 2024-05-07
+---
+
 # Site architecture
 
 The toolbox intentionally avoids a build pipeline. Each page is authored as standalone HTML with inline CSS and a small script bundle. The repository’s shared behaviours live in the landing page, the offline bootstrap flow, and the service worker. This section documents how those pieces interact.

--- a/ai_docs/docs/data-maintenance.md
+++ b/ai_docs/docs/data-maintenance.md
@@ -1,3 +1,12 @@
+---
+layout: ai_docs
+title: Data maintenance
+summary: Datasets, manifests, and embeddings
+nav_order: 4
+permalink: /ai_docs/data-maintenance/
+last_updated: 2024-05-07
+---
+
 # Data maintenance
 
 Content-heavy apps rely on shared datasets stored under `data/` plus machine-generated snapshots that live alongside each app. This guide documents the files that need to stay in sync and the scripts that regenerate them.

--- a/ai_docs/docs/development-guide.md
+++ b/ai_docs/docs/development-guide.md
@@ -1,3 +1,12 @@
+---
+layout: ai_docs
+title: Development guide
+summary: Coding conventions and contributor tasks
+nav_order: 6
+permalink: /ai_docs/development-guide/
+last_updated: 2024-05-07
+---
+
 # Development guide
 
 This guide distils the practices captured across the repository’s `AGENTS.md` files and README so contributors can keep the toolbox consistent.
@@ -36,5 +45,5 @@ This guide distils the practices captured across the repository’s `AGENTS.md` 
 
 ## Documentation upkeep
 
-- The `ai_docs/` folder hosts this documentation hub. Whenever you add a new guide, update `ai_docs/index.html` to register it in the navigation.
+- The `ai_docs/` folder hosts this documentation hub. Add new guides under `ai_docs/docs/` with the correct Jekyll front matter so the navigation updates automatically, then rebuild with `bundle exec jekyll build` before committing.
 - Keep the docs in sync with behavioural changes (new scripts, updated datasets, revised tests). Treat documentation updates as part of each pull request that changes workflows.

--- a/ai_docs/docs/overview.md
+++ b/ai_docs/docs/overview.md
@@ -1,3 +1,12 @@
+---
+layout: ai_docs
+title: Overview
+summary: Start here
+nav_order: 1
+permalink: /ai_docs/
+last_updated: 2024-05-07
+---
+
 # Toolbox documentation hub
 
 The Toolbox repository hosts a static collection of mini web applications that run entirely in the browser. The landing page (`index.html`) exposes curated cards for every tool, while each app ships as a standalone HTML document with inline styles and a lightweight script bundle. Datasets, embeddings, and similarity reports live under `data/`, and a service worker keeps the full bundle available offline.

--- a/ai_docs/docs/testing-and-automation.md
+++ b/ai_docs/docs/testing-and-automation.md
@@ -1,3 +1,12 @@
+---
+layout: ai_docs
+title: Testing & automation
+summary: Playwright suite and CI workflows
+nav_order: 5
+permalink: /ai_docs/testing-and-automation/
+last_updated: 2024-05-07
+---
+
 # Testing and automation
 
 Playwright drives the regression coverage for the toolbox, and a handful of Node scripts make it easy to run the suite, capture diagnostics, and keep the offline bundle up to date. This guide summarises the workflows.

--- a/offline-manifest.json
+++ b/offline-manifest.json
@@ -1,36 +1,32 @@
 {
-  "version": "20250924-53bfea517b5a-d2a5aa91e1b3-dirty",
-  "generatedAt": "2025-09-24T03:35:57.931Z",
-  "totalAssets": 65,
-  "totalBytes": 6299678,
+  "version": "20250924-c5ee6d9883e0-8ef9ec7a4176-dirty",
+  "generatedAt": "2025-09-24T03:52:34.305Z",
+  "totalAssets": 64,
+  "totalBytes": 6373035,
   "assets": [
     {
-      "path": "ai_docs/docs/apps.md",
-      "bytes": 7338
+      "path": "ai_docs/apps/index.html",
+      "bytes": 23351
     },
     {
-      "path": "ai_docs/docs/architecture.md",
-      "bytes": 4464
+      "path": "ai_docs/architecture/index.html",
+      "bytes": 16542
     },
     {
-      "path": "ai_docs/docs/data-maintenance.md",
-      "bytes": 5139
+      "path": "ai_docs/data-maintenance/index.html",
+      "bytes": 19481
     },
     {
-      "path": "ai_docs/docs/development-guide.md",
-      "bytes": 3577
-    },
-    {
-      "path": "ai_docs/docs/overview.md",
-      "bytes": 3231
-    },
-    {
-      "path": "ai_docs/docs/testing-and-automation.md",
-      "bytes": 3683
+      "path": "ai_docs/development-guide/index.html",
+      "bytes": 15897
     },
     {
       "path": "ai_docs/index.html",
-      "bytes": 13942
+      "bytes": 14376
+    },
+    {
+      "path": "ai_docs/testing-and-automation/index.html",
+      "bytes": 16808
     },
     {
       "path": "apps/asset-observatory/app.js",
@@ -134,11 +130,11 @@
     },
     {
       "path": "apps/wiki/articles-data.js",
-      "bytes": 4490
+      "bytes": 4514
     },
     {
       "path": "apps/wiki/index.html",
-      "bytes": 12065
+      "bytes": 12140
     },
     {
       "path": "data/curated-quotes.json",
@@ -258,7 +254,7 @@
     },
     {
       "path": "index.html",
-      "bytes": 30447
+      "bytes": 38624
     },
     {
       "path": "service-worker.js",
@@ -266,8 +262,8 @@
     }
   ],
   "commit": {
-    "hash": "d2a5aa91e1b3ac507a160e43457e4a1af6043419",
-    "short": "d2a5aa91e1b3",
+    "hash": "8ef9ec7a417601f526c273a2cb933b5a7b4070a8",
+    "short": "8ef9ec7a4176",
     "dirty": true
   }
 }

--- a/tools/generate-offline-manifest.js
+++ b/tools/generate-offline-manifest.js
@@ -5,13 +5,17 @@ const { execFile } = require('child_process');
 const { promisify } = require('util');
 
 const ROOT = process.cwd();
+const BUILD_DIR = '_site';
 const OUTPUT_PATH = path.join(ROOT, 'offline-manifest.json');
-const INCLUDE_DIRECTORIES = ['apps', 'data', path.join('ai_docs', 'docs')];
-const INCLUDE_FILES = ['index.html', 'service-worker.js', path.join('ai_docs', 'index.html')];
+const SITE_ROOT = path.join(ROOT, BUILD_DIR);
+const INCLUDE_DIRECTORIES = ['apps', 'data', 'ai_docs'];
+const INCLUDE_FILES = ['index.html', 'service-worker.js'];
 const ALLOWED_EXTENSIONS = new Set(['.html', '.js', '.json']);
 const execFileAsync = promisify(execFile);
 
 async function main() {
+  await buildSite();
+
   const assets = [];
   const digest = crypto.createHash('sha256');
 
@@ -57,7 +61,7 @@ async function main() {
 }
 
 async function walk(directory, assets, digest) {
-  const absoluteDir = path.join(ROOT, directory);
+  const absoluteDir = path.join(SITE_ROOT, directory);
   let entries;
 
   try {
@@ -76,9 +80,7 @@ async function walk(directory, assets, digest) {
       await walk(entryPath, assets, digest);
     } else if (entry.isFile()) {
       const extension = path.extname(entry.name).toLowerCase();
-      const normalizedEntryPath = toPosixPath(entryPath);
-      const isDocMarkdown = normalizedEntryPath.startsWith('ai_docs/docs/') && extension === '.md';
-      if (!ALLOWED_EXTENSIONS.has(extension) && !isDocMarkdown) {
+      if (!ALLOWED_EXTENSIONS.has(extension)) {
         continue;
       }
 
@@ -88,7 +90,7 @@ async function walk(directory, assets, digest) {
 }
 
 async function addAsset(relativePath, assets, digest) {
-  const absolutePath = path.join(ROOT, relativePath);
+  const absolutePath = path.join(SITE_ROOT, relativePath);
   let stats;
 
   try {
@@ -152,6 +154,23 @@ async function readCommitInfo() {
 
 function toPosixPath(filePath) {
   return filePath.split(path.sep).join('/');
+}
+
+async function buildSite() {
+  const bundleCommand = process.platform === 'win32' ? 'bundle.cmd' : 'bundle';
+  const args = ['exec', 'jekyll', 'build', '--destination', BUILD_DIR];
+
+  try {
+    const { stdout, stderr } = await execFileAsync(bundleCommand, args, { cwd: ROOT });
+    if (stdout) {
+      process.stdout.write(stdout);
+    }
+    if (stderr) {
+      process.stderr.write(stderr);
+    }
+  } catch (error) {
+    throw new Error('Failed to build the Jekyll site. Install Ruby dependencies with "bundle install" and retry.');
+  }
 }
 
 function formatBytes(bytes) {


### PR DESCRIPTION
## Summary
- replace the hand-rolled AI docs shell with a reusable Jekyll layout and add site configuration
- add Jekyll front matter to every guide so navigation and metadata render automatically
- update the offline manifest tooling to build the Jekyll site and cache the generated HTML pages

## Testing
- bundle exec jekyll build
- node tools/generate-offline-manifest.js

------
https://chatgpt.com/codex/tasks/task_e_68d368a850708328b2303f59db1ce79f