### PR TITLE
Move Total Recall entry to Labs & tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,14 +456,6 @@
             </a>
           </div>
         </li>
-        <li class="app-row" data-group="total-recall" role="group" aria-label="Total Recall">
-          <div class="app-row__actions">
-            <a class="app-button app-button--secondary" href="apps/total-recall/">
-              <span aria-hidden="true">🧠</span>
-              <span>Total Recall</span>
-            </a>
-          </div>
-        </li>
         <li class="app-row" data-group="slang" role="group" aria-label="Slang">
           <div class="app-row__actions">
             <a class="app-button app-button--secondary" href="apps/slang/">
@@ -496,6 +488,12 @@
           <a class="app-button app-button--secondary app-button--wide" href="apps/asset-observatory/">
             <span aria-hidden="true">📊</span>
             <span>Asset Observatory</span>
+          </a>
+        </li>
+        <li>
+          <a class="app-button app-button--secondary app-button--wide" href="apps/total-recall/">
+            <span aria-hidden="true">🧠</span>
+            <span>Total Recall</span>
           </a>
         </li>
         <li>


### PR DESCRIPTION
## Summary
- relocate the Total Recall link from the deck collections group to the Labs & tools section
- ensure the link uses the wide secondary button style to match other tools

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d4b5322ed88328b010988983b220d6