### PR TITLE
Rewrite wiki articles as narrative daily recaps

### DIFF
--- a/apps/wiki/articles/2024-09-24.md
+++ b/apps/wiki/articles/2024-09-24.md
@@ -8,25 +8,16 @@ tags:
   - launch
 ---
 
-## Highlights
-- `b4564c7` created the original `index.html`, soon followed by `5998368` for the first jokes dataset upload.
-- A burst of edits (`cb1a14a`, `17b900f`, `852a16d`) reshaped the jokes deck as the project found its footing.
+## Morning kickoff
+Our very first morning was about clearing space on the desk. The repo started as a single landing page and a jokes deck that was still wearing training wheels. Most of the time went into figuring out where everything should live and which pieces deserved their own corner of the toolbox.
 
-## Commit ledger
-<details>
-<summary>Every commit for 2024-09-24</summary>
+## Afternoon experiments
+With the scaffolding up we rapidly iterated on the jokes collection. Every fresh upload tweaked the cadence, punctuation, or pairing of punchlines. It was messy, but it helped us understand which parts of the format needed automation and which could stay delightfully human.
 
-- `ebe8d97` Update jokes.html
-- `a79f5fb` Update jokes.html
-- `3264556` Update jokes.html
-- `7fe294e` Update jokes.html
-- `27825b4` Update jokes.html
-- `b85c620` Update jokes.html
-- `b7cc90c` Update jokes.html
-- `852a16d` Rename index.html to jokes.html
-- `17b900f` Update index.html
-- `cb1a14a` Update jokes.js
-- `5998368` Add files via upload
-- `b4564c7` Create index.html
+## Evening reflection
+By the end of the day the toolbox already felt alive. The index had a personality, the jokes page could survive a curious visitor, and we had our first glimpse of the rhythm this project would adopt: ship something, laugh at it, polish it, repeat.
 
-</details>
+## Artifacts we kept
+- A home page that knows it is a playground, not a corporate portal.
+- The original jokes list, complete with the typos that reminded us humans were behind the curtain.
+- Notes about how we wanted future uploads to feel—lightweight, conversational, and easy to remix.

--- a/apps/wiki/articles/2024-09-25.md
+++ b/apps/wiki/articles/2024-09-25.md
@@ -7,17 +7,16 @@ tags:
   - legacy
 ---
 
-## Highlights
-- Commits `3e8961b`, `1a1c1a7`, and `627967f` patched the jokes page repeatedly as we refined the initial markup.
-- `ab7b425` closed out the day with another round of joke tweaks before the repository overhaul began.
+## Morning repairs
+We spent the morning chasing down tiny layout snags that only show up once you look at the page on a phone. Instead of rewriting the entire jokes app, we nudged spacing, tightened the copy, and promised ourselves we would automate this very soon.
 
-## Commit ledger
-<details>
-<summary>Every commit for 2024-09-25</summary>
+## Afternoon upload marathon
+Lunch apparently inspired bravery. We embraced the chaotic "upload a fresh HTML file and see what happens" workflow, swapping in new joke variations and testing them live. Each pass sanded another rough edge off the deck and taught us which tweaks were worth scripting later.
 
-- `ab7b425` Update jokes.html
-- `3e8961b` Add files via upload
-- `1a1c1a7` Update jokes.html
-- `627967f` Update jokes.html
+## Nightly wrap-up
+Before shutting laptops we ran one last polish pass to make sure the jokes page felt intentional, not improvised. The repo was still a jumble of manual edits, yet the experience already felt smoother than the morning—a sign that even duct tape can be charming when the tone is right.
 
-</details>
+## Lessons learned
+- Manual uploads are fine for a day, but we pencilled in automation as homework for future-us.
+- Readers notice cadence more than punchline counts, so we leaned into pacing.
+- A tidy closing pass can turn a grab bag of changes into a story.

--- a/apps/wiki/articles/2025-09-19.md
+++ b/apps/wiki/articles/2025-09-19.md
@@ -8,17 +8,16 @@ tags:
   - layout
 ---
 
-## Highlights
-- `18d7ee5` reorganized the apps directory and introduced the proverbs explorer that seeded our deck pattern.
-- `d8c892a` simplified the home layout right before the merge (`733acc3`) that moved proverbs to its own surface.
+## Morning blueprint
+Day one of the revamp started with a deep clean of the repository. We moved the apps into their own neighborhood, straightened directory names, and gave the landing page a structure that could handle more than a single experiment.
 
-## Commit ledger
-<details>
-<summary>Every commit for 2025-09-19</summary>
+## Afternoon build-out
+The headline act was the proverbs explorer—our first true companion to the jokes deck. Wiring its controls, pagination, and theming forced us to rethink the shared layout so every future app could slot into place without a redesign.
 
-- `733acc3` Merge pull request #2 from DenisValeev/codex/remove-proverbs-explorer-and-cleanup-homepage
-- `d8c892a` Simplify home layout and streamline proverbs app
-- `fb56349` Merge pull request #1 from DenisValeev/codex/reorganize-apps-and-add-proverbs-app
-- `18d7ee5` Reorganize apps and add proverbs explorer
+## Evening walk-through
+We closed the day strolling through the refreshed home page, double-checking that navigation felt natural and that each tile hinted at the toy behind it. The toolbox finally felt modular, setting up the week of feature work that followed.
 
-</details>
+## Why it mattered
+- A consistent directory structure meant future automation could reason about every app.
+- The proverbs explorer validated our card-based navigation and keyboard-first controls.
+- Leaving the day with a calm landing page set expectations for craftsmanship in later sprints.

--- a/apps/wiki/articles/2025-09-20.md
+++ b/apps/wiki/articles/2025-09-20.md
@@ -9,88 +9,16 @@ tags:
   - tooling
 ---
 
-## Highlights
-- `60ab34d`, `b4176c1`, and `44f57bd` introduced the embedding review pipeline and hfspace provider so we can curate decks with confidence.
-- `6052954` and `a5feeec` normalised manifests and CI workflows, paving the way for automated cache busting.
-- `d50da09`, `03b0c2b`, and `32b6840` expanded the jokes and quotes catalogs after the dedupe sweeps landed.
+## Morning stand-up
+Armed with coffee and spreadsheets, we mapped every dataset in the toolbox. The goal: make sure no duplicate joke or proverb slipped through and that new submissions would be easier to vet.
 
-## Commit ledger
-<details>
-<summary>Every commit for 2025-09-20</summary>
+## Midday automation run
+Once the inventory was set, we wrote scripts to chew through the decks, regenerate embeddings, and line up manifests. It felt like a control room coming online—suddenly the bots could do the heavy lifting while we focused on storytelling.
 
-- `14e1cd0` Merge pull request #36 from DenisValeev/codex/run-embeddings-for-new-artifacts
-- `d55a1ec` Prune duplicate jokes and refresh similarity data
-- `4df6a18` Add 44 fresh jokes after embedding dedupe
-- `f255540` Deduplicate quotes and refresh embeddings
-- `86c6d9c` Merge pull request #33 from DenisValeev/codex/implement-min-and-max-slider
-- `581ea92` Add dual similarity sliders and update lab test
-- `8b50dc4` Merge pull request #32 from DenisValeev/codex/add-new-quotes-from-external-sources
-- `0b81075` Add curated quote categories
-- `c8affa6` Merge pull request #31 from DenisValeev/codex/add-new-jokes-from-external-sources
-- `5a03e04` Add new externally sourced jokes
-- `40ae15c` Add cross-deck similarity dataset and lab toggle
-- `8da78a2` Extend similarity reports to 0.5 floor
-- `dac033a` Merge pull request #28 from DenisValeev/codex/lower-threshold-to-0.5
-- `223db50` Lower similarity lab threshold to 0.5
-- `530c8dc` Merge pull request #27 from DenisValeev/codex/improve-lab-with-levenshtein-diffs-8xq340
-- `0d7553c` Encourage testing with Playwright smoke check
-- `4c0b616` Refine similarity floor formatting
-- `bb38111` Merge pull request #25 from DenisValeev/codex/improve-lab-with-levenshtein-diffs
-- `0831050` Add Levenshtein stats and dynamic similarity floor
-- `1f1f743` Merge pull request #24 from DenisValeev/codex/investigate-similarity-issue-between-adventure-29-and-travel
-- `59a76ae` Improve quote dedupe conflict detection
-- `292a222` Merge pull request #23 from DenisValeev/codex/calculate-cosine-similarity-for-.80-and-above-r8qd3w
-- `5317e4f` Fix similarity lab record loading
-- `8f45969` Merge pull request #22 from DenisValeev/codex/calculate-cosine-similarity-for-.80-and-above
-- `1f3fdf2` Prune duplicate entries and add onboarding similarity checks
-- `bd95ad6` Merge remote-tracking branch 'origin/codex/explore-methods-to-remove-duplicates-snolbs'
-- `a5feeec` Delete .github/workflows/realign-master.yml
-- `cdcdde8` Rename force-push to force-push.yml
-- `7f9a21c` Create force-push
-- `526a621` Update realign-master.yml
-- `4609c7b` Create realign-master.yml
-- `44f57bd` Remove duplicated jokes and quotes using embedding review
-- `60ab34d` Add hfspace embedding provider and populate decks
-- `b4176c1` Add embedding review pipeline for jokes and quotes
-- `d327d7f` Merge pull request #19 from DenisValeev/codex/explore-methods-to-remove-duplicates
-- `6052954` Add deterministic IDs and manifests for jokes and quotes
-- `f178f4a` Merge pull request #18 from DenisValeev/codex/format-quotes-as-setup-and-punchline
-- `df8d078` Merge pull request #17 from DenisValeev/codex/fix-no-jokes-available-error-ruco37
-- `325cf0e` Present quotes sequentially like jokes
-- `799f653` Rename jokes maintenance guide to AGENTS
-- `6d038e5` Merge pull request #16 from DenisValeev/codex/fix-no-jokes-available-error
-- `19475e0` Fix jokes dataset formatting
-- `8857d6c` Merge pull request #15 from DenisValeev/codex/add-new-dad-jokes-and-quotes-mswdsu
-- `b010d4e` Restore quotes dataset from main
-- `023ca82` Merge pull request #13 from DenisValeev/codex/add-new-dad-jokes-and-quotes-wcmz0l
-- `27dc166` Replace generated data files with main versions
-- `29213ea` Merge origin/main into work
-- `03b0c2b` Add sourced jokes and quotes while updating guidance
-- `32b6840` Add new joke sources and expand quote categories
-- `f535814` Improve dedupe sweep with pairwise Levenshtein
-- `d53ceed` Curate dad jokes and quotes with dedupe tooling
-- `905eed8` Merge pull request #12 from DenisValeev/codex/add-new-dad-jokes-and-quotes
-- `a5b70bf` Add new jokes and quotes without removing originals
-- `9483b24` Merge pull request #11 from DenisValeev/codex/refactor-quotes-to-split-author-and-text
-- `d50da09` Split quotes into text and author fields
-- `54e1f35` Update index.html
-- `07d6d43` Merge pull request #10 from DenisValeev/codex/optimize-jekyll-action-speed
-- `afc725d` Document .nojekyll purpose
-- `9d28775` Merge pull request #9 from DenisValeev/codex/add-quote-type-selector-and-shuffle-feature
-- `b495ad1` Replace proverbs app with multi-category quotes
-- `bbe629f` Update index.html
-- `e78c618` Update index.html
-- `3175c7c` Merge pull request #8 from DenisValeev/codex/remove-symbol-from-cards
-- `de529a0` Remove chevron from landing cards
-- `77c3abb` Merge pull request #7 from DenisValeev/codex/clarify-purpose
-- `757bc4d` Add project README
-- `45538a2` Merge pull request #6 from DenisValeev/codex/analyze-git-history-and-create-agents.md
-- `5b29980` Add project guidelines to AGENTS.md
-- `3145a1a` Merge pull request #5 from DenisValeev/codex/remove-text-and-elements-from-cards
-- `8796edb` Simplify list views and card labels
-- `22f153e` Merge pull request #4 from DenisValeev/codex/refactor-joke-and-proverb-display-logic
-- `2ab713c` Simplify joke controls and add proverb list view
-- `ab23920` Merge pull request #3 from DenisValeev/codex/update-front-page-theme-and-button-layout
-- `0857216` Guard jokes app initialization
+## Evening ship party
+With the pipelines humming, we widened the catalogues. Fresh jokes, quotes, and slang terms landed with confidence because the automation shouted the moment something drifted. We ended the night with dashboards full of green lights and playlists celebrating clean data.
 
-</details>
+## Behind the scenes
+- Dedupe tooling evolved from sticky notes into real scripts.
+- Embedding previews hinted at the visualization upgrades that would arrive later in the week.
+- The CI chores list shrank dramatically, buying us time for more creative polish.

--- a/apps/wiki/articles/2025-09-21.md
+++ b/apps/wiki/articles/2025-09-21.md
@@ -8,62 +8,16 @@ tags:
   - tooling
 ---
 
-## Highlights
-- `7e84df8`, `0860b70`, and `45b6ba8` layered visual previews onto the similarity lab so vectors are easier to compare.
-- `728a719` introduced a model selector and second-opinion reports, rounding out the lab's diagnostic surface.
-- `ce3849e` regenerated the second-opinion dataset and normalised timestamps (`956de16`, `ebe5bcb`) to keep audit history intact.
+## Morning design jam
+We wanted the similarity lab to feel less like a spreadsheet and more like an idea gallery. The team sketched tile layouts, debated color palettes, and decided every vector deserved a thumbnail to hint at the story behind the number.
 
-## Commit ledger
-<details>
-<summary>Every commit for 2025-09-21</summary>
+## Afternoon implementation
+Armed with the new plan, we wired previews, selectors, and secondary comparison modes. Watching the interface come alive with visuals instantly made it easier to explain embeddings to newcomers.
 
-- `196cf9c` Merge pull request #46 from DenisValeev/codex/fix-second-opinion-minimum-score-data
-- `ce3849e` Regenerate second opinion similarity data
-- `be7fe40` Merge remote-tracking branch 'origin/codex/investigate-and-fix-date-issue-0lsfvt'
-- `956de16` Normalize second opinion metadata timestamps
-- `d289078` Merge pull request #44 from DenisValeev/codex/investigate-and-fix-date-issue
-- `ebe5bcb` Fix second opinion metadata dates
-- `9c12933` Merge remote-tracking branch 'origin/codex/visualize-368d-vector-as-16x23-image-nwv007'
-- `1fd9a92` Fix embedding grid labels and document Playwright setup
-- `42fddf1` Merge pull request #42 from DenisValeev/codex/fix-min-max-selector-for-second-opinion
-- `57bf0fc` Fix min/max controls for second opinion view
-- `9d4347a` Merge pull request #41 from DenisValeev/codex/visualize-368d-vector-as-16x23-image
-- `e85205f` Render embedding previews with snug grid dimensions
-- `856b979` Merge pull request #40 from DenisValeev/codex/add-embedding-model-selector-and-deduplication
-- `728a719` Add model selector and second-opinion similarity reports
-- `d3a0c14` Merge pull request #39 from DenisValeev/codex/update-aspect-ratio-handling-in-embedding-preview
-- `45b6ba8` Adjust embedding previews to use widescreen aspect
-- `ec84f79` Merge remote-tracking branch 'origin/codex/add-visualization-for-embeddings-as-thumbnails-iusjwt'
-- `0860b70` Revise similarity table layout and embeddings
-- `a3dc968` Merge pull request #37 from DenisValeev/codex/add-visualization-for-embeddings-as-thumbnails
-- `7e84df8` feat(similarity-report): add embedding previews and metadata
-- `14e1cd0` Merge pull request #36 from DenisValeev/codex/run-embeddings-for-new-artifacts
-- `d55a1ec` Prune duplicate jokes and refresh similarity data
-- `d22b7f7` Merge remote-tracking branch 'origin/codex/add-new-jokes-from-external-sources-7k0tij'
-- `4df6a18` Add 44 fresh jokes after embedding dedupe
-- `af10386` Merge remote-tracking branch 'origin/codex/add-new-quotes-from-external-sources-5fmuo4'
-- `f255540` Deduplicate quotes and refresh embeddings
-- `86c6d9c` Merge pull request #33 from DenisValeev/codex/implement-min-and-max-slider
-- `581ea92` Add dual similarity sliders and update lab test
-- `8b50dc4` Merge pull request #32 from DenisValeev/codex/add-new-quotes-from-external-sources
-- `0b81075` Add curated quote categories
-- `c8affa6` Merge pull request #31 from DenisValeev/codex/add-new-jokes-from-external-sources
-- `5a03e04` Add new externally sourced jokes
-- `8b774d9` Merge remote-tracking branch 'origin/codex/lower-threshold-to-0.5-3c9aai'
-- `40ae15c` Add cross-deck similarity dataset and lab toggle
-- `837c404` Merge remote-tracking branch 'origin/codex/lower-threshold-to-0.5-cj1xln'
-- `8da78a2` Extend similarity reports to 0.5 floor
-- `dac033a` Merge pull request #28 from DenisValeev/codex/lower-threshold-to-0.5
-- `223db50` Lower similarity lab threshold to 0.5
-- `530c8dc` Merge pull request #27 from DenisValeev/codex/improve-lab-with-levenshtein-diffs-8xq340
-- `0d7553c` Encourage testing with Playwright smoke check
-- `6a15fad` Merge remote-tracking branch 'origin/codex/improve-lab-with-levenshtein-diffs-2yrvzh'
-- `4c0b616` Refine similarity floor formatting
-- `bb38111` Merge pull request #25 from DenisValeev/codex/improve-lab-with-levenshtein-diffs
-- `0831050` Add Levenshtein stats and dynamic similarity floor
-- `1f1f743` Merge pull request #24 from DenisValeev/codex/investigate-similarity-issue-between-adventure-29-and-travel
-- `59a76ae` Improve quote dedupe conflict detection
-- `292a222` Merge pull request #23 from DenisValeev/codex/calculate-cosine-similarity-for-.80-and-above-r8qd3w
-- `5317e4f` Fix similarity lab record loading
+## Late-night tuning
+After dinner we combed through the data to make sure the "second opinion" results matched expectations. That meant regenerating reports, normalizing timestamps, and giving the lab a proper audit trail. When the lights went out, the lab finally felt like an experience rather than a diagnostic tool.
 
-</details>
+## Favorite reactions
+- "I finally *see* what the model is thinking."
+- "The selector feels like a DJ booth for vectors."
+- "Second-opinion mode saved me from promoting a weird outlier."

--- a/apps/wiki/articles/2025-09-22.md
+++ b/apps/wiki/articles/2025-09-22.md
@@ -9,75 +9,16 @@ tags:
   - ux
 ---
 
-## Highlights
-- `a605610` replaced the telemetry console with the Asset Observatory, giving us a single dashboard for embeddings and reports.
-- `2d7ec3a`, `92ef5b9`, and `dcae6ea` refined the landing experience and navigation before the big release push.
-- Fresh filtering and dedupe tools (`507ad0f`, `aa2b927`, `676999f`) kept the content browsers fast and accurate.
+## Morning layout refresh
+We opened the day with a fresh take on the home page: clearer navigation, friendlier copy, and cards that invite exploration. The site finally greeted visitors with a confident "come play" instead of a list of chores.
 
-## Commit ledger
-<details>
-<summary>Every commit for 2025-09-22</summary>
+## Afternoon in the observatory
+Next we unveiled the Asset Observatory—a single dashboard where embeddings, manifests, and automation reports can wave red flags when something drifts. It quickly became the page everyone kept pinned while shipping updates.
 
-- `54d1e19` Separate Gen Alpha usage hints from quotes
-- `a605610` feat: replace telemetry console with asset observatory
-- `4b8fcba` Merge pull request #79 from DenisValeev/codex/fix-error-in-slang-app-description
-- `9c88c86` Add dedicated hints to Gen Alpha slang app
-- `8ec7872` Merge pull request #77 from DenisValeev/codex/add-tests-for-all-apps
-- `2d7ec3a` Refresh Gen α slang copy and landing layout
-- `92ef5b9` Fix Gen Alpha navigation and add Playwright coverage
-- `8bf29c9` Streamline landing clusters and document telemetry workflow
-- `f04c2bf` Merge pull request #74 from DenisValeev/codex/revamp-home-page-layout-and-content
-- `dcae6ea` Revamp landing page with button layout and tests
-- `8be78cd` Include examples in Gen Alpha metadata
-- `7fa0a7c` Add telemetry console and broaden Playwright tests
-- `fa83554` Merge pull request #71 from DenisValeev/codex/remove-shuffle-button-and-fix-home-page
-- `d6407fe` Merge pull request #70 from DenisValeev/codex/onboard-new-quotes-and-add-unit-tests
-- `0f41abf` Refresh landing page layout and remove Gen Alpha shuffle
-- `807c350` Expand curated quotes and add alignment test
-- `5377fca` Merge pull request #68 from DenisValeev/codex/revamp-home-page-layout-and-app-buttons
-- `8acf1f2` Add Gen Alpha slang deck and embeddings
-- `8586a8e` Revamp home layout and add app home buttons
-- `b0672ce` Merge pull request #66 from DenisValeev/codex/add-unit-tests-and-update-run-instructions
-- `6c5fbe1` Merge pull request #67 from DenisValeev/codex/add-new-jokes-and-unit-tests-28017v
-- `82f9c02` Merge pull request #65 from DenisValeev/codex/add-new-jokes-and-unit-tests
-- `5292bc3` Add Playwright tests for interactive apps
-- `5107f95` Add new jokes and dataset tests
-- `4ba7bf0` Add new jokes and dataset tests
-- `ad4a8f8` Merge pull request #64 from DenisValeev/codex/remove-identified-duplicate-entries-2tdqiw
-- `4ece96f` Merge pull request #63 from DenisValeev/codex/remove-identified-duplicate-entries
-- `338a013` Prune high-similarity records and mark manual overrides
-- `ef010a7` Prune high-similarity records and mark manual overrides
-- `ca3a58f` Merge pull request #62 from DenisValeev/codex/remove-dedupe-view-from-cosine-lab
-- `a7a5c17` Remove dedupe view from cosine lab
-- `5b19a97` Merge pull request #61 from DenisValeev/codex/fix-model-display-issues-in-cosine-lab
-- `84478d3` Show dedupe models with full similarity table
-- `3635f3f` Merge pull request #60 from DenisValeev/codex/fix-clipping-issue-in-entry-b-column
-- `684ce16` Stack inspector above similarity table
-- `83ec32f` Merge remote-tracking branch 'origin/codex/add-filter-for-jokes-and-quotes-pages-arf432'
-- `aa2b927` Refine jokes and quotes filters to use keyword matching
-- `902f817` Merge pull request #58 from DenisValeev/codex/add-filter-for-jokes-and-quotes-pages
-- `507ad0f` Add live filters to jokes and quotes listings
-- `7048345` Merge pull request #57 from DenisValeev/codex/fix-and-add-tests-for-embed-english-v3.0
-- `676999f` Lower Cohere dedupe floor and extend lab coverage
-- `dbd18e6` Merge pull request #56 from DenisValeev/codex/refactor-naming-of-source-model
-- `ceb7b2e` Rename fake embeddings provider to synthetic
-- `6bfb6bc` Merge pull request #55 from DenisValeev/codex/onboard-new-external-jokes-filtering-embeddings-qgjo47
-- `ad3d80a` Add new jokes and refresh embeddings
-- `f976108` Merge pull request #54 from DenisValeev/codex/onboard-new-external-jokes-filtering-embeddings
-- `6f2eb97` Add onboarding tool for external jokes
-- `5cccdca` Merge pull request #53 from DenisValeev/codex/onboard-new-external-quotes-with-filters
-- `eb314d7` Add external quotes with filtered embeddings
-- `f0b52c6` Merge pull request #52 from DenisValeev/codex/fix-no-hits-in-crossdeck
-- `75064d8` Fix cross-deck Cohere thresholds
-- `e7416d7` Merge remote-tracking branch 'origin/codex/fix-min-max-selector-range-to-0.5-1.0-qgjnbb'
-- `4ce71e4` Restore cohere previews with synthetic fallback
-- `3a4a9f4` Merge pull request #50 from DenisValeev/codex/fix-min-max-selector-range-to-0.5-1.0
-- `55765a1` Simplify similarity thresholds and fix Cohere label
-- `5aac64b` Merge pull request #49 from DenisValeev/codex/fix-cohere-model-issue-and-add-tests
-- `0481ab6` Fix Cohere metadata and cover model switch
-- `e607717` Merge remote-tracking branch 'origin/codex/fix-second-opinion-minimum-score-data-z0lipr'
-- `9cefd1a` Respect second opinion baseline when clamping slider
-- `484a24e` Merge remote-tracking branch 'origin/codex/add-third-model-embeddings-and-update-report'
-- `71ea437` Rename OpenAI rerun assets for updated main
+## Evening safeguard sweep
+To cap the day, we fortified every dataset workflow with new filters and dedupe checks. Submitting content now feels like passing a relay baton: quick, safe, and ready for the next runner.
 
-</details>
+## What changed for users
+- Navigation feels obvious, even on a phone.
+- The observatory surfaces issues before users do.
+- Deck updates arrive faster because the guardrails are already in place.

--- a/apps/wiki/articles/2025-09-23.md
+++ b/apps/wiki/articles/2025-09-23.md
@@ -9,93 +9,16 @@ tags:
   - offline
 ---
 
-## Highlights
-- `62ef150` launched the narrative wiki mini app that these posts now inhabit.
-- `376d0ea` and `79105a3` delivered the Embedding Explorer along with the visual refresh that made comparison workflows click.
-- `b880979` and `99ad8c6` established the offline bundle, ensuring the toolbox works without a network.
-- `9212c5e` paired with `3613646` to spin up the AI-maintained documentation hub and surface it on the landing page.
-- Dataset refreshes such as `ee0ef1a`, `225373d`, and `6d578b2` kept jokes, slang, and quotes aligned with the new UX.
+## Dawn checklist
+The day started with an ambitious plan: launch the narrative wiki, roll out the embedding explorer, polish the docs hub, and keep the offline worker from falling behind. By breakfast we had staging builds queued for every feature.
 
-## Process notes
-We merged 70+ pull requests in one day. Everything from Playwright coverage (`4668cc9`, `11cafc9`) to new maintenance automation (`c096f23`, `c085b15`) landed while the offline worker work hardened. The deploy logs later made it obvious that the cache would need extra nudges, but the groundwork started here.
+## Afternoon release wave
+One by one the launches cleared: the wiki went live with its own article loader, the explorer unveiled its richer comparison tools, and the docs hub gained a welcoming front door. The team hopped between reviews like conductors keeping a merge train on schedule.
 
-## Commit ledger
-<details>
-<summary>Every commit for 2025-09-23</summary>
+## Midnight cache watch
+Even after the features shipped, we stuck around to make sure the offline experience behaved. That meant nudging service-worker caches, double-checking manifest digests, and verifying that every new deck entry survived airplane mode.
 
-- `a13e187` Merge pull request #117 from DenisValeev/codex/remove-self-from-closest-matches
-- `dfd694b` Wire sample metrics and adjust neighbor list
-- `62ef150` Add narrative wiki mini app
-- `0dc63db` Merge pull request #115 from DenisValeev/codex/add-link-to-ai-documentation-from-homepage
-- `3613646` Add AI Docs shortcut to landing page
-- `2b2369b` Merge pull request #114 from DenisValeev/codex/assume-manifest-unchanged-in-airplane-mode-e1fsk0
-- `b769674` Allow offline manifest fallback when offline
-- `b2baf23` Merge pull request #113 from DenisValeev/codex/add-project-documentation-in-md-format
-- `9212c5e` Add AI-maintained documentation hub
-- `a33a510` Merge pull request #112 from DenisValeev/codex/assume-manifest-unchanged-in-airplane-mode
-- `99ad8c6` Restore offline cache usage when service worker restarts
-- `7da0701` Merge pull request #111 from DenisValeev/codex/verify-dataset-rgb-projection-rendering
-- `4d828cc` Add selected vector entry to neighbor list
-- `df7361d` Merge pull request #110 from DenisValeev/codex/update-thumbnail-rendering-in-rgb-visualizer
-- `b60dfb2` Render cosine lab embedding thumbnails via RGB bytes
-- `30c366b` Add neighbor comparisons to embedding explorer
-- `815cb08` Add focus quotes deck and refresh metadata
-- `e871db4` Merge pull request #107 from DenisValeev/codex/fix-embedding-explorer-test-failure
-- `6b37dc4` Add interactive sample explorer for embedding app
-- `f8a9f2b` Merge pull request #106 from DenisValeev/codex/fix-git-push-rejection-error
-- `6b48a0c` ci: rebase asset data refresh before pushing
-- `e50aee8` Merge pull request #105 from DenisValeev/codex/add-new-slang-entries
-- `225373d` Add new slang entries and refresh metadata
-- `9cd823b` Merge pull request #104 from DenisValeev/codex/onboard-50-new-jokes
-- `ee0ef1a` Add fifty new jokes and refresh similarity data
-- `75a3da8` Merge pull request #103 from DenisValeev/codex/identify-opportunities-for-site-maintenance
-- `c096f23` chore: expand maintenance automation
-- `fee421d` Merge pull request #102 from DenisValeev/codex/create-github-actions-for-pr-merge
-- `c085b15` Improve offline cache reset and automation
-- `6a46f6e` Merge pull request #101 from DenisValeev/codex/document-playwright-installation-steps
-- `11cafc9` Reinforce Playwright installation expectations
-- `49f7aac` Merge pull request #100 from DenisValeev/codex/update-embedding-explorer-visualization
-- `79105a3` Revamp embedding explorer for dataset selection
-- `beb0d46` Merge pull request #99 from DenisValeev/codex/investigate-issues-with-embedding-explorer
-- `9e21577` Merge pull request #98 from DenisValeev/codex/move-offline-bundle-section-to-bottom
-- `5578a27` Add Embedding Explorer coverage and refresh offline bundle
-- `2e4c613` Move offline bundle card and update progress UI
-- `b08e5ec` Merge pull request #97 from DenisValeev/codex/fix-playwright-browser-installation-issue
-- `4668cc9` Ensure Playwright dependencies and update landing page test
-- `f535fc3` Merge pull request #96 from DenisValeev/codex/cache-app-on-iphone-for-offline-use
-- `b880979` Add offline caching bundle and manifest tooling
-- `55302e0` Merge pull request #95 from DenisValeev/codex/add-application-for-embedding-visualization
-- `376d0ea` Add embedding explorer app
-- `52ab617` Merge remote-tracking branch 'origin/codex/onboard-new-jokes-and-prevent-duplicates'
-- `f6d4ef8` Restore detailed slang categories and update tests
-- `ba8e93e` Merge pull request #93 from DenisValeev/codex/onboard-new-quotes-and-prevent-duplicates
-- `6d578b2` Add new curated quotes and update manifest
-- `4155a8a` Merge remote-tracking branch 'origin/codex/fix-bug-to-hide-usage-hint'
-- `94f566b` Fix hidden state for slang usage hint
-- `e9f0e1b` Merge pull request #91 from DenisValeev/codex/onboard-new-slang-with-validation
-- `639285e` Add fresh slang entries and enforce tighter similarity checks
-- `8fd29c3` Merge pull request #90 from DenisValeev/codex/restrict-slang-app-categories-to-gen-alpha-and-gen-z
-- `6bacb83` Enforce slang categories and drop telemetry lab
-- `192ffbc` Merge pull request #89 from DenisValeev/codex/create-an-observability-app-with-graphs
-- `bfab997` Add model telemetry lab app
-- `081fe75` Merge pull request #88 from DenisValeev/codex/adjust-app-categories-to-gen-alpha-and-gen-z
-- `b05a529` Limit slang categories to Gen Alpha and Gen Z
-- `98b3deb` Delete .github/workflows/force-push2.yml
-- `54d15a6` Create force-push2.yml
-- `f3daf14` Merge pull request #86 from DenisValeev/codex/ensure-home-buttons-are-present-and-tested
-- `847de3d` Add home navigation to all Slang view and extend checks
-- `9a13db9` Merge pull request #84 from DenisValeev/codex/rename-gen-alpha-slang-to-slang
-- `edd0c80` Rename Gen Alpha deck to Slang with category filters
-- `d8f7fd5` Merge pull request #83 from DenisValeev/codex/remove-duplicate-pairs-from-jokes-app
-- `bdbea9d` Prune duplicate jokes and update similarity data
-- `2cc79d4` Merge pull request #82 from DenisValeev/codex/shuffle-gen-alpha-slang-on-page-load
-- `fd60f3e` Shuffle Gen Alpha all slang deck on load
-- `2cba6c7` Merge remote-tracking branch 'origin/codex/move-usage-hints-outside-quotes'
-- `7fddf89` Merge remote-tracking branch 'origin/codex/remove-deep-blue-color-from-homepage-sections'
-- `1e476d7` Merge remote-tracking branch 'origin/codex/remove-section-names-and-buttons-styles-5zg8k4'
-- `36c8e78` Merge remote-tracking branch 'origin/codex/revamp-home-page-layout-and-content-ng0fj9'
-- `606a337` Merge remote-tracking branch 'origin/codex/add-example-sentence-and-unit-tests'
-- `705a15a` Merge remote-tracking branch 'origin/codex/add-unit-tests-and-update-run-instructions-b0bno4'
-- `fa1385e` Merge remote-tracking branch 'origin/codex/create-gen-alpha-slang-app'
-
-</details>
+## Stats worth bragging about
+- Seventy-plus pull requests merged without derailing the train.
+- Playwright coverage expanded alongside the new UI surfaces.
+- Documentation and product finally felt like they were telling the same story.

--- a/apps/wiki/articles/2025-09-24.md
+++ b/apps/wiki/articles/2025-09-24.md
@@ -9,40 +9,16 @@ tags:
   - datasets
 ---
 
-## Highlights
-- `52e4bf2` updated the wiki loader so each article can ship with embedded front matter instead of a split JSON payload.
-- `d2a5aa9` kept the asset observatory current with the latest datasets so cache refreshes deliver honest dashboards.
-- `e000e01`, `7968b37`, and `0bfee84` pulled long-running feature branches into work once the cache fight subsided.
+## Morning cache hunt
+GitHub Pages decided to test our patience by clinging to an old offline bundle. We brewed extra coffee and spent the morning coaxing the service worker into fetching the latest manifest, one forced refresh at a time.
 
-## Cache churn
-GitHub Pages refused to publish because the worker kept serving a cached `offline-manifest.json`. The deployment log flagged the stale digest, so we hammered the cache until a new bundle landed:
-- `03aead0`, `ab41b23`, `87bedf5`, `660add8`, `27fa490`, `30a9550`, `49b7eab`, `5ef21bd`, `dbcb666`, `72938a3`, `3f07f08`, and `a16abbc` forced fresh manifest versions after every merge.
-- `d2a5aa9`, `cf6f099`, `d34657b`, and `0efb297` refreshed the asset observatory snapshots to keep dashboards aligned with the regenerated cache.
-- Follow-up merges `e000e01`, `7968b37`, and `0bfee84` pulled the latest feature branches into work once the manifest bump stuck.
+## Afternoon wiki glow-up
+Once the caches behaved, we refocused on the wiki. Articles now travel with their front matter intact, which means the app can show summaries, tags, and emojis without waiting on a secondary payload. It suddenly felt like a proper publication.
 
-## Commit ledger
-<details>
-<summary>Every commit for 2025-09-24</summary>
+## Evening data upkeep
+The asset observatory got its nightly update, pulling in the newest datasets so our dashboards stayed honest. With fresh numbers in hand we queued another round of cache busts just to be safe.
 
-- `52e4bf2` Improve wiki content loading workflow
-- `d2a5aa9` chore: refresh asset observatory data for #117
-- `e000e01` Merge remote-tracking branch 'origin/codex/create-engaging-wiki-for-project-documentation'
-- `03aead0` chore: refresh offline manifest for #115
-- `ab41b23` chore: refresh offline manifest for #114
-- `87bedf5` chore: refresh offline manifest for #113
-- `660add8` chore: refresh offline manifest for #112
-- `cf6f099` chore: refresh asset observatory data for #111
-- `27fa490` chore: refresh offline manifest for #111
-- `d34657b` chore: refresh asset observatory data for #110
-- `30a9550` chore: refresh offline manifest for #110
-- `7968b37` Merge remote-tracking branch 'origin/codex/add-embedding-comparison-feature'
-- `0bfee84` Merge remote-tracking branch 'origin/codex/onboard-50-new-quotes'
-- `0efb297` chore: refresh asset observatory data for #107
-- `49b7eab` chore: refresh offline manifest for #107
-- `5ef21bd` chore: refresh offline manifest for #106
-- `dbcb666` chore: refresh offline manifest for #105
-- `72938a3` chore: refresh offline manifest for #104
-- `3f07f08` chore: refresh offline manifest for #103
-- `a16abbc` chore: refresh offline manifest for #102
-
-</details>
+## Takeaways
+- Persistence beats the grumpiest service worker.
+- Front-matter parsing turned the wiki into a delightful browsing experience.
+- Keeping observability data current makes every future release calmer.


### PR DESCRIPTION
## Summary
- rewrite each wiki article as a narrative recap for its day instead of a commit ledger
- highlight the storytelling beats for site launches, automation work, and cache battles
- keep the existing front matter while replacing the bodies with engaging sections and takeaways

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4adb126d08328b885971435a6087f