### PR TITLE
Keep the toolbox worker out of Pad

### DIFF
--- a/offline-manifest.json
+++ b/offline-manifest.json
@@ -1,8 +1,8 @@
 {
-  "version": "20260718-e313daf3cc6f-b7acc193c155-dirty",
-  "generatedAt": "2026-07-18T23:01:44.222Z",
+  "version": "20260726-58ab4692b8ef-43415d5ac648-dirty",
+  "generatedAt": "2026-07-26T13:47:30.358Z",
   "totalAssets": 81,
-  "totalBytes": 6553892,
+  "totalBytes": 6553977,
   "assets": [
     {
       "path": "apps/asset-observatory/AGENTS.md",
@@ -326,12 +326,12 @@
     },
     {
       "path": "service-worker.js",
-      "bytes": 13093
+      "bytes": 13178
     }
   ],
   "commit": {
-    "hash": "b7acc193c1555b00972775c6c0a57dd24b5e5ffb",
-    "short": "b7acc193c155",
+    "hash": "43415d5ac64801e204f22ef376623982bfdd78f9",
+    "short": "43415d5ac648",
     "dirty": true
   }
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -47,6 +47,9 @@ self.addEventListener('fetch', (event) => {
   if (url.origin !== self.location.origin) {
     return;
   }
+  if (url.pathname === '/pad' || url.pathname.startsWith('/pad/')) {
+    return;
+  }
 
   if (url.pathname === SERVICE_WORKER_PATH) {
     return;


### PR DESCRIPTION
## What changed

- The root toolbox service worker now ignores `/pad` and `/pad/*` before any `respondWith` path.
- The generated offline manifest was refreshed with the changed worker bytes.

## Why

The root-scoped cache-first worker was crossing the application boundary and storing Pad HTML, hashed assets, and API responses. That allowed a pre-curriculum samples response to outlive a Pad deployment despite Pad's `no-store` policy.

## Impact

Toolbox offline behavior is unchanged for its own apps. Pad now owns its own release and cache policy.

## Validation

- `node --check service-worker.js`
- Offline manifest regenerated successfully
- `npx playwright test tests/offline-manifest.spec.js` — 2 passed
- Independent review found no remaining issues