### PR TITLE
Rename wiki entry to blog and move it to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,14 +475,6 @@
             </a>
           </div>
         </li>
-        <li class="app-row" data-group="wiki" role="group" aria-label="Project Wiki">
-          <div class="app-row__actions">
-            <a class="app-button app-button--secondary" href="apps/wiki/">
-              <span aria-hidden="true">📚</span>
-              <span>Project Wiki</span>
-            </a>
-          </div>
-        </li>
       </ul>
     </section>
     <section class="app-groups" aria-labelledby="tools-section">
@@ -516,6 +508,12 @@
           <a class="docs-button app-button--secondary app-button--wide" href="ai_docs/">
             <span aria-hidden="true">📚</span>
             <span>AI Docs</span>
+          </a>
+        </li>
+        <li>
+          <a class="app-button app-button--secondary app-button--wide" href="apps/wiki/">
+            <span aria-hidden="true">📚</span>
+            <span>Blog</span>
           </a>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- rename the Project Wiki entry to Blog in the toolbox navigation
- relocate the blog link to the bottom of the Labs & tools section so it appears last in the toolbox

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4b080c2cc832890f3295c430898f1