### PR TITLE
Document 27 Sep workflow failures

### DIFF
--- a/docs/docs/deploy-logs.md
+++ b/docs/docs/deploy-logs.md
@@ -1,3 +1,27 @@
+# Deploy log — 27 Sep 2025
+
+## Log excerpt
+
+```
+2025-09-27T03:58:07Z  error   Run Playwright tests (exit code 1) — workflow 18054737285 / run-playwright job 51382917936
+2025-09-27T03:58:17Z  error   Commit offline manifest update (exit code 1) — workflow 18054738379 / update-offline-manifest job 51382920581
+```
+
+## What went wrong
+
+- **Playwright smoke tests** for PR #155 failed during the `Run Playwright tests` step. The job exited with code 1 before publishing logs, leaving only the workflow metadata to diagnose the failure remotely.【067ba0†L12-L23】【c028a5†L1-L21】【c78c2c†L1-L5】
+- **Refresh offline manifest** for the same merge stalled while trying to push an updated manifest back to `main`. The `git push` in the "Commit offline manifest update" step returned exit code 1, which typically happens when another workflow updates the branch between checkout and push—the repo history shows earlier manifest commits for PRs #148–#153 landing within minutes of this failure.【49cbe0†L1-L34】【cd774a†L1-L24】
+
+## Mitigation
+
+- Re-run the Playwright suite locally (or re-trigger the workflow with full log access) to capture the failing spec details, then adjust selectors or copy expectations introduced in PR #155 so they line up with the new embedding explorer UI.
+- Add a `git pull --rebase origin ${{ github.event.pull_request.base.ref }}` (or `git fetch` followed by `git reset --hard origin/...`) before committing the offline manifest so each run rebases onto the latest bot commit. Alternatively, push with `--force-with-lease` after confirming only the manifest file changed.
+
+## Follow-up
+
+1. Collect the Playwright trace bundle for run 18054737285 and document which specs broke so the tests can evolve alongside the UI changes.
+2. Update `.github/workflows/update-offline-manifest.yml` to rebase or force-push safely, preventing manifest runs from racing each other on busy merge trains.
+
 # Deploy log — 25 Sep 2025
 
 ## Log excerpt


### PR DESCRIPTION
## Summary
- add a 27 Sep 2025 entry to the deploy log capturing the failing Playwright and offline-manifest workflows
- outline likely causes, mitigation steps, and follow-up tasks for the pair of automation regressions

## Testing
- no automated tests were run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7607563d88328ab8b158691658b26