### PR TITLE
Convert wiki app into blog with sequential navigation

### DIFF
--- a/apps/wiki/app.js
+++ b/apps/wiki/app.js
@@ -1,13 +1,12 @@
 (function () {
-  const listEl = document.querySelector('[data-article-list]');
-  const countEl = document.querySelector('[data-count]');
   const articleTitleEl = document.querySelector('[data-article-title]');
   const articleMetaEl = document.querySelector('[data-article-meta]');
   const articleBodyEl = document.querySelector('[data-article-body]');
   const articleTagsEl = document.querySelector('[data-article-tags]');
-  const emptyMessageEl = document.querySelector('[data-empty-message]');
+  const previousButton = document.querySelector('[data-article-prev]');
+  const nextButton = document.querySelector('[data-article-next]');
 
-  if (!listEl || !countEl || !articleTitleEl || !articleMetaEl || !articleBodyEl || !articleTagsEl) {
+  if (!articleTitleEl || !articleMetaEl || !articleBodyEl || !articleTagsEl || !previousButton || !nextButton) {
     return;
   }
 
@@ -616,94 +615,6 @@
     return { entries, hadErrors };
   }
 
-  function updateCountBadge() {
-    if (!countEl) {
-      return;
-    }
-
-    const count = articles.length;
-    if (!count) {
-      countEl.textContent = '0 entries';
-      return;
-    }
-
-    const label = count === 1 ? 'entry' : 'entries';
-    countEl.textContent = `${count.toLocaleString()} ${label}`;
-  }
-
-  function buildList() {
-    if (!articles.length) {
-      listEl.innerHTML = '';
-      const emptyItem = document.createElement('li');
-      emptyItem.className = 'article-empty';
-      emptyItem.textContent = loadErrorMessage || 'No chronicles yet—check back soon!';
-      listEl.appendChild(emptyItem);
-      return;
-    }
-
-    if (emptyMessageEl) {
-      emptyMessageEl.remove();
-    }
-
-    const fragment = document.createDocumentFragment();
-
-    articles.forEach((article) => {
-      const item = document.createElement('li');
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'article-card';
-      button.dataset.articleSlug = article.slug;
-      button.setAttribute('aria-pressed', 'false');
-
-      const emojiSpan = document.createElement('span');
-      emojiSpan.className = 'article-card__emoji';
-      emojiSpan.textContent = article.accentEmoji || '📝';
-      button.appendChild(emojiSpan);
-
-      const contentWrapper = document.createElement('span');
-      contentWrapper.className = 'article-card__content';
-
-      const titleSpan = document.createElement('span');
-      titleSpan.className = 'article-card__title';
-      titleSpan.textContent = article.title;
-      contentWrapper.appendChild(titleSpan);
-
-      const summarySpan = document.createElement('span');
-      summarySpan.className = 'article-card__summary';
-      summarySpan.textContent = article.summary || 'Tap to read the full saga.';
-      contentWrapper.appendChild(summarySpan);
-
-      const metaSpan = document.createElement('span');
-      metaSpan.className = 'article-card__meta';
-      const dateLabel = formatDate(article.published);
-      const metaParts = [];
-      if (dateLabel) {
-        metaParts.push(dateLabel);
-      }
-      if (article.readingTime) {
-        metaParts.push(article.readingTime);
-      }
-      metaSpan.textContent = metaParts.join(' • ');
-      contentWrapper.appendChild(metaSpan);
-
-      button.appendChild(contentWrapper);
-      item.appendChild(button);
-      fragment.appendChild(item);
-    });
-
-    listEl.innerHTML = '';
-    listEl.appendChild(fragment);
-  }
-
-  function highlightActive(slug) {
-    const buttons = listEl.querySelectorAll('.article-card');
-    buttons.forEach((button) => {
-      const matches = button.dataset.articleSlug === slug;
-      button.classList.toggle('is-active', matches);
-      button.setAttribute('aria-pressed', matches ? 'true' : 'false');
-    });
-  }
-
   function renderTags(tags) {
     articleTagsEl.innerHTML = '';
     if (!tags || !tags.length) {
@@ -719,6 +630,64 @@
     });
     articleTagsEl.appendChild(fragment);
     articleTagsEl.hidden = false;
+  }
+
+  function updateNavigationControls() {
+    if (!previousButton || !nextButton) {
+      return;
+    }
+
+    if (!articles.length) {
+      previousButton.disabled = true;
+      nextButton.disabled = true;
+      delete previousButton.dataset.articleSlug;
+      delete nextButton.dataset.articleSlug;
+      previousButton.setAttribute('aria-label', 'No previous post');
+      previousButton.removeAttribute('title');
+      nextButton.setAttribute('aria-label', 'No next post');
+      nextButton.removeAttribute('title');
+      return;
+    }
+
+    const index = articles.findIndex((article) => article.slug === activeSlug);
+    if (index === -1) {
+      previousButton.disabled = true;
+      nextButton.disabled = true;
+      delete previousButton.dataset.articleSlug;
+      delete nextButton.dataset.articleSlug;
+      previousButton.setAttribute('aria-label', 'No previous post');
+      previousButton.removeAttribute('title');
+      nextButton.setAttribute('aria-label', 'No next post');
+      nextButton.removeAttribute('title');
+      return;
+    }
+
+    const previousArticle = index > 0 ? articles[index - 1] : null;
+    const nextArticle = index < articles.length - 1 ? articles[index + 1] : null;
+
+    if (previousArticle) {
+      previousButton.disabled = false;
+      previousButton.dataset.articleSlug = previousArticle.slug;
+      previousButton.setAttribute('aria-label', `Previous post: ${previousArticle.title}`);
+      previousButton.title = `Previous post: ${previousArticle.title}`;
+    } else {
+      previousButton.disabled = true;
+      delete previousButton.dataset.articleSlug;
+      previousButton.setAttribute('aria-label', 'No previous post');
+      previousButton.removeAttribute('title');
+    }
+
+    if (nextArticle) {
+      nextButton.disabled = false;
+      nextButton.dataset.articleSlug = nextArticle.slug;
+      nextButton.setAttribute('aria-label', `Next post: ${nextArticle.title}`);
+      nextButton.title = `Next post: ${nextArticle.title}`;
+    } else {
+      nextButton.disabled = true;
+      delete nextButton.dataset.articleSlug;
+      nextButton.setAttribute('aria-label', 'No next post');
+      nextButton.removeAttribute('title');
+    }
   }
 
   function renderArticle(article, options) {
@@ -748,8 +717,7 @@
       articleTitleEl.focus();
     }
 
-    highlightActive(article.slug);
-    document.title = `${article.title} · Project Wiki`;
+    document.title = `${article.title} · Project Blog`;
   }
 
   function selectArticle(slug, options = {}) {
@@ -764,6 +732,7 @@
 
     activeSlug = match.slug;
     renderArticle(match, options);
+    updateNavigationControls();
 
     if (options.updateHistory !== false) {
       try {
@@ -823,18 +792,53 @@
   }
 
   function bindEvents() {
-    listEl.addEventListener('click', (event) => {
-      const button = event.target.closest('.article-card');
-      if (!button) {
+    previousButton.addEventListener('click', () => {
+      if (previousButton.disabled) {
         return;
       }
 
-      const slug = button.dataset.articleSlug;
-      if (!slug) {
+      const slug = previousButton.dataset.articleSlug;
+      if (slug) {
+        selectArticle(slug, { focus: true });
+      }
+    });
+
+    nextButton.addEventListener('click', () => {
+      if (nextButton.disabled) {
         return;
       }
 
-      selectArticle(slug, { focus: true });
+      const slug = nextButton.dataset.articleSlug;
+      if (slug) {
+        selectArticle(slug, { focus: true });
+      }
+    });
+
+    window.addEventListener('keydown', (event) => {
+      if (!articles.length || !activeSlug || event.defaultPrevented) {
+        return;
+      }
+
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return;
+      }
+
+      if (event.key === 'ArrowLeft') {
+        const slug = previousButton.dataset.articleSlug;
+        if (slug && !previousButton.disabled) {
+          selectArticle(slug, { focus: true });
+          event.preventDefault();
+        }
+        return;
+      }
+
+      if (event.key === 'ArrowRight') {
+        const slug = nextButton.dataset.articleSlug;
+        if (slug && !nextButton.disabled) {
+          selectArticle(slug, { focus: true });
+          event.preventDefault();
+        }
+      }
     });
 
     window.addEventListener('popstate', handlePopState);
@@ -847,7 +851,7 @@
     try {
       loadResult = await loadArticlesFromFiles();
     } catch (error) {
-      console.error('Failed to load wiki articles.', error);
+      console.error('Failed to load blog posts.', error);
       loadResult = { entries: [], hadErrors: true };
     }
 
@@ -861,7 +865,7 @@
         normalized = inlineArticles;
         usedInlineFallback = true;
         if (loadResult.hadErrors) {
-          console.warn('Using inline wiki articles while the file-backed entries are unavailable.');
+          console.warn('Using inline blog posts while the file-backed entries are unavailable.');
         }
       }
     }
@@ -870,25 +874,24 @@
     activeSlug = null;
 
     if (loadResult.hadErrors && !articles.length && !usedInlineFallback) {
-      loadErrorMessage = 'Unable to load wiki entries right now.';
+      loadErrorMessage = 'Unable to load blog posts right now.';
     } else {
       loadErrorMessage = '';
     }
 
-    updateCountBadge();
-    buildList();
+    updateNavigationControls();
 
     if (!articles.length) {
-      articleTitleEl.textContent = loadErrorMessage ? 'Unable to load entries' : 'No entries yet';
+      articleTitleEl.textContent = loadErrorMessage ? 'Unable to load posts' : 'No posts yet';
       articleMetaEl.hidden = true;
       articleMetaEl.textContent = '';
       articleTagsEl.hidden = true;
       articleTagsEl.innerHTML = '';
       const fallbackMessage = loadErrorMessage
         ? `<p class="article-empty">${loadErrorMessage}</p>`
-        : '<p class="article-empty">Add a slug to <code>apps/wiki/articles/index.yaml</code> and create matching <code>.json</code> and <code>.md</code> files to publish your first entry.</p>';
+        : '<p class="article-empty">Add a slug to <code>apps/wiki/articles/index.yaml</code> and create a matching markdown file to publish your first post.</p>';
       articleBodyEl.innerHTML = fallbackMessage;
-      document.title = 'Project Wiki';
+      document.title = 'Project Blog';
       return;
     }
 

--- a/apps/wiki/index.html
+++ b/apps/wiki/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Project Wiki</title>
+  <title>Project Blog</title>
   <style>
     :root {
       color-scheme: light dark;
@@ -116,7 +116,14 @@
     .page-header {
       display: flex;
       flex-direction: column;
-      gap: 14px;
+      gap: 16px;
+    }
+
+    .page-header__top {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 12px;
     }
 
     .page-header h1 {
@@ -132,133 +139,51 @@
       color: var(--text-secondary);
     }
 
-    .wiki-layout {
-      display: grid;
-      grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
-      gap: clamp(18px, 2.4vw, 36px);
-    }
-
-    .article-panel {
+    .article-nav {
       display: flex;
-      flex-direction: column;
-      gap: 16px;
-      background: var(--surface-alt);
-      border: 1px solid var(--list-border);
-      border-radius: 18px;
-      padding: clamp(16px, 2.2vw, 22px);
-    }
-
-    .panel-header {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-
-    .panel-header h2 {
-      margin: 0;
-      font-size: clamp(1.1rem, 0.4vw + 1rem, 1.3rem);
-      letter-spacing: 0.02em;
-      text-transform: uppercase;
-    }
-
-    .panel-description {
-      margin: 0;
-      color: var(--text-secondary);
-      font-size: 0.95rem;
-    }
-
-    .count-pill {
-      display: inline-flex;
+      flex-wrap: wrap;
       align-items: center;
-      gap: 6px;
-      padding: 4px 10px;
-      border-radius: 999px;
-      background: var(--badge-background);
-      color: var(--badge-text);
-      font-size: 0.85rem;
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      width: fit-content;
-    }
-
-    .article-list {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
       gap: 12px;
     }
 
-    .article-card {
-      width: 100%;
-      border: 1px solid transparent;
-      border-radius: 16px;
-      padding: 14px 16px;
-      background: rgba(255, 255, 255, 0.72);
+    .article-nav__button {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 18px;
+      border-radius: 999px;
+      border: 1px solid var(--surface-border);
+      background: var(--accent-soft);
       color: inherit;
-      text-align: left;
-      display: flex;
-      gap: 14px;
-      align-items: flex-start;
+      font-weight: 600;
+      font-size: 0.95rem;
       cursor: pointer;
-      font: inherit;
-      transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
     }
 
-    .article-card:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 12px 28px rgba(74, 99, 255, 0.16);
-      border-color: var(--surface-border);
-      background: rgba(255, 255, 255, 0.86);
-    }
-
-    .article-card:focus-visible {
-      outline: none;
-      border-color: var(--accent);
-      box-shadow: 0 0 0 3px var(--focus-ring);
-    }
-
-    .article-card__emoji {
-      font-size: 1.6rem;
-      flex-shrink: 0;
+    .article-nav__button span[aria-hidden="true"] {
+      font-size: 1.2rem;
       line-height: 1;
     }
 
-    .article-card__content {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-      flex: 1 1 auto;
-      min-width: 0;
-    }
-
-    .article-card__title {
-      font-weight: 650;
-      font-size: 1.05rem;
-      line-height: 1.3;
-      word-break: break-word;
-    }
-
-    .article-card__summary {
-      margin: 0;
-      color: var(--text-secondary);
-      font-size: 0.95rem;
-      line-height: 1.4;
-    }
-
-    .article-card__meta {
-      color: var(--text-secondary);
-      font-size: 0.85rem;
-      letter-spacing: 0.02em;
-      text-transform: uppercase;
-    }
-
-    .article-card.is-active {
+    .article-nav__button:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 30px rgba(74, 99, 255, 0.24);
       border-color: var(--accent);
-      background: rgba(74, 99, 255, 0.12);
-      box-shadow: inset 0 0 0 1px rgba(74, 99, 255, 0.2);
+      background: var(--accent-strong);
+    }
+
+    .article-nav__button:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px var(--focus-ring);
+    }
+
+    .article-nav__button:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+      transform: none;
+      box-shadow: none;
+      background: rgba(74, 99, 255, 0.08);
     }
 
     .article-view {
@@ -395,22 +320,12 @@
       text-decoration: underline;
     }
 
-    @media (max-width: 960px) {
-      .wiki-layout {
-        grid-template-columns: 1fr;
-      }
-
-      .article-panel,
-      .article-view {
-        padding: clamp(16px, 3vw, 22px);
-      }
-
-      .article-panel {
-        order: 1;
-      }
-
-      .article-view {
-        order: 2;
+    @media (min-width: 720px) {
+      .page-header__top {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
       }
     }
 
@@ -423,8 +338,9 @@
         border-radius: 18px;
       }
 
-      .article-card {
-        padding: 12px 14px;
+      .article-nav__button {
+        width: 100%;
+        justify-content: center;
       }
 
       .article-body {
@@ -436,32 +352,32 @@
 <body>
   <main>
     <header class="page-header">
-      <h1>Project Wiki</h1>
-      <p class="page-tagline">A gloriously biased chronicle of how this project crawls, sprints, and occasionally cartwheels toward greatness.</p>
+      <div class="page-header__top">
+        <h1>Project Blog</h1>
+        <nav class="article-nav" aria-label="Blog post navigation">
+          <button type="button" class="article-nav__button" data-article-prev disabled>
+            <span aria-hidden="true">←</span>
+            <span>Previous post</span>
+          </button>
+          <button type="button" class="article-nav__button" data-article-next disabled>
+            <span>Next post</span>
+            <span aria-hidden="true">→</span>
+          </button>
+        </nav>
+      </div>
+      <p class="page-tagline">Field reports from the build front lines—updates, breakthroughs, and the occasional detour.</p>
     </header>
-    <div class="wiki-layout">
-      <aside class="article-panel" aria-labelledby="article-list-title">
-        <div class="panel-header">
-          <h2 id="article-list-title">Field notes</h2>
-          <p class="panel-description">Pick an entry to eavesdrop on our latest experiments, mishaps, and triumphs.</p>
-          <span class="count-pill" data-count>0 entries</span>
-        </div>
-        <ul class="article-list" data-article-list>
-          <li class="article-empty" data-empty-message>No chronicles yet—check back soon!</li>
-        </ul>
-      </aside>
-      <article class="article-view" data-article aria-labelledby="article-title">
-        <header class="article-header">
-          <p class="article-kicker">Currently reading</p>
-          <h2 class="article-title" id="article-title" data-article-title tabindex="-1">Pick an entry from the list</h2>
-          <p class="article-meta" data-article-meta hidden></p>
-          <ul class="tag-list" data-article-tags hidden aria-label="Topics"></ul>
-        </header>
-        <div class="article-body" data-article-body>
-          <p class="article-empty">Select an article from the left to dive into the chaos.</p>
-        </div>
-      </article>
-    </div>
+    <article class="article-view" data-article aria-labelledby="article-title">
+      <header class="article-header">
+        <p class="article-kicker">Currently reading</p>
+        <h2 class="article-title" id="article-title" data-article-title tabindex="-1">Choose a post to start reading</h2>
+        <p class="article-meta" data-article-meta hidden></p>
+        <ul class="tag-list" data-article-tags hidden aria-label="Topics"></ul>
+      </header>
+      <div class="article-body" data-article-body>
+        <p class="article-empty">Use the arrows above to browse the latest updates.</p>
+      </div>
+    </article>
     <nav class="home-nav" aria-label="Back to toolbox">
       <a class="home-link" href="../../index.html">
         <span aria-hidden="true">🏠</span>


### PR DESCRIPTION
## Summary
- rename the wiki landing page as a blog and swap the sidebar for inline previous/next controls
- restyle the blog layout so the navigation buttons sit in the header and remain responsive across breakpoints
- rework the article loader to drive the new navigation buttons, update history, and provide keyboard shortcuts

## Testing
- npx playwright test tests/home-navigation.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d75c8077cc83289eb620ebdad6d7ef