### PR TITLE
Promote Total Recall tool on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,6 +473,12 @@
       <h2 id="tools-section" class="section-title">Labs &amp; tools</h2>
       <ul class="tool-list">
         <li>
+          <a class="app-button app-button--secondary app-button--wide" href="apps/total-recall/">
+            <span aria-hidden="true">🧠</span>
+            <span>Total Recall</span>
+          </a>
+        </li>
+        <li>
           <a class="app-button app-button--secondary app-button--wide" href="apps/similarity-report/">
             <span aria-hidden="true">🧪</span>
             <span>Cosine Similarity Lab</span>
@@ -488,12 +494,6 @@
           <a class="app-button app-button--secondary app-button--wide" href="apps/asset-observatory/">
             <span aria-hidden="true">📊</span>
             <span>Asset Observatory</span>
-          </a>
-        </li>
-        <li>
-          <a class="app-button app-button--secondary app-button--wide" href="apps/total-recall/">
-            <span aria-hidden="true">🧠</span>
-            <span>Total Recall</span>
           </a>
         </li>
         <li>


### PR DESCRIPTION
## Summary
- move the Total Recall button to the top of the Labs & tools list on the landing page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d75c0ce7208328a9d1e5d7cf2f142b