### PR TITLE
Replace Total Recall defaults with clear action

### DIFF
--- a/apps/total-recall/app.js
+++ b/apps/total-recall/app.js
@@ -6,7 +6,7 @@
   const nextButton = document.querySelector('[data-next]');
   const shuffleButton = document.querySelector('[data-shuffle]');
   const saveButton = document.querySelector('[data-save]');
-  const resetButton = document.querySelector('[data-reset]');
+  const clearButton = document.querySelector('[data-clear]');
   const statusEl = document.querySelector('[data-status]');
 
   if (
@@ -17,7 +17,7 @@
     !nextButton ||
     !shuffleButton ||
     !saveButton ||
-    !resetButton ||
+    !clearButton ||
     !statusEl
   ) {
     return;
@@ -163,17 +163,22 @@
     }
   }
 
-  function handleReset() {
-    notesInput.value = DEFAULT_NOTES;
-    handleSave();
-    setStatus('Restored the default joke deck.');
+  function handleClear() {
+    notesInput.value = '';
+    try {
+      localStorage.setItem(STORAGE_KEY, '');
+    } catch (error) {
+      console.error('Failed to clear notes in localStorage', error); // eslint-disable-line no-console
+    }
+    updateEntriesFrom('');
+    setStatus('Cleared notes. Add new entries to continue.');
   }
 
   prevButton.addEventListener('click', showPrev);
   nextButton.addEventListener('click', showNext);
   shuffleButton.addEventListener('click', reshuffleDeck);
   saveButton.addEventListener('click', handleSave);
-  resetButton.addEventListener('click', handleReset);
+  clearButton.addEventListener('click', handleClear);
 
   document.addEventListener('keydown', (event) => {
     if (event.defaultPrevented) {

--- a/apps/total-recall/index.html
+++ b/apps/total-recall/index.html
@@ -367,7 +367,6 @@
     </nav>
     <header class="app-header">
       <h1>Total Recall</h1>
-      <p>Drop your raw notes here, split by blank lines, and train yourself with randomized memory cards.</p>
     </header>
     <article class="card" aria-live="polite">
       <div class="card__meta">
@@ -399,8 +398,8 @@
           <button class="control-button control-button--primary" type="button" data-save>
             Save notes
           </button>
-          <button class="control-button control-button--secondary" type="button" data-reset>
-            Restore defaults
+          <button class="control-button control-button--secondary" type="button" data-clear>
+            Clear notes
           </button>
         </div>
         <p class="editor__status" aria-live="polite" data-status></p>


### PR DESCRIPTION
## Summary
- remove the introductory helper copy from the Total Recall header
- replace the Restore defaults control with a Clear notes action that empties the deck
- persist the cleared state in localStorage and update the status message accordingly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4831863d483289faeceef083b6ac6