### PR TITLE
Add refresh pulse insights to asset observatory

### DIFF
--- a/apps/asset-observatory/app.js
+++ b/apps/asset-observatory/app.js
@@ -9,11 +9,12 @@
   const providerChartContainer = document.querySelector('[data-provider-chart]');
   const datasetTableBody = document.querySelector('[data-dataset-table]');
   const similarityGrid = document.querySelector('[data-similarity-grid]');
+  const freshnessGrid = document.querySelector('[data-freshness-grid]');
   const sourceList = document.querySelector('[data-source-list]');
   const generatedAtNode = document.querySelector('[data-generated-at]');
   const providerCountNode = document.querySelector('[data-provider-count]');
 
-  if (!summaryRoot || !datasetChartContainer || !providerChartContainer || !datasetTableBody || !similarityGrid || !sourceList) {
+  if (!summaryRoot || !datasetChartContainer || !providerChartContainer || !datasetTableBody || !similarityGrid || !freshnessGrid || !sourceList) {
     return;
   }
 
@@ -58,6 +59,103 @@
     });
   };
 
+  const toDate = (value) => {
+    if (!value) {
+      return null;
+    }
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value;
+    }
+    if (typeof value === 'string' || typeof value === 'number') {
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+    return null;
+  };
+
+  const msPerDay = 1000 * 60 * 60 * 24;
+
+  const differenceInDays = (laterDate, earlierDate) => {
+    const later = toDate(laterDate);
+    const earlier = toDate(earlierDate);
+    if (!later || !earlier) {
+      return null;
+    }
+    const diff = later.getTime() - earlier.getTime();
+    if (!Number.isFinite(diff) || diff <= 0) {
+      return 0;
+    }
+    return diff / msPerDay;
+  };
+
+  const formatRelativeDays = (days) => {
+    if (days === null || !Number.isFinite(days)) {
+      return 'No signal';
+    }
+    if (days < 0.5) {
+      return 'today';
+    }
+    if (days < 1.5) {
+      return '1 day ago';
+    }
+    if (days < 7) {
+      return `${decimalFormatter.format(days)} days ago`;
+    }
+    return `${Math.round(days)} days ago`;
+  };
+
+  const classifyFreshness = (ageDays) => {
+    if (ageDays === null || !Number.isFinite(ageDays)) {
+      return { bucket: 'missing', className: 'status-muted', toneLabel: 'Missing' };
+    }
+    if (ageDays <= 2) {
+      return { bucket: 'fresh', className: 'status-healthy', toneLabel: 'Fresh' };
+    }
+    if (ageDays <= 7) {
+      return { bucket: 'due', className: 'status-warning', toneLabel: 'Due soon' };
+    }
+    return { bucket: 'stale', className: 'status-critical', toneLabel: 'Needs refresh' };
+  };
+
+  const referenceDate = toDate(data.generatedAt) || new Date();
+
+  const computeComponentStatus = (timestamps, count) => {
+    const valid = timestamps
+      .map((entry) => toDate(entry))
+      .filter((entry) => entry);
+
+    if (valid.length === 0) {
+      return {
+        count,
+        bucket: 'missing',
+        className: 'status-muted',
+        toneLabel: count > 0 ? 'Untracked' : 'Missing',
+        newestDate: null,
+        oldestDate: null,
+        ageDays: null,
+        spanDays: null,
+      };
+    }
+
+    const sorted = valid.slice().sort((a, b) => a.getTime() - b.getTime());
+    const oldestDate = sorted[0];
+    const newestDate = sorted[sorted.length - 1];
+    const ageDays = differenceInDays(referenceDate, newestDate);
+    const spanDays = sorted.length > 1 ? differenceInDays(newestDate, oldestDate) : 0;
+    const classification = classifyFreshness(ageDays);
+
+    return {
+      count,
+      bucket: classification.bucket,
+      className: classification.className,
+      toneLabel: classification.toneLabel,
+      newestDate,
+      oldestDate,
+      ageDays,
+      spanDays,
+    };
+  };
+
   if (generatedAtNode) {
     generatedAtNode.textContent = formatTimestamp(data.generatedAt);
   }
@@ -68,6 +166,68 @@
       : (Array.isArray(data.providers) ? data.providers.length : 0);
     providerCountNode.textContent = formatNumber(providerCount);
   }
+
+  const datasets = [...data.datasets];
+  const providerTotals = Array.isArray(data.providers) ? [...data.providers] : [];
+
+  const deckFreshness = datasets.map((deck) => {
+    const manifestStatus = computeComponentStatus([deck.manifest?.generatedAt], deck.manifest ? 1 : 0);
+    const embeddingRecords = Array.isArray(deck.embeddings) ? deck.embeddings : [];
+    const similarityRecords = Array.isArray(deck.similarityReports) ? deck.similarityReports : [];
+    const embeddingStatus = computeComponentStatus(embeddingRecords.map((record) => record.generatedAt), embeddingRecords.length);
+    const similarityStatus = computeComponentStatus(similarityRecords.map((record) => record.generatedAt), similarityRecords.length);
+    const statuses = [manifestStatus, embeddingStatus, similarityStatus];
+
+    const latestTimestamp = statuses.reduce((accumulator, status) => {
+      if (!status.newestDate) {
+        return accumulator;
+      }
+      if (!accumulator || status.newestDate.getTime() > accumulator.getTime()) {
+        return status.newestDate;
+      }
+      return accumulator;
+    }, null);
+
+    const latestAgeDays = latestTimestamp ? differenceInDays(referenceDate, latestTimestamp) : null;
+
+    const statusCounts = {
+      dueSoon: statuses.filter((status) => status.bucket === 'due').length,
+      stale: statuses.filter((status) => status.bucket === 'stale').length,
+      missing: statuses.filter((status) => status.bucket === 'missing').length,
+    };
+
+    return {
+      id: deck.id,
+      label: deck.label,
+      statuses: {
+        manifest: manifestStatus,
+        embeddings: embeddingStatus,
+        similarity: similarityStatus,
+      },
+      counts: {
+        embeddings: embeddingStatus.count,
+        similarityReports: similarityStatus.count,
+      },
+      latestTimestamp,
+      latestAgeDays,
+      statusCounts,
+    };
+  });
+
+  const totalAttention = deckFreshness.reduce((accumulator, entry) => accumulator + entry.statusCounts.dueSoon + entry.statusCounts.stale, 0);
+  const totalStale = deckFreshness.reduce((accumulator, entry) => accumulator + entry.statusCounts.stale, 0);
+  const totalMissingSignals = deckFreshness.reduce((accumulator, entry) => accumulator + entry.statusCounts.missing, 0);
+  const averageLagDays = (() => {
+    const values = deckFreshness
+      .map((entry) => entry.latestAgeDays)
+      .filter((value) => value !== null && Number.isFinite(value));
+    if (values.length === 0) {
+      return null;
+    }
+    const sum = values.reduce((accumulator, value) => accumulator + value, 0);
+    return sum / values.length;
+  })();
+  const averageLagLabel = averageLagDays === null ? '—' : formatRelativeDays(averageLagDays);
 
   const summaryMetrics = [
     {
@@ -89,6 +249,11 @@
       label: 'Asset footprint',
       value: formatBytes(data.totals?.totalBytes || 0),
       detail: `${formatNumber(data.totals?.totalFiles || 0)} files across datasets & sources`,
+    },
+    {
+      label: 'Refresh queue',
+      value: formatNumber(totalAttention),
+      detail: `${formatNumber(totalStale)} stale • ${formatNumber(totalMissingSignals)} missing signals • avg refresh ${averageLagLabel}`,
     },
   ];
 
@@ -112,10 +277,119 @@
     summaryRoot.appendChild(card);
   });
 
-  const datasets = [...data.datasets];
-  const providerTotals = Array.isArray(data.providers) ? [...data.providers] : [];
-
   const datasetById = new Map(datasets.map((deck) => [deck.id, deck]));
+
+  const buildFreshnessCards = (assessments) => {
+    freshnessGrid.innerHTML = '';
+
+    if (!Array.isArray(assessments) || assessments.length === 0) {
+      const fallback = document.createElement('p');
+      fallback.textContent = 'No decks available to audit.';
+      fallback.style.color = 'var(--text-secondary)';
+      freshnessGrid.appendChild(fallback);
+      return;
+    }
+
+    assessments.forEach((assessment) => {
+      const card = document.createElement('article');
+      card.className = 'freshness-card';
+
+      if (assessment.statusCounts.stale > 0) {
+        card.classList.add('needs-action');
+      } else if (assessment.statusCounts.dueSoon > 0) {
+        card.classList.add('due-soon');
+      }
+
+      const heading = document.createElement('h3');
+      heading.textContent = assessment.label;
+      card.appendChild(heading);
+
+      const lastRefresh = document.createElement('p');
+      if (assessment.latestAgeDays === null) {
+        lastRefresh.textContent = 'No refresh timestamps captured.';
+      } else {
+        const timestampLabel = assessment.latestTimestamp
+          ? formatTimestamp(assessment.latestTimestamp.toISOString())
+          : '—';
+        lastRefresh.textContent = `Last refresh ${formatRelativeDays(assessment.latestAgeDays)} (${timestampLabel})`;
+      }
+      card.appendChild(lastRefresh);
+
+      const meta = document.createElement('p');
+      meta.className = 'freshness-meta';
+      const embeddingLabel = `${formatNumber(assessment.counts.embeddings)} embedding store${assessment.counts.embeddings === 1 ? '' : 's'}`;
+      const similarityLabel = `${formatNumber(assessment.counts.similarityReports)} similarity report${assessment.counts.similarityReports === 1 ? '' : 's'}`;
+      meta.textContent = `${embeddingLabel} • ${similarityLabel}`;
+      card.appendChild(meta);
+
+      const statusList = document.createElement('ul');
+      statusList.className = 'freshness-status-list';
+
+      const descriptors = [
+        { key: 'manifest', label: 'Manifest', missing: 'Manifest not generated' },
+        { key: 'embeddings', label: 'Embeddings', missing: 'No embedding stores tracked' },
+        { key: 'similarity', label: 'Similarity', missing: 'No similarity reports' },
+      ];
+
+      descriptors.forEach((descriptor) => {
+        const info = assessment.statuses[descriptor.key];
+        const item = document.createElement('li');
+        item.className = `status-chip ${info.className || 'status-muted'}`;
+
+        const title = document.createElement('span');
+        title.className = 'status-chip__title';
+        title.textContent = descriptor.label;
+        item.appendChild(title);
+
+        const value = document.createElement('span');
+        value.className = 'status-chip__value';
+        if (info.ageDays === null) {
+          value.textContent = info.count > 0 ? 'Timestamp missing' : descriptor.missing;
+        } else {
+          value.textContent = formatRelativeDays(info.ageDays);
+        }
+        item.appendChild(value);
+
+        const detailParts = [];
+
+        if (info.ageDays !== null) {
+          detailParts.push(info.toneLabel);
+        }
+
+        if (descriptor.key === 'embeddings') {
+          const storeLabel = `${formatNumber(info.count)} store${info.count === 1 ? '' : 's'}`;
+          detailParts.push(storeLabel);
+          if (info.spanDays && info.spanDays > 0.4) {
+            detailParts.push(`spread ${decimalFormatter.format(info.spanDays)}d`);
+          }
+        } else if (descriptor.key === 'similarity') {
+          const reportLabel = `${formatNumber(info.count)} report${info.count === 1 ? '' : 's'}`;
+          detailParts.push(reportLabel);
+          if (info.spanDays && info.spanDays > 0.4) {
+            detailParts.push(`span ${decimalFormatter.format(info.spanDays)}d`);
+          }
+        } else if (descriptor.key === 'manifest' && info.count > 0 && info.ageDays !== null) {
+          detailParts.push('1 file');
+        }
+
+        if (info.newestDate) {
+          detailParts.push(formatTimestamp(info.newestDate.toISOString()));
+        }
+
+        if (detailParts.length > 0) {
+          const detail = document.createElement('span');
+          detail.className = 'status-chip__detail';
+          detail.textContent = detailParts.join(' • ');
+          item.appendChild(detail);
+        }
+
+        statusList.appendChild(item);
+      });
+
+      card.appendChild(statusList);
+      freshnessGrid.appendChild(card);
+    });
+  };
 
   const buildDatasetChart = () => {
     datasetChartContainer.innerHTML = '';
@@ -521,6 +795,7 @@
     });
   };
 
+  buildFreshnessCards(deckFreshness);
   buildDatasetChart();
   buildProviderChart();
   buildDatasetTable();

--- a/apps/asset-observatory/asset-data.js
+++ b/apps/asset-observatory/asset-data.js
@@ -1,5 +1,5 @@
 window.assetObservatoryData = {
-  "generatedAt": "2025-09-27T03:45:40.763Z",
+  "generatedAt": "2025-09-27T03:53:29.383Z",
   "datasets": [
     {
       "id": "jokes",

--- a/apps/asset-observatory/index.html
+++ b/apps/asset-observatory/index.html
@@ -24,6 +24,14 @@
       --chart-fill-alt: linear-gradient(135deg, rgba(255, 189, 92, 0.78), rgba(255, 211, 133, 0.58));
       --chip-bg: rgba(11, 18, 36, 0.06);
       --chip-text: rgba(11, 18, 36, 0.72);
+      --status-healthy-bg: rgba(64, 201, 155, 0.18);
+      --status-healthy-text: #0f5132;
+      --status-warning-bg: rgba(255, 189, 92, 0.2);
+      --status-warning-text: #7c4700;
+      --status-critical-bg: rgba(255, 99, 99, 0.18);
+      --status-critical-text: #7a1414;
+      --status-muted-bg: rgba(11, 18, 36, 0.08);
+      --status-muted-text: rgba(11, 18, 36, 0.6);
     }
 
     @media (prefers-color-scheme: dark) {
@@ -42,6 +50,14 @@
         --grid-line: rgba(238, 241, 255, 0.12);
         --chip-bg: rgba(238, 241, 255, 0.12);
         --chip-text: rgba(238, 241, 255, 0.8);
+        --status-healthy-bg: rgba(64, 201, 155, 0.28);
+        --status-healthy-text: #befce4;
+        --status-warning-bg: rgba(255, 189, 92, 0.28);
+        --status-warning-text: #ffe9c6;
+        --status-critical-bg: rgba(255, 99, 99, 0.3);
+        --status-critical-text: #ffd5d5;
+        --status-muted-bg: rgba(238, 241, 255, 0.16);
+        --status-muted-text: rgba(238, 241, 255, 0.7);
       }
     }
 
@@ -284,6 +300,7 @@
       display: inline-flex;
     }
 
+    .freshness-section,
     .dataset-section,
     .similarity-section,
     .sources-section {
@@ -292,6 +309,7 @@
       gap: 14px;
     }
 
+    .freshness-section header,
     .dataset-section header,
     .similarity-section header,
     .sources-section header {
@@ -300,6 +318,7 @@
       gap: 6px;
     }
 
+    .freshness-section h2,
     .dataset-section h2,
     .similarity-section h2,
     .sources-section h2 {
@@ -307,6 +326,7 @@
       font-size: 1.2rem;
     }
 
+    .freshness-section p,
     .dataset-section p,
     .similarity-section p,
     .sources-section p {
@@ -314,6 +334,113 @@
       color: var(--text-secondary);
       font-size: 0.95rem;
       line-height: 1.6;
+    }
+
+    .freshness-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: clamp(14px, 3vw, 20px);
+    }
+
+    .freshness-card {
+      border-radius: 18px;
+      border: 1px solid rgba(11, 18, 36, 0.1);
+      background: rgba(255, 255, 255, 0.92);
+      padding: clamp(14px, 2vw, 20px);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      box-shadow: 0 18px 36px rgba(12, 18, 36, 0.12);
+    }
+
+    .freshness-card.due-soon {
+      border-color: rgba(255, 189, 92, 0.32);
+      box-shadow: 0 20px 44px rgba(255, 189, 92, 0.18);
+    }
+
+    .freshness-card.needs-action {
+      border-color: rgba(255, 99, 99, 0.34);
+      box-shadow: 0 22px 48px rgba(255, 99, 99, 0.22);
+    }
+
+    .freshness-card h3 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .freshness-card p {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      line-height: 1.5;
+    }
+
+    .freshness-meta {
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-secondary);
+    }
+
+    .freshness-status-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .status-chip {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      padding: 8px 12px;
+      border-radius: 12px;
+      border: 1px solid transparent;
+      background: var(--status-muted-bg);
+      color: var(--status-muted-text);
+    }
+
+    .status-chip__title {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .status-chip__value {
+      font-size: 0.95rem;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .status-chip__detail {
+      font-size: 0.78rem;
+      color: inherit;
+      opacity: 0.85;
+    }
+
+    .status-healthy {
+      background: var(--status-healthy-bg);
+      color: var(--status-healthy-text);
+      border-color: rgba(64, 201, 155, 0.24);
+    }
+
+    .status-warning {
+      background: var(--status-warning-bg);
+      color: var(--status-warning-text);
+      border-color: rgba(255, 189, 92, 0.32);
+    }
+
+    .status-critical {
+      background: var(--status-critical-bg);
+      color: var(--status-critical-text);
+      border-color: rgba(255, 99, 99, 0.32);
+    }
+
+    .status-muted {
+      background: var(--status-muted-bg);
+      color: var(--status-muted-text);
+      border-color: rgba(11, 18, 36, 0.14);
     }
 
     .table-shell {
@@ -479,6 +606,13 @@
       </dl>
     </header>
     <section class="summary-grid" aria-label="Global asset metrics" data-summary></section>
+    <section class="freshness-section" aria-label="Refresh health snapshot">
+      <header>
+        <h2>Refresh pulse</h2>
+        <p>Track how recently every deck regenerated its manifests, embedding stores, and similarity runs. Use this to spot stale artefacts before they snowball.</p>
+      </header>
+      <div class="freshness-grid" data-freshness-grid></div>
+    </section>
     <section class="chart-grid" aria-label="Deck payload visualisations">
       <article class="chart-card">
         <header>

--- a/tests/asset-observatory.spec.js
+++ b/tests/asset-observatory.spec.js
@@ -9,12 +9,22 @@ test.describe('Asset Observatory dashboard', () => {
     await expect(homeLink).toContainText('Home');
 
     const summaryCards = page.locator('.summary-card');
-    await expect(summaryCards).toHaveCount(4);
+    await expect(summaryCards).toHaveCount(5);
     await expect(summaryCards.nth(0).locator('h3')).toHaveText('Curated entries');
     await expect(summaryCards.nth(1).locator('h3')).toHaveText('Embedding vectors');
     await expect(summaryCards.nth(2).locator('h3')).toHaveText('Similarity pairs monitored');
     await expect(summaryCards.nth(3).locator('h3')).toHaveText('Asset footprint');
+    await expect(summaryCards.nth(4).locator('h3')).toHaveText('Refresh queue');
     await expect(summaryCards.locator('strong').first()).not.toHaveText(/^0$/);
+
+    const freshnessCards = page.locator('.freshness-card');
+    await expect(freshnessCards).toHaveCount(3);
+    await expect(freshnessCards.first().locator('h3')).toContainText('Dad Jokes');
+    await expect(freshnessCards.first().locator('.status-chip__title')).toHaveText([
+      'Manifest',
+      'Embeddings',
+      'Similarity',
+    ]);
 
     const datasetChart = page.locator('[data-dataset-chart] svg');
     await expect(datasetChart).toBeVisible();


### PR DESCRIPTION
## Summary
- add a refresh pulse section with styled status chips to highlight manifest, embedding, and similarity freshness per deck
- compute freshness metrics in the app script to power the new summary card and detail cards
- regenerate the asset data snapshot and update the Playwright spec expectations for the new UI

## Testing
- npx playwright test tests/asset-observatory.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d75e6dd808832884e13b574cb3fb6c