### PR TITLE
Handle missing text for cosine pair selections

### DIFF
--- a/apps/embedding-explorer/app.js
+++ b/apps/embedding-explorer/app.js
@@ -89,6 +89,7 @@
       filterInput: leftFilterInput,
       activeDatasetId: '',
       activeRecordId: '',
+      activePreviewText: '',
       currentRecords: [],
       filteredRecords: [],
     },
@@ -101,6 +102,7 @@
       filterInput: rightFilterInput,
       activeDatasetId: '',
       activeRecordId: '',
+      activePreviewText: '',
       currentRecords: [],
       filteredRecords: [],
     },
@@ -321,14 +323,47 @@
     }
   }
 
-  function renderContentText(container, contentKey, entry, placeholder) {
+  function renderPreviewTextRecord(container, contentKey, preview) {
+    if (!container || !preview) {
+      return;
+    }
+
+    const wrapper = document.createElement('article');
+    wrapper.className = 'text-record';
+
+    const heading = document.createElement('h3');
+    heading.className = 'text-record__heading';
+    const baseTitle = getContentTitle(contentKey);
+    heading.textContent = baseTitle ? `${baseTitle} preview` : 'Source preview';
+    wrapper.appendChild(heading);
+
+    const list = document.createElement('dl');
+    list.className = 'text-record__list';
+
+    const dt = document.createElement('dt');
+    dt.textContent = 'Preview';
+    const dd = document.createElement('dd');
+    dd.textContent = preview;
+    list.append(dt, dd);
+
+    wrapper.appendChild(list);
+    container.appendChild(wrapper);
+  }
+
+  function renderContentText(container, contentKey, entry, placeholder, previewFallback) {
     if (!container) {
       return;
     }
 
     container.innerHTML = '';
 
+    const preview = typeof previewFallback === 'string' ? previewFallback.trim() : '';
+
     if (!entry) {
+      if (preview) {
+        renderPreviewTextRecord(container, contentKey, preview);
+        return;
+      }
       const message = document.createElement('p');
       message.className = 'placeholder';
       message.textContent = placeholder || 'Source text not available for this vector.';
@@ -339,6 +374,10 @@
     const fields = getContentFields(contentKey, entry);
 
     if (!fields.length) {
+      if (preview) {
+        renderPreviewTextRecord(container, contentKey, preview);
+        return;
+      }
       const message = document.createElement('p');
       message.className = 'placeholder';
       message.textContent = placeholder || 'Source text not available for this vector.';
@@ -541,7 +580,14 @@
     }
 
     if (pane.text) {
-      renderContentText(pane.text, options.contentKey || '', options.contentEntry || null, textPlaceholder);
+      const previewFallback = typeof options.previewFallback === 'string' ? options.previewFallback : '';
+      renderContentText(
+        pane.text,
+        options.contentKey || '',
+        options.contentEntry || null,
+        textPlaceholder,
+        previewFallback
+      );
     }
   }
 
@@ -582,6 +628,7 @@
     const contentEntry = record ? getContentEntry(contentKey, record.id) : null;
     const captionIdle = 'Pick a vector to render its fingerprint.';
     const captionActive = record ? `Binary fingerprint for ${record.id}.` : captionIdle;
+    const previewFallback = sides.left.activePreviewText || '';
 
     renderPane(primaryPane, record, datasetData?.meta, datasetData?.source, {
       metaPlaceholder: 'Select a vector to inspect its details.',
@@ -590,12 +637,14 @@
       captionActive,
       contentKey,
       contentEntry,
+      previewFallback,
     });
   }
 
   function renderSecondaryPane(leftRecord, rightRecord, datasetData) {
     const contentKey = datasetData?.contentKey || '';
     const contentEntry = rightRecord ? getContentEntry(contentKey, rightRecord.id) : null;
+    const previewFallback = sides.right.activePreviewText || '';
     const hasLeftSelection = Boolean(leftRecord);
     const captionIdle = hasLeftSelection
       ? 'Select a right-side vector to view its fingerprint.'
@@ -629,6 +678,7 @@
       contentKey,
       contentEntry,
       extraMeta,
+      previewFallback,
     });
   }
 
@@ -714,7 +764,7 @@
     side.recordList.appendChild(fragment);
   }
 
-  function setActiveRecord(sideKey, recordId) {
+  function setActiveRecord(sideKey, recordId, options = {}) {
     const side = sides[sideKey];
     if (!side) {
       return;
@@ -723,6 +773,7 @@
     const datasetId = side.activeDatasetId;
     if (!datasetId) {
       side.activeRecordId = '';
+      side.activePreviewText = '';
       renderComparison();
       return;
     }
@@ -734,13 +785,16 @@
 
     if (!recordId || !datasetData.recordMap.has(recordId)) {
       side.activeRecordId = '';
+      side.activePreviewText = '';
       renderRecordList(side);
       updateRecordStatus(side);
       renderComparison();
       return;
     }
 
+    const previewText = typeof options.preview === 'string' ? options.preview.trim() : '';
     side.activeRecordId = recordId;
+    side.activePreviewText = previewText;
     renderRecordList(side);
     updateRecordStatus(side);
     renderComparison();
@@ -808,6 +862,7 @@
 
     side.activeDatasetId = '';
     side.activeRecordId = '';
+    side.activePreviewText = '';
     side.currentRecords = [];
     side.filteredRecords = [];
     side.filterInput.value = '';
@@ -894,7 +949,7 @@
       return Promise.resolve();
     }
 
-    const { recordId = '' } = options;
+    const { recordId = '', preview = '' } = options;
 
     if (!datasetId) {
       resetSide(side);
@@ -926,7 +981,8 @@
       const candidateId = recordId && datasetData.recordMap.has(recordId)
         ? recordId
         : datasetData.records[0]?.id || '';
-      setActiveRecord(sideKey, candidateId);
+      const candidatePreview = candidateId === recordId ? preview : '';
+      setActiveRecord(sideKey, candidateId, { preview: candidatePreview });
     };
 
     const cached = datasetCache.get(datasetId);
@@ -945,6 +1001,7 @@
     }
     side.activeDatasetId = datasetId;
     side.activeRecordId = '';
+    side.activePreviewText = '';
 
     return loadDatasetData(datasetId)
       .then((datasetData) => {
@@ -1129,8 +1186,14 @@
     pairStatus.textContent = 'Loading selected pair…';
 
     Promise.all([
-      setDatasetForSide('left', pair.datasetIdLeft, { recordId: pair.idLeft }),
-      setDatasetForSide('right', pair.datasetIdRight, { recordId: pair.idRight }),
+      setDatasetForSide('left', pair.datasetIdLeft, {
+        recordId: pair.idLeft,
+        preview: pair.previewLeft || '',
+      }),
+      setDatasetForSide('right', pair.datasetIdRight, {
+        recordId: pair.idRight,
+        preview: pair.previewRight || '',
+      }),
     ])
       .then(() => {
         updatePairStatus(pair);

--- a/tests/embedding-explorer.spec.js
+++ b/tests/embedding-explorer.spec.js
@@ -1,38 +1,38 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('Embedding Explorer app', () => {
-test('renders dataset metadata and comparison panes for stored embeddings', async ({ page }) => {
-  await page.goto('/apps/embedding-explorer/');
+  test('renders dataset metadata and comparison panes for stored embeddings', async ({ page }) => {
+    await page.goto('/apps/embedding-explorer/');
 
-  const leftDatasetSelect = page.locator('[data-left-dataset-select]');
-  await leftDatasetSelect.locator('option').first().waitFor({ state: 'attached' });
-  await leftDatasetSelect.selectOption('jokes-synthetic');
+    const leftDatasetSelect = page.locator('[data-left-dataset-select]');
+    await leftDatasetSelect.locator('option').first().waitFor({ state: 'attached' });
+    await leftDatasetSelect.selectOption('jokes-synthetic');
 
-  const leftRecordStatus = page.locator('[data-left-record-status]');
-  await expect(leftRecordStatus).toContainText('Showing');
+    const leftRecordStatus = page.locator('[data-left-record-status]');
+    await expect(leftRecordStatus).toContainText('Showing');
 
-  const leftDatasetInfo = page.locator('[data-left-dataset-info]');
-  await expect(leftDatasetInfo).toContainText('Records');
+    const leftDatasetInfo = page.locator('[data-left-dataset-info]');
+    await expect(leftDatasetInfo).toContainText('Records');
 
-  const recordButton = page
-    .locator('[data-left-record-list] .record-button')
-    .locator(':visible')
-    .first();
-  await recordButton.waitFor({ state: 'visible' });
-  await recordButton.click();
+    const recordButton = page
+      .locator('[data-left-record-list] .record-button')
+      .locator(':visible')
+      .first();
+    await recordButton.waitFor({ state: 'visible' });
+    await recordButton.click();
 
-  await expect(page.locator('[data-left-record-status]')).toContainText('Showing');
-  await expect(page.locator('[data-primary-meta]')).not.toContainText('Select a vector to inspect its details.');
-  await expect(page.locator('[data-primary-text]')).not.toContainText('Choose a vector to load its source text.');
+    await expect(page.locator('[data-left-record-status]')).toContainText('Showing');
+    await expect(page.locator('[data-primary-meta]')).not.toContainText('Select a vector to inspect its details.');
+    await expect(page.locator('[data-primary-text]')).not.toContainText('Choose a vector to load its source text.');
 
-  const primaryVectorId = (await page.locator('[data-primary-meta] dd').first().textContent())?.trim() || '';
+    const primaryVectorId = (await page.locator('[data-primary-meta] dd').first().textContent())?.trim() || '';
 
-  if (primaryVectorId) {
-    await expect(page.locator('[data-primary-caption]')).toContainText(primaryVectorId);
-  }
+    if (primaryVectorId) {
+      await expect(page.locator('[data-primary-caption]')).toContainText(primaryVectorId);
+    }
 
-  await expect(page.locator('[data-secondary-caption]')).toContainText('Comparing');
-});
+    await expect(page.locator('[data-secondary-caption]')).toContainText('Comparing');
+  });
 
   test('filters dataset vectors and populates comparison panes', async ({ page }) => {
     await page.goto('/apps/embedding-explorer/');
@@ -69,5 +69,32 @@ test('renders dataset metadata and comparison panes for stored embeddings', asyn
 
       await recordFilter.fill('');
     }
+  });
+
+  test('loads curated cosine pairs including comparison text', async ({ page }) => {
+    await page.goto('/apps/embedding-explorer/');
+
+    const pairSelect = page.locator('[data-pair-select]');
+    await pairSelect.locator('option').first().waitFor({ state: 'attached' });
+    await expect(pairSelect).toBeEnabled();
+
+    const optionValues = await pairSelect.locator('option:not([disabled])').evaluateAll((options) =>
+      options.map((option) => option.value)
+    );
+
+    const targetValue = optionValues.find((value) => value !== '');
+    expect(targetValue, 'expected at least one selectable pair').toBeDefined();
+
+    if (targetValue) {
+      await pairSelect.selectOption(targetValue);
+    }
+
+    const primaryText = page.locator('[data-primary-text]');
+    const secondaryText = page.locator('[data-secondary-text]');
+
+    await expect(primaryText.locator('.text-record__heading')).toBeVisible();
+    await expect(secondaryText.locator('.text-record__heading')).toBeVisible();
+
+    await expect(secondaryText).not.toContainText('Choose a right-side vector to view its source text.');
   });
 });


### PR DESCRIPTION
## Summary
- render fallback source previews when a dataset record lacks a mapped text entry by reusing pair report snippets
- track preview copy alongside the active record so the comparison pane can surface text even for sparse datasets
- extend the embedding explorer Playwright spec to cover curated pair loading and ensure the comparison text renders

## Testing
- `npx playwright test tests/embedding-explorer.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68d4c11b510083288008a942ad5b6253