### PR TITLE
Surface joke categories and add new dad jokes

### DIFF
--- a/apps/jokes/all-jokes-compact.html
+++ b/apps/jokes/all-jokes-compact.html
@@ -19,6 +19,8 @@
       --table-stripe: rgba(15, 23, 42, 0.03);
       --table-border: rgba(15, 23, 42, 0.1);
       --badge-bg: rgba(74, 99, 255, 0.14);
+      --category-pill-bg: rgba(74, 99, 255, 0.14);
+      --category-pill-text: rgba(31, 50, 143, 0.92);
       background-color: var(--bg-color);
       color: var(--text-primary);
     }
@@ -36,6 +38,8 @@
         --table-stripe: rgba(255, 255, 255, 0.04);
         --table-border: rgba(148, 163, 209, 0.12);
         --badge-bg: rgba(105, 128, 255, 0.16);
+        --category-pill-bg: rgba(105, 128, 255, 0.18);
+        --category-pill-text: rgba(225, 232, 255, 0.92);
       }
 
       .filter input[type="search"] {
@@ -141,6 +145,26 @@
       font-size: 0.9rem;
       font-weight: 600;
       color: inherit;
+    }
+
+    .category-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .category-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      font-weight: 600;
+      background: var(--category-pill-bg);
+      color: var(--category-pill-text);
     }
 
     .filter {
@@ -284,17 +308,19 @@
             <th scope="col">#</th>
             <th scope="col">Joke</th>
             <th scope="col">Punchline</th>
+            <th scope="col">Categories</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td colspan="3">Loading jokes…</td>
+            <td colspan="4">Loading jokes…</td>
           </tr>
         </tbody>
       </table>
     </div>
   </main>
   <script src="jokes.js" defer></script>
+  <script src="joke-categories.js" defer></script>
   <script src="render-all.js" defer></script>
 </body>
 </html>

--- a/apps/jokes/all-jokes.html
+++ b/apps/jokes/all-jokes.html
@@ -52,6 +52,11 @@
         border-color: rgba(241, 245, 255, 0.35);
         color: inherit;
       }
+
+      .category-pill {
+        background: rgba(148, 163, 209, 0.24);
+        color: rgba(241, 245, 255, 0.9);
+      }
     }
 
     main {
@@ -107,6 +112,26 @@
 
     .count {
       font-weight: 600;
+    }
+
+    .category-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin: 12px 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .category-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      background: rgba(48, 86, 211, 0.12);
+      color: rgba(48, 56, 140, 0.92);
     }
 
     .filter {
@@ -180,7 +205,7 @@
       </a>
     </nav>
     <h1>All Jokes</h1>
-    <p>Every joke from the dataset in one place. Use the filter to zero in on a favourite.</p>
+    <p>Every joke from the dataset in one place—complete with quick-hit categories. Use the filter to zero in on a favourite or explore a topic.</p>
     <p class="count">Showing <span data-count>0</span> of <span data-total>0</span> jokes</p>
     <form class="filter" data-filter-form>
       <label for="joke-filter">Filter jokes</label>
@@ -196,6 +221,7 @@
     </table>
   </main>
   <script src="jokes.js" defer></script>
+  <script src="joke-categories.js" defer></script>
   <script src="render-all.js" defer></script>
 </body>
 </html>

--- a/apps/jokes/app.js
+++ b/apps/jokes/app.js
@@ -4,6 +4,7 @@
   const prevButton = document.getElementById('prev-button');
   const nextButton = document.getElementById('next-button');
   const revealButton = document.getElementById('reveal-button');
+  const categoryList = document.getElementById('joke-categories');
 
   if (!setupEl || !punchlineEl || !prevButton || !nextButton || !revealButton) {
     return;
@@ -16,6 +17,35 @@
   let deck = [];
   let index = 0;
   let punchlineVisible = false;
+
+  const categorize =
+    window.jokeCategoryHelper && typeof window.jokeCategoryHelper.categorize === 'function'
+      ? window.jokeCategoryHelper.categorize
+      : null;
+
+  const fallbackCategory =
+    window.jokeCategoryHelper && typeof window.jokeCategoryHelper.fallback === 'string'
+      ? window.jokeCategoryHelper.fallback
+      : 'Classic Dad';
+
+  function renderCategories(values) {
+    if (!categoryList) {
+      return;
+    }
+
+    categoryList.textContent = '';
+
+    const items = Array.isArray(values) && values.length ? values : [fallbackCategory];
+
+    items.forEach((label) => {
+      const pill = document.createElement('li');
+      pill.className = 'category-pill';
+      pill.textContent = label;
+      categoryList.appendChild(pill);
+    });
+
+    categoryList.hidden = false;
+  }
 
   function shuffle(array) {
     const copy = array.slice();
@@ -51,6 +81,10 @@
       revealButton.hidden = true;
       prevButton.disabled = true;
       nextButton.disabled = true;
+      if (categoryList) {
+        categoryList.textContent = '';
+        categoryList.hidden = true;
+      }
       return;
     }
 
@@ -58,12 +92,16 @@
     const current = deck[index];
     const hasPunchline = typeof current.punchline === 'string' && current.punchline.trim().length > 0;
     const punchlineText = hasPunchline ? current.punchline : '💩';
+    const categories = categorize
+      ? categorize(current.joke, current.punchline)
+      : [fallbackCategory];
 
     setupEl.textContent = current.joke;
     punchlineEl.textContent = punchlineText;
     revealButton.hidden = false;
 
     setPunchlineVisible(false);
+    renderCategories(categories);
 
     const buttonsDisabled = deck.length <= 1;
     prevButton.disabled = buttonsDisabled;

--- a/apps/jokes/index.html
+++ b/apps/jokes/index.html
@@ -75,6 +75,34 @@
       gap: 20px;
     }
 
+    .category-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .category-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 12px;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      background: rgba(48, 86, 211, 0.12);
+      color: var(--accent);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .category-pill {
+        background: rgba(112, 132, 255, 0.18);
+        color: #b8c1ff;
+      }
+    }
+
     .home-nav {
       display: flex;
       justify-content: flex-start;
@@ -219,6 +247,7 @@
     </nav>
     <article class="card" aria-live="polite">
       <div class="card__content">
+        <ul id="joke-categories" class="category-list" aria-label="Joke categories" hidden></ul>
         <p id="joke-setup">Loading joke…</p>
         <p id="joke-punchline" aria-hidden="true"></p>
       </div>
@@ -234,6 +263,7 @@
     </div>
   </main>
   <script src="jokes.js" defer></script>
+  <script src="joke-categories.js" defer></script>
   <script src="app.js" defer></script>
 </body>
 </html>

--- a/apps/jokes/joke-categories.js
+++ b/apps/jokes/joke-categories.js
@@ -1,0 +1,410 @@
+(function () {
+  const fallbackCategory = 'Classic Dad';
+
+  function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function createKeywordTester(keywords) {
+    const matchers = keywords.map((keyword) => {
+      const normalized = keyword.toLowerCase();
+      if (/\s/.test(normalized)) {
+        return (text) => text.includes(normalized);
+      }
+      const pattern = new RegExp(`\\b${escapeRegExp(normalized)}\\b`);
+      return (text) => pattern.test(text);
+    });
+    return (text) => matchers.some((matcher) => matcher(text));
+  }
+
+  const rules = [
+    {
+      label: 'Animals',
+      matches: createKeywordTester([
+        'animal',
+        'beak',
+        'bird',
+        'cat',
+        'chicken',
+        'cow',
+        'crab',
+        'dog',
+        'duck',
+        'eagle',
+        'elephant',
+        'fish',
+        'fox',
+        'frog',
+        'goat',
+        'horse',
+        'llama',
+        'monkey',
+        'mouse',
+        'owl',
+        'penguin',
+        'pig',
+        'shark',
+        'sheep',
+        'snake',
+        'spider',
+        'squirrel',
+        'whale',
+        'zebra',
+      ]),
+    },
+    {
+      label: 'Food & Drink',
+      matches: createKeywordTester([
+        'bacon',
+        'barbecue',
+        'beer',
+        'bread',
+        'brew',
+        'cake',
+        'cheese',
+        'chef',
+        'coffee',
+        'cook',
+        'cuisine',
+        'diner',
+        'drink',
+        'grill',
+        'kitchen',
+        'meal',
+        'pizza',
+        'restaurant',
+        'salad',
+        'sauce',
+        'snack',
+        'spice',
+        'steak',
+        'tea',
+        'toast',
+        'wine',
+      ]),
+    },
+    {
+      label: 'Tech & Gadgets',
+      matches: createKeywordTester([
+        'algorithm',
+        'app',
+        'binary',
+        'cloud',
+        'code',
+        'computer',
+        'cpu',
+        'data',
+        'digital',
+        'download',
+        'gamer',
+        'internet',
+        'keyboard',
+        'laptop',
+        'phone',
+        'robot',
+        'server',
+        'software',
+        'tech',
+        'virtual',
+        'wifi',
+      ]),
+    },
+    {
+      label: 'Science & Space',
+      matches: createKeywordTester([
+        'asteroid',
+        'atom',
+        'biology',
+        'chemist',
+        'dna',
+        'experiment',
+        'galaxy',
+        'gravity',
+        'lab',
+        'molecule',
+        'orbit',
+        'physics',
+        'planet',
+        'rocket',
+        'science',
+        'space',
+        'star',
+        'telescope',
+      ]),
+    },
+    {
+      label: 'Work & Careers',
+      matches: createKeywordTester([
+        'boss',
+        'career',
+        'coworker',
+        'desk',
+        'email',
+        'employee',
+        'interview',
+        'meeting',
+        'office',
+        'profession',
+        'resume',
+        'salary',
+        'startup',
+        'work',
+      ]),
+    },
+    {
+      label: 'School & Learning',
+      matches: createKeywordTester([
+        'algebra',
+        'assignment',
+        'class',
+        'college',
+        'exam',
+        'homework',
+        'lesson',
+        'math',
+        'professor',
+        'school',
+        'student',
+        'study',
+        'teacher',
+        'textbook',
+        'university',
+      ]),
+    },
+    {
+      label: 'Sports & Games',
+      matches: createKeywordTester([
+        'athlete',
+        'baseball',
+        'basketball',
+        'coach',
+        'football',
+        'golf',
+        'hockey',
+        'olympic',
+        'race',
+        'referee',
+        'score',
+        'soccer',
+        'sport',
+        'stadium',
+        'team',
+        'tennis',
+        'tournament',
+        'umpire',
+      ]),
+    },
+    {
+      label: 'Music & Arts',
+      matches: createKeywordTester([
+        'art',
+        'artist',
+        'band',
+        'canvas',
+        'choir',
+        'concert',
+        'dance',
+        'gallery',
+        'guitar',
+        'museum',
+        'music',
+        'note',
+        'opera',
+        'paint',
+        'piano',
+        'song',
+        'stage',
+        'studio',
+        'theater',
+        'violin',
+      ]),
+    },
+    {
+      label: 'Travel & Places',
+      matches: createKeywordTester([
+        'airport',
+        'beach',
+        'bridge',
+        'cabin',
+        'city',
+        'hotel',
+        'island',
+        'journey',
+        'map',
+        'mountain',
+        'plane',
+        'road',
+        'tour',
+        'train',
+        'travel',
+        'vacation',
+      ]),
+    },
+    {
+      label: 'Money & Finance',
+      matches: createKeywordTester([
+        'bank',
+        'budget',
+        'cash',
+        'coin',
+        'credit',
+        'debt',
+        'dollar',
+        'economy',
+        'expense',
+        'finance',
+        'interest',
+        'investment',
+        'loan',
+        'money',
+        'tax',
+        'wallet',
+      ]),
+    },
+    {
+      label: 'Health & Wellness',
+      matches: createKeywordTester([
+        'doctor',
+        'exercise',
+        'gym',
+        'health',
+        'hospital',
+        'nurse',
+        'patient',
+        'pharmacy',
+        'pill',
+        'sleep',
+        'surgery',
+        'wellness',
+        'yoga',
+      ]),
+    },
+    {
+      label: 'Home & DIY',
+      matches: createKeywordTester([
+        'appliance',
+        'basement',
+        'bathroom',
+        'broom',
+        'carpet',
+        'ceiling',
+        'furniture',
+        'garage',
+        'garden',
+        'hammer',
+        'house',
+        'kitchen',
+        'ladder',
+        'lawn',
+        'paint',
+        'plumber',
+        'repair',
+        'roof',
+        'tool',
+      ]),
+    },
+    {
+      label: 'Family & Relationships',
+      matches: createKeywordTester([
+        'baby',
+        'bride',
+        'child',
+        'dad',
+        'daughter',
+        'family',
+        'father',
+        'grandma',
+        'grandpa',
+        'husband',
+        'kid',
+        'marriage',
+        'mom',
+        'mother',
+        'parent',
+        'son',
+        'wife',
+      ]),
+    },
+    {
+      label: 'Seasonal & Weather',
+      matches: createKeywordTester([
+        'autumn',
+        'christmas',
+        'cold',
+        'fall',
+        'holiday',
+        'pumpkin',
+        'season',
+        'snow',
+        'spring',
+        'summer',
+        'sunny',
+        'weather',
+        'winter',
+      ]),
+    },
+    {
+      label: 'Numbers & Math',
+      matches: (text) => /\b(calculus|count|equation|geometry|math|measure|number|percent|pi|ratio|statistics?)\b/.test(text),
+    },
+    {
+      label: 'Wordplay & Language',
+      matches: createKeywordTester([
+        'alphabet',
+        'dictionary',
+        'grammar',
+        'language',
+        'letter',
+        'pun',
+        'rhyme',
+        'sentence',
+        'spell',
+        'word',
+      ]),
+    },
+    {
+      label: 'Bathroom Humor',
+      matches: createKeywordTester([
+        'bathroom',
+        'flush',
+        'poop',
+        'potty',
+        'toilet',
+      ]),
+    },
+    {
+      label: 'Cheeky Mischief',
+      matches: (text) => /\b(cheek|flirt|kiss|lingerie|naked|romance|sassy|saucy|sly|snowball|spicy|wink)\b/.test(text) || text.includes('balls'),
+    },
+  ];
+
+  function categorizeJoke(setup, punchline) {
+    const source = `${setup || ''} ${punchline || ''}`.toLowerCase();
+    const collected = [];
+
+    rules.forEach((rule) => {
+      try {
+        if (rule.matches(source)) {
+          collected.push(rule.label);
+        }
+      } catch (error) {
+        // Ignore matcher errors to keep categorization resilient.
+      }
+    });
+
+    const unique = collected.filter((label, index) => collected.indexOf(label) === index);
+
+    if (!unique.length) {
+      unique.push(fallbackCategory);
+    }
+
+    return unique.slice(0, 3);
+  }
+
+  if (!window.jokeCategoryHelper) {
+    window.jokeCategoryHelper = {};
+  }
+
+  window.jokeCategoryHelper.categorize = categorizeJoke;
+  window.jokeCategoryHelper.fallback = fallbackCategory;
+})();

--- a/apps/jokes/jokes.js
+++ b/apps/jokes/jokes.js
@@ -3621,6 +3621,26 @@ window.jokes = [
             "id": "j-0970",
             "joke": "Why did the candle maker attend business school?",
             "punchline": "They wanted to wax poetic about profits."
+        }, {
+            "id": "j-0971",
+            "joke": "What's the difference between a snowman and a snowwoman?",
+            "punchline": "Snowballs."
+        }, {
+            "id": "j-0972",
+            "joke": "Why did the dad bring a ladder to the bar?",
+            "punchline": "He heard the drinks were on the house."
+        }, {
+            "id": "j-0973",
+            "joke": "Why did the electrician start telling jokes at family dinner?",
+            "punchline": "He wanted to keep the current conversation lively."
+        }, {
+            "id": "j-0974",
+            "joke": "How does a handyman dad propose to his partner?",
+            "punchline": "With a hardware ring."
+        }, {
+            "id": "j-0975",
+            "joke": "Why did the grill-master dad launch a podcast?",
+            "punchline": "He wanted to share his rare takes."
         }
     ];
 

--- a/apps/jokes/render-all.js
+++ b/apps/jokes/render-all.js
@@ -5,6 +5,14 @@
   const filterForm = document.querySelector('[data-filter-form]');
   const filterInput = document.querySelector('[data-filter-input]');
   const isCompact = document.body && document.body.dataset.compact === 'true';
+  const categorize =
+    window.jokeCategoryHelper && typeof window.jokeCategoryHelper.categorize === 'function'
+      ? window.jokeCategoryHelper.categorize
+      : null;
+  const fallbackCategory =
+    window.jokeCategoryHelper && typeof window.jokeCategoryHelper.fallback === 'string'
+      ? window.jokeCategoryHelper.fallback
+      : 'Classic Dad';
 
   if (!tbody) {
     return;
@@ -40,7 +48,10 @@
           if (!setup) {
             return null;
           }
-          return { setup, rawPunchline };
+          const categories = categorize
+            ? categorize(setup, rawPunchline)
+            : [fallbackCategory];
+          return { setup, rawPunchline, categories };
         })
         .filter(Boolean)
     : [];
@@ -48,11 +59,15 @@
   const deck = shuffle(
     rawJokes.map((entry) => {
       const punchline = formatPunchline(entry.rawPunchline);
-      const searchText = `${entry.setup} ${entry.rawPunchline}`.toLowerCase();
+      const categoryList = Array.isArray(entry.categories) && entry.categories.length
+        ? entry.categories
+        : [fallbackCategory];
+      const searchText = `${entry.setup} ${entry.rawPunchline} ${categoryList.join(' ')}`.toLowerCase();
       return {
         setup: entry.setup,
         punchline,
         searchText,
+        categories: categoryList,
       };
     })
   );
@@ -68,6 +83,19 @@
     }
   }
 
+  function buildCategoryList(categories) {
+    const list = document.createElement('ul');
+    list.className = 'category-list';
+    const items = Array.isArray(categories) && categories.length ? categories : [fallbackCategory];
+    items.forEach((label) => {
+      const pill = document.createElement('li');
+      pill.className = 'category-pill';
+      pill.textContent = label;
+      list.appendChild(pill);
+    });
+    return list;
+  }
+
   function renderRows(list, term) {
     tbody.textContent = '';
 
@@ -75,7 +103,7 @@
       const emptyRow = document.createElement('tr');
       const emptyCell = document.createElement('td');
       if (isCompact) {
-        emptyCell.colSpan = 3;
+        emptyCell.colSpan = 4;
       }
       emptyCell.textContent = term ? `No jokes match “${term}”.` : 'No jokes available.';
       emptyRow.appendChild(emptyCell);
@@ -104,6 +132,11 @@
         compactPunchlineCell.textContent = entry.punchline;
         row.appendChild(compactPunchlineCell);
 
+        const categoriesCell = document.createElement('td');
+        categoriesCell.className = 'category-cell';
+        categoriesCell.appendChild(buildCategoryList(entry.categories));
+        row.appendChild(categoriesCell);
+
         fragment.appendChild(row);
         return;
       }
@@ -112,7 +145,12 @@
 
       const setupCell = document.createElement('td');
       setupCell.className = 'setup-cell';
-      setupCell.textContent = entry.setup;
+      const setupText = document.createElement('div');
+      setupText.textContent = entry.setup;
+      setupCell.appendChild(setupText);
+      const setupCategories = buildCategoryList(entry.categories);
+      setupCategories.setAttribute('aria-label', 'Joke categories');
+      setupCell.appendChild(setupCategories);
 
       setupRow.appendChild(setupCell);
 

--- a/data/jokes-embeddings.json
+++ b/data/jokes-embeddings.json
@@ -3,8 +3,8 @@
     "provider": "synthetic",
     "model": "synthetic-64",
     "dimensions": 64,
-    "generatedAt": "2025-09-24T01:06:46.473Z",
-    "recordCount": 905
+    "generatedAt": "2025-09-25T02:54:18.632Z",
+    "recordCount": 910
   },
   "records": {
     "j-0001": {
@@ -8151,6 +8151,51 @@
       "dimensions": 64,
       "textHash": "e2ccad488df008b4f41000ccd9fe285eb98ddec1c7d81cd56e94ab44b3957725",
       "updatedAt": "2025-09-24T01:06:46.473Z"
+    },
+    "j-0971": {
+      "vector": "jo0Nv/z7e7/5+Pi9rKsrP9rZWb/y8XG//v19v4+Ojj6qqSk/sK8vv83MTL6UkxO/wL8/v5GQEL3z8vI+yslJv9nY2L2urS0/3t1dP8PCwj6Qjw+/0dBQPYmIiL3FxES+u7q6vomIiL3Ix0e/y8rKvrGwMD2enR0/vr09P4eGhj6OjQ2//Pt7v/n4+L2sqys/2tlZv/Lxcb/+/X2/j46OPqqpKT+wry+/zcxMvpSTE7/Avz+/kZAQvfPy8j7KyUm/2djYva6tLT/e3V0/w8LCPpCPD7/R0FA9iYiIvcXERL67urq+iYiIvcjHR7/Lysq+sbAwPZ6dHT++vT0/h4aGPg==",
+      "vectorSha256": "52bec924b0e1d6a6f4c5e4270189554d9e370ecb79b01d010778ea603432f602",
+      "model": "synthetic-64",
+      "provider": "synthetic",
+      "dimensions": 64,
+      "textHash": "390270d5130701a3d4286636207bbc1b72d6eeb03886776751771c4d85cedea1",
+      "updatedAt": "2025-09-25T02:54:18.629Z"
+    },
+    "j-0972": {
+      "vector": "0M9Pv87NTT/KyUm/vLs7P6qpKb+amRk/+vl5P/f29j7R0FC9q6qqvq2sLL7Ew0M/x8bGvvj3d7/KyUm/g4KCPt/e3j739vY+6ulpP/79fT+SkRE//v19v769PT+ioSE/nZwcPqKhIb+bmpq+8vFxv/r5eb/h4OA8zMtLP9jXV7/Qz0+/zs1NP8rJSb+8uzs/qqkpv5qZGT/6+Xk/9/b2PtHQUL2rqqq+rawsvsTDQz/Hxsa++Pd3v8rJSb+DgoI+397ePvf29j7q6Wk//v19P5KRET/+/X2/vr09P6KhIT+dnBw+oqEhv5uamr7y8XG/+vl5v+Hg4DzMy0s/2NdXvw==",
+      "vectorSha256": "4582a7a498ac0470e681118973ee79bf96af4e4a5d4b7c1b892820456e790a86",
+      "model": "synthetic-64",
+      "provider": "synthetic",
+      "dimensions": 64,
+      "textHash": "18e61bdd2bccfcbd79556ae14e041ba0b7bdf4fec801ded0932f59070383e514",
+      "updatedAt": "2025-09-25T02:54:18.630Z"
+    },
+    "j-0973": {
+      "vector": "iYiIPdrZWb+/vr6+oaCgPImIiL2dnBy+rawsvt7dXT/8+3u/y8rKPtLRUb+amRm/uLc3v7i3N7/s62s/m5qavpGQEL3Qz08/w8LCvqWkJD60szM/srExP5GQEL2SkRE/np0dv8jHR7/S0VE/7u1tv8HAQLzd3Fy+hYQEvru6ur6JiIg92tlZv7++vr6hoKA8iYiIvZ2cHL6trCy+3t1dP/z7e7/Lyso+0tFRv5qZGb+4tze/uLc3v+zraz+bmpq+kZAQvdDPTz/DwsK+paQkPrSzMz+ysTE/kZAQvZKRET+enR2/yMdHv9LRUT/u7W2/wcBAvN3cXL6FhAS+u7q6vg==",
+      "vectorSha256": "11335b6cfc4f5cd191a6bef57d29d35dad9988c76260cfa7dfeeb59a703b7d8b",
+      "model": "synthetic-64",
+      "provider": "synthetic",
+      "dimensions": 64,
+      "textHash": "88135082776c6aee02b217332424f5597be74f94d9d87bc8311ce8097e646f51",
+      "updatedAt": "2025-09-25T02:54:18.630Z"
+    },
+    "j-0974": {
+      "vector": "vr09P4qJCT/Lysq+7+7uPv38fD69vDw+6+rqPri3Nz+SkRE/+vl5v6GgoDyxsDC95ONjv/Dvbz+urS0/rq0tv8fGxr6zsrI+2NdXP/Tzcz/CwUE/t7a2vr++vj7X1tY+3dxcPtHQUD2xsDA96Odnv7KxMb///v6+//7+PpmYmD2+vT0/iokJP8vKyr7v7u4+/fx8Pr28PD7r6uo+uLc3P5KRET/6+Xm/oaCgPLGwML3k42O/8O9vP66tLT+urS2/x8bGvrOysj7Y11c/9PNzP8LBQT+3tra+v76+PtfW1j7d3Fw+0dBQPbGwMD3o52e/srExv//+/r7//v4+mZiYPQ==",
+      "vectorSha256": "f93f47cd129fdcc1fe7c41e93326e51d051cbeb2ebcfcd0b6494bd2e973bb102",
+      "model": "synthetic-64",
+      "provider": "synthetic",
+      "dimensions": 64,
+      "textHash": "dec44dbb9f97badbc803827a0ef7d6294eacebf9e052afb59b86850c2740bf89",
+      "updatedAt": "2025-09-25T02:54:18.631Z"
+    },
+    "j-0975": {
+      "vector": "iokJv7Oysj7c21u/srExv/n4+D3JyMg9k5KSvomIiL3X1tY+0tFRv6WkJD7u7W0/AACAP6yrK7/a2Vm/+Pd3P5uamr6RkBC9lpUVv7i3Nz+fnp4+o6Kivvn4+D2Pjo6+kI8Pv8PCwr7//v4+6OdnP8nIyL3o52e/7exsvvHwcD2KiQm/s7KyPtzbW7+ysTG/+fj4PcnIyD2TkpK+iYiIvdfW1j7S0VG/paQkPu7tbT8AAIA/rKsrv9rZWb/493c/m5qavpGQEL2WlRW/uLc3P5+enj6joqK++fj4PY+Ojr6Qjw+/w8LCvv/+/j7o52c/ycjIvejnZ7/t7Gy+8fBwPQ==",
+      "vectorSha256": "728abe24d62e57744ce5426940744b3d4e14af95ef96db138ab2affcdf90fc89",
+      "model": "synthetic-64",
+      "provider": "synthetic",
+      "dimensions": 64,
+      "textHash": "3bac12278f8c5b77b51794f6ff2a13fb597b35dba7578f5c384fbff3730c6287",
+      "updatedAt": "2025-09-25T02:54:18.632Z"
     }
   }
 }

--- a/data/similarity-report-jokes.json
+++ b/data/similarity-report-jokes.json
@@ -1,7 +1,7 @@
 {
   "dataset": "jokes",
   "threshold": 0.5,
-  "generatedAt": "2025-09-24T01:07:55.875Z",
+  "generatedAt": "2025-09-25T02:55:49.612Z",
   "provider": "hfspace",
   "model": "sentence-transformers/all-MiniLM-L6-v2 (hf.space/BienKieu)",
   "matches": [
@@ -468,6 +468,13 @@
       "previewB": "Why did the programmer always carry a pencil? • They preferred to write in C#."
     },
     {
+      "idA": "j-0920",
+      "idB": "j-0975",
+      "similarity": 0.5572646988797786,
+      "previewA": "Why did the gardener start a podcast? • They had a lot of growing to talk about.",
+      "previewB": "Why did the grill-master dad launch a podcast? • He wanted to share his rare takes."
+    },
+    {
       "idA": "j-0146",
       "idB": "j-0644",
       "similarity": 0.5559689173304857,
@@ -529,6 +536,13 @@
       "similarity": 0.5459684506833805,
       "previewA": "What do you call cheese by itself? • Provolone.",
       "previewB": "What cheese can never be yours? • Nacho cheese."
+    },
+    {
+      "idA": "j-0331",
+      "idB": "j-0971",
+      "similarity": 0.5449912983379034,
+      "previewA": "What do you get when you cross a snowman with a vampire? • Frostbite.",
+      "previewB": "What's the difference between a snowman and a snowwoman? • Snowballs."
     },
     {
       "idA": "j-0213",


### PR DESCRIPTION
## Summary
- add a categorisation helper and surface category chips in the random joke view
- expose the same categories in both "all jokes" tables and wire them into filtering
- onboard five new dad jokes and refresh the embeddings + similarity reports

## Testing
- node --check apps/jokes/jokes.js
- node -e "global.window = {}; require('./apps/jokes/jokes.js'); console.log(Array.isArray(window.jokes), window.jokes.length);"
- node --check apps/jokes/app.js
- node --check apps/jokes/render-all.js
- node tools/review-content-similarity.js --dataset=jokes --provider=synthetic --write --update-manifest
- node tools/review-content-similarity.js --dataset=jokes --provider=hfspace --model=bienkieu/sentence-embedding --batch-size=8 --force --threshold-jokes=0.5 --report=data/similarity-report-jokes.json

------
https://chatgpt.com/codex/tasks/task_e_68d4ad579b0c83288ff2a8e85a7ba173